### PR TITLE
feat: Add "Short Power Button Click" option to rotate reader orientation

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -114,7 +114,7 @@ class CrossPointSettings {
   };
 
   // Short power button press actions
-  enum SHORT_PWRBTN { IGNORE = 0, SLEEP = 1, PAGE_TURN = 2, SHORT_PWRBTN_COUNT };
+  enum SHORT_PWRBTN { IGNORE = 0, SLEEP = 1, PAGE_TURN = 2, ROTATE_ORIENTATION = 3, SHORT_PWRBTN_COUNT };
 
   // Hide battery percentage
   enum HIDE_BATTERY_PERCENTAGE { HIDE_NEVER = 0, HIDE_READER = 1, HIDE_ALWAYS = 2, HIDE_BATTERY_PERCENTAGE_COUNT };

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -73,8 +73,8 @@ inline std::vector<SettingInfo> getSettingsList() {
       SettingInfo::Toggle(StrId::STR_LONG_PRESS_SKIP, &CrossPointSettings::longPressChapterSkip, "longPressChapterSkip",
                           StrId::STR_CAT_CONTROLS),
       SettingInfo::Enum(StrId::STR_SHORT_PWR_BTN, &CrossPointSettings::shortPwrBtn,
-                        {StrId::STR_IGNORE, StrId::STR_SLEEP, StrId::STR_PAGE_TURN}, "shortPwrBtn",
-                        StrId::STR_CAT_CONTROLS),
+                        {StrId::STR_IGNORE, StrId::STR_SLEEP, StrId::STR_PAGE_TURN, StrId::READER_ROTATE},
+                        "shortPwrBtn", StrId::STR_CAT_CONTROLS),
 
       // --- System ---
       SettingInfo::Enum(StrId::STR_TIME_TO_SLEEP, &CrossPointSettings::sleepTimeout,

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -32,22 +32,7 @@ void TxtReaderActivity::onEnter() {
   }
 
   // Configure screen orientation based on settings
-  switch (SETTINGS.orientation) {
-    case CrossPointSettings::ORIENTATION::PORTRAIT:
-      renderer.setOrientation(GfxRenderer::Orientation::Portrait);
-      break;
-    case CrossPointSettings::ORIENTATION::LANDSCAPE_CW:
-      renderer.setOrientation(GfxRenderer::Orientation::LandscapeClockwise);
-      break;
-    case CrossPointSettings::ORIENTATION::INVERTED:
-      renderer.setOrientation(GfxRenderer::Orientation::PortraitInverted);
-      break;
-    case CrossPointSettings::ORIENTATION::LANDSCAPE_CCW:
-      renderer.setOrientation(GfxRenderer::Orientation::LandscapeCounterClockwise);
-      break;
-    default:
-      break;
-  }
+  renderer.setOrientation(static_cast<GfxRenderer::Orientation>(SETTINGS.orientation));
 
   txt->setupCacheDir();
 
@@ -90,6 +75,19 @@ void TxtReaderActivity::loop() {
   // Short press BACK goes directly to home
   if (mappedInput.wasReleased(MappedInputManager::Button::Back) && mappedInput.getHeldTime() < goHomeMs) {
     onGoHome();
+    return;
+  }
+
+  // Short press power rotates the screen, if configured
+  if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::ROTATE_ORIENTATION &&
+      mappedInput.wasReleased(MappedInputManager::Button::Power)) {
+    SETTINGS.orientation = (SETTINGS.orientation + 1) % CrossPointSettings::ORIENTATION::ORIENTATION_COUNT;
+    SETTINGS.saveToFile();
+    renderer.setOrientation(static_cast<GfxRenderer::Orientation>(SETTINGS.orientation));
+    initialized = false;
+    pageOffsets.clear();
+    currentPageLines.clear();
+    updateRequired = true;
     return;
   }
 

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -19,6 +19,16 @@
 const StrId SettingsActivity::categoryNames[categoryCount] = {StrId::STR_CAT_DISPLAY, StrId::STR_CAT_READER,
                                                               StrId::STR_CAT_CONTROLS, StrId::STR_CAT_SYSTEM};
 
+//Make it safe to static_cast between the orientation enums
+static_assert(static_cast<GfxRenderer::Orientation>(CrossPointSettings::ORIENTATION::PORTRAIT)
+  == GfxRenderer::Orientation::Portrait);
+static_assert(static_cast<GfxRenderer::Orientation>(CrossPointSettings::ORIENTATION::LANDSCAPE_CW)
+  == GfxRenderer::Orientation::LandscapeClockwise);
+static_assert(static_cast<GfxRenderer::Orientation>(CrossPointSettings::ORIENTATION::INVERTED)
+  == GfxRenderer::Orientation::PortraitInverted);
+static_assert(static_cast<GfxRenderer::Orientation>(CrossPointSettings::ORIENTATION::LANDSCAPE_CCW)
+  == GfxRenderer::Orientation::LandscapeCounterClockwise);
+
 void SettingsActivity::onEnter() {
   Activity::onEnter();
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
I wanted a quicker way to rotate the display to best fit the content that I'm reading.
* **What changes are included?**
Added an additional option to Settings->Controls->Short Power Button Click, "Reader Rotate". When this option is chosen, short pressing the power button while reading will rotate the display.

![IMG_3078](https://github.com/user-attachments/assets/b5823b16-6d77-43d5-b4e9-c0eb67ff7bdb)

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).
Also removed the `applyReaderOrientation` helper function across several readers. By using static_assert we can make casting between the Gfx and Settings orientation enums safe, so the helper function amounts to a cast which can just be done inline.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

**Did you use AI tools to help write this code?**
Partially, yes. I asked GPT 5.2 Codex to identify the areas that would need to be changed for this change, let it make the change, reviewed its changes, tested on device, and made an additional change myself to avoid overflowing text in the settings menu. Then when rebasing I went over everything again and rewrote most of it (and removed some bits that in retrospect didn't make any sense).