### PR TITLE
fix(epub): avoid crashes when CSS cache is missing

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -277,6 +277,11 @@ void Epub::parseCssFiles() const {
 bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   Serial.printf("[%lu] [EBP] Loading ePub: %s\n", millis(), filepath.c_str());
 
+  // Avoid expensive/fragile CSS parsing when memory is tight.
+  // (ESP32-C3 without PSRAM can crash if C++ allocation throws during parsing.)
+  constexpr int MIN_HEAP_FOR_CSS_PARSE = 140 * 1024;
+  constexpr int LARGE_SPINE_SKIP_CSS_PARSE = 400;
+
   // Initialize spine/TOC cache
   bookMetadataCache.reset(new BookMetadataCache(cachePath));
   // Always create CssParser - needed for inline style parsing even without CSS files
@@ -285,18 +290,25 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   // Try to load existing cache first
   if (bookMetadataCache->load()) {
     if (!skipLoadingCss && !loadCssRulesFromCache()) {
-      Serial.printf("[%lu] [EBP] Warning: CSS rules cache not found, attempting to parse CSS files\n", millis());
-      // to get CSS file list
-      try {
-        if (!parseContentOpf(bookMetadataCache->coreMetadata)) {
-          Serial.printf("[%lu] [EBP] Could not parse content.opf from cached bookMetadata for CSS files\n", millis());
-          // continue anyway - book will work without CSS and we'll still load any inline style CSS
+      const int freeHeap = ESP.getFreeHeap();
+      const int spineCount = bookMetadataCache->getSpineCount();
+      Serial.printf(
+          "[%lu] [EBP] CSS rules cache not found (freeHeap=%d, spine=%d). Skipping CSS parse to avoid crashes\n",
+          millis(), freeHeap, spineCount);
+
+      // Heuristic: parsing content.opf just to discover CSS files is expensive for large books.
+      // Also skip if memory is tight.
+      if (freeHeap >= MIN_HEAP_FOR_CSS_PARSE && spineCount < LARGE_SPINE_SKIP_CSS_PARSE) {
+        Serial.printf("[%lu] [EBP] Attempting best-effort CSS parse\n", millis());
+        try {
+          if (!parseContentOpf(bookMetadataCache->coreMetadata)) {
+            Serial.printf("[%lu] [EBP] Could not parse content.opf for CSS files; continuing without CSS\n", millis());
+          } else {
+            parseCssFiles();
+          }
+        } catch (...) {
+          Serial.printf("[%lu] [EBP] Exception while parsing CSS files; continuing without CSS\n", millis());
         }
-        parseCssFiles();
-      } catch (...) {
-        // On ESP32, some STL allocations may throw and abort if uncaught.
-        // CSS parsing is optional, so prefer failing open.
-        Serial.printf("[%lu] [EBP] Exception while parsing CSS files; continuing without CSS\n", millis());
       }
     }
     Serial.printf("[%lu] [EBP] Loaded ePub: %s\n", millis(), filepath.c_str());
@@ -397,10 +409,16 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
 
   if (!skipLoadingCss) {
     // Parse CSS files after cache reload
-    try {
-      parseCssFiles();
-    } catch (...) {
-      Serial.printf("[%lu] [EBP] Exception while parsing CSS files; continuing without CSS\n", millis());
+    const int freeHeap = ESP.getFreeHeap();
+    const int spineCount = bookMetadataCache->getSpineCount();
+    if (freeHeap < MIN_HEAP_FOR_CSS_PARSE || spineCount >= LARGE_SPINE_SKIP_CSS_PARSE) {
+      Serial.printf("[%lu] [EBP] Skipping CSS parse (freeHeap=%d, spine=%d)\n", millis(), freeHeap, spineCount);
+    } else {
+      try {
+        parseCssFiles();
+      } catch (...) {
+        Serial.printf("[%lu] [EBP] Exception while parsing CSS files; continuing without CSS\n", millis());
+      }
     }
   }
 

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -591,7 +591,15 @@ bool Epub::generateThumbBmp(int height) const {
 
     if (!success) {
       Serial.printf("[%lu] [EBP] Failed to generate thumb BMP from JPG cover image\n", millis());
-      SdMan.remove(getThumbBmpPath(height).c_str());
+
+      // Avoid retrying on every Home entry (some EPUB covers are unsupported by our JPEG decoder).
+      // Remove any partial output and create an empty sentinel file so `exists()` short-circuits future attempts.
+      const std::string thumbPath = getThumbBmpPath(height);
+      SdMan.remove(thumbPath.c_str());
+      FsFile sentinel;
+      if (SdMan.openFileForWrite("EBP", thumbPath, sentinel)) {
+        sentinel.close();
+      }
     }
     Serial.printf("[%lu] [EBP] Generated thumb BMP from JPG cover image, success: %s\n", millis(),
                   success ? "yes" : "no");

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -88,7 +88,8 @@ RecentBook RecentBooksStore::getDataFromBook(std::string path) const {
   // If epub, try to load the metadata for title/author and cover
   if (StringUtils::checkFileExtension(lastBookFileName, ".epub")) {
     Epub epub(path, "/.crosspoint");
-    epub.load(false);
+    // We only need metadata + thumb path here; skip CSS parsing to avoid heavy work/OOM.
+    epub.load(false, true);
     return RecentBook{path, epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".xtch") ||
              StringUtils::checkFileExtension(lastBookFileName, ".xtc")) {

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -303,8 +303,19 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
         }
 
         if (!hasCover) {
-          renderer.drawRect(tileX + hPaddingInSelection, tileY + hPaddingInSelection,
-                            tileWidth - 2 * hPaddingInSelection, LyraMetrics::values.homeCoverHeight);
+          const int coverX = tileX + hPaddingInSelection;
+          const int coverY = tileY + hPaddingInSelection;
+          const int coverW = tileWidth - 2 * hPaddingInSelection;
+          const int coverH = LyraMetrics::values.homeCoverHeight;
+          renderer.drawRect(coverX, coverY, coverW, coverH);
+
+          // Fallback: show title when cover image is missing/invalid.
+          const auto title = renderer.truncatedText(UI_10_FONT_ID, recentBooks[i].title.c_str(), coverW - 6);
+          const int textW = renderer.getTextWidth(UI_10_FONT_ID, title.c_str());
+          const int textH = renderer.getLineHeight(UI_10_FONT_ID);
+          const int textX = coverX + (coverW - textW) / 2;
+          const int textY = coverY + (coverH - textH) / 2;
+          renderer.drawText(UI_10_FONT_ID, textX, textY, title.c_str(), true);
         }
       }
 


### PR DESCRIPTION
## Summary

Prevents EPUB reader reboot loops when `css_rules.cache` is missing, and stops Home from repeatedly retrying cover thumbnail generation for unsupported EPUB cover images.

Fixes #761.

## Problem

Two issues that show up most often on ESP32-C3 with large EPUBs:

1) CSS cache miss can crash the reader
- If `/.crosspoint/epub_<hash>/css_rules.cache` is missing, we try to parse CSS on-demand.
- On large books / tight heap this can throw/abort and the device ends up reboot-looping.

2) Home periodically pauses with a "Loading..." popup
- Home attempts to generate `thumb_<height>.bmp` for recent book covers.
- Some EPUB covers are progressive JPEGs, which picojpeg doesn’t support (error `37` / `PJPG_UNSUPPORTED_MODE`).
- Since the thumb never appears, Home keeps retrying on subsequent renders → periodic pauses.

## Solution

- CSS cache miss: fail open (continue without CSS) instead of crashing
  - Skip CSS parsing on cache-miss when the book is large or free heap is low
  - Guard best-effort CSS parsing so exceptions don’t crash the device
- Home thumbnails:
  - If JPEG decode fails, write a 0-byte thumb sentinel so Home stops retrying forever
  - Lyra theme: when cover is missing/invalid, render a simple placeholder with the book title in the cover box
- Metadata reads / recents migration: always skip CSS parsing (metadata only)

## Notes / tradeoffs

- On books that hit the “skip CSS parse” path, rendering may be less styled (we intentionally skip building CSS rules to prioritize stability over perfect styling).
- For progressive JPEG covers, we intentionally stop retrying; users can convert the cover to baseline JPEG if they want the thumb.

## Testing

On hardware (Xteink X4 / ESP32-C3):
- Delete `/.crosspoint/epub_<hash>/css_rules.cache` for a large EPUB, then open it → should not reboot; should log skipping CSS parse
- Return to Home repeatedly → should not keep retrying thumb generation for the same book/thumb size
- Verify Lyra Home shows title fallback when cover thumb is missing/invalid

## Files changed

- `lib/Epub/Epub.cpp`
- `src/RecentBooksStore.cpp`
- `src/components/themes/lyra/LyraTheme.cpp`

