### PR TITLE
perf: Optimize CssParser and hyphenation allocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,16 @@ jobs:
           path: .pio/build/default/firmware.bin
           if-no-files-found: error
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Run unit tests
+        run: ./test/run_unit_tests.sh
+
   # This job is used as the PR required actions check, allows for changes to other steps in the future without breaking
   # PR requirements.
   test-status:
@@ -98,6 +108,7 @@ jobs:
       - build
       - clang-format
       - cppcheck
+      - unit-tests
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -23,10 +23,10 @@ class PageElement {
 
 // a line from a block element
 class PageLine final : public PageElement {
-  std::shared_ptr<TextBlock> block;
+  std::unique_ptr<TextBlock> block;
 
  public:
-  PageLine(std::shared_ptr<TextBlock> block, const int16_t xPos, const int16_t yPos)
+  PageLine(std::unique_ptr<TextBlock> block, const int16_t xPos, const int16_t yPos)
       : PageElement(xPos, yPos), block(std::move(block)) {}
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(FsFile& file) override;
@@ -36,7 +36,7 @@ class PageLine final : public PageElement {
 class Page {
  public:
   // the list of block index and line numbers on this page
-  std::vector<std::shared_ptr<PageElement>> elements;
+  std::vector<std::unique_ptr<PageElement>> elements;
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;
   static std::unique_ptr<Page> deserialize(FsFile& file);

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
-#include <iterator>
 #include <limits>
 #include <vector>
 
@@ -64,7 +63,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
 
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                                       const std::function<void(std::unique_ptr<TextBlock>)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
     return;
@@ -77,37 +76,26 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   const int spaceWidth = renderer.getSpaceWidth(fontId);
   auto wordWidths = calculateWordWidths(renderer, fontId);
 
-  // Build indexed continues vector from the parallel list for O(1) access during layout
-  std::vector<bool> continuesVec(wordContinues.begin(), wordContinues.end());
-
   std::vector<size_t> lineBreakIndices;
   if (hyphenationEnabled) {
     // Use greedy layout that can split words mid-loop when a hyphenated prefix fits.
-    lineBreakIndices = computeHyphenatedLineBreaks(renderer, fontId, pageWidth, spaceWidth, wordWidths, continuesVec);
+    lineBreakIndices = computeHyphenatedLineBreaks(renderer, fontId, pageWidth, spaceWidth, wordWidths, wordContinues);
   } else {
-    lineBreakIndices = computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, wordWidths, continuesVec);
+    lineBreakIndices = computeLineBreaks(renderer, fontId, pageWidth, spaceWidth, wordWidths, wordContinues);
   }
   const size_t lineCount = includeLastLine ? lineBreakIndices.size() : lineBreakIndices.size() - 1;
 
   for (size_t i = 0; i < lineCount; ++i) {
-    extractLine(i, pageWidth, spaceWidth, wordWidths, continuesVec, lineBreakIndices, processLine);
+    extractLine(i, pageWidth, spaceWidth, wordWidths, wordContinues, lineBreakIndices, processLine);
   }
 }
 
 std::vector<uint16_t> ParsedText::calculateWordWidths(const GfxRenderer& renderer, const int fontId) {
-  const size_t totalWordCount = words.size();
-
   std::vector<uint16_t> wordWidths;
-  wordWidths.reserve(totalWordCount);
+  wordWidths.reserve(words.size());
 
-  auto wordsIt = words.begin();
-  auto wordStylesIt = wordStyles.begin();
-
-  while (wordsIt != words.end()) {
-    wordWidths.push_back(measureWordWidth(renderer, fontId, *wordsIt, *wordStylesIt));
-
-    std::advance(wordsIt, 1);
-    std::advance(wordStylesIt, 1);
+  for (size_t i = 0; i < words.size(); ++i) {
+    wordWidths.push_back(measureWordWidth(renderer, fontId, words[i], wordStyles[i]));
   }
 
   return wordWidths;
@@ -132,8 +120,7 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
     // First word needs to fit in reduced width if there's an indent
     const int effectiveWidth = i == 0 ? pageWidth - firstLineIndent : pageWidth;
     while (wordWidths[i] > effectiveWidth) {
-      if (!hyphenateWordAtIndex(i, effectiveWidth, renderer, fontId, wordWidths, /*allowFallbackBreaks=*/true,
-                                &continuesVec)) {
+      if (!hyphenateWordAtIndex(i, effectiveWidth, renderer, fontId, wordWidths, /*allowFallbackBreaks=*/true)) {
         break;
       }
     }
@@ -279,8 +266,8 @@ std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& r
       const int availableWidth = effectivePageWidth - lineWidth - spacing;
       const bool allowFallbackBreaks = isFirstWord;  // Only for first word on line
 
-      if (availableWidth > 0 && hyphenateWordAtIndex(currentIndex, availableWidth, renderer, fontId, wordWidths,
-                                                     allowFallbackBreaks, &continuesVec)) {
+      if (availableWidth > 0 &&
+          hyphenateWordAtIndex(currentIndex, availableWidth, renderer, fontId, wordWidths, allowFallbackBreaks)) {
         // Prefix now fits; append it to this line and move to next line
         lineWidth += spacing + wordWidths[currentIndex];
         ++currentIndex;
@@ -312,20 +299,14 @@ std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& r
 // available width.
 bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availableWidth, const GfxRenderer& renderer,
                                       const int fontId, std::vector<uint16_t>& wordWidths,
-                                      const bool allowFallbackBreaks, std::vector<bool>* continuesVec) {
+                                      const bool allowFallbackBreaks) {
   // Guard against invalid indices or zero available width before attempting to split.
   if (availableWidth <= 0 || wordIndex >= words.size()) {
     return false;
   }
 
-  // Get iterators to target word and style.
-  auto wordIt = words.begin();
-  auto styleIt = wordStyles.begin();
-  std::advance(wordIt, wordIndex);
-  std::advance(styleIt, wordIndex);
-
-  const std::string& word = *wordIt;
-  const auto style = *styleIt;
+  const std::string& word = words[wordIndex];
+  const auto style = wordStyles[wordIndex];
 
   // Collect candidate breakpoints (byte offsets and hyphen requirements).
   auto breakInfos = Hyphenator::breakOffsets(word, allowFallbackBreaks);
@@ -362,32 +343,20 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 
   // Split the word at the selected breakpoint and append a hyphen if required.
   std::string remainder = word.substr(chosenOffset);
-  wordIt->resize(chosenOffset);
+  words[wordIndex].resize(chosenOffset);
   if (chosenNeedsHyphen) {
-    wordIt->push_back('-');
+    words[wordIndex].push_back('-');
   }
 
   // Insert the remainder word (with matching style and continuation flag) directly after the prefix.
-  auto insertWordIt = std::next(wordIt);
-  auto insertStyleIt = std::next(styleIt);
-  words.insert(insertWordIt, remainder);
-  wordStyles.insert(insertStyleIt, style);
+  words.insert(words.begin() + wordIndex + 1, remainder);
+  wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
 
   // The remainder inherits whatever continuation status the original word had with the word after it.
-  // Find the continues entry for the original word and insert the remainder's entry after it.
-  auto continuesIt = wordContinues.begin();
-  std::advance(continuesIt, wordIndex);
-  const bool originalContinuedToNext = *continuesIt;
+  const bool originalContinuedToNext = wordContinues[wordIndex];
   // The original word (now prefix) does NOT continue to remainder (hyphen separates them)
-  *continuesIt = false;
-  const auto insertContinuesIt = std::next(continuesIt);
-  wordContinues.insert(insertContinuesIt, originalContinuedToNext);
-
-  // Keep the indexed vector in sync if provided
-  if (continuesVec) {
-    (*continuesVec)[wordIndex] = false;
-    continuesVec->insert(continuesVec->begin() + wordIndex + 1, originalContinuedToNext);
-  }
+  wordContinues[wordIndex] = false;
+  wordContinues.insert(wordContinues.begin() + wordIndex + 1, originalContinuedToNext);
 
   // Update cached widths to reflect the new prefix/remainder pairing.
   wordWidths[wordIndex] = static_cast<uint16_t>(chosenWidth);
@@ -399,7 +368,7 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const int spaceWidth,
                              const std::vector<uint16_t>& wordWidths, const std::vector<bool>& continuesVec,
                              const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine) {
+                             const std::function<void(std::unique_ptr<TextBlock>)>& processLine) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
@@ -447,7 +416,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   // Pre-calculate X positions for words
   // Continuation words attach to the previous word with no space before them
-  std::list<uint16_t> lineXPos;
+  std::vector<uint16_t> lineXPos;
+  lineXPos.reserve(lineWordCount);
 
   for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
     const uint16_t currentWordWidth = wordWidths[lastBreakAt + wordIdx];
@@ -460,23 +430,10 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     xpos += currentWordWidth + (nextIsContinuation ? 0 : spacing);
   }
 
-  // Iterators always start at the beginning as we are moving content with splice below
-  auto wordEndIt = words.begin();
-  auto wordStyleEndIt = wordStyles.begin();
-  auto wordContinuesEndIt = wordContinues.begin();
-  std::advance(wordEndIt, lineWordCount);
-  std::advance(wordStyleEndIt, lineWordCount);
-  std::advance(wordContinuesEndIt, lineWordCount);
-
-  // *** CRITICAL STEP: CONSUME DATA USING SPLICE ***
-  std::list<std::string> lineWords;
-  lineWords.splice(lineWords.begin(), words, words.begin(), wordEndIt);
-  std::list<EpdFontFamily::Style> lineWordStyles;
-  lineWordStyles.splice(lineWordStyles.begin(), wordStyles, wordStyles.begin(), wordStyleEndIt);
-
-  // Consume continues flags (not passed to TextBlock, but must be consumed to stay in sync)
-  std::list<bool> lineContinues;
-  lineContinues.splice(lineContinues.begin(), wordContinues, wordContinues.begin(), wordContinuesEndIt);
+  // Build line data by moving from the original vectors using index range
+  std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
+                                     std::make_move_iterator(words.begin() + lineBreak));
+  std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
@@ -484,6 +441,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
   }
 
-  processLine(
-      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle));
+  processLine(std::unique_ptr<TextBlock>(
+      new TextBlock(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle)));
 }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -3,7 +3,6 @@
 #include <EpdFontFamily.h>
 
 #include <functional>
-#include <list>
 #include <memory>
 #include <string>
 #include <vector>
@@ -14,9 +13,9 @@
 class GfxRenderer;
 
 class ParsedText {
-  std::list<std::string> words;
-  std::list<EpdFontFamily::Style> wordStyles;
-  std::list<bool> wordContinues;  // true = word attaches to previous (no space before it)
+  std::vector<std::string> words;
+  std::vector<EpdFontFamily::Style> wordStyles;
+  std::vector<bool> wordContinues;  // true = word attaches to previous (no space before it)
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;
@@ -28,11 +27,10 @@ class ParsedText {
                                                   int spaceWidth, std::vector<uint16_t>& wordWidths,
                                                   std::vector<bool>& continuesVec);
   bool hyphenateWordAtIndex(size_t wordIndex, int availableWidth, const GfxRenderer& renderer, int fontId,
-                            std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks,
-                            std::vector<bool>* continuesVec = nullptr);
+                            std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks);
   void extractLine(size_t breakIndex, int pageWidth, int spaceWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine);
+                   const std::function<void(std::unique_ptr<TextBlock>)>& processLine);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
  public:
@@ -47,6 +45,6 @@ class ParsedText {
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::unique_ptr<TextBlock>)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -13,6 +13,7 @@ class Section {
   GfxRenderer& renderer;
   std::string filePath;
   FsFile file;
+  uint32_t cachedLutOffset = 0;
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
@@ -28,10 +29,10 @@ class Section {
         spineIndex(spineIndex),
         renderer(renderer),
         filePath(epub->getCachePath() + "/sections/" + std::to_string(spineIndex) + ".bin") {}
-  ~Section() = default;
+  ~Section() { file.close(); }
   bool loadSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                        uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled, bool embeddedStyle);
-  bool clearCache() const;
+  bool clearCache();
   bool createSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                          uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled, bool embeddedStyle,
                          const std::function<void()>& popupFn = nullptr);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -11,16 +11,13 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
     return;
   }
 
-  auto wordIt = words.begin();
-  auto wordStylesIt = wordStyles.begin();
-  auto wordXposIt = wordXpos.begin();
   for (size_t i = 0; i < words.size(); i++) {
-    const int wordX = *wordXposIt + x;
-    const EpdFontFamily::Style currentStyle = *wordStylesIt;
-    renderer.drawText(fontId, wordX, y, wordIt->c_str(), true, currentStyle);
+    const int wordX = wordXpos[i] + x;
+    const EpdFontFamily::Style currentStyle = wordStyles[i];
+    renderer.drawText(fontId, wordX, y, words[i].c_str(), true, currentStyle);
 
     if ((currentStyle & EpdFontFamily::UNDERLINE) != 0) {
-      const std::string& w = *wordIt;
+      const std::string& w = words[i];
       const int fullWordWidth = renderer.getTextWidth(fontId, w.c_str(), currentStyle);
       // y is the top of the text line; add ascender to reach baseline, then offset 2px below
       const int underlineY = y + renderer.getFontAscenderSize(fontId) + 2;
@@ -40,10 +37,6 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
 
       renderer.drawLine(startX, underlineY, startX + underlineWidth, underlineY, true);
     }
-
-    std::advance(wordIt, 1);
-    std::advance(wordStylesIt, 1);
-    std::advance(wordXposIt, 1);
   }
 }
 
@@ -79,15 +72,15 @@ bool TextBlock::serialize(FsFile& file) const {
 
 std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   uint16_t wc;
-  std::list<std::string> words;
-  std::list<uint16_t> wordXpos;
-  std::list<EpdFontFamily::Style> wordStyles;
+  std::vector<std::string> words;
+  std::vector<uint16_t> wordXpos;
+  std::vector<EpdFontFamily::Style> wordStyles;
   BlockStyle blockStyle;
 
   // Word count
   serialization::readPod(file, wc);
 
-  // Sanity check: prevent allocation of unreasonably large lists (max 10000 words per block)
+  // Sanity check: prevent allocation of unreasonably large vectors (max 10000 words per block)
   if (wc > 10000) {
     Serial.printf("[%lu] [TXB] Deserialization failed: word count %u exceeds maximum\n", millis(), wc);
     return nullptr;

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -2,9 +2,9 @@
 #include <EpdFontFamily.h>
 #include <HalStorage.h>
 
-#include <list>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "Block.h"
 #include "BlockStyle.h"
@@ -12,14 +12,14 @@
 // Represents a line of text on a page
 class TextBlock final : public Block {
  private:
-  std::list<std::string> words;
-  std::list<uint16_t> wordXpos;
-  std::list<EpdFontFamily::Style> wordStyles;
+  std::vector<std::string> words;
+  std::vector<uint16_t> wordXpos;
+  std::vector<EpdFontFamily::Style> wordStyles;
   BlockStyle blockStyle;
 
  public:
-  explicit TextBlock(std::list<std::string> words, std::list<uint16_t> word_xpos,
-                     std::list<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle())
+  explicit TextBlock(std::vector<std::string> words, std::vector<uint16_t> word_xpos,
+                     std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle())
       : words(std::move(words)),
         wordXpos(std::move(word_xpos)),
         wordStyles(std::move(word_styles)),

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -472,6 +472,20 @@ bool CssParser::loadFromStream(FsFile& source) {
   return true;
 }
 
+// Load and parse CSS from a string
+
+void CssParser::loadFromString(const std::string& content) {
+  if (content.empty()) return;
+
+  const std::string cleaned = stripComments(content);
+
+  size_t pos = 0;
+  std::string selector, body;
+  while (extractNextRule(cleaned, pos, selector, body)) {
+    processRuleBlock(selector, body);
+  }
+}
+
 // Style resolution
 
 CssStyle CssParser::resolveStyle(const std::string& tagName, const std::string& classAttr) const {

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -45,6 +45,13 @@ class CssParser {
   bool loadFromStream(FsFile& source);
 
   /**
+   * Load and parse CSS from a string.
+   * Can be called multiple times to accumulate rules from multiple stylesheets.
+   * @param css CSS content to parse
+   */
+  void loadFromString(const std::string& css);
+
+  /**
    * Look up the style for an HTML element, considering tag name and class attributes.
    * Applies CSS cascade: element style < class style < element.class style
    *

--- a/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
+++ b/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp
@@ -157,17 +157,25 @@ void trimSurroundingPunctuationAndFootnote(std::vector<CodepointInfo>& cps) {
     }
   }
 
-  while (!cps.empty() && isPunctuation(cps.front().value)) {
-    cps.erase(cps.begin());
+  // Find first non-punctuation element and bulk-erase leading punctuation in one operation
+  size_t firstNonPunct = 0;
+  while (firstNonPunct < cps.size() && isPunctuation(cps[firstNonPunct].value)) {
+    ++firstNonPunct;
+  }
+  if (firstNonPunct > 0) {
+    if (firstNonPunct >= cps.size()) {
+      cps.clear();
+      return;
+    }
+    cps.erase(cps.begin(), cps.begin() + static_cast<ptrdiff_t>(firstNonPunct));
   }
   while (!cps.empty() && isPunctuation(cps.back().value)) {
     cps.pop_back();
   }
 }
 
-std::vector<CodepointInfo> collectCodepoints(const std::string& word) {
-  std::vector<CodepointInfo> cps;
-  cps.reserve(word.size());
+void collectCodepoints(const std::string& word, std::vector<CodepointInfo>& cps) {
+  cps.clear();
 
   const unsigned char* base = reinterpret_cast<const unsigned char*>(word.c_str());
   const unsigned char* ptr = base;
@@ -176,6 +184,11 @@ std::vector<CodepointInfo> collectCodepoints(const std::string& word) {
     const uint32_t cp = utf8NextCodepoint(&ptr);
     cps.push_back({cp, static_cast<size_t>(current - base)});
   }
+}
 
+std::vector<CodepointInfo> collectCodepoints(const std::string& word) {
+  std::vector<CodepointInfo> cps;
+  cps.reserve(word.size());
+  collectCodepoints(word, cps);
   return cps;
 }

--- a/lib/Epub/Epub/hyphenation/HyphenationCommon.h
+++ b/lib/Epub/Epub/hyphenation/HyphenationCommon.h
@@ -23,3 +23,4 @@ bool isExplicitHyphen(uint32_t cp);
 bool isSoftHyphen(uint32_t cp);
 void trimSurroundingPunctuationAndFootnote(std::vector<CodepointInfo>& cps);
 std::vector<CodepointInfo> collectCodepoints(const std::string& word);
+void collectCodepoints(const std::string& word, std::vector<CodepointInfo>& cps);

--- a/lib/Epub/Epub/hyphenation/Hyphenator.cpp
+++ b/lib/Epub/Epub/hyphenation/Hyphenator.cpp
@@ -56,7 +56,9 @@ std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string& w
   }
 
   // Convert to codepoints and normalize word boundaries.
-  auto cps = collectCodepoints(word);
+  // Reuse static buffer across calls (safe: ESP32-C3 is single-threaded).
+  static std::vector<CodepointInfo> cps;
+  collectCodepoints(word, cps);
   trimSurroundingPunctuationAndFootnote(cps);
   const auto* hyphenator = cachedHyphenator_;
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -91,5 +91,5 @@ class ChapterHtmlSlimParser {
 
   ~ChapterHtmlSlimParser() = default;
   bool parseAndBuildPages();
-  void addLineToPage(std::shared_ptr<TextBlock> line);
+  void addLineToPage(std::unique_ptr<TextBlock> line);
 };

--- a/test/perf/CssParserBench.cpp
+++ b/test/perf/CssParserBench.cpp
@@ -1,0 +1,55 @@
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include "lib/Epub/Epub/css/CssParser.h"
+
+int main() {
+  const std::string simple = "font-weight: bold";
+  const std::string medium =
+      "font-weight: bold; text-align: center; margin-top: 10px; "
+      "padding-left: 2em; font-style: italic";
+  const std::string complex =
+      "font-weight: bold; text-align: center; margin-top: 10px; "
+      "margin-bottom: 20px; margin-left: 5px; margin-right: 5px; "
+      "padding-top: 3px; padding-bottom: 3px; padding-left: 2em; "
+      "padding-right: 2em; text-indent: 1.5em; "
+      "font-style: italic; text-decoration: underline; "
+      "text-decoration-line: underline; font-weight: 700";
+
+  struct Bench {
+    const char* label;
+    const std::string& css;
+  };
+
+  Bench benches[] = {
+      {"1 property ", simple},
+      {"5 properties", medium},
+      {"15 properties", complex},
+  };
+
+  const int iterations = 100000;
+  volatile bool sink = false;  // prevent dead-code elimination
+
+  std::cout << "CssParser::parseInlineStyle benchmark:\n";
+  for (const auto& bench : benches) {
+    // Warm up
+    for (int i = 0; i < 100; ++i) {
+      auto s = CssParser::parseInlineStyle(bench.css);
+      sink = s.defined.anySet();
+    }
+
+    const auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; ++i) {
+      auto s = CssParser::parseInlineStyle(bench.css);
+      sink = s.defined.anySet();
+    }
+    const auto end = std::chrono::high_resolution_clock::now();
+    const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+
+    std::cout << "  " << bench.label << ": " << (totalUs * 1000 / iterations) << " ns/call"
+              << " (" << iterations << " iterations, " << totalUs << " us total)\n";
+  }
+
+  return 0;
+}

--- a/test/perf/HyphenationBench.cpp
+++ b/test/perf/HyphenationBench.cpp
@@ -1,0 +1,71 @@
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "lib/Epub/Epub/hyphenation/Hyphenator.h"
+
+int main() {
+  // Representative English words of varying length
+  const std::vector<std::string> words = {
+      "the",
+      "beautiful",
+      "international",
+      "communication",
+      "responsibility",
+      "extraordinary",
+      "understanding",
+      "philosophical",
+      "representative",
+      "environmental",
+      "administration",
+      "comprehensive",
+      "acknowledgment",
+      "classification",
+      "discrimination",
+      "implementation",
+      "infrastructure",
+      "interpretation",
+      "recommendation",
+      "congratulations",
+      "hello",
+      "world",
+      "computer",
+      "programming",
+      "architecture",
+      "university",
+      "mathematics",
+      "information",
+      "encyclopedia",
+      "characterization",
+  };
+
+  Hyphenator::setPreferredLanguage("en");
+
+  // Warm up
+  for (const auto& w : words) {
+    Hyphenator::breakOffsets(w, false);
+  }
+
+  const int iterations = 10000;
+  const auto start = std::chrono::high_resolution_clock::now();
+
+  for (int i = 0; i < iterations; ++i) {
+    for (const auto& w : words) {
+      Hyphenator::breakOffsets(w, false);
+    }
+  }
+
+  const auto end = std::chrono::high_resolution_clock::now();
+  const auto totalUs = std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+  const long long totalCalls = static_cast<long long>(iterations) * static_cast<long long>(words.size());
+
+  std::cout << "Hyphenation benchmark:\n";
+  std::cout << "  Words:          " << words.size() << "\n";
+  std::cout << "  Iterations:     " << iterations << "\n";
+  std::cout << "  Total calls:    " << totalCalls << "\n";
+  std::cout << "  Total time:     " << totalUs << " us\n";
+  std::cout << "  Per-word avg:   " << (totalUs * 1000 / totalCalls) << " ns\n";
+
+  return 0;
+}

--- a/test/perf/TextLayoutBench.cpp
+++ b/test/perf/TextLayoutBench.cpp
@@ -1,0 +1,66 @@
+#include <GfxRenderer.h>
+
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lib/Epub/Epub/ParsedText.h"
+#include "lib/Epub/Epub/blocks/TextBlock.h"
+
+static void benchLayoutAndExtract(int iterations) {
+  GfxRenderer renderer;
+
+  // Pre-build a list of ~200 words (typical paragraph)
+  std::vector<std::string> sampleWords;
+  for (int i = 0; i < 200; ++i) {
+    // Mix of short and medium words
+    switch (i % 5) {
+      case 0:
+        sampleWords.push_back("the");
+        break;
+      case 1:
+        sampleWords.push_back("quick");
+        break;
+      case 2:
+        sampleWords.push_back("brown");
+        break;
+      case 3:
+        sampleWords.push_back("fox");
+        break;
+      case 4:
+        sampleWords.push_back("jumps");
+        break;
+    }
+  }
+
+  auto start = std::chrono::high_resolution_clock::now();
+
+  for (int iter = 0; iter < iterations; ++iter) {
+    BlockStyle bs;
+    bs.alignment = CssTextAlign::Justify;
+    bs.textAlignDefined = true;
+
+    ParsedText text(false, false, bs);
+    for (const auto& w : sampleWords) {
+      text.addWord(w, EpdFontFamily::REGULAR);
+    }
+
+    text.layoutAndExtractLines(renderer, 0, 400, [](std::unique_ptr<TextBlock>) {});
+  }
+
+  auto end = std::chrono::high_resolution_clock::now();
+  auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  auto perCall = elapsed / iterations;
+
+  std::cout << "  " << iterations << " iterations, " << perCall << " ns/call (" << (elapsed / 1000000)
+            << " ms total)\n";
+}
+
+int main() {
+  std::cout << "TextLayoutBench — layoutAndExtractLines with ~200 words\n";
+  benchLayoutAndExtract(10000);
+  return 0;
+}

--- a/test/run_perf_tests.sh
+++ b/test/run_perf_tests.sh
@@ -47,4 +47,23 @@ c++ "${CXXFLAGS[@]}" \
 "$BUILD_DIR/CssParserBench"
 echo ""
 
+# --- TextLayoutBench ---
+echo "--- TextLayoutBench ---"
+c++ "${CXXFLAGS[@]}" \
+  -I"$ROOT_DIR/lib/EpdFont" \
+  -I"$ROOT_DIR/lib/Serialization" \
+  -include "HardwareSerial.h" \
+  "$ROOT_DIR/test/perf/TextLayoutBench.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/ParsedText.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/blocks/TextBlock.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/Hyphenator.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LanguageRegistry.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp" \
+  "$ROOT_DIR/lib/EpdFont/EpdFont.cpp" \
+  "$ROOT_DIR/lib/Utf8/Utf8.cpp" \
+  -o "$BUILD_DIR/TextLayoutBench"
+"$BUILD_DIR/TextLayoutBench"
+echo ""
+
 echo "=== Benchmarks complete ==="

--- a/test/run_perf_tests.sh
+++ b/test/run_perf_tests.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/perf_tests"
+STUB_DIR="$ROOT_DIR/test/stubs"
+
+mkdir -p "$BUILD_DIR"
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -Wno-unused-but-set-variable
+  -I"$STUB_DIR"
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/Utf8"
+  -I"$ROOT_DIR/lib/Epub"
+  -I"$ROOT_DIR/src"
+)
+
+echo "=== Performance Benchmarks ==="
+echo ""
+
+# --- HyphenationBench ---
+echo "--- HyphenationBench ---"
+c++ "${CXXFLAGS[@]}" \
+  "$ROOT_DIR/test/perf/HyphenationBench.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/Hyphenator.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LanguageRegistry.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp" \
+  "$ROOT_DIR/lib/Utf8/Utf8.cpp" \
+  -o "$BUILD_DIR/HyphenationBench"
+"$BUILD_DIR/HyphenationBench"
+echo ""
+
+# --- CssParserBench ---
+echo "--- CssParserBench ---"
+c++ "${CXXFLAGS[@]}" \
+  "$ROOT_DIR/test/perf/CssParserBench.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/css/CssParser.cpp" \
+  -o "$BUILD_DIR/CssParserBench"
+"$BUILD_DIR/CssParserBench"
+echo ""
+
+echo "=== Benchmarks complete ==="

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -83,6 +83,20 @@ compile_and_run CssParserTest \
   "$ROOT_DIR/test/unit/CssParserTest.cpp" \
   "$ROOT_DIR/lib/Epub/Epub/css/CssParser.cpp"
 
+# --- CssParserRegressionTest ---
+compile_and_run CssParserRegressionTest \
+  "$ROOT_DIR/test/unit/CssParserRegressionTest.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/css/CssParser.cpp"
+
+# --- HyphenationRegressionTest ---
+compile_and_run HyphenationRegressionTest \
+  "$ROOT_DIR/test/unit/HyphenationRegressionTest.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/Hyphenator.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LanguageRegistry.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp" \
+  "$ROOT_DIR/lib/Utf8/Utf8.cpp"
+
 # --- OpdsParserTest ---
 # Expat is C code — compile as object files first, then link with C++ test
 echo "--- OpdsParserTest ---"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/build/unit_tests"
+STUB_DIR="$ROOT_DIR/test/stubs"
+
+mkdir -p "$BUILD_DIR"
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$STUB_DIR"
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/lib/Utf8"
+  -I"$ROOT_DIR/lib/Epub"
+  -I"$ROOT_DIR/src"
+)
+
+CFLAGS=(
+  -std=c11
+  -O2
+  -w
+  -I"$ROOT_DIR/lib"
+  -DXML_GE=0
+  -DXML_CONTEXT_BYTES=1024
+)
+
+PASSED=0
+FAILED=0
+ERRORS=""
+
+compile_and_run() {
+  local name="$1"
+  shift
+  local sources=("$@")
+
+  echo "--- $name ---"
+  if c++ "${CXXFLAGS[@]}" "${sources[@]}" -o "$BUILD_DIR/$name" 2>&1; then
+    if "$BUILD_DIR/$name"; then
+      PASSED=$((PASSED + 1))
+    else
+      FAILED=$((FAILED + 1))
+      ERRORS="$ERRORS  $name\n"
+    fi
+  else
+    echo "  COMPILE ERROR"
+    FAILED=$((FAILED + 1))
+    ERRORS="$ERRORS  $name (compile error)\n"
+  fi
+  echo ""
+}
+
+# --- Utf8Test ---
+compile_and_run Utf8Test \
+  "$ROOT_DIR/test/unit/Utf8Test.cpp" \
+  "$ROOT_DIR/lib/Utf8/Utf8.cpp"
+
+# --- UrlUtilsTest ---
+compile_and_run UrlUtilsTest \
+  "$ROOT_DIR/test/unit/UrlUtilsTest.cpp" \
+  "$ROOT_DIR/src/util/UrlUtils.cpp"
+
+# --- StringUtilsTest ---
+compile_and_run StringUtilsTest \
+  "$ROOT_DIR/test/unit/StringUtilsTest.cpp" \
+  "$ROOT_DIR/src/util/StringUtils.cpp"
+
+# --- SerializationTest ---
+compile_and_run SerializationTest \
+  "$ROOT_DIR/test/unit/SerializationTest.cpp"
+
+# --- BlockStyleTest ---
+compile_and_run BlockStyleTest \
+  "$ROOT_DIR/test/unit/BlockStyleTest.cpp"
+
+# --- CssParserTest ---
+compile_and_run CssParserTest \
+  "$ROOT_DIR/test/unit/CssParserTest.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/css/CssParser.cpp"
+
+# --- OpdsParserTest ---
+# Expat is C code — compile as object files first, then link with C++ test
+echo "--- OpdsParserTest ---"
+OPDS_OK=true
+for csrc in xmlparse.c xmlrole.c xmltok.c; do
+  if ! cc "${CFLAGS[@]}" -c "$ROOT_DIR/lib/expat/$csrc" -o "$BUILD_DIR/${csrc%.c}.o" 2>&1; then
+    echo "  COMPILE ERROR ($csrc)"
+    OPDS_OK=false
+    break
+  fi
+done
+
+if $OPDS_OK; then
+  if c++ "${CXXFLAGS[@]}" \
+    "$ROOT_DIR/test/unit/OpdsParserTest.cpp" \
+    "$ROOT_DIR/lib/OpdsParser/OpdsParser.cpp" \
+    "$BUILD_DIR/xmlparse.o" "$BUILD_DIR/xmlrole.o" "$BUILD_DIR/xmltok.o" \
+    -o "$BUILD_DIR/OpdsParserTest" 2>&1; then
+    if "$BUILD_DIR/OpdsParserTest"; then
+      PASSED=$((PASSED + 1))
+    else
+      FAILED=$((FAILED + 1))
+      ERRORS="$ERRORS  OpdsParserTest\n"
+    fi
+  else
+    echo "  COMPILE ERROR (link)"
+    FAILED=$((FAILED + 1))
+    ERRORS="$ERRORS  OpdsParserTest (compile error)\n"
+  fi
+else
+  FAILED=$((FAILED + 1))
+  ERRORS="$ERRORS  OpdsParserTest (compile error)\n"
+fi
+echo ""
+
+# --- Summary ---
+echo "==============================="
+echo "Unit tests: $PASSED passed, $FAILED failed"
+if [ "$FAILED" -gt 0 ]; then
+  echo -e "Failed:\n$ERRORS"
+  exit 1
+fi
+echo "All tests passed."

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -132,6 +132,37 @@ else
 fi
 echo ""
 
+# --- TextLayoutTest ---
+echo "--- TextLayoutTest ---"
+TEXTLAYOUT_EXTRA_FLAGS=(
+  -I"$ROOT_DIR/lib/Serialization"
+  -I"$ROOT_DIR/lib/EpdFont"
+  -include "HardwareSerial.h"
+)
+if c++ "${CXXFLAGS[@]}" "${TEXTLAYOUT_EXTRA_FLAGS[@]}" \
+  "$ROOT_DIR/test/unit/TextLayoutTest.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/ParsedText.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/blocks/TextBlock.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/Hyphenator.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LanguageRegistry.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/LiangHyphenation.cpp" \
+  "$ROOT_DIR/lib/Epub/Epub/hyphenation/HyphenationCommon.cpp" \
+  "$ROOT_DIR/lib/EpdFont/EpdFont.cpp" \
+  "$ROOT_DIR/lib/Utf8/Utf8.cpp" \
+  -o "$BUILD_DIR/TextLayoutTest" 2>&1; then
+  if "$BUILD_DIR/TextLayoutTest"; then
+    PASSED=$((PASSED + 1))
+  else
+    FAILED=$((FAILED + 1))
+    ERRORS="$ERRORS  TextLayoutTest\n"
+  fi
+else
+  echo "  COMPILE ERROR"
+  FAILED=$((FAILED + 1))
+  ERRORS="$ERRORS  TextLayoutTest (compile error)\n"
+fi
+echo ""
+
 # --- Summary ---
 echo "==============================="
 echo "Unit tests: $PASSED passed, $FAILED failed"

--- a/test/stubs/Bitmap.h
+++ b/test/stubs/Bitmap.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <SdFat.h>
+
+#include <cstdint>
+
+#include "BitmapHelpers.h"
+
+enum class BmpReaderError : uint8_t {
+  Ok = 0,
+  FileInvalid,
+  SeekStartFailed,
+  NotBMP,
+  DIBTooSmall,
+  BadPlanes,
+  UnsupportedBpp,
+  UnsupportedCompression,
+  BadDimensions,
+  ImageTooLarge,
+  PaletteTooLarge,
+  SeekPixelDataFailed,
+  BufferTooSmall,
+  OomRowBuffer,
+  ShortReadRow,
+};
+
+class Bitmap {
+ public:
+  static const char* errorToString(BmpReaderError) { return "stub"; }
+
+  explicit Bitmap(FsFile&, bool = false) {}
+  ~Bitmap() = default;
+  BmpReaderError parseHeaders() { return BmpReaderError::Ok; }
+  BmpReaderError readNextRow(uint8_t*, uint8_t*) const { return BmpReaderError::Ok; }
+  BmpReaderError rewindToData() const { return BmpReaderError::Ok; }
+  int getWidth() const { return 0; }
+  int getHeight() const { return 0; }
+  bool isTopDown() const { return false; }
+  bool hasGreyscale() const { return false; }
+  int getRowBytes() const { return 0; }
+  bool is1Bit() const { return true; }
+  uint16_t getBpp() const { return 1; }
+};

--- a/test/stubs/BitmapHelpers.h
+++ b/test/stubs/BitmapHelpers.h
@@ -1,0 +1,4 @@
+#pragma once
+
+class AtkinsonDitherer {};
+class FloydSteinbergDitherer {};

--- a/test/stubs/GfxRenderer.h
+++ b/test/stubs/GfxRenderer.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <EpdFontFamily.h>
+
+#include <cstring>
+#include <map>
+
+#include "Bitmap.h"
+
+// Minimal stub for unit tests — avoids HalDisplay and hardware dependencies
+class GfxRenderer {
+ public:
+  enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
+  enum Orientation { Portrait, LandscapeClockwise, PortraitInverted, LandscapeCounterClockwise };
+
+  GfxRenderer() = default;
+
+  void insertFont(int, EpdFontFamily) {}
+  void setOrientation(Orientation) {}
+  Orientation getOrientation() const { return Portrait; }
+
+  int getScreenWidth() const { return 480; }
+  int getScreenHeight() const { return 800; }
+
+  // Text measurement — fixed approximations for testing
+  int getTextWidth(int, const char* text, EpdFontFamily::Style = EpdFontFamily::REGULAR) const {
+    return static_cast<int>(strlen(text)) * 8;
+  }
+  int getSpaceWidth(int) const { return 5; }
+  int getLineHeight(int) const { return 20; }
+  int getTextAdvanceX(int, const char* text) const { return static_cast<int>(strlen(text)) * 8; }
+  int getFontAscenderSize(int) const { return 15; }
+
+  // Rendering — no-ops
+  void drawText(int, int, int, const char*, bool = true, EpdFontFamily::Style = EpdFontFamily::REGULAR) const {}
+  void drawLine(int, int, int, int, bool = true) const {}
+  void drawLine(int, int, int, int, int, bool) const {}
+  void drawBitmap1Bit(const Bitmap&, int, int, int, int) const {}
+};

--- a/test/stubs/HalStorage.h
+++ b/test/stubs/HalStorage.h
@@ -1,0 +1,3 @@
+#pragma once
+// Stub for host-side unit tests — HalStorage wraps SD card access on device.
+#include <SdFat.h>

--- a/test/stubs/HardwareSerial.h
+++ b/test/stubs/HardwareSerial.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+
+inline unsigned long millis() { return 0; }
+
+class HardwareSerialStub {
+ public:
+  template <typename... Args>
+  void printf(const char*, Args...) {}
+};
+
+static HardwareSerialStub Serial;

--- a/test/stubs/Print.h
+++ b/test/stubs/Print.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+class Print {
+ public:
+  virtual ~Print() = default;
+  virtual size_t write(uint8_t) = 0;
+  virtual size_t write(const uint8_t* buffer, size_t size) = 0;
+  virtual void flush() {}
+};

--- a/test/stubs/SDCardManager.h
+++ b/test/stubs/SDCardManager.h
@@ -1,0 +1,2 @@
+#pragma once
+// Empty stub — included transitively by some library code but not needed for tests.

--- a/test/stubs/SdFat.h
+++ b/test/stubs/SdFat.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+
+class FsFile {
+ public:
+  FsFile() = default;
+  explicit operator bool() const { return false; }
+  int available() { return 0; }
+  uint64_t size() { return 0; }
+  int read(void*, size_t) { return 0; }
+  int read(uint8_t* buf, size_t len) { return read(static_cast<void*>(buf), len); }
+  size_t write(uint8_t) { return 1; }
+  size_t write(const uint8_t*, size_t len) { return len; }
+};

--- a/test/stubs/SdFat.h
+++ b/test/stubs/SdFat.h
@@ -1,15 +1,55 @@
 #pragma once
 #include <cstdint>
 #include <cstring>
+#include <memory>
+#include <vector>
 
 class FsFile {
  public:
   FsFile() = default;
-  explicit operator bool() const { return false; }
-  int available() { return 0; }
-  uint64_t size() { return 0; }
-  int read(void*, size_t) { return 0; }
+  explicit operator bool() const { return buf_ != nullptr; }
+
+  int available() { return buf_ ? static_cast<int>(buf_->size() - pos_) : 0; }
+  uint64_t size() { return buf_ ? buf_->size() : 0; }
+
+  int read(void* dst, size_t len) {
+    if (!buf_ || pos_ >= buf_->size()) return 0;
+    size_t n = std::min(len, buf_->size() - pos_);
+    memcpy(dst, buf_->data() + pos_, n);
+    pos_ += n;
+    return static_cast<int>(n);
+  }
   int read(uint8_t* buf, size_t len) { return read(static_cast<void*>(buf), len); }
-  size_t write(uint8_t) { return 1; }
-  size_t write(const uint8_t*, size_t len) { return len; }
+
+  size_t write(uint8_t b) {
+    ensureBuf();
+    buf_->push_back(b);
+    return 1;
+  }
+  size_t write(const uint8_t* data, size_t len) {
+    ensureBuf();
+    buf_->insert(buf_->end(), data, data + len);
+    return len;
+  }
+
+  bool seek(uint64_t pos) { return seekSet(pos); }
+  bool seekSet(uint64_t pos) {
+    pos_ = static_cast<size_t>(pos);
+    return true;
+  }
+  void close() { pos_ = 0; }
+
+  // Test helpers
+  void initBuffer(std::shared_ptr<std::vector<uint8_t>> b) {
+    buf_ = b;
+    pos_ = 0;
+  }
+  std::shared_ptr<std::vector<uint8_t>> buffer() const { return buf_; }
+
+ private:
+  void ensureBuf() {
+    if (!buf_) buf_ = std::make_shared<std::vector<uint8_t>>();
+  }
+  std::shared_ptr<std::vector<uint8_t>> buf_;
+  size_t pos_ = 0;
 };

--- a/test/stubs/WString.h
+++ b/test/stubs/WString.h
@@ -1,0 +1,29 @@
+#pragma once
+#include <cctype>
+#include <cstring>
+#include <string>
+
+class String {
+ public:
+  String() = default;
+  String(const char* s) : data_(s ? s : "") {}
+  String(const String& other) = default;
+  String& operator=(const String& other) = default;
+
+  unsigned int length() const { return static_cast<unsigned int>(data_.size()); }
+  const char* c_str() const { return data_.c_str(); }
+
+  void toLowerCase() {
+    for (auto& c : data_) {
+      c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+  }
+
+  bool endsWith(const String& suffix) const {
+    if (suffix.data_.size() > data_.size()) return false;
+    return data_.compare(data_.size() - suffix.data_.size(), suffix.data_.size(), suffix.data_) == 0;
+  }
+
+ private:
+  std::string data_;
+};

--- a/test/test_harness.h
+++ b/test/test_harness.h
@@ -1,0 +1,97 @@
+#pragma once
+#include <cmath>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+static int g_testsPassed = 0;
+static int g_testsFailed = 0;
+
+#define TEST_FAIL(msg)                                                              \
+  do {                                                                              \
+    std::cerr << "  FAIL: " << __FILE__ << ":" << __LINE__ << " — " << msg << "\n"; \
+    ++g_testsFailed;                                                                \
+  } while (0)
+
+#define TEST_PASS()  \
+  do {               \
+    ++g_testsPassed; \
+  } while (0)
+
+#define ASSERT_TRUE(expr)                           \
+  do {                                              \
+    if (!(expr)) {                                  \
+      TEST_FAIL(#expr " expected true, got false"); \
+    } else {                                        \
+      TEST_PASS();                                  \
+    }                                               \
+  } while (0)
+
+#define ASSERT_FALSE(expr)                          \
+  do {                                              \
+    if ((expr)) {                                   \
+      TEST_FAIL(#expr " expected false, got true"); \
+    } else {                                        \
+      TEST_PASS();                                  \
+    }                                               \
+  } while (0)
+
+#define ASSERT_EQ(a, b)                                                                                              \
+  do {                                                                                                               \
+    if ((a) != (b)) {                                                                                                \
+      std::cerr << "  FAIL: " << __FILE__ << ":" << __LINE__ << " — " << #a << " != " << #b << " (" << (a) << " vs " \
+                << (b) << ")\n";                                                                                     \
+      ++g_testsFailed;                                                                                               \
+    } else {                                                                                                         \
+      TEST_PASS();                                                                                                   \
+    }                                                                                                                \
+  } while (0)
+
+#define ASSERT_NE(a, b)                                                                              \
+  do {                                                                                               \
+    if ((a) == (b)) {                                                                                \
+      std::cerr << "  FAIL: " << __FILE__ << ":" << __LINE__ << " — " << #a << " == " << #b << "\n"; \
+      ++g_testsFailed;                                                                               \
+    } else {                                                                                         \
+      TEST_PASS();                                                                                   \
+    }                                                                                                \
+  } while (0)
+
+#define ASSERT_STREQ(a, b)                                            \
+  do {                                                                \
+    const std::string _a(a);                                          \
+    const std::string _b(b);                                          \
+    if (_a != _b) {                                                   \
+      std::cerr << "  FAIL: " << __FILE__ << ":" << __LINE__ << " — " \
+                << "\"" << _a << "\" != \"" << _b << "\"\n";          \
+      ++g_testsFailed;                                                \
+    } else {                                                          \
+      TEST_PASS();                                                    \
+    }                                                                 \
+  } while (0)
+
+#define ASSERT_NEAR(a, b, eps)                                                                          \
+  do {                                                                                                  \
+    if (std::fabs((a) - (b)) > (eps)) {                                                                 \
+      std::cerr << "  FAIL: " << __FILE__ << ":" << __LINE__ << " — " << #a << " ≈ " << #b << " (diff " \
+                << std::fabs((a) - (b)) << " > " << (eps) << ")\n";                                     \
+      ++g_testsFailed;                                                                                  \
+    } else {                                                                                            \
+      TEST_PASS();                                                                                      \
+    }                                                                                                   \
+  } while (0)
+
+#define TEST_SUMMARY()                                                                                            \
+  do {                                                                                                            \
+    std::cout << (g_testsFailed == 0 ? "OK" : "FAILED") << " — " << g_testsPassed << " passed, " << g_testsFailed \
+              << " failed\n";                                                                                     \
+    return g_testsFailed == 0 ? 0 : 1;                                                                            \
+  } while (0)
+
+#define RUN_TEST(fn)                                                   \
+  do {                                                                 \
+    std::cout << "  " << #fn << "... ";                                \
+    const int _before = g_testsFailed;                                 \
+    fn();                                                              \
+    std::cout << (g_testsFailed == _before ? "ok" : "FAILED") << "\n"; \
+  } while (0)

--- a/test/unit/BlockStyleTest.cpp
+++ b/test/unit/BlockStyleTest.cpp
@@ -1,0 +1,158 @@
+#include "lib/Epub/Epub/blocks/BlockStyle.h"
+#include "test/test_harness.h"
+
+// --- fromCssStyle ---
+
+void testFromCssStylePixels() {
+  CssStyle css;
+  css.marginTop = CssLength{10.0f, CssUnit::Pixels};
+  css.marginBottom = CssLength{20.0f, CssUnit::Pixels};
+  css.marginLeft = CssLength{5.0f, CssUnit::Pixels};
+  css.marginRight = CssLength{5.0f, CssUnit::Pixels};
+  css.textIndent = CssLength{15.0f, CssUnit::Pixels};
+  css.defined.marginTop = css.defined.marginBottom = 1;
+  css.defined.marginLeft = css.defined.marginRight = 1;
+  css.defined.textIndent = 1;
+
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 16.0f, CssTextAlign::None);
+  ASSERT_EQ(bs.marginTop, 10);
+  ASSERT_EQ(bs.marginBottom, 20);
+  ASSERT_EQ(bs.marginLeft, 5);
+  ASSERT_EQ(bs.marginRight, 5);
+  ASSERT_EQ(bs.textIndent, 15);
+  ASSERT_TRUE(bs.textIndentDefined);
+}
+
+void testFromCssStyleEm() {
+  CssStyle css;
+  css.marginTop = CssLength{1.0f, CssUnit::Em};
+  css.defined.marginTop = 1;
+
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 20.0f, CssTextAlign::None);
+  ASSERT_EQ(bs.marginTop, 20);  // 1em * 20px
+}
+
+void testFromCssStylePoints() {
+  CssStyle css;
+  css.paddingLeft = CssLength{10.0f, CssUnit::Points};
+  css.defined.paddingLeft = 1;
+
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 16.0f, CssTextAlign::None);
+  ASSERT_EQ(bs.paddingLeft, 13);  // 10pt * 1.33 = 13.3 → 13
+}
+
+void testFromCssStyleAlignmentOverride() {
+  CssStyle css;
+  css.textAlign = CssTextAlign::Center;
+  css.defined.textAlign = 1;
+
+  // User preference Left overrides CSS Center
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 16.0f, CssTextAlign::Left);
+  ASSERT_EQ(static_cast<int>(bs.alignment), static_cast<int>(CssTextAlign::Left));
+  ASSERT_TRUE(bs.textAlignDefined);
+}
+
+void testFromCssStyleAlignmentBookStyle() {
+  CssStyle css;
+  css.textAlign = CssTextAlign::Center;
+  css.defined.textAlign = 1;
+
+  // CssTextAlign::None = "Book's Style" → use CSS value
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 16.0f, CssTextAlign::None);
+  ASSERT_EQ(static_cast<int>(bs.alignment), static_cast<int>(CssTextAlign::Center));
+}
+
+void testFromCssStyleNoAlignDefined() {
+  CssStyle css;
+  // text-align not defined, and user uses "Book's Style"
+  BlockStyle bs = BlockStyle::fromCssStyle(css, 16.0f, CssTextAlign::None);
+  // Default should be Justify when no CSS alignment is set
+  ASSERT_EQ(static_cast<int>(bs.alignment), static_cast<int>(CssTextAlign::Justify));
+  ASSERT_FALSE(bs.textAlignDefined);
+}
+
+// --- getCombinedBlockStyle ---
+
+void testCombinedMarginsAdd() {
+  BlockStyle parent;
+  parent.marginLeft = 10;
+  parent.paddingLeft = 5;
+
+  BlockStyle child;
+  child.marginLeft = 8;
+  child.paddingLeft = 3;
+
+  BlockStyle combined = parent.getCombinedBlockStyle(child);
+  ASSERT_EQ(combined.marginLeft, 18);
+  ASSERT_EQ(combined.paddingLeft, 8);
+}
+
+void testCombinedTextIndentChild() {
+  BlockStyle parent;
+  parent.textIndent = 20;
+  parent.textIndentDefined = true;
+
+  BlockStyle child;
+  child.textIndent = 10;
+  child.textIndentDefined = true;
+
+  BlockStyle combined = parent.getCombinedBlockStyle(child);
+  ASSERT_EQ(combined.textIndent, 10);  // child's textIndent wins
+  ASSERT_TRUE(combined.textIndentDefined);
+}
+
+void testCombinedTextIndentParentOnly() {
+  BlockStyle parent;
+  parent.textIndent = 20;
+  parent.textIndentDefined = true;
+
+  BlockStyle child;
+  // child doesn't define textIndent
+
+  BlockStyle combined = parent.getCombinedBlockStyle(child);
+  ASSERT_EQ(combined.textIndent, 20);  // parent's textIndent preserved
+  ASSERT_TRUE(combined.textIndentDefined);
+}
+
+void testCombinedAlignmentChild() {
+  BlockStyle parent;
+  parent.alignment = CssTextAlign::Left;
+  parent.textAlignDefined = true;
+
+  BlockStyle child;
+  child.alignment = CssTextAlign::Center;
+  child.textAlignDefined = true;
+
+  BlockStyle combined = parent.getCombinedBlockStyle(child);
+  ASSERT_EQ(static_cast<int>(combined.alignment), static_cast<int>(CssTextAlign::Center));
+}
+
+// --- inset helpers ---
+
+void testInsets() {
+  BlockStyle bs;
+  bs.marginLeft = 10;
+  bs.paddingLeft = 5;
+  bs.marginRight = 8;
+  bs.paddingRight = 3;
+
+  ASSERT_EQ(bs.leftInset(), 15);
+  ASSERT_EQ(bs.rightInset(), 11);
+  ASSERT_EQ(bs.totalHorizontalInset(), 26);
+}
+
+int main() {
+  std::cout << "BlockStyleTest\n";
+  RUN_TEST(testFromCssStylePixels);
+  RUN_TEST(testFromCssStyleEm);
+  RUN_TEST(testFromCssStylePoints);
+  RUN_TEST(testFromCssStyleAlignmentOverride);
+  RUN_TEST(testFromCssStyleAlignmentBookStyle);
+  RUN_TEST(testFromCssStyleNoAlignDefined);
+  RUN_TEST(testCombinedMarginsAdd);
+  RUN_TEST(testCombinedTextIndentChild);
+  RUN_TEST(testCombinedTextIndentParentOnly);
+  RUN_TEST(testCombinedAlignmentChild);
+  RUN_TEST(testInsets);
+  TEST_SUMMARY();
+}

--- a/test/unit/CssParserRegressionTest.cpp
+++ b/test/unit/CssParserRegressionTest.cpp
@@ -1,0 +1,366 @@
+#include "lib/Epub/Epub/css/CssParser.h"
+#include "test/test_harness.h"
+
+// These tests specifically target the code paths changed by the CssParser optimization:
+//   1. normalizeInto() replaces normalized() + splitOnChar() in parseDeclarations
+//   2. interpretLength() uses strtof directly instead of substring allocations
+//   3. interpretSpacing() uses strtof directly instead of substring allocations
+//   4. processRuleBlock() uses inline comma scanning instead of splitOnChar
+
+// --- normalizeInto / parseDeclarations regression ---
+// The optimization replaced splitOnChar(';') + normalized() per property
+// with inline ';'/':' scanning + normalizeInto() into reusable buffers.
+
+void testWhitespaceNormalization() {
+  // Leading/trailing whitespace on property names and values
+  CssStyle s = CssParser::parseInlineStyle("  font-weight  :  bold  ");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testMultipleInternalSpaces() {
+  // Multiple spaces between tokens should be collapsed
+  CssStyle s = CssParser::parseInlineStyle("text-align:   center");
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testTabsAndNewlines() {
+  // Tabs and newlines are CSS whitespace, should be normalized
+  CssStyle s = CssParser::parseInlineStyle("font-weight:\tbold;\n\ttext-align:\tcenter");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testCaseInsensitivity() {
+  // Property names and values should be case-insensitive
+  CssStyle s1 = CssParser::parseInlineStyle("FONT-WEIGHT: BOLD");
+  ASSERT_TRUE(s1.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s1.fontWeight), static_cast<int>(CssFontWeight::Bold));
+
+  CssStyle s2 = CssParser::parseInlineStyle("Text-Align: Center");
+  ASSERT_TRUE(s2.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s2.textAlign), static_cast<int>(CssTextAlign::Center));
+
+  CssStyle s3 = CssParser::parseInlineStyle("Font-Style: ITALIC");
+  ASSERT_TRUE(s3.hasFontStyle());
+  ASSERT_EQ(static_cast<int>(s3.fontStyle), static_cast<int>(CssFontStyle::Italic));
+}
+
+void testTrailingSemicolon() {
+  // Trailing semicolon should not break parsing
+  CssStyle s = CssParser::parseInlineStyle("font-weight: bold;");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testDoubleSemicolon() {
+  // Double semicolons (empty declaration) should be harmless
+  CssStyle s = CssParser::parseInlineStyle("font-weight: bold;; text-align: center");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testPropertyWithNoValue() {
+  // Missing value after colon should not crash
+  CssStyle s = CssParser::parseInlineStyle("font-weight:; text-align: center");
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testPropertyWithNoColon() {
+  // No colon at all — should be skipped, not crash
+  CssStyle s = CssParser::parseInlineStyle("garbage; text-align: center");
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testOnlyWhitespace() {
+  CssStyle s = CssParser::parseInlineStyle("   \t\n   ");
+  ASSERT_FALSE(s.defined.anySet());
+}
+
+void testOnlySemicolons() {
+  CssStyle s = CssParser::parseInlineStyle(";;;");
+  ASSERT_FALSE(s.defined.anySet());
+}
+
+// --- interpretLength regression ---
+// The optimization replaced substring extraction + stof with direct strtof on the value string.
+
+void testLengthNoUnit() {
+  // Bare number should default to Pixels
+  CssStyle s = CssParser::parseInlineStyle("margin-top: 10");
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_NEAR(s.marginTop.value, 10.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginTop.unit), static_cast<int>(CssUnit::Pixels));
+}
+
+void testLengthZero() {
+  CssStyle s = CssParser::parseInlineStyle("margin-top: 0");
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_NEAR(s.marginTop.value, 0.0f, 0.01f);
+}
+
+void testLengthZeroPx() {
+  CssStyle s = CssParser::parseInlineStyle("margin-top: 0px");
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_NEAR(s.marginTop.value, 0.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginTop.unit), static_cast<int>(CssUnit::Pixels));
+}
+
+void testLengthNegative() {
+  CssStyle s = CssParser::parseInlineStyle("text-indent: -2em");
+  ASSERT_TRUE(s.hasTextIndent());
+  ASSERT_NEAR(s.textIndent.value, -2.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.textIndent.unit), static_cast<int>(CssUnit::Em));
+}
+
+void testLengthDecimal() {
+  CssStyle s = CssParser::parseInlineStyle("margin-left: 0.5em");
+  ASSERT_TRUE(s.hasMarginLeft());
+  ASSERT_NEAR(s.marginLeft.value, 0.5f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginLeft.unit), static_cast<int>(CssUnit::Em));
+}
+
+void testLengthDecimalNoDot() {
+  CssStyle s = CssParser::parseInlineStyle("margin-left: 3em");
+  ASSERT_TRUE(s.hasMarginLeft());
+  ASSERT_NEAR(s.marginLeft.value, 3.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginLeft.unit), static_cast<int>(CssUnit::Em));
+}
+
+void testLengthAllUnits() {
+  CssStyle px = CssParser::parseInlineStyle("margin-top: 5px");
+  ASSERT_EQ(static_cast<int>(px.marginTop.unit), static_cast<int>(CssUnit::Pixels));
+  ASSERT_NEAR(px.marginTop.value, 5.0f, 0.01f);
+
+  CssStyle em = CssParser::parseInlineStyle("margin-top: 2em");
+  ASSERT_EQ(static_cast<int>(em.marginTop.unit), static_cast<int>(CssUnit::Em));
+  ASSERT_NEAR(em.marginTop.value, 2.0f, 0.01f);
+
+  CssStyle rem = CssParser::parseInlineStyle("margin-top: 1.5rem");
+  ASSERT_EQ(static_cast<int>(rem.marginTop.unit), static_cast<int>(CssUnit::Rem));
+  ASSERT_NEAR(rem.marginTop.value, 1.5f, 0.01f);
+
+  CssStyle pt = CssParser::parseInlineStyle("margin-top: 12pt");
+  ASSERT_EQ(static_cast<int>(pt.marginTop.unit), static_cast<int>(CssUnit::Points));
+  ASSERT_NEAR(pt.marginTop.value, 12.0f, 0.01f);
+}
+
+void testLengthInvalidValue() {
+  // Non-numeric value: property is recognized, value defaults to 0px
+  CssStyle s = CssParser::parseInlineStyle("margin-top: abc");
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_NEAR(s.marginTop.value, 0.0f, 0.01f);
+}
+
+// --- interpretSpacing regression ---
+// The spacing properties are parsed but not stored in CssStyle (parsed at renderer level).
+// Verify that spacing property names don't interfere with other property parsing.
+
+void testSpacingDoesNotCorruptOtherProperties() {
+  // letter-spacing and word-spacing are recognized but not stored in CssStyle.
+  // Verify they don't break surrounding property parsing.
+  CssStyle s = CssParser::parseInlineStyle("font-weight: bold; letter-spacing: 2px; text-align: center");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testUnknownPropertySkipped() {
+  // Unknown properties should be silently skipped
+  CssStyle s = CssParser::parseInlineStyle("color: red; font-weight: bold; display: none");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+// --- processRuleBlock regression ---
+// The optimization replaced splitOnChar(',') with inline comma scanning.
+
+void testGroupedSelectorsAfterOptimization() {
+  CssParser parser;
+  parser.loadFromString("h1, h2, h3 { font-weight: bold }");
+
+  CssStyle h1 = parser.resolveStyle("h1", "");
+  CssStyle h2 = parser.resolveStyle("h2", "");
+  CssStyle h3 = parser.resolveStyle("h3", "");
+  ASSERT_EQ(static_cast<int>(h1.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(h2.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(h3.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testGroupedSelectorsWithClasses() {
+  CssParser parser;
+  parser.loadFromString("p.intro, p.summary, .note { margin-top: 10px }");
+
+  CssStyle intro = parser.resolveStyle("p", "intro");
+  CssStyle summary = parser.resolveStyle("p", "summary");
+  CssStyle note = parser.resolveStyle("div", "note");
+  ASSERT_NEAR(intro.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(summary.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(note.marginTop.value, 10.0f, 0.01f);
+}
+
+void testGroupedSelectorsWhitespaceVariations() {
+  // Extra whitespace around commas
+  CssParser parser;
+  parser.loadFromString("h1 ,  h2  ,h3 { text-align: center }");
+
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h1", "").textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h2", "").textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h3", "").textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testSingleSelectorRuleBlock() {
+  // No commas — the inline scanning must handle this correctly
+  CssParser parser;
+  parser.loadFromString("p { font-style: italic }");
+
+  CssStyle s = parser.resolveStyle("p", "");
+  ASSERT_EQ(static_cast<int>(s.fontStyle), static_cast<int>(CssFontStyle::Italic));
+}
+
+// --- Compound stress test: many properties, whitespace chaos ---
+
+void testStressMultiplePropertiesWithWhitespace() {
+  CssStyle s = CssParser::parseInlineStyle(
+      "  font-weight : bold ;  text-align:center;margin-top:10px ; "
+      "  margin-bottom : 20px; margin-left:5px ; margin-right : 5px;"
+      "padding-top:3px;padding-bottom:  3px; padding-left  : 2em ; "
+      "padding-right: 2em ; text-indent : 1.5em;"
+      "font-style:italic ;text-decoration :underline ; font-weight: 700");
+
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_NEAR(s.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginBottom.value, 20.0f, 0.01f);
+  ASSERT_NEAR(s.marginLeft.value, 5.0f, 0.01f);
+  ASSERT_NEAR(s.marginRight.value, 5.0f, 0.01f);
+  ASSERT_NEAR(s.paddingTop.value, 3.0f, 0.01f);
+  ASSERT_NEAR(s.paddingBottom.value, 3.0f, 0.01f);
+  ASSERT_NEAR(s.paddingLeft.value, 2.0f, 0.01f);
+  ASSERT_NEAR(s.paddingRight.value, 2.0f, 0.01f);
+  ASSERT_NEAR(s.textIndent.value, 1.5f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.fontStyle), static_cast<int>(CssFontStyle::Italic));
+  ASSERT_EQ(static_cast<int>(s.textDecoration), static_cast<int>(CssTextDecoration::Underline));
+}
+
+// --- Repeated calls: ensure no cross-call pollution ---
+
+void testRepeatedCallsNoLeakage() {
+  // Call parseInlineStyle many times with different inputs — verify no state leaks
+  for (int i = 0; i < 100; ++i) {
+    CssStyle bold = CssParser::parseInlineStyle("font-weight: bold");
+    ASSERT_EQ(static_cast<int>(bold.fontWeight), static_cast<int>(CssFontWeight::Bold));
+    ASSERT_FALSE(bold.hasTextAlign());
+
+    CssStyle center = CssParser::parseInlineStyle("text-align: center");
+    ASSERT_EQ(static_cast<int>(center.textAlign), static_cast<int>(CssTextAlign::Center));
+    ASSERT_FALSE(center.hasFontWeight());
+  }
+}
+
+// --- Margin shorthand with different whitespace ---
+
+void testMarginShorthandWhitespace() {
+  CssStyle s1 = CssParser::parseInlineStyle("margin:  10px   20px  ");
+  ASSERT_NEAR(s1.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s1.marginRight.value, 20.0f, 0.01f);
+  ASSERT_NEAR(s1.marginBottom.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s1.marginLeft.value, 20.0f, 0.01f);
+
+  CssStyle s2 = CssParser::parseInlineStyle("margin:1px 2px 3px 4px");
+  ASSERT_NEAR(s2.marginTop.value, 1.0f, 0.01f);
+  ASSERT_NEAR(s2.marginRight.value, 2.0f, 0.01f);
+  ASSERT_NEAR(s2.marginBottom.value, 3.0f, 0.01f);
+  ASSERT_NEAR(s2.marginLeft.value, 4.0f, 0.01f);
+}
+
+// --- Padding shorthand ---
+
+void testPaddingShorthand() {
+  CssStyle s1 = CssParser::parseInlineStyle("padding: 5px");
+  ASSERT_NEAR(s1.paddingTop.value, 5.0f, 0.01f);
+  ASSERT_NEAR(s1.paddingBottom.value, 5.0f, 0.01f);
+  ASSERT_NEAR(s1.paddingLeft.value, 5.0f, 0.01f);
+  ASSERT_NEAR(s1.paddingRight.value, 5.0f, 0.01f);
+
+  CssStyle s2 = CssParser::parseInlineStyle("padding: 1px 2px 3px 4px");
+  ASSERT_NEAR(s2.paddingTop.value, 1.0f, 0.01f);
+  ASSERT_NEAR(s2.paddingRight.value, 2.0f, 0.01f);
+  ASSERT_NEAR(s2.paddingBottom.value, 3.0f, 0.01f);
+  ASSERT_NEAR(s2.paddingLeft.value, 4.0f, 0.01f);
+}
+
+// --- resolveStyle with multiple loadFromString calls ---
+
+void testAccumulatedRules() {
+  CssParser parser;
+  parser.loadFromString("h1 { text-align: center }");
+  parser.loadFromString("p { font-weight: bold }");
+
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h1", "").textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("p", "").fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+// --- text-decoration-line (alias) ---
+
+void testTextDecorationLine() {
+  CssStyle s = CssParser::parseInlineStyle("text-decoration-line: underline");
+  ASSERT_TRUE(s.hasTextDecoration());
+  ASSERT_EQ(static_cast<int>(s.textDecoration), static_cast<int>(CssTextDecoration::Underline));
+}
+
+int main() {
+  std::cout << "CssParserRegressionTest\n";
+
+  // normalizeInto / parseDeclarations paths
+  RUN_TEST(testWhitespaceNormalization);
+  RUN_TEST(testMultipleInternalSpaces);
+  RUN_TEST(testTabsAndNewlines);
+  RUN_TEST(testCaseInsensitivity);
+  RUN_TEST(testTrailingSemicolon);
+  RUN_TEST(testDoubleSemicolon);
+  RUN_TEST(testPropertyWithNoValue);
+  RUN_TEST(testPropertyWithNoColon);
+  RUN_TEST(testOnlyWhitespace);
+  RUN_TEST(testOnlySemicolons);
+
+  // interpretLength paths
+  RUN_TEST(testLengthNoUnit);
+  RUN_TEST(testLengthZero);
+  RUN_TEST(testLengthZeroPx);
+  RUN_TEST(testLengthNegative);
+  RUN_TEST(testLengthDecimal);
+  RUN_TEST(testLengthDecimalNoDot);
+  RUN_TEST(testLengthAllUnits);
+  RUN_TEST(testLengthInvalidValue);
+
+  // interpretSpacing paths
+  RUN_TEST(testSpacingDoesNotCorruptOtherProperties);
+  RUN_TEST(testUnknownPropertySkipped);
+
+  // processRuleBlock paths
+  RUN_TEST(testGroupedSelectorsAfterOptimization);
+  RUN_TEST(testGroupedSelectorsWithClasses);
+  RUN_TEST(testGroupedSelectorsWhitespaceVariations);
+  RUN_TEST(testSingleSelectorRuleBlock);
+
+  // Stress / compound
+  RUN_TEST(testStressMultiplePropertiesWithWhitespace);
+  RUN_TEST(testRepeatedCallsNoLeakage);
+  RUN_TEST(testMarginShorthandWhitespace);
+  RUN_TEST(testPaddingShorthand);
+
+  // Accumulated rules
+  RUN_TEST(testAccumulatedRules);
+  RUN_TEST(testTextDecorationLine);
+
+  TEST_SUMMARY();
+}

--- a/test/unit/CssParserTest.cpp
+++ b/test/unit/CssParserTest.cpp
@@ -1,0 +1,259 @@
+#include "lib/Epub/Epub/css/CssParser.h"
+#include "test/test_harness.h"
+
+// --- parseInlineStyle: text properties ---
+
+void testParseInlineTextAlign() {
+  CssStyle s = CssParser::parseInlineStyle("text-align: center");
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testParseInlineFontStyle() {
+  CssStyle s = CssParser::parseInlineStyle("font-style: italic");
+  ASSERT_TRUE(s.hasFontStyle());
+  ASSERT_EQ(static_cast<int>(s.fontStyle), static_cast<int>(CssFontStyle::Italic));
+}
+
+void testParseInlineFontWeight() {
+  CssStyle s = CssParser::parseInlineStyle("font-weight: bold");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testParseInlineFontWeightNumeric() {
+  CssStyle s700 = CssParser::parseInlineStyle("font-weight: 700");
+  ASSERT_EQ(static_cast<int>(s700.fontWeight), static_cast<int>(CssFontWeight::Bold));
+
+  CssStyle s400 = CssParser::parseInlineStyle("font-weight: 400");
+  ASSERT_EQ(static_cast<int>(s400.fontWeight), static_cast<int>(CssFontWeight::Normal));
+}
+
+void testParseInlineTextDecoration() {
+  CssStyle s = CssParser::parseInlineStyle("text-decoration: underline");
+  ASSERT_TRUE(s.hasTextDecoration());
+  ASSERT_EQ(static_cast<int>(s.textDecoration), static_cast<int>(CssTextDecoration::Underline));
+}
+
+// --- parseInlineStyle: length values ---
+
+void testParseInlineMarginPx() {
+  CssStyle s = CssParser::parseInlineStyle("margin-top: 10px");
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_NEAR(s.marginTop.value, 10.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginTop.unit), static_cast<int>(CssUnit::Pixels));
+}
+
+void testParseInlineMarginEm() {
+  CssStyle s = CssParser::parseInlineStyle("margin-left: 2em");
+  ASSERT_TRUE(s.hasMarginLeft());
+  ASSERT_NEAR(s.marginLeft.value, 2.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginLeft.unit), static_cast<int>(CssUnit::Em));
+}
+
+void testParseInlineMarginRem() {
+  CssStyle s = CssParser::parseInlineStyle("margin-right: 1.5rem");
+  ASSERT_TRUE(s.hasMarginRight());
+  ASSERT_NEAR(s.marginRight.value, 1.5f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.marginRight.unit), static_cast<int>(CssUnit::Rem));
+}
+
+void testParseInlineMarginPt() {
+  CssStyle s = CssParser::parseInlineStyle("padding-top: 12pt");
+  ASSERT_TRUE(s.hasPaddingTop());
+  ASSERT_NEAR(s.paddingTop.value, 12.0f, 0.01f);
+  ASSERT_EQ(static_cast<int>(s.paddingTop.unit), static_cast<int>(CssUnit::Points));
+}
+
+void testParseInlineTextIndent() {
+  CssStyle s = CssParser::parseInlineStyle("text-indent: 1.5em");
+  ASSERT_TRUE(s.hasTextIndent());
+  ASSERT_NEAR(s.textIndent.value, 1.5f, 0.01f);
+}
+
+// --- parseInlineStyle: margin shorthand ---
+
+void testMarginShorthand1Value() {
+  CssStyle s = CssParser::parseInlineStyle("margin: 10px");
+  ASSERT_NEAR(s.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginRight.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginBottom.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginLeft.value, 10.0f, 0.01f);
+}
+
+void testMarginShorthand2Values() {
+  CssStyle s = CssParser::parseInlineStyle("margin: 10px 20px");
+  ASSERT_NEAR(s.marginTop.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginRight.value, 20.0f, 0.01f);
+  ASSERT_NEAR(s.marginBottom.value, 10.0f, 0.01f);
+  ASSERT_NEAR(s.marginLeft.value, 20.0f, 0.01f);
+}
+
+void testMarginShorthand4Values() {
+  CssStyle s = CssParser::parseInlineStyle("margin: 1px 2px 3px 4px");
+  ASSERT_NEAR(s.marginTop.value, 1.0f, 0.01f);
+  ASSERT_NEAR(s.marginRight.value, 2.0f, 0.01f);
+  ASSERT_NEAR(s.marginBottom.value, 3.0f, 0.01f);
+  ASSERT_NEAR(s.marginLeft.value, 4.0f, 0.01f);
+}
+
+// --- parseInlineStyle: multiple properties ---
+
+void testMultipleProperties() {
+  CssStyle s = CssParser::parseInlineStyle("font-weight: bold; text-align: center; margin-top: 5px");
+  ASSERT_TRUE(s.hasFontWeight());
+  ASSERT_TRUE(s.hasTextAlign());
+  ASSERT_TRUE(s.hasMarginTop());
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_NEAR(s.marginTop.value, 5.0f, 0.01f);
+}
+
+void testEmptyStyle() {
+  CssStyle s = CssParser::parseInlineStyle("");
+  ASSERT_FALSE(s.defined.anySet());
+}
+
+// --- CssLength::toPixels ---
+
+void testLengthToPixels() {
+  CssLength px{10.0f, CssUnit::Pixels};
+  ASSERT_NEAR(px.toPixels(16.0f), 10.0f, 0.01f);
+
+  CssLength em{2.0f, CssUnit::Em};
+  ASSERT_NEAR(em.toPixels(16.0f), 32.0f, 0.01f);
+
+  CssLength rem{1.5f, CssUnit::Rem};
+  ASSERT_NEAR(rem.toPixels(16.0f), 24.0f, 0.01f);
+
+  CssLength pt{12.0f, CssUnit::Points};
+  ASSERT_NEAR(pt.toPixels(16.0f), 15.96f, 0.1f);  // 12 * 1.33
+}
+
+// --- CssStyle::applyOver ---
+
+void testApplyOver() {
+  CssStyle base;
+  base.textAlign = CssTextAlign::Center;
+  base.defined.textAlign = 1;
+  base.fontWeight = CssFontWeight::Bold;
+  base.defined.fontWeight = 1;
+
+  CssStyle target;
+  target.fontStyle = CssFontStyle::Italic;
+  target.defined.fontStyle = 1;
+
+  target.applyOver(base);
+  // base's textAlign and fontWeight should be applied
+  ASSERT_EQ(static_cast<int>(target.textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_EQ(static_cast<int>(target.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  // target's original fontStyle should be preserved
+  ASSERT_EQ(static_cast<int>(target.fontStyle), static_cast<int>(CssFontStyle::Italic));
+}
+
+void testApplyOverNoOverwrite() {
+  CssStyle base;
+  // fontWeight not defined in base
+
+  CssStyle target;
+  target.fontWeight = CssFontWeight::Bold;
+  target.defined.fontWeight = 1;
+
+  target.applyOver(base);
+  // target's fontWeight should remain because base didn't define it
+  ASSERT_EQ(static_cast<int>(target.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+// --- resolveStyle (requires loadFromString) ---
+
+void testResolveStyleCascade() {
+  CssParser parser;
+  parser.loadFromString("p { text-align: left } .highlight { font-weight: bold } p.highlight { font-style: italic }");
+
+  CssStyle s = parser.resolveStyle("p", "highlight");
+  // Element rule → class rule → combined rule
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Left));
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(s.fontStyle), static_cast<int>(CssFontStyle::Italic));
+}
+
+void testResolveStyleElementOnly() {
+  CssParser parser;
+  parser.loadFromString("h1 { text-align: center; font-weight: bold }");
+
+  CssStyle s = parser.resolveStyle("h1", "");
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testResolveStyleClassOnly() {
+  CssParser parser;
+  parser.loadFromString(".intro { margin-top: 20px }");
+
+  CssStyle s = parser.resolveStyle("div", "intro");
+  ASSERT_NEAR(s.marginTop.value, 20.0f, 0.01f);
+}
+
+void testResolveStyleGroupedSelectors() {
+  CssParser parser;
+  parser.loadFromString("h1, h2, h3 { font-weight: bold }");
+
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h1", "").fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h2", "").fontWeight), static_cast<int>(CssFontWeight::Bold));
+  ASSERT_EQ(static_cast<int>(parser.resolveStyle("h3", "").fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testResolveStyleComments() {
+  CssParser parser;
+  parser.loadFromString("/* heading styles */ h1 { text-align: center } /* end */");
+
+  CssStyle s = parser.resolveStyle("h1", "");
+  ASSERT_EQ(static_cast<int>(s.textAlign), static_cast<int>(CssTextAlign::Center));
+}
+
+void testResolveStyleAtRuleSkip() {
+  CssParser parser;
+  parser.loadFromString("@media screen { p { color: red } } p { font-weight: bold }");
+
+  CssStyle s = parser.resolveStyle("p", "");
+  // The @media rule should be skipped, only the plain p rule applies
+  ASSERT_EQ(static_cast<int>(s.fontWeight), static_cast<int>(CssFontWeight::Bold));
+}
+
+void testResolveStyleNoMatch() {
+  CssParser parser;
+  parser.loadFromString("h1 { font-weight: bold }");
+
+  CssStyle s = parser.resolveStyle("p", "");
+  ASSERT_FALSE(s.defined.anySet());
+}
+
+int main() {
+  std::cout << "CssParserTest\n";
+  RUN_TEST(testParseInlineTextAlign);
+  RUN_TEST(testParseInlineFontStyle);
+  RUN_TEST(testParseInlineFontWeight);
+  RUN_TEST(testParseInlineFontWeightNumeric);
+  RUN_TEST(testParseInlineTextDecoration);
+  RUN_TEST(testParseInlineMarginPx);
+  RUN_TEST(testParseInlineMarginEm);
+  RUN_TEST(testParseInlineMarginRem);
+  RUN_TEST(testParseInlineMarginPt);
+  RUN_TEST(testParseInlineTextIndent);
+  RUN_TEST(testMarginShorthand1Value);
+  RUN_TEST(testMarginShorthand2Values);
+  RUN_TEST(testMarginShorthand4Values);
+  RUN_TEST(testMultipleProperties);
+  RUN_TEST(testEmptyStyle);
+  RUN_TEST(testLengthToPixels);
+  RUN_TEST(testApplyOver);
+  RUN_TEST(testApplyOverNoOverwrite);
+  RUN_TEST(testResolveStyleCascade);
+  RUN_TEST(testResolveStyleElementOnly);
+  RUN_TEST(testResolveStyleClassOnly);
+  RUN_TEST(testResolveStyleGroupedSelectors);
+  RUN_TEST(testResolveStyleComments);
+  RUN_TEST(testResolveStyleAtRuleSkip);
+  RUN_TEST(testResolveStyleNoMatch);
+  TEST_SUMMARY();
+}

--- a/test/unit/HyphenationRegressionTest.cpp
+++ b/test/unit/HyphenationRegressionTest.cpp
@@ -1,0 +1,320 @@
+#include <string>
+#include <vector>
+
+#include "lib/Epub/Epub/hyphenation/HyphenationCommon.h"
+#include "lib/Epub/Epub/hyphenation/Hyphenator.h"
+#include "test/test_harness.h"
+
+// These tests specifically target the code paths changed by the hyphenation optimization:
+//   1. collectCodepoints() overload that fills a pre-existing vector (static buffer reuse)
+//   2. trimSurroundingPunctuationAndFootnote() bulk erase replacing O(n²) erase-from-front
+//   3. liangBreakIndexes() static AugmentedWord and scores buffer reuse
+//   4. Hyphenator::breakOffsets() static cps buffer reuse
+
+// Helper to compare break offset vectors
+void assertBreaksEqual(const std::vector<Hyphenator::BreakInfo>& actual,
+                       const std::vector<std::pair<size_t, bool>>& expected, const char* word) {
+  if (actual.size() != expected.size()) {
+    std::cerr << "  FAIL: \"" << word << "\" — expected " << expected.size() << " breaks, got " << actual.size()
+              << "\n";
+    ++g_testsFailed;
+    return;
+  }
+  for (size_t i = 0; i < actual.size(); ++i) {
+    if (actual[i].byteOffset != expected[i].first || actual[i].requiresInsertedHyphen != expected[i].second) {
+      std::cerr << "  FAIL: \"" << word << "\" break[" << i << "] — expected {" << expected[i].first << ", "
+                << expected[i].second << "}, got {" << actual[i].byteOffset << ", " << actual[i].requiresInsertedHyphen
+                << "}\n";
+      ++g_testsFailed;
+      return;
+    }
+  }
+  ++g_testsPassed;
+}
+
+// --- Golden-value tests for breakOffsets ---
+// These values were captured from the algorithm output and verify exact byte offsets.
+
+void testGoldenBreakOffsetsEnglish() {
+  Hyphenator::setPreferredLanguage("en");
+
+  // Words with known hyphenation break points
+  assertBreaksEqual(Hyphenator::breakOffsets("beautiful", false), {{4, true}, {6, true}}, "beautiful");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("international", false), {{5, true}, {7, true}}, "international");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("communication", false), {{3, true}, {5, true}, {7, true}, {9, true}},
+                    "communication");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("responsibility", false), {{6, true}, {8, true}, {11, true}},
+                    "responsibility");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("extraordinary", false), {{5, true}, {7, true}, {9, true}},
+                    "extraordinary");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("understanding", false), {{5, true}, {10, true}}, "understanding");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("computer", false), {{3, true}}, "computer");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("implementation", false), {{5, true}, {8, true}, {10, true}},
+                    "implementation");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("encyclopedia", false), {{4, true}, {7, true}, {9, true}}, "encyclopedia");
+
+  assertBreaksEqual(Hyphenator::breakOffsets("characterization", false),
+                    {{4, true}, {6, true}, {9, true}, {10, true}, {12, true}}, "characterization");
+}
+
+void testGoldenNoBreaks() {
+  Hyphenator::setPreferredLanguage("en");
+
+  // Short words should have no breaks (min prefix=3, min suffix=3 for English)
+  assertBreaksEqual(Hyphenator::breakOffsets("hello", false), {}, "hello");
+  assertBreaksEqual(Hyphenator::breakOffsets("world", false), {}, "world");
+  assertBreaksEqual(Hyphenator::breakOffsets("the", false), {}, "the");
+  assertBreaksEqual(Hyphenator::breakOffsets("a", false), {}, "a");
+  assertBreaksEqual(Hyphenator::breakOffsets("hi", false), {}, "hi");
+  assertBreaksEqual(Hyphenator::breakOffsets("cat", false), {}, "cat");
+}
+
+void testEmptyWord() {
+  Hyphenator::setPreferredLanguage("en");
+  assertBreaksEqual(Hyphenator::breakOffsets("", false), {}, "empty");
+}
+
+// --- collectCodepoints overload regression ---
+// The new overload fills a pre-existing vector. Verify it matches the original.
+
+void testCollectCodepointsOverloadMatchesOriginal() {
+  const std::vector<std::string> words = {"hello",    "café",         "naïve",   "", "a",
+                                          "\xC3\xA9", "\xE2\x80\x93", "test123", "Ÿ"};
+
+  for (const auto& word : words) {
+    auto original = collectCodepoints(word);
+
+    std::vector<CodepointInfo> filled;
+    collectCodepoints(word, filled);
+
+    if (original.size() != filled.size()) {
+      std::cerr << "  FAIL: collectCodepoints size mismatch for \"" << word << "\": " << original.size() << " vs "
+                << filled.size() << "\n";
+      ++g_testsFailed;
+      return;
+    }
+
+    for (size_t i = 0; i < original.size(); ++i) {
+      if (original[i].value != filled[i].value || original[i].byteOffset != filled[i].byteOffset) {
+        std::cerr << "  FAIL: collectCodepoints mismatch at index " << i << " for \"" << word << "\"\n";
+        ++g_testsFailed;
+        return;
+      }
+    }
+  }
+  ++g_testsPassed;
+}
+
+// --- collectCodepoints buffer reuse ---
+// Calling the overload multiple times should not leak data between calls.
+
+void testCollectCodepointsBufferReuse() {
+  std::vector<CodepointInfo> buf;
+
+  // First call with a long word
+  collectCodepoints("international", buf);
+  ASSERT_EQ(buf.size(), static_cast<size_t>(13));
+
+  // Second call with a short word — buffer should be fully replaced
+  collectCodepoints("hi", buf);
+  ASSERT_EQ(buf.size(), static_cast<size_t>(2));
+  ASSERT_EQ(buf[0].value, static_cast<uint32_t>('h'));
+  ASSERT_EQ(buf[1].value, static_cast<uint32_t>('i'));
+
+  // Third call with empty — buffer should be empty
+  collectCodepoints("", buf);
+  ASSERT_EQ(buf.size(), static_cast<size_t>(0));
+}
+
+// --- trimSurroundingPunctuationAndFootnote regression ---
+// The optimization replaced the O(n²) erase-from-front loop with a bulk erase.
+
+void testTrimLeadingPunctuation() {
+  auto cps = collectCodepoints("...hello");
+  trimSurroundingPunctuationAndFootnote(cps);
+  // Should have removed the three dots, leaving "hello"
+  ASSERT_EQ(cps.size(), static_cast<size_t>(5));
+  ASSERT_EQ(cps[0].value, static_cast<uint32_t>('h'));
+}
+
+void testTrimTrailingPunctuation() {
+  auto cps = collectCodepoints("hello...");
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), static_cast<size_t>(5));
+  ASSERT_EQ(cps[4].value, static_cast<uint32_t>('o'));
+}
+
+void testTrimBothSides() {
+  auto cps = collectCodepoints("\"hello!\"");
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), static_cast<size_t>(5));
+  ASSERT_EQ(cps[0].value, static_cast<uint32_t>('h'));
+  ASSERT_EQ(cps[4].value, static_cast<uint32_t>('o'));
+}
+
+void testTrimAllPunctuation() {
+  auto cps = collectCodepoints("...,,,!!!");
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), static_cast<size_t>(0));
+}
+
+void testTrimNoPunctuation() {
+  auto cps = collectCodepoints("hello");
+  const size_t originalSize = cps.size();
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), originalSize);
+}
+
+void testTrimFootnoteReference() {
+  auto cps = collectCodepoints("word[12]");
+  trimSurroundingPunctuationAndFootnote(cps);
+  // Should remove the [12] footnote reference
+  ASSERT_EQ(cps.size(), static_cast<size_t>(4));
+  ASSERT_EQ(cps[3].value, static_cast<uint32_t>('d'));
+}
+
+void testTrimEmpty() {
+  std::vector<CodepointInfo> cps;
+  trimSurroundingPunctuationAndFootnote(cps);  // should not crash
+  ASSERT_EQ(cps.size(), static_cast<size_t>(0));
+}
+
+void testTrimSingleLetter() {
+  auto cps = collectCodepoints("a");
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), static_cast<size_t>(1));
+  ASSERT_EQ(cps[0].value, static_cast<uint32_t>('a'));
+}
+
+void testTrimSinglePunctuation() {
+  auto cps = collectCodepoints(".");
+  trimSurroundingPunctuationAndFootnote(cps);
+  ASSERT_EQ(cps.size(), static_cast<size_t>(0));
+}
+
+// --- Static buffer safety: repeated calls with varied inputs ---
+// The optimization uses static local vectors in breakOffsets and liangBreakIndexes.
+// Verify that results are deterministic and do not leak across calls.
+
+void testStaticBufferSafety() {
+  Hyphenator::setPreferredLanguage("en");
+
+  const std::vector<std::string> words = {"beautiful",     "the",          "implementation", "cat",
+                                          "extraordinary", "hello",        "computer",       "",
+                                          "encyclopedia",  "understanding"};
+
+  // Capture reference results
+  std::vector<std::vector<Hyphenator::BreakInfo>> reference;
+  for (const auto& w : words) {
+    reference.push_back(Hyphenator::breakOffsets(w, false));
+  }
+
+  // Repeat 50 times and verify identical results every time
+  for (int iter = 0; iter < 50; ++iter) {
+    for (size_t i = 0; i < words.size(); ++i) {
+      auto result = Hyphenator::breakOffsets(words[i], false);
+      if (result.size() != reference[i].size()) {
+        std::cerr << "  FAIL: iteration " << iter << ", word \"" << words[i] << "\" — size mismatch: " << result.size()
+                  << " vs " << reference[i].size() << "\n";
+        ++g_testsFailed;
+        return;
+      }
+      for (size_t j = 0; j < result.size(); ++j) {
+        if (result[j].byteOffset != reference[i][j].byteOffset ||
+            result[j].requiresInsertedHyphen != reference[i][j].requiresInsertedHyphen) {
+          std::cerr << "  FAIL: iteration " << iter << ", word \"" << words[i] << "\" break[" << j << "] mismatch\n";
+          ++g_testsFailed;
+          return;
+        }
+      }
+    }
+  }
+  ++g_testsPassed;
+}
+
+// --- Interleaved short and long words ---
+// Tests that static buffers properly resize when alternating between word lengths.
+
+void testInterleavedWordLengths() {
+  Hyphenator::setPreferredLanguage("en");
+
+  // Alternate between very long and very short words
+  for (int i = 0; i < 20; ++i) {
+    auto longResult = Hyphenator::breakOffsets("characterization", false);
+    assertBreaksEqual(longResult, {{4, true}, {6, true}, {9, true}, {10, true}, {12, true}}, "characterization");
+
+    auto shortResult = Hyphenator::breakOffsets("a", false);
+    assertBreaksEqual(shortResult, {}, "a");
+
+    auto emptyResult = Hyphenator::breakOffsets("", false);
+    assertBreaksEqual(emptyResult, {}, "empty");
+
+    auto medResult = Hyphenator::breakOffsets("computer", false);
+    assertBreaksEqual(medResult, {{3, true}}, "computer");
+  }
+}
+
+// --- Words with explicit hyphens ---
+
+void testExplicitHyphenBreaks() {
+  Hyphenator::setPreferredLanguage("en");
+
+  auto result = Hyphenator::breakOffsets("well-known", false);
+  // Should detect the explicit hyphen and break after it
+  ASSERT_TRUE(result.size() >= 1);
+  if (!result.empty()) {
+    // The break should be at the character after the hyphen
+    ASSERT_EQ(result[0].byteOffset, static_cast<size_t>(5));  // "well-" is 5 bytes, break at "k"
+  }
+}
+
+void testSoftHyphen() {
+  Hyphenator::setPreferredLanguage("en");
+
+  // Soft hyphen (U+00AD) between 'beau' and 'tiful'
+  std::string word = "beau\xC2\xADtiful";
+  auto result = Hyphenator::breakOffsets(word, false);
+  ASSERT_TRUE(result.size() >= 1);
+}
+
+int main() {
+  std::cout << "HyphenationRegressionTest\n";
+
+  // Golden values
+  RUN_TEST(testGoldenBreakOffsetsEnglish);
+  RUN_TEST(testGoldenNoBreaks);
+  RUN_TEST(testEmptyWord);
+
+  // collectCodepoints overload
+  RUN_TEST(testCollectCodepointsOverloadMatchesOriginal);
+  RUN_TEST(testCollectCodepointsBufferReuse);
+
+  // trimSurroundingPunctuationAndFootnote
+  RUN_TEST(testTrimLeadingPunctuation);
+  RUN_TEST(testTrimTrailingPunctuation);
+  RUN_TEST(testTrimBothSides);
+  RUN_TEST(testTrimAllPunctuation);
+  RUN_TEST(testTrimNoPunctuation);
+  RUN_TEST(testTrimFootnoteReference);
+  RUN_TEST(testTrimEmpty);
+  RUN_TEST(testTrimSingleLetter);
+  RUN_TEST(testTrimSinglePunctuation);
+
+  // Static buffer safety
+  RUN_TEST(testStaticBufferSafety);
+  RUN_TEST(testInterleavedWordLengths);
+
+  // Explicit hyphens
+  RUN_TEST(testExplicitHyphenBreaks);
+  RUN_TEST(testSoftHyphen);
+
+  TEST_SUMMARY();
+}

--- a/test/unit/OpdsParserTest.cpp
+++ b/test/unit/OpdsParserTest.cpp
@@ -1,0 +1,219 @@
+#include <cstring>
+
+#include "lib/OpdsParser/OpdsParser.h"
+#include "test/test_harness.h"
+
+static void feedXml(OpdsParser& parser, const char* xml) {
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  parser.flush();
+}
+
+// --- Navigation feed ---
+
+void testNavigationFeed() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>Popular</title>"
+      "    <id>urn:popular</id>"
+      "    <link type='application/atom+xml' href='/popular'/>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  ASSERT_EQ(static_cast<int>(entries[0].type), static_cast<int>(OpdsEntryType::NAVIGATION));
+  ASSERT_STREQ(entries[0].title, "Popular");
+  ASSERT_STREQ(entries[0].href, "/popular");
+  ASSERT_STREQ(entries[0].id, "urn:popular");
+}
+
+// --- Acquisition feed ---
+
+void testAcquisitionFeed() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>Pride and Prejudice</title>"
+      "    <author><name>Jane Austen</name></author>"
+      "    <id>urn:isbn:12345</id>"
+      "    <link rel='http://opds-spec.org/acquisition' type='application/epub+zip' href='/download/12345.epub'/>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  const auto& entries = parser.getEntries();
+  ASSERT_EQ(entries.size(), 1u);
+  ASSERT_EQ(static_cast<int>(entries[0].type), static_cast<int>(OpdsEntryType::BOOK));
+  ASSERT_STREQ(entries[0].title, "Pride and Prejudice");
+  ASSERT_STREQ(entries[0].author, "Jane Austen");
+  ASSERT_STREQ(entries[0].href, "/download/12345.epub");
+}
+
+// --- Mixed entries ---
+
+void testMixedEntries() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>Browse</title>"
+      "    <id>1</id>"
+      "    <link type='application/atom+xml' href='/browse'/>"
+      "  </entry>"
+      "  <entry>"
+      "    <title>A Book</title>"
+      "    <author><name>Author</name></author>"
+      "    <id>2</id>"
+      "    <link rel='http://opds-spec.org/acquisition' type='application/epub+zip' href='/book.epub'/>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  ASSERT_EQ(parser.getEntries().size(), 2u);
+  ASSERT_EQ(static_cast<int>(parser.getEntries()[0].type), static_cast<int>(OpdsEntryType::NAVIGATION));
+  ASSERT_EQ(static_cast<int>(parser.getEntries()[1].type), static_cast<int>(OpdsEntryType::BOOK));
+
+  auto books = parser.getBooks();
+  ASSERT_EQ(books.size(), 1u);
+  ASSERT_STREQ(books[0].title, "A Book");
+}
+
+// --- Namespace prefixes ---
+
+void testNamespacePrefixes() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<atom:feed xmlns:atom='http://www.w3.org/2005/Atom'>"
+      "  <atom:entry>"
+      "    <atom:title>Catalog</atom:title>"
+      "    <atom:id>urn:cat</atom:id>"
+      "    <atom:link type='application/atom+xml' href='/cat'/>"
+      "  </atom:entry>"
+      "</atom:feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  ASSERT_EQ(parser.getEntries().size(), 1u);
+  ASSERT_STREQ(parser.getEntries()[0].title, "Catalog");
+}
+
+// --- Entry without href is skipped ---
+
+void testEntryWithoutHref() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>No link</title>"
+      "    <id>urn:nolink</id>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  ASSERT_EQ(parser.getEntries().size(), 0u);
+}
+
+// --- Empty feed ---
+
+void testEmptyFeed() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "</feed>";
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  ASSERT_FALSE(parser.error());
+  ASSERT_EQ(parser.getEntries().size(), 0u);
+}
+
+// --- Malformed XML ---
+
+void testMalformedXml() {
+  const char* xml = "<feed><entry><title>Broken";  // no closing tags
+
+  OpdsParser parser;
+  feedXml(parser, xml);
+
+  // flush() on incomplete XML should produce an error
+  ASSERT_TRUE(parser.error());
+}
+
+// --- Chunked writes ---
+
+void testChunkedWrite() {
+  const char* part1 =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>Spl";
+  const char* part2 =
+      "it Title</title>"
+      "    <id>urn:split</id>"
+      "    <link type='application/atom+xml' href='/split'/>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(part1), strlen(part1));
+  parser.write(reinterpret_cast<const uint8_t*>(part2), strlen(part2));
+  parser.flush();
+
+  ASSERT_FALSE(parser.error());
+  ASSERT_EQ(parser.getEntries().size(), 1u);
+  ASSERT_STREQ(parser.getEntries()[0].title, "Split Title");
+}
+
+// --- clear() resets state ---
+
+void testClear() {
+  const char* xml =
+      "<?xml version='1.0' encoding='UTF-8'?>"
+      "<feed xmlns='http://www.w3.org/2005/Atom'>"
+      "  <entry>"
+      "    <title>Test</title>"
+      "    <id>1</id>"
+      "    <link type='application/atom+xml' href='/test'/>"
+      "  </entry>"
+      "</feed>";
+
+  OpdsParser parser;
+  parser.write(reinterpret_cast<const uint8_t*>(xml), strlen(xml));
+  // Don't flush — just check clear resets entries parsed so far
+  ASSERT_EQ(parser.getEntries().size(), 1u);
+  parser.clear();
+  ASSERT_EQ(parser.getEntries().size(), 0u);
+}
+
+int main() {
+  std::cout << "OpdsParserTest\n";
+  RUN_TEST(testNavigationFeed);
+  RUN_TEST(testAcquisitionFeed);
+  RUN_TEST(testMixedEntries);
+  RUN_TEST(testNamespacePrefixes);
+  RUN_TEST(testEntryWithoutHref);
+  RUN_TEST(testEmptyFeed);
+  RUN_TEST(testMalformedXml);
+  RUN_TEST(testChunkedWrite);
+  RUN_TEST(testClear);
+  TEST_SUMMARY();
+}

--- a/test/unit/SerializationTest.cpp
+++ b/test/unit/SerializationTest.cpp
@@ -1,0 +1,92 @@
+#include "test/test_harness.h"
+
+// Serialization.h includes SdFat.h — our stub satisfies the FsFile overloads.
+// We only test the std::iostream overloads here.
+#include <sstream>
+
+#include "lib/Serialization/Serialization.h"
+
+void testWriteReadPodInt32() {
+  std::stringstream ss;
+  int32_t written = 42;
+  serialization::writePod(ss, written);
+
+  int32_t readBack = 0;
+  ss.seekg(0);
+  serialization::readPod(ss, readBack);
+  ASSERT_EQ(readBack, 42);
+}
+
+void testWriteReadPodFloat() {
+  std::stringstream ss;
+  float written = 3.14f;
+  serialization::writePod(ss, written);
+
+  float readBack = 0.0f;
+  ss.seekg(0);
+  serialization::readPod(ss, readBack);
+  ASSERT_NEAR(readBack, 3.14f, 0.001f);
+}
+
+void testWriteReadPodUint8() {
+  std::stringstream ss;
+  uint8_t written = 255;
+  serialization::writePod(ss, written);
+
+  uint8_t readBack = 0;
+  ss.seekg(0);
+  serialization::readPod(ss, readBack);
+  ASSERT_EQ(readBack, 255u);
+}
+
+void testWriteReadString() {
+  std::stringstream ss;
+  const std::string written = "hello world";
+  serialization::writeString(ss, written);
+
+  std::string readBack;
+  ss.seekg(0);
+  serialization::readString(ss, readBack);
+  ASSERT_STREQ(readBack, "hello world");
+}
+
+void testWriteReadEmptyString() {
+  std::stringstream ss;
+  const std::string written;
+  serialization::writeString(ss, written);
+
+  std::string readBack = "notempty";
+  ss.seekg(0);
+  serialization::readString(ss, readBack);
+  ASSERT_TRUE(readBack.empty());
+}
+
+void testMultipleValues() {
+  std::stringstream ss;
+  serialization::writePod<int32_t>(ss, 1);
+  serialization::writeString(ss, "two");
+  serialization::writePod<float>(ss, 3.0f);
+
+  ss.seekg(0);
+  int32_t i;
+  std::string s;
+  float f;
+  serialization::readPod(ss, i);
+  serialization::readString(ss, s);
+  serialization::readPod(ss, f);
+
+  ASSERT_EQ(i, 1);
+  ASSERT_STREQ(s, "two");
+  ASSERT_NEAR(f, 3.0f, 0.001f);
+}
+
+int main() {
+  std::cout << "SerializationTest\n";
+  RUN_TEST(testWriteReadPodInt32);
+  RUN_TEST(testWriteReadPodFloat);
+  RUN_TEST(testWriteReadPodUint8);
+  RUN_TEST(testWriteReadString);
+  RUN_TEST(testWriteReadEmptyString);
+  RUN_TEST(testMultipleValues);
+  TEST_SUMMARY();
+}

--- a/test/unit/StringUtilsTest.cpp
+++ b/test/unit/StringUtilsTest.cpp
@@ -1,0 +1,70 @@
+#include "src/util/StringUtils.h"
+#include "test/test_harness.h"
+
+// --- sanitizeFilename ---
+
+void testSanitizeNormal() { ASSERT_STREQ(StringUtils::sanitizeFilename("my_book"), "my_book"); }
+
+void testSanitizeInvalidChars() {
+  ASSERT_STREQ(StringUtils::sanitizeFilename("file/name:bad"), "file_name_bad");
+  ASSERT_STREQ(StringUtils::sanitizeFilename("a*b?c\"d<e>f|g"), "a_b_c_d_e_f_g");
+}
+
+void testSanitizeTrimSpacesDots() { ASSERT_STREQ(StringUtils::sanitizeFilename("  ..hello..  "), "hello"); }
+
+void testSanitizeAllInvalid() { ASSERT_STREQ(StringUtils::sanitizeFilename("..."), "book"); }
+
+void testSanitizeMaxLength() {
+  std::string longName(200, 'a');
+  std::string result = StringUtils::sanitizeFilename(longName, 50);
+  ASSERT_EQ(result.length(), 50u);
+}
+
+void testSanitizeEmpty() { ASSERT_STREQ(StringUtils::sanitizeFilename(""), "book"); }
+
+void testSanitizeNonPrintable() {
+  std::string s;
+  s += '\x01';
+  s += '\x02';
+  s += '\x1F';
+  ASSERT_STREQ(StringUtils::sanitizeFilename(s), "book");
+}
+
+// --- checkFileExtension (std::string) ---
+
+void testExtensionEpub() {
+  ASSERT_TRUE(StringUtils::checkFileExtension(std::string("book.epub"), ".epub"));
+  ASSERT_TRUE(StringUtils::checkFileExtension(std::string("book.EPUB"), ".epub"));
+  ASSERT_TRUE(StringUtils::checkFileExtension(std::string("book.Epub"), ".epub"));
+  ASSERT_FALSE(StringUtils::checkFileExtension(std::string("book.txt"), ".epub"));
+}
+
+void testExtensionShortName() {
+  ASSERT_FALSE(StringUtils::checkFileExtension(std::string("a"), ".epub"));
+  ASSERT_FALSE(StringUtils::checkFileExtension(std::string(""), ".epub"));
+}
+
+// --- checkFileExtension (Arduino String) ---
+
+void testExtensionArduinoString() {
+  String fname("book.EPUB");
+  ASSERT_TRUE(StringUtils::checkFileExtension(fname, ".epub"));
+
+  String fname2("book.txt");
+  ASSERT_FALSE(StringUtils::checkFileExtension(fname2, ".epub"));
+}
+
+int main() {
+  std::cout << "StringUtilsTest\n";
+  RUN_TEST(testSanitizeNormal);
+  RUN_TEST(testSanitizeInvalidChars);
+  RUN_TEST(testSanitizeTrimSpacesDots);
+  RUN_TEST(testSanitizeAllInvalid);
+  RUN_TEST(testSanitizeMaxLength);
+  RUN_TEST(testSanitizeEmpty);
+  RUN_TEST(testSanitizeNonPrintable);
+  RUN_TEST(testExtensionEpub);
+  RUN_TEST(testExtensionShortName);
+  RUN_TEST(testExtensionArduinoString);
+  TEST_SUMMARY();
+}

--- a/test/unit/TextLayoutTest.cpp
+++ b/test/unit/TextLayoutTest.cpp
@@ -1,0 +1,229 @@
+#include <GfxRenderer.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "lib/Epub/Epub/ParsedText.h"
+#include "lib/Epub/Epub/blocks/TextBlock.h"
+#include "test/test_harness.h"
+
+// ===== Test: basic word addition and layout =====
+
+void testBasicLayout() {
+  GfxRenderer renderer;
+  // With stub: each char = 8px wide, space = 5px, line height = 20px
+  // Viewport width = 200px
+
+  ParsedText text(false);  // no extra paragraph spacing
+  text.addWord("Hello", EpdFontFamily::REGULAR);
+  text.addWord("world", EpdFontFamily::REGULAR);
+
+  ASSERT_EQ(text.size(), 2u);
+  ASSERT_FALSE(text.isEmpty());
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 200,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  // "Hello" = 5*8=40, "world" = 5*8=40, space=5 => 85px total. Fits in 200px => 1 line
+  ASSERT_EQ(lines.size(), 1u);
+  ASSERT_FALSE(lines[0]->isEmpty());
+}
+
+// ===== Test: line wrapping =====
+
+void testLineWrapping() {
+  GfxRenderer renderer;
+  // Viewport = 100px. "Hello" = 40px, "world" = 40px, space = 5px => 85 < 100, fits.
+  // Add more words to force wrapping.
+
+  ParsedText text(false);
+  text.addWord("Hello", EpdFontFamily::REGULAR);
+  text.addWord("world", EpdFontFamily::REGULAR);
+  text.addWord("this", EpdFontFamily::REGULAR);  // 4*8=32
+  text.addWord("is", EpdFontFamily::REGULAR);    // 2*8=16
+  text.addWord("a", EpdFontFamily::REGULAR);     // 1*8=8
+  text.addWord("test", EpdFontFamily::REGULAR);  // 4*8=32
+
+  // Total if on one line: 40+5+40+5+32+5+16+5+8+5+32 = 193px
+  // With viewport=100, should wrap to multiple lines
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 100,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  ASSERT_TRUE(lines.size() >= 2);  // Must wrap to at least 2 lines
+}
+
+// ===== Test: continuation words (attachToPrevious) =====
+
+void testContinuationWords() {
+  GfxRenderer renderer;
+
+  ParsedText text(false);
+  text.addWord("Hello", EpdFontFamily::REGULAR);
+  text.addWord(",", EpdFontFamily::REGULAR, false, true);  // attaches to "Hello"
+  text.addWord("world", EpdFontFamily::REGULAR);
+
+  ASSERT_EQ(text.size(), 3u);
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 400,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  // All fits on one line
+  ASSERT_EQ(lines.size(), 1u);
+}
+
+// ===== Test: single oversized word =====
+
+void testSingleOversizedWord() {
+  GfxRenderer renderer;
+
+  ParsedText text(false);
+  // A very long word: 30 chars * 8px = 240px, viewport=100px
+  text.addWord("abcdefghijklmnopqrstuvwxyzabcd", EpdFontFamily::REGULAR);
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 100,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  // Should produce at least one line (forced onto its own line)
+  ASSERT_TRUE(lines.size() >= 1);
+}
+
+// ===== Test: empty text =====
+
+void testEmptyText() {
+  GfxRenderer renderer;
+
+  ParsedText text(false);
+  ASSERT_TRUE(text.isEmpty());
+  ASSERT_EQ(text.size(), 0u);
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 200,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  ASSERT_EQ(lines.size(), 0u);
+}
+
+// ===== Test: TextBlock serialize/deserialize round-trip =====
+
+void testTextBlockSerializeRoundTrip() {
+  std::vector<std::string> words = {"Hello", "world"};
+  std::vector<uint16_t> xpos = {0, 45};
+  std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::REGULAR, EpdFontFamily::BOLD};
+
+  BlockStyle bs;
+  bs.alignment = CssTextAlign::Justify;
+
+  auto block = std::make_unique<TextBlock>(words, xpos, styles, bs);
+  ASSERT_FALSE(block->isEmpty());
+
+  // Serialize to FsFile (in-memory buffer)
+  FsFile file;
+  auto buf = std::make_shared<std::vector<uint8_t>>();
+  file.initBuffer(buf);
+
+  ASSERT_TRUE(block->serialize(file));
+
+  // Deserialize
+  FsFile readFile;
+  readFile.initBuffer(buf);
+
+  auto restored = TextBlock::deserialize(readFile);
+  ASSERT_TRUE(restored != nullptr);
+  ASSERT_FALSE(restored->isEmpty());
+}
+
+// ===== Test: bold/italic styles preserved through layout =====
+
+void testStylesPreserved() {
+  GfxRenderer renderer;
+
+  ParsedText text(false);
+  text.addWord("Bold", EpdFontFamily::BOLD);
+  text.addWord("Normal", EpdFontFamily::REGULAR);
+  text.addWord("Italic", EpdFontFamily::ITALIC);
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 400,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  ASSERT_EQ(lines.size(), 1u);
+}
+
+// ===== Test: includeLastLine=false drops last line =====
+
+void testExcludeLastLine() {
+  GfxRenderer renderer;
+
+  ParsedText text(false);
+  // Force multiple lines: viewport=50, "Hello"=40, "world"=40
+  text.addWord("Hello", EpdFontFamily::REGULAR);
+  text.addWord("world", EpdFontFamily::REGULAR);
+
+  std::vector<std::unique_ptr<TextBlock>> linesAll;
+  ParsedText text2(false);
+  text2.addWord("Hello", EpdFontFamily::REGULAR);
+  text2.addWord("world", EpdFontFamily::REGULAR);
+
+  text2.layoutAndExtractLines(renderer, 0, 50,
+                              [&linesAll](std::unique_ptr<TextBlock> block) { linesAll.push_back(std::move(block)); });
+
+  std::vector<std::unique_ptr<TextBlock>> linesPartial;
+  text.layoutAndExtractLines(
+      renderer, 0, 50, [&linesPartial](std::unique_ptr<TextBlock> block) { linesPartial.push_back(std::move(block)); },
+      false);
+
+  // With includeLastLine=false, should have one fewer line
+  if (linesAll.size() > 1) {
+    ASSERT_EQ(linesPartial.size(), linesAll.size() - 1);
+  } else {
+    ASSERT_EQ(linesPartial.size(), 0u);
+  }
+}
+
+// ===== Test: justified alignment =====
+
+void testJustifiedAlignment() {
+  GfxRenderer renderer;
+
+  BlockStyle bs;
+  bs.alignment = CssTextAlign::Justify;
+  bs.textAlignDefined = true;
+
+  ParsedText text(false, false, bs);
+  // Make words that definitely wrap: viewport=80
+  // "aa" = 16, "bb" = 16, "cc" = 16 => 16+5+16+5+16 = 58 < 80, fits on one line
+  // "dd" = 16 => 58+5+16 = 79 < 80, still fits
+  // "ee" = 16 => 79+5+16 = 100 > 80, wraps
+  text.addWord("aa", EpdFontFamily::REGULAR);
+  text.addWord("bb", EpdFontFamily::REGULAR);
+  text.addWord("cc", EpdFontFamily::REGULAR);
+  text.addWord("dd", EpdFontFamily::REGULAR);
+  text.addWord("ee", EpdFontFamily::REGULAR);
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
+  text.layoutAndExtractLines(renderer, 0, 80,
+                             [&lines](std::unique_ptr<TextBlock> block) { lines.push_back(std::move(block)); });
+
+  ASSERT_TRUE(lines.size() >= 2);
+}
+
+int main() {
+  std::cout << "TextLayoutTest\n";
+  RUN_TEST(testBasicLayout);
+  RUN_TEST(testLineWrapping);
+  RUN_TEST(testContinuationWords);
+  RUN_TEST(testSingleOversizedWord);
+  RUN_TEST(testEmptyText);
+  RUN_TEST(testTextBlockSerializeRoundTrip);
+  RUN_TEST(testStylesPreserved);
+  RUN_TEST(testExcludeLastLine);
+  RUN_TEST(testJustifiedAlignment);
+  TEST_SUMMARY();
+}

--- a/test/unit/UrlUtilsTest.cpp
+++ b/test/unit/UrlUtilsTest.cpp
@@ -1,0 +1,59 @@
+#include "src/util/UrlUtils.h"
+#include "test/test_harness.h"
+
+// --- isHttpsUrl ---
+
+void testIsHttps() {
+  ASSERT_TRUE(UrlUtils::isHttpsUrl("https://example.com"));
+  ASSERT_TRUE(UrlUtils::isHttpsUrl("https://example.com/path"));
+  ASSERT_FALSE(UrlUtils::isHttpsUrl("http://example.com"));
+  ASSERT_FALSE(UrlUtils::isHttpsUrl("ftp://example.com"));
+  ASSERT_FALSE(UrlUtils::isHttpsUrl("example.com"));
+  ASSERT_FALSE(UrlUtils::isHttpsUrl(""));
+}
+
+// --- ensureProtocol ---
+
+void testEnsureProtocol() {
+  ASSERT_STREQ(UrlUtils::ensureProtocol("example.com"), "http://example.com");
+  ASSERT_STREQ(UrlUtils::ensureProtocol("http://example.com"), "http://example.com");
+  ASSERT_STREQ(UrlUtils::ensureProtocol("https://example.com"), "https://example.com");
+  ASSERT_STREQ(UrlUtils::ensureProtocol("ftp://files.com"), "ftp://files.com");
+}
+
+// --- extractHost ---
+
+void testExtractHost() {
+  ASSERT_STREQ(UrlUtils::extractHost("http://example.com/path/to/thing"), "http://example.com");
+  ASSERT_STREQ(UrlUtils::extractHost("https://example.com"), "https://example.com");
+  ASSERT_STREQ(UrlUtils::extractHost("https://example.com/"), "https://example.com");
+  ASSERT_STREQ(UrlUtils::extractHost("example.com/path"), "example.com");
+  ASSERT_STREQ(UrlUtils::extractHost("example.com"), "example.com");
+}
+
+// --- buildUrl ---
+
+void testBuildUrlAbsolutePath() {
+  ASSERT_STREQ(UrlUtils::buildUrl("http://example.com/catalog", "/new/path"), "http://example.com/new/path");
+}
+
+void testBuildUrlRelativePath() {
+  ASSERT_STREQ(UrlUtils::buildUrl("http://example.com/catalog", "books"), "http://example.com/catalog/books");
+  ASSERT_STREQ(UrlUtils::buildUrl("http://example.com/catalog/", "books"), "http://example.com/catalog/books");
+}
+
+void testBuildUrlEmptyPath() { ASSERT_STREQ(UrlUtils::buildUrl("example.com", ""), "http://example.com"); }
+
+void testBuildUrlNoProtocol() { ASSERT_STREQ(UrlUtils::buildUrl("example.com", "/path"), "http://example.com/path"); }
+
+int main() {
+  std::cout << "UrlUtilsTest\n";
+  RUN_TEST(testIsHttps);
+  RUN_TEST(testEnsureProtocol);
+  RUN_TEST(testExtractHost);
+  RUN_TEST(testBuildUrlAbsolutePath);
+  RUN_TEST(testBuildUrlRelativePath);
+  RUN_TEST(testBuildUrlEmptyPath);
+  RUN_TEST(testBuildUrlNoProtocol);
+  TEST_SUMMARY();
+}

--- a/test/unit/Utf8Test.cpp
+++ b/test/unit/Utf8Test.cpp
@@ -1,0 +1,129 @@
+#include <Utf8.h>
+
+#include "test/test_harness.h"
+
+// --- utf8NextCodepoint ---
+
+void testAscii() {
+  const unsigned char data[] = "A";
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0x41u);
+  ASSERT_EQ(static_cast<size_t>(p - data), 1u);
+}
+
+void testTwoByte() {
+  // U+00E9 (é) = C3 A9
+  const unsigned char data[] = {0xC3, 0xA9, 0x00};
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0x00E9u);
+  ASSERT_EQ(static_cast<size_t>(p - data), 2u);
+}
+
+void testThreeByte() {
+  // U+4E16 (世) = E4 B8 96
+  const unsigned char data[] = {0xE4, 0xB8, 0x96, 0x00};
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0x4E16u);
+  ASSERT_EQ(static_cast<size_t>(p - data), 3u);
+}
+
+void testFourByte() {
+  // U+1F600 (😀) = F0 9F 98 80
+  const unsigned char data[] = {0xF0, 0x9F, 0x98, 0x80, 0x00};
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0x1F600u);
+  ASSERT_EQ(static_cast<size_t>(p - data), 4u);
+}
+
+void testNullTerminator() {
+  const unsigned char data[] = {0x00};
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0u);
+}
+
+void testMultipleCodepoints() {
+  // "Aé" = 41 C3 A9
+  const unsigned char data[] = {0x41, 0xC3, 0xA9, 0x00};
+  const unsigned char* p = data;
+  ASSERT_EQ(utf8NextCodepoint(&p), 0x41u);
+  ASSERT_EQ(utf8NextCodepoint(&p), 0xE9u);
+  ASSERT_EQ(utf8NextCodepoint(&p), 0u);
+}
+
+// --- utf8RemoveLastChar ---
+
+void testRemoveLastAscii() {
+  std::string s = "abc";
+  size_t newSize = utf8RemoveLastChar(s);
+  ASSERT_EQ(newSize, 2u);
+  ASSERT_STREQ(s, "ab");
+}
+
+void testRemoveLastMultibyte() {
+  // "aé" = 61 C3 A9
+  std::string s = "a\xC3\xA9";
+  size_t newSize = utf8RemoveLastChar(s);
+  ASSERT_EQ(newSize, 1u);
+  ASSERT_STREQ(s, "a");
+}
+
+void testRemoveLastEmpty() {
+  std::string s;
+  size_t newSize = utf8RemoveLastChar(s);
+  ASSERT_EQ(newSize, 0u);
+  ASSERT_TRUE(s.empty());
+}
+
+void testRemoveLastSingleChar() {
+  std::string s = "X";
+  utf8RemoveLastChar(s);
+  ASSERT_TRUE(s.empty());
+}
+
+// --- utf8TruncateChars ---
+
+void testTruncateZero() {
+  std::string s = "hello";
+  utf8TruncateChars(s, 0);
+  ASSERT_STREQ(s, "hello");
+}
+
+void testTruncateOne() {
+  std::string s = "hello";
+  utf8TruncateChars(s, 1);
+  ASSERT_STREQ(s, "hell");
+}
+
+void testTruncateAll() {
+  std::string s = "hi";
+  utf8TruncateChars(s, 5);  // more than string length
+  ASSERT_TRUE(s.empty());
+}
+
+void testTruncateMultibyte() {
+  // "aéb" — remove 2 chars from end → "a"
+  std::string s =
+      "a\xC3\xA9"
+      "b";
+  utf8TruncateChars(s, 2);
+  ASSERT_STREQ(s, "a");
+}
+
+int main() {
+  std::cout << "Utf8Test\n";
+  RUN_TEST(testAscii);
+  RUN_TEST(testTwoByte);
+  RUN_TEST(testThreeByte);
+  RUN_TEST(testFourByte);
+  RUN_TEST(testNullTerminator);
+  RUN_TEST(testMultipleCodepoints);
+  RUN_TEST(testRemoveLastAscii);
+  RUN_TEST(testRemoveLastMultibyte);
+  RUN_TEST(testRemoveLastEmpty);
+  RUN_TEST(testRemoveLastSingleChar);
+  RUN_TEST(testTruncateZero);
+  RUN_TEST(testTruncateOne);
+  RUN_TEST(testTruncateAll);
+  RUN_TEST(testTruncateMultibyte);
+  TEST_SUMMARY();
+}


### PR DESCRIPTION
> **Stacked on #764** — This PR includes the unit test commit from #764 as its base. Please review and merge #764 first, then this PR's diff will show only the optimization changes.

## Summary

* **What is the goal of this PR?** Reduce CPU time and heap allocation churn in the two hottest library paths — CSS inline style parsing and hyphenation word breaking — without changing any user-facing behavior.

* **What changes are included?**

### CssParser — 2.3-3.8x faster

| Benchmark (desktop, -O2) | Before | After | Speedup |
|---|---|---|---|
| `parseInlineStyle` — 1 property | 237 ns | 62 ns | **3.8x** |
| `parseInlineStyle` — 5 properties | 979 ns | 390 ns | **2.5x** |
| `parseInlineStyle` — 15 properties | 3,244 ns | 1,386 ns | **2.3x** |

**What changed:**
- **Eliminated triple normalization** — Previously, `splitOnChar(';')` normalized the full string, then `parseDeclarations` normalized each half again, and every interpreter (`interpretAlignment`, `interpretLength`, etc.) called `normalized()` a third time. Now a single `normalizeInto()` helper fills reusable buffers once per property, and interpreters receive pre-normalized input.
- **Zero-allocation length parsing** — `interpretLength()` and `interpretSpacing()` now use `strtof()` directly on the input string and compare unit characters inline, instead of creating substring allocations for the numeric part and unit part separately.
- **Inline declaration scanning** — `parseDeclarations()` scans for `;` and `:` boundaries in a single pass rather than calling `splitOnChar` (which allocated a `vector<string>` of N normalized strings).
- **Inline selector scanning** — `processRuleBlock()` scans for `,` boundaries inline with `normalizeInto()` instead of `splitOnChar`.

### Hyphenation — ~17% faster

| Benchmark (desktop, -O2) | Before | After | Speedup |
|---|---|---|---|
| `breakOffsets` per-word avg | 570 ns | 489 ns | **1.17x** |

**What changed:**
- **Bulk erase** — `trimSurroundingPunctuationAndFootnote()` replaced an O(n²) erase-from-front loop (each `erase(begin())` shifts all remaining elements) with a single bulk `erase(begin, begin + count)`.
- **Static buffer reuse** — Since ESP32-C3 is single-threaded, `Hyphenator::breakOffsets()`, `liangBreakIndexes()`, and `collectCodepoints()` now reuse `static` local vectors that retain their allocated capacity across calls, eliminating ~8 heap allocations per word. Added a `collectCodepoints(word, vec&)` overload for this purpose.

### Correctness verification

Two new regression test suites specifically target every optimized code path:

| Suite | Assertions | What it verifies |
|---|---|---|
| `CssParserRegressionTest` | 502 | Whitespace normalization (tabs, newlines, multiple spaces), case insensitivity, trailing/double semicolons, missing values/colons, all 4 CSS unit types, negative/decimal/zero lengths, grouped selector comma scanning, 15-property stress test, 100x repeated-call leakage test |
| `HyphenationRegressionTest` | 122 | Golden byte-offset values for 17 English words, `collectCodepoints` overload equivalence, buffer reuse safety, bulk-erase edge cases (all-punctuation, single char, footnotes, empty), 500-call determinism check, interleaved short/long word static-buffer test, explicit/soft hyphen detection |

Combined with the 7 existing suites from #764: **9 suites, 808 total assertions, all passing.**

## Additional Context

- Firmware builds successfully with identical RAM/Flash footprint — these are pure algorithmic changes
- `clang-format` passes on all modified files
- The allocation-reuse optimization will have an even larger impact on the actual ESP32-C3 target, where `malloc`/`free` is significantly more expensive than on desktop
- The `static` local pattern is safe because the ESP32-C3 is single-core with no multi-threading