### PR TITLE
perf: Cache section file handle between page loads

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -103,13 +103,15 @@ bool Section::loadSectionFile(const int fontId, const float lineCompression, con
   }
 
   serialization::readPod(file, pageCount);
+  serialization::readPod(file, cachedLutOffset);
   file.close();
   Serial.printf("[%lu] [SCT] Deserialization succeeded: %d pages\n", millis(), pageCount);
   return true;
 }
 
-// Your updated class method (assuming you are using the 'SD' object, which is a wrapper for a specific filesystem)
-bool Section::clearCache() const {
+bool Section::clearCache() {
+  file.close();
+  cachedLutOffset = 0;
   if (!Storage.exists(filePath.c_str())) {
     Serial.printf("[%lu] [SCT] Cache does not exist, no action needed\n", millis());
     return true;
@@ -128,6 +130,9 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
                                 const uint8_t paragraphAlignment, const uint16_t viewportWidth,
                                 const uint16_t viewportHeight, const bool hyphenationEnabled, const bool embeddedStyle,
                                 const std::function<void()>& popupFn) {
+#ifdef CROSSPOINT_PERF_TIMING
+  const auto t0 = millis();
+#endif
   const auto localPath = epub->getSpineItem(spineIndex).href;
   const auto tmpHtmlPath = epub->getCachePath() + "/.tmp_" + std::to_string(spineIndex) + ".html";
 
@@ -196,7 +201,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
     return false;
   }
 
-  const uint32_t lutOffset = file.position();
+  cachedLutOffset = file.position();
   bool hasFailedLutRecords = false;
   // Write LUT
   for (const uint32_t& pos : lut) {
@@ -217,25 +222,37 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   // Go back and write LUT offset
   file.seek(HEADER_SIZE - sizeof(uint32_t) - sizeof(pageCount));
   serialization::writePod(file, pageCount);
-  serialization::writePod(file, lutOffset);
+  serialization::writePod(file, cachedLutOffset);
   file.close();
+
+#ifdef CROSSPOINT_PERF_TIMING
+  Serial.printf("[%lu] [SCT] createSectionFile: %lu ms, %d pages\n", millis(), millis() - t0, pageCount);
+#endif
+
   return true;
 }
 
 std::unique_ptr<Page> Section::loadPageFromSectionFile() {
-  if (!Storage.openFileForRead("SCT", filePath, file)) {
-    return nullptr;
+#ifdef CROSSPOINT_PERF_TIMING
+  const auto t0 = millis();
+#endif
+
+  if (!file) {
+    if (!Storage.openFileForRead("SCT", filePath, file)) {
+      return nullptr;
+    }
   }
 
-  file.seek(HEADER_SIZE - sizeof(uint32_t));
-  uint32_t lutOffset;
-  serialization::readPod(file, lutOffset);
-  file.seek(lutOffset + sizeof(uint32_t) * currentPage);
+  file.seek(cachedLutOffset + sizeof(uint32_t) * currentPage);
   uint32_t pagePos;
   serialization::readPod(file, pagePos);
   file.seek(pagePos);
 
   auto page = Page::deserialize(file);
-  file.close();
+
+#ifdef CROSSPOINT_PERF_TIMING
+  Serial.printf("[%lu] [SCT] loadPage %d: %lu ms\n", millis(), currentPage, millis() - t0);
+#endif
+
   return page;
 }

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -13,6 +13,7 @@ class Section {
   GfxRenderer& renderer;
   std::string filePath;
   FsFile file;
+  uint32_t cachedLutOffset = 0;
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
@@ -28,10 +29,10 @@ class Section {
         spineIndex(spineIndex),
         renderer(renderer),
         filePath(epub->getCachePath() + "/sections/" + std::to_string(spineIndex) + ".bin") {}
-  ~Section() = default;
+  ~Section() { file.close(); }
   bool loadSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                        uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled, bool embeddedStyle);
-  bool clearCache() const;
+  bool clearCache();
   bool createSectionFile(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                          uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled, bool embeddedStyle,
                          const std::function<void()>& popupFn = nullptr);


### PR DESCRIPTION
## Summary

- Keep the section cache file handle open across page flips instead of opening/closing per page load
- Cache the LUT offset during section load/creation so page lookups can seek directly without re-reading the file header
- Close the file handle on section destruction or cache invalidation

## Why

Previously, every page flip in `loadPageFromSectionFile()` would:
1. Open the section file from SD card
2. Seek to the header to read the LUT offset
3. Seek to the LUT entry for the current page
4. Read the page data
5. Close the file

Steps 1, 2, and 5 are redundant when flipping through pages of the same section. SD card file open/close operations have measurable latency on the ESP32-C3, especially with SPI bus contention.

After this change, the file is opened once (on first page load) and the LUT offset is cached from the initial section load, so each page flip only does two seeks and two reads.

## On-device verification

Includes `#define CROSSPOINT_PERF_TIMING` guarded `millis()` instrumentation in `loadPageFromSectionFile()` and `createSectionFile()`. Enable with `-DCROSSPOINT_PERF_TIMING` in build flags to see timing on serial output.

## Files changed

- `lib/Epub/Epub/Section.h`
- `lib/Epub/Epub/Section.cpp`

## AI Usage

YES

## Test plan

- [ ] Open a book, navigate forward and backward through pages — verify correct rendering
- [ ] Jump to a specific page via "Go to %" — verify correct page loads
- [ ] Switch chapters — verify section transitions work (old file handle closed, new one opened)
- [ ] Change reader settings (font, spacing) — verify cache invalidation triggers rebuild
- [ ] Open multiple books in sequence — verify no file handle leaks