### PR TITLE
fix: Fix heap fragmentation causing XTC page buffer allocation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ First, make sure all required Python packages are installed:
 ```python
 python3 -m pip install pyserial colorama matplotlib
 ```
-after that run the script:
+
+Then run the debugging monitor script:
+
 ```sh
 # For Linux
 # This was tested on Debian and should work on most Linux systems.
@@ -115,6 +117,18 @@ python3 scripts/debugging_monitor.py
 # For macOS
 python3 scripts/debugging_monitor.py /dev/cu.usbmodem2101
 ```
+
+**Note:** If the device resets immediately when connecting the serial monitor, use the `--without-restart` flag to employ low-level POSIX serial handling on Linux/macOS:
+
+```sh
+python3 scripts/debugging_monitor.py --without-restart
+
+# Or with custom port
+python3 scripts/debugging_monitor.py /dev/cu.usbmodem2101 --without-restart
+```
+
+This flag avoids DTR/RTS modem line toggling that can trigger device reset on some systems.
+
 Minor adjustments may be required for Windows.
 
 ## Internals

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -21,6 +21,18 @@ class XtcReaderActivity final : public ActivityWithSubactivity {
   uint32_t currentPage = 0;
   int pagesUntilFullRefresh = 0;
   bool updateRequired = false;
+  /*
+   * Pre-allocated page buffer and its size.
+   * Purpose: reserve one contiguous buffer early (in `onEnter`) sized to the
+   * page bitmap so later renders avoid large `malloc` calls that can fail
+   * due to heap fragmentation immediately after boot. If allocation fails
+   * we fall back to per-render `malloc` and continue normally.
+   *
+   * Lifecycle: allocated in `onEnter()`, reused by `renderPage()` when it
+   * fits, and freed in `onExit()`.
+   */
+  uint8_t* preallocPageBuffer = nullptr;
+  size_t preallocPageBufferSize = 0;
   const std::function<void()> onGoBack;
   const std::function<void()> onGoHome;
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Fixes XTC ebook page rendering failures on boot by pre-allocating the page buffer when heap fragmentation is minimal.
* **What changes are included?**

- Pre-allocate ~96KB page buffer in XtcReaderActivity::onEnter()
- Reuse buffer across renders instead of per-render [malloc()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Fall back to dynamic allocation if pre-allocation fails
- Proper cleanup in onExit() to prevent leaks

## Additional Context

- **Root Cause Discovery**: Post-boot heap fragmentation was identified only after adding `--without-restart` flag to the debug monitor, which allowed capture of boot-time logs without device reset. Analysis revealed 178KB free memory split into fragments too small for 96KB allocation.
- **Solution**: Reserve buffer early when heap is contiguous, reuse for all renders
- **Impact**: Eliminates allocation failures; slight memory overhead (~96KB)
- **Backward Compatible**: Full fallback to `malloc()` if needed; no API changes
- **Testing**: Focus on boot rendering, activity re-entry, and fallback scenarios

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
