### PR TITLE
feat: Add QR code text input option in keyboard

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -128,8 +128,13 @@ void KeyboardEntryActivity::loop() {
       webInputServer->handleClient();
       if (webInputServer->hasReceivedText()) {
         std::string received = webInputServer->consumeReceivedText();
-        if (maxLength > 0 && text.length() + received.length() > maxLength) {
-          received.resize(maxLength - text.length());
+        if (maxLength > 0) {
+          const size_t remaining = text.length() < maxLength ? maxLength - text.length() : 0;
+          if (remaining == 0) {
+            received.clear();
+          } else if (received.length() > remaining) {
+            received.resize(remaining);
+          }
         }
         text += received;
         stopWebInputServer();

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -11,7 +11,7 @@
 // Keyboard layouts - lowercase
 const char* const KeyboardEntryActivity::keyboard[NUM_ROWS] = {
     "`1234567890-=", "qwertyuiop[]\\", "asdfghjkl;'", "zxcvbnm,./",
-  "^  ____<QR OK"  // ^ = shift, _ = space, < = backspace, QR = remote input, OK = done
+    "^  ____<QR OK"  // ^ = shift, _ = space, < = backspace, QR = remote input, OK = done
 };
 
 // Keyboard layouts - uppercase/symbols
@@ -375,6 +375,7 @@ void KeyboardEntryActivity::renderQRScreen() const {
 
   if (webInputServer && webInputServer->isRunning()) {
     if (webInputServer->isApMode()) {
+      // === AP mode layout (matching File Transfer) ===
       int apStartY = 55;
 
       renderer.drawCenteredText(UI_10_FONT_ID, apStartY, "Hotspot Mode", true, EpdFontFamily::BOLD);
@@ -382,8 +383,7 @@ void KeyboardEntryActivity::renderQRScreen() const {
       std::string ssidInfo = "Network: " + webInputServer->getApSSID();
       renderer.drawCenteredText(UI_10_FONT_ID, apStartY + LINE_SPACING, ssidInfo.c_str());
 
-      renderer.drawCenteredText(SMALL_FONT_ID, apStartY + LINE_SPACING * 2,
-                                "Connect your device to this WiFi network");
+      renderer.drawCenteredText(SMALL_FONT_ID, apStartY + LINE_SPACING * 2, "Connect your device to this WiFi network");
       renderer.drawCenteredText(SMALL_FONT_ID, apStartY + LINE_SPACING * 3,
                                 "or scan QR code with your phone to connect to Wifi.");
 
@@ -402,6 +402,7 @@ void KeyboardEntryActivity::renderQRScreen() const {
       QRCodeHelper::drawQRCode(renderer, (pageWidth - QR_TOTAL) / 2, apStartY + LINE_SPACING * 7, url);
 
     } else {
+      // === STA mode layout (WiFi already connected, matching File Transfer) ===
       constexpr int staStartY = 65;
 
       const std::string ip = webInputServer->getIP();
@@ -409,8 +410,7 @@ void KeyboardEntryActivity::renderQRScreen() const {
       renderer.drawCenteredText(UI_10_FONT_ID, staStartY, ipInfo.c_str());
 
       std::string webUrl = "http://" + ip + "/";
-      renderer.drawCenteredText(UI_10_FONT_ID, staStartY + LINE_SPACING * 2, webUrl.c_str(), true,
-                                EpdFontFamily::BOLD);
+      renderer.drawCenteredText(UI_10_FONT_ID, staStartY + LINE_SPACING * 2, webUrl.c_str(), true, EpdFontFamily::BOLD);
 
       std::string hostnameUrl = std::string("or http://") + NetworkConstants::AP_HOSTNAME + ".local/";
       renderer.drawCenteredText(SMALL_FONT_ID, staStartY + LINE_SPACING * 3, hostnameUrl.c_str());

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -2,10 +2,12 @@
 #include <GfxRenderer.h>
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <utility>
 
 #include "../Activity.h"
+#include "network/KeyboardWebInputServer.h"
 #include "util/ButtonNavigator.h"
 
 /**
@@ -69,10 +71,14 @@ class KeyboardEntryActivity : public Activity {
   int selectedRow = 0;
   int selectedCol = 0;
   int shiftState = 0;  // 0 = lower case, 1 = upper case, 2 = shift lock)
+  bool showingQR = false;
 
   // Callbacks
   OnCompleteCallback onComplete;
   OnCancelCallback onCancel;
+
+  // Remote text input server
+  std::unique_ptr<KeyboardWebInputServer> webInputServer;
 
   // Keyboard layout
   static constexpr int NUM_ROWS = 5;
@@ -85,11 +91,15 @@ class KeyboardEntryActivity : public Activity {
   static constexpr int SPECIAL_ROW = 4;
   static constexpr int SHIFT_COL = 0;
   static constexpr int SPACE_COL = 2;
-  static constexpr int BACKSPACE_COL = 7;
-  static constexpr int DONE_COL = 9;
+  static constexpr int BACKSPACE_COL = 6;
+  static constexpr int QR_COL = 8;
+  static constexpr int DONE_COL = 10;
 
   char getSelectedChar() const;
   void handleKeyPress();
   int getRowLength(int row) const;
+  void renderQRScreen() const;
   void renderItemWithSelector(int x, int y, const char* item, bool isSelected) const;
+  void startWebInputServer();
+  void stopWebInputServer();
 };

--- a/src/network/KeyboardWebInputServer.cpp
+++ b/src/network/KeyboardWebInputServer.cpp
@@ -1,0 +1,187 @@
+#include "KeyboardWebInputServer.h"
+
+#include <ESPmDNS.h>
+#include <WiFi.h>
+#include <esp_wifi.h>
+
+#include "NetworkConstants.h"
+#include "html/TextInputPageHtml.generated.h"
+
+KeyboardWebInputServer::~KeyboardWebInputServer() { stop(); }
+
+bool KeyboardWebInputServer::start() {
+  if (running) {
+    return true;
+  }
+
+  Serial.printf("[%lu] [KB-WEB] Starting keyboard web input server...\n", millis());
+
+  // Save current WiFi sleep mode to restore later
+  wifi_ps_type_t psType;
+  if (esp_wifi_get_ps(&psType) == ESP_OK) {
+    previousSleepMode = psType;
+  }
+
+  // Check if WiFi is already connected in STA mode
+  const wifi_mode_t wifiMode = WiFi.getMode();
+  const bool isStaConnected = (wifiMode & WIFI_MODE_STA) && (WiFi.status() == WL_CONNECTED);
+
+  if (isStaConnected) {
+    // Reuse existing WiFi connection
+    apModeStarted = false;
+    ipAddress = WiFi.localIP().toString().c_str();
+    Serial.printf("[%lu] [KB-WEB] Using existing STA connection, IP: %s\n", millis(), ipAddress.c_str());
+  } else {
+    // Start our own Access Point
+    Serial.printf("[%lu] [KB-WEB] No WiFi connection, starting AP...\n", millis());
+
+    WiFi.mode(WIFI_AP);
+    delay(100);
+
+    if (NetworkConstants::AP_PASSWORD && strlen(NetworkConstants::AP_PASSWORD) >= 8) {
+      WiFi.softAP(NetworkConstants::AP_SSID, NetworkConstants::AP_PASSWORD, NetworkConstants::AP_CHANNEL, false,
+                  NetworkConstants::AP_MAX_CONNECTIONS);
+    } else {
+      WiFi.softAP(NetworkConstants::AP_SSID, nullptr, NetworkConstants::AP_CHANNEL, false,
+                  NetworkConstants::AP_MAX_CONNECTIONS);
+    }
+
+    // Wait for AP to fully initialize
+    delay(100);
+
+    const IPAddress apIP = WiFi.softAPIP();
+    ipAddress = apIP.toString().c_str();
+    apModeStarted = true;
+
+    Serial.printf("[%lu] [KB-WEB] AP started - SSID: %s, IP: %s\n", millis(), NetworkConstants::AP_SSID,
+                  ipAddress.c_str());
+
+    // Start DNS server for captive portal behavior
+    // This redirects all DNS queries to our IP, making any domain resolve to us
+    dnsServer.reset(new DNSServer());
+    dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
+    dnsServer->start(NetworkConstants::DNS_PORT, "*", apIP);
+    Serial.printf("[%lu] [KB-WEB] DNS server started for captive portal\n", millis());
+  }
+
+  // Start mDNS
+  if (MDNS.begin(NetworkConstants::AP_HOSTNAME)) {
+    MDNS.addService("http", "tcp", NetworkConstants::HTTP_PORT);
+    Serial.printf("[%lu] [KB-WEB] mDNS started: http://%s.local/\n", millis(), NetworkConstants::AP_HOSTNAME);
+  }
+
+  // Disable WiFi sleep for responsiveness
+  WiFi.setSleep(false);
+
+  // Create and start web server
+  server.reset(new WebServer(NetworkConstants::HTTP_PORT));
+  setupRoutes();
+  server->begin();
+
+  running = true;
+  textReceived = false;
+  receivedText.clear();
+
+  Serial.printf("[%lu] [KB-WEB] Server started on port %d\n", millis(), NetworkConstants::HTTP_PORT);
+  return true;
+}
+
+void KeyboardWebInputServer::stop() {
+  if (!running) {
+    return;
+  }
+
+  Serial.printf("[%lu] [KB-WEB] Stopping keyboard web input server...\n", millis());
+
+  if (server) {
+    server->stop();
+    server.reset();
+  }
+
+  MDNS.end();
+
+  // Stop DNS server if running (AP mode captive portal)
+  if (dnsServer) {
+    dnsServer->stop();
+    dnsServer.reset();
+    Serial.printf("[%lu] [KB-WEB] DNS server stopped\n", millis());
+  }
+
+  // Brief wait for LWIP stack to flush pending packets
+  delay(50);
+
+  if (apModeStarted) {
+    WiFi.softAPdisconnect(true);
+    delay(30);
+    WiFi.mode(WIFI_OFF);
+    apModeStarted = false;
+    Serial.printf("[%lu] [KB-WEB] AP stopped\n", millis());
+  } else {
+    // Restore previous WiFi sleep mode
+    esp_wifi_set_ps(previousSleepMode);
+  }
+
+  running = false;
+  Serial.printf("[%lu] [KB-WEB] Server stopped\n", millis());
+}
+
+void KeyboardWebInputServer::handleClient() {
+  if (running && server) {
+    server->handleClient();
+  }
+  // Process DNS requests for captive portal (AP mode)
+  if (running && dnsServer) {
+    dnsServer->processNextRequest();
+  }
+}
+
+std::string KeyboardWebInputServer::consumeReceivedText() {
+  textReceived = false;
+  std::string result = std::move(receivedText);
+  receivedText.clear();
+  return result;
+}
+
+std::string KeyboardWebInputServer::getApSSID() const { return NetworkConstants::AP_SSID; }
+
+std::string KeyboardWebInputServer::getUrl() const {
+  if (apModeStarted) {
+    return std::string("http://") + NetworkConstants::AP_HOSTNAME + ".local/";
+  }
+  return "http://" + ipAddress + "/";
+}
+
+std::string KeyboardWebInputServer::getWifiQRString() const {
+  return std::string("WIFI:S:") + NetworkConstants::AP_SSID + ";;";
+}
+
+void KeyboardWebInputServer::setupRoutes() {
+  server->on("/", HTTP_GET, [this] { handleRootPage(); });
+  server->on("/api/keyboard-input", HTTP_POST, [this] { handleTextSubmit(); });
+
+  // Captive portal: redirect any unknown page to root
+  server->onNotFound([this] {
+    server->sendHeader("Location", "/", true);
+    server->send(302, "text/plain", "Redirecting...");
+  });
+}
+
+void KeyboardWebInputServer::handleRootPage() {
+  server->send(200, "text/html", TextInputPageHtml);
+  Serial.printf("[%lu] [KB-WEB] Served text input page\n", millis());
+}
+
+void KeyboardWebInputServer::handleTextSubmit() {
+  if (!server->hasArg("text")) {
+    server->send(400, "text/plain", "Missing 'text' parameter");
+    return;
+  }
+
+  receivedText = server->arg("text").c_str();
+  textReceived = true;
+
+  Serial.printf("[%lu] [KB-WEB] Received text (%zu chars): %.40s%s\n", millis(), receivedText.length(),
+                receivedText.c_str(), receivedText.length() > 40 ? "..." : "");
+
+  server->send(200, "text/plain", "OK");
+}

--- a/src/network/KeyboardWebInputServer.h
+++ b/src/network/KeyboardWebInputServer.h
@@ -63,9 +63,14 @@ class KeyboardWebInputServer {
 
   /**
    * Get the WiFi QR code string for connecting to the AP.
-   * Format: WIFI:S:<ssid>;;
+   * Format: WIFI:T:nopass;S:<ssid>;;
    */
   std::string getWifiQRString() const;
+
+  /**
+   * Get the session PIN displayed on screen for request validation.
+   */
+  std::string getSessionPin() const { return sessionPin; }
 
   /**
    * Get the device IP address.
@@ -82,8 +87,11 @@ class KeyboardWebInputServer {
   bool textReceived = false;
   std::string receivedText;
   std::string ipAddress;
+  std::string sessionPin;
   wifi_ps_type_t previousSleepMode = WIFI_PS_NONE;
 
+  static std::string generateSessionPin();
+  static std::string escapeWifiSpecialChars(const std::string& input);
   void setupRoutes();
   void handleRootPage();
   void handleTextSubmit();

--- a/src/network/KeyboardWebInputServer.h
+++ b/src/network/KeyboardWebInputServer.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <DNSServer.h>
+#include <WebServer.h>
+#include <WiFi.h>
+
+#include <memory>
+#include <string>
+
+/**
+ * Lightweight web server for remote text input via a phone/browser.
+ * Used by KeyboardEntryActivity to allow users to type text on their
+ * phone instead of using the on-screen keyboard on the e-ink display.
+ *
+ * If WiFi is already connected (STA mode), it reuses the existing connection.
+ * Otherwise, it creates a WiFi Access Point so the phone can connect directly.
+ */
+class KeyboardWebInputServer {
+ public:
+  KeyboardWebInputServer() = default;
+  ~KeyboardWebInputServer();
+
+  /**
+   * Start the server. Creates an AP if WiFi is not already connected.
+   * @return true if started successfully
+   */
+  bool start();
+
+  /**
+   * Stop the server and clean up WiFi AP if we started one.
+   */
+  void stop();
+
+  /**
+   * Call periodically from the activity loop to handle incoming HTTP requests.
+   */
+  void handleClient();
+
+  /**
+   * Check if text has been received since last call to consumeReceivedText().
+   */
+  bool hasReceivedText() const { return textReceived; }
+
+  /**
+   * Get the received text and clear the received flag.
+   */
+  std::string consumeReceivedText();
+
+  /**
+   * Get the URL for QR code display.
+   */
+  std::string getUrl() const;
+
+  /**
+   * Check if the server started its own AP (vs reusing STA connection).
+   */
+  bool isApMode() const { return apModeStarted; }
+
+  /**
+   * Get the AP SSID (for WiFi QR code). Only meaningful if isApMode() is true.
+   */
+  std::string getApSSID() const;
+
+  /**
+   * Get the WiFi QR code string for connecting to the AP.
+   * Format: WIFI:S:<ssid>;;
+   */
+  std::string getWifiQRString() const;
+
+  /**
+   * Get the device IP address.
+   */
+  std::string getIP() const { return ipAddress; }
+
+  bool isRunning() const { return running; }
+
+ private:
+  std::unique_ptr<WebServer> server;
+  std::unique_ptr<DNSServer> dnsServer;
+  bool running = false;
+  bool apModeStarted = false;
+  bool textReceived = false;
+  std::string receivedText;
+  std::string ipAddress;
+  wifi_ps_type_t previousSleepMode = WIFI_PS_NONE;
+
+  void setupRoutes();
+  void handleRootPage();
+  void handleTextSubmit();
+};

--- a/src/network/NetworkConstants.h
+++ b/src/network/NetworkConstants.h
@@ -1,0 +1,18 @@
+#pragma once
+
+/**
+ * Shared network constants used by both the File Transfer web server
+ * (CrossPointWebServerActivity) and the Keyboard remote input server
+ * (KeyboardWebInputServer).
+ */
+namespace NetworkConstants {
+
+constexpr const char* AP_SSID = "CrossPoint-Reader";
+constexpr const char* AP_PASSWORD = nullptr;  // Open network for ease of use
+constexpr const char* AP_HOSTNAME = "crosspoint";
+constexpr uint8_t AP_CHANNEL = 1;
+constexpr uint8_t AP_MAX_CONNECTIONS = 4;
+constexpr uint16_t HTTP_PORT = 80;
+constexpr uint16_t DNS_PORT = 53;
+
+}  // namespace NetworkConstants

--- a/src/network/html/TextInputPage.html
+++ b/src/network/html/TextInputPage.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CrossPoint - Text Input</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5; color: #333;
+      display: flex; flex-direction: column; align-items: center;
+      min-height: 100vh; padding: 20px;
+    }
+    .container {
+      width: 100%; max-width: 500px;
+      background: white; border-radius: 12px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+      padding: 24px; margin-top: 20px;
+    }
+    h1 {
+      text-align: center; font-size: 22px;
+      margin-bottom: 8px; color: #222;
+    }
+    .subtitle {
+      text-align: center; color: #666;
+      font-size: 14px; margin-bottom: 20px;
+    }
+    textarea {
+      width: 100%; height: 120px;
+      font-size: 18px; padding: 12px;
+      border: 2px solid #ddd; border-radius: 8px;
+      resize: vertical; outline: none;
+      transition: border-color 0.2s;
+    }
+    textarea:focus { border-color: #007bff; }
+    .btn {
+      width: 100%; padding: 16px;
+      font-size: 18px; font-weight: 600;
+      color: white; border: none; border-radius: 8px;
+      cursor: pointer; margin-top: 12px;
+      transition: opacity 0.2s;
+    }
+    .btn:active { opacity: 0.8; }
+    .btn-send { background: #007bff; }
+    .btn-send:disabled { background: #aaa; cursor: not-allowed; }
+    .status {
+      text-align: center; margin-top: 16px;
+      font-size: 16px; min-height: 24px;
+    }
+    .status.success { color: #28a745; }
+    .status.error { color: #dc3545; }
+    .status.sending { color: #666; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>&#9000; CrossPoint Text Input</h1>
+    <p class="subtitle">Type your text and send it to the device</p>
+    <textarea id="textInput" autofocus placeholder="Type your text here..."></textarea>
+    <button class="btn btn-send" id="sendBtn" onclick="sendText()">Send to Device</button>
+    <div class="status" id="status"></div>
+  </div>
+  <script>
+    const textInput = document.getElementById('textInput');
+    const sendBtn = document.getElementById('sendBtn');
+    const statusEl = document.getElementById('status');
+
+    async function sendText() {
+      const text = textInput.value;
+      if (!text) {
+        statusEl.className = 'status error';
+        statusEl.textContent = 'Please enter some text';
+        return;
+      }
+      sendBtn.disabled = true;
+      statusEl.className = 'status sending';
+      statusEl.textContent = 'Sending...';
+      try {
+        const resp = await fetch('/api/keyboard-input', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'text=' + encodeURIComponent(text)
+        });
+        if (resp.ok) {
+          statusEl.className = 'status success';
+          statusEl.textContent = '✓ Text sent successfully!';
+          textInput.value = '';
+        } else {
+          throw new Error('Server error');
+        }
+      } catch (e) {
+        statusEl.className = 'status error';
+        statusEl.textContent = '✗ Failed to send. Try again.';
+      }
+      sendBtn.disabled = false;
+    }
+
+    // Allow Ctrl+Enter to send
+    textInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+        sendText();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/src/network/html/TextInputPage.html
+++ b/src/network/html/TextInputPage.html
@@ -57,6 +57,7 @@
   <div class="container">
     <h1>&#9000; CrossPoint Text Input</h1>
     <p class="subtitle">Type your text and send it to the device</p>
+    <p class="subtitle" style="font-weight:600;color:#007bff;">Session PIN: {{SESSION_PIN}}</p>
     <textarea id="textInput" autofocus placeholder="Type your text here..."></textarea>
     <button class="btn btn-send" id="sendBtn" onclick="sendText()">Send to Device</button>
     <div class="status" id="status"></div>
@@ -80,7 +81,7 @@
         const resp = await fetch('/api/keyboard-input', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: 'text=' + encodeURIComponent(text)
+          body: 'pin={{SESSION_PIN}}&text=' + encodeURIComponent(text)
         });
         if (resp.ok) {
           statusEl.className = 'status success';

--- a/src/util/QRCodeHelper.h
+++ b/src/util/QRCodeHelper.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <GfxRenderer.h>
+#include <qrcode.h>
+
+#include <string>
+
+/**
+ * Shared QR code rendering utility.
+ * Renders a Version 4 QR code (33 modules) with ECC_LOW on an e-ink display.
+ */
+namespace QRCodeHelper {
+
+/// Version 4 QR code = 33 modules per side
+constexpr uint8_t QR_MODULES = 33;
+
+/// Default pixels per QR module (same as File Transfer)
+constexpr uint8_t DEFAULT_PX = 6;
+
+/**
+ * Draw a QR code on the display.
+ * @param renderer  The GfxRenderer to draw on
+ * @param x         Top-left X coordinate
+ * @param y         Top-left Y coordinate
+ * @param data      The data to encode in the QR code
+ * @param px        Pixels per QR module (default: 6)
+ */
+inline void drawQRCode(const GfxRenderer& renderer, const int x, const int y, const std::string& data,
+                       const uint8_t px = DEFAULT_PX) {
+  QRCode qrcode;
+  uint8_t qrcodeBytes[qrcode_getBufferSize(4)];
+  qrcode_initText(&qrcode, qrcodeBytes, 4, ECC_LOW, data.c_str());
+  for (uint8_t cy = 0; cy < qrcode.size; cy++) {
+    for (uint8_t cx = 0; cx < qrcode.size; cx++) {
+      if (qrcode_getModule(&qrcode, cx, cy)) {
+        renderer.fillRect(x + px * cx, y + px * cy, px, px, true);
+      }
+    }
+  }
+}
+
+/**
+ * Calculate the total pixel size of a QR code.
+ * @param px  Pixels per module
+ * @return    Total size in pixels (width = height)
+ */
+constexpr int qrSize(const uint8_t px = DEFAULT_PX) { return px * QR_MODULES; }
+
+}  // namespace QRCodeHelper


### PR DESCRIPTION
## Summary
* **What is the goal of this PR?** 
  Add a QR code option to the on-screen keyboard that allows users to enter text from their phone instead of navigating the on-screen keyboard with the device buttons. This makes entering WiFi passwords, URLs, and other text much faster and easier.
* **What changes are included?**
  - New `KeyboardWebInputServer` class that serves a mobile-friendly HTML input page
  - New QR button added to the keyboard layout (between backspace and OK)
  - When pressed, displays a QR code that opens a text input page on the user's phone
  - If WiFi is already connected, reuses that connection; otherwise creates a temporary WiFi AP
  - Text submitted from the phone is automatically inserted into the keyboard input field
  - Helper utilities for QR code rendering and network constants
## Additional Context
* This feature is especially useful for:
  - Entering WiFi passwords (the most painful use case currently)
  - Entering long URLs for OPDS servers
  - Entering KOReader sync credentials
* The temporary AP mode ensures this works even before WiFi is configured
* The web page is responsive and works well on both iOS and Android

| | | | |
|:---:|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/4d0c1cee-5b25-418b-a1dd-b013514fa051" width="200"> | <img src="https://github.com/user-attachments/assets/05aa1fab-0da4-44a7-be91-a776252acb10" width="200"> | <img src="https://github.com/user-attachments/assets/8f7b25ab-ffd7-4647-a1c4-e3b9d2c0b0a2" width="200">  | <img src="https://github.com/user-attachments/assets/69a079be-6b6c-4d0f-bc77-ea702cc2a0b3" width="200"> |

---
### AI Usage
Did you use AI tools to help write this code? _**YES**_