### PR TITLE
feat: show loading progress when opening an EPUB for the first time

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -329,7 +329,8 @@ void Epub::parseCssFiles() const {
 }
 
 // load in the meta data for the epub file
-bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
+bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss,
+                const std::function<void(int progress)>& progressFn) {
   LOG_DBG("EBP", "Loading ePub: %s", filepath.c_str());
 
   // Initialize spine/TOC cache
@@ -361,6 +362,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   LOG_DBG("EBP", "Cache not found, building spine/TOC cache");
   setupCacheDir();
 
+  if (progressFn) {
+    progressFn(0);
+  }
+
   const uint32_t indexingStart = millis();
 
   // Begin building cache - stream entries to disk immediately
@@ -385,6 +390,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
     return false;
   }
   LOG_DBG("EBP", "OPF pass completed in %lu ms", millis() - opfStart);
+
+  if (progressFn) {
+    progressFn(30);
+  }
 
   // TOC Pass - try EPUB 3 nav first, fall back to NCX
   const uint32_t tocStart = millis();
@@ -418,6 +427,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   }
   LOG_DBG("EBP", "TOC pass completed in %lu ms", millis() - tocStart);
 
+  if (progressFn) {
+    progressFn(60);
+  }
+
   // Close the cache files
   if (!bookMetadataCache->endWrite()) {
     LOG_ERR("EBP", "Could not end writing cache");
@@ -433,6 +446,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   LOG_DBG("EBP", "buildBookBin completed in %lu ms", millis() - buildStart);
   LOG_DBG("EBP", "Total indexing completed in %lu ms", millis() - indexingStart);
 
+  if (progressFn) {
+    progressFn(85);
+  }
+
   if (!bookMetadataCache->cleanupTmpFiles()) {
     LOG_DBG("EBP", "Could not cleanup tmp files - ignoring");
   }
@@ -447,6 +464,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   if (!skipLoadingCss) {
     // Parse CSS files after cache reload
     parseCssFiles();
+  }
+
+  if (progressFn) {
+    progressFn(100);
   }
 
   LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -2,6 +2,7 @@
 
 #include <Print.h>
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -43,7 +44,8 @@ class Epub {
   }
   ~Epub() = default;
   std::string& getBasePath() { return contentBasePath; }
-  bool load(bool buildIfMissing = true, bool skipLoadingCss = false);
+  bool load(bool buildIfMissing = true, bool skipLoadingCss = false,
+            const std::function<void(int progress)>& progressFn = nullptr);
   bool clearCache() const;
   void setupCacheDir() const;
   const std::string& getCachePath() const;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -1,6 +1,7 @@
 #include "ReaderActivity.h"
 
 #include <HalStorage.h>
+#include <I18n.h>
 
 #include "CrossPointSettings.h"
 #include "Epub.h"
@@ -10,6 +11,7 @@
 #include "Xtc.h"
 #include "XtcReaderActivity.h"
 #include "activities/util/FullScreenMessageActivity.h"
+#include "components/UITheme.h"
 #include "util/StringUtils.h"
 
 std::string ReaderActivity::extractFolderPath(const std::string& filePath) {
@@ -36,7 +38,19 @@ std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
   }
 
   auto epub = std::unique_ptr<Epub>(new Epub(path, "/.crosspoint"));
-  if (epub->load(true, SETTINGS.embeddedStyle == 0)) {
+
+  bool popupShown = false;
+  Rect popupRect;
+  const auto progressFn = [this, &popupShown, &popupRect](int progress) {
+    if (!popupShown) {
+      popupShown = true;
+      renderer.clearScreen();
+      popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
+    }
+    GUI.fillPopupProgress(renderer, popupRect, progress);
+  };
+
+  if (epub->load(true, SETTINGS.embeddedStyle == 0, progressFn)) {
     return epub;
   }
 

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -44,7 +44,6 @@ std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
   const auto progressFn = [this, &popupShown, &popupRect](int progress) {
     if (!popupShown) {
       popupShown = true;
-      renderer.clearScreen();
       popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
     }
     GUI.fillPopupProgress(renderer, popupRect, progress);

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -13,7 +13,7 @@ class ReaderActivity final : public ActivityWithSubactivity {
   std::string currentBookPath;  // Track current book path for navigation
   const std::function<void()> onGoBack;
   const std::function<void(const std::string&)> onGoToLibrary;
-  static std::unique_ptr<Epub> loadEpub(const std::string& path);
+  std::unique_ptr<Epub> loadEpub(const std::string& path);
   static std::unique_ptr<Xtc> loadXtc(const std::string& path);
   static std::unique_ptr<Txt> loadTxt(const std::string& path);
   static bool isXtcFile(const std::string& path);


### PR DESCRIPTION
Add a progress popup with bar during initial book metadata parsing (OPF, TOC, book.bin, CSS) so users get visual feedback when opening large EPUBs. Reuses the existing drawPopup/fillPopupProgress UI.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**
