### PR TITLE
fix: Enable DESTRUCTOR_CLOSES_FILE flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ build_flags =
   -DMINIZ_NO_STDIO=1
   -DEINK_DISPLAY_SINGLE_BUFFER_MODE=1
   -DDISABLE_FS_H_WARNING=1
+  -DDESTRUCTOR_CLOSES_FILE=1
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
@@ -90,4 +91,3 @@ build_flags =
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
-  


### PR DESCRIPTION
## Summary

* Enable `DESTRUCTOR_CLOSES_FILE` flag
* We're never intending to not close files, so if we accidentally leave them open as they're destructured, this will help close them.

## Additional Context

* As spotted in https://github.com/crosspoint-reader/crosspoint-reader/pull/869, there are cases where we were accidentally not closing files

Looks to use about 5K of flash.

```
RAM:   [===       ]  31.5% (used 103100 bytes from 327680 bytes)
Flash: [=======   ]  68.9% (used 4513220 bytes from 6553600 bytes)
```

```
RAM:   [===       ]  31.5% (used 103100 bytes from 327680 bytes)
Flash: [=======   ]  68.9% (used 4518498 bytes from 6553600 bytes)
```


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? No
