### PR TITLE
feat: Reading progress and time on recent books

### DIFF
--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -249,6 +249,8 @@ bool JsonSettingsIO::saveRecentBooks(const RecentBooksStore& store, const char* 
     obj["title"] = book.title;
     obj["author"] = book.author;
     obj["coverBmpPath"] = book.coverBmpPath;
+    obj["progressPercent"] = book.progressPercent;
+    obj["readingSeconds"] = book.readingSeconds;
   }
 
   String json;
@@ -273,6 +275,14 @@ bool JsonSettingsIO::loadRecentBooks(RecentBooksStore& store, const char* json) 
     book.title = obj["title"] | std::string("");
     book.author = obj["author"] | std::string("");
     book.coverBmpPath = obj["coverBmpPath"] | std::string("");
+    book.progressPercent = obj["progressPercent"] | -1;
+    if (book.progressPercent > 100) {
+      book.progressPercent = 100;
+    }
+    if (book.progressPercent < -1) {
+      book.progressPercent = -1;
+    }
+    book.readingSeconds = obj["readingSeconds"] | 0;
     store.recentBooks.push_back(book);
   }
 

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -1,6 +1,7 @@
 #include "RecentBooksStore.h"
 
 #include <Epub.h>
+#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <JsonSettingsIO.h>
 #include <Logging.h>
@@ -9,6 +10,8 @@
 
 #include <algorithm>
 
+#include "components/themes/BaseTheme.h"
+#include "fontIds.h"
 #include "util/StringUtils.h"
 
 namespace {
@@ -17,27 +20,37 @@ constexpr char RECENT_BOOKS_FILE_BIN[] = "/.crosspoint/recent.bin";
 constexpr char RECENT_BOOKS_FILE_JSON[] = "/.crosspoint/recent.json";
 constexpr char RECENT_BOOKS_FILE_BAK[] = "/.crosspoint/recent.bin.bak";
 constexpr int MAX_RECENT_BOOKS = 10;
+constexpr int16_t UNKNOWN_PROGRESS_PERCENT = -1;
+constexpr uint32_t INITIAL_READING_SECONDS = 0;
+constexpr int BASE_CONTENT_WIDTH_OFFSET = 5;
+constexpr int SUBTITLE_RIGHT_GAP = 8;
 }  // namespace
 
 RecentBooksStore RecentBooksStore::instance;
 
 void RecentBooksStore::addBook(const std::string& path, const std::string& title, const std::string& author,
                                const std::string& coverBmpPath) {
+  int16_t progressPercent = UNKNOWN_PROGRESS_PERCENT;
+  uint32_t readingSeconds = INITIAL_READING_SECONDS;
+
   // Remove existing entry if present
   auto it =
       std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
   if (it != recentBooks.end()) {
+    progressPercent = it->progressPercent;
+    readingSeconds = it->readingSeconds;
     recentBooks.erase(it);
   }
 
   // Add to front
-  recentBooks.insert(recentBooks.begin(), {path, title, author, coverBmpPath});
+  recentBooks.insert(recentBooks.begin(), {path, title, author, coverBmpPath, progressPercent, readingSeconds});
 
   // Trim to max size
   if (recentBooks.size() > MAX_RECENT_BOOKS) {
     recentBooks.resize(MAX_RECENT_BOOKS);
   }
 
+  refreshComputedFields(recentBooks.front());
   saveToFile();
 }
 
@@ -50,9 +63,100 @@ void RecentBooksStore::updateBook(const std::string& path, const std::string& ti
     book.title = title;
     book.author = author;
     book.coverBmpPath = coverBmpPath;
+    refreshComputedFields(book);
     saveToFile();
   }
 }
+
+void RecentBooksStore::updateBookProgress(const std::string& path, const int16_t progressPercent) {
+  const int16_t clamped = std::max<int16_t>(0, std::min<int16_t>(100, progressPercent));
+  auto it =
+      std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
+  if (it == recentBooks.end() || it->progressPercent == clamped) {
+    return;
+  }
+
+  it->progressPercent = clamped;
+  refreshComputedFields(*it);
+  saveToFile();
+}
+
+void RecentBooksStore::addBookReadingTime(const std::string& path, const uint32_t elapsedSeconds) {
+  if (elapsedSeconds == 0) {
+    return;
+  }
+
+  auto it =
+      std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
+  if (it == recentBooks.end()) {
+    return;
+  }
+
+  const uint32_t previous = it->readingSeconds;
+  it->readingSeconds += elapsedSeconds;
+  if (it->readingSeconds < previous) {
+    it->readingSeconds = UINT32_MAX;
+  }
+  refreshComputedFields(*it);
+  saveToFile();
+}
+
+std::vector<RecentBookListRowData> RecentBooksStore::buildListRowData(const std::vector<RecentBook>& books,
+                                                                      const GfxRenderer& renderer,
+                                                                      const ThemeMetrics& metrics, const int pageWidth,
+                                                                      const int contentHeight) const {
+  std::vector<RecentBookListRowData> rows;
+  rows.reserve(books.size());
+  const int rowHeight = metrics.listWithSubtitleRowHeight;
+  const int pageItems = std::max(1, contentHeight / rowHeight);
+  const int totalPages = (static_cast<int>(books.size()) + pageItems - 1) / pageItems;
+  const int contentWidth = pageWidth - (totalPages > 1 ? (metrics.scrollBarWidth + metrics.scrollBarRightOffset)
+                                                       : BASE_CONTENT_WIDTH_OFFSET);
+  const int subtitleFont = UI_10_FONT_ID;
+  const int subtitleLeftX = metrics.contentSidePadding;
+
+  for (const auto& book : books) {
+    RecentBookListRowData row;
+    row.metricsRightText = book.metricsSubtitle;
+    const int rightWidth = renderer.getTextWidth(subtitleFont, row.metricsRightText.c_str());
+    row.metricsRightX = contentWidth - metrics.contentSidePadding - rightWidth;
+    const int maxAuthorWidth = std::max(0, row.metricsRightX - subtitleLeftX - SUBTITLE_RIGHT_GAP);
+    row.authorSubtitle = renderer.truncatedText(subtitleFont, book.author.c_str(), maxAuthorWidth);
+    rows.push_back(std::move(row));
+  }
+
+  return rows;
+}
+
+void RecentBooksStore::drawMetricsOverlay(const GfxRenderer& renderer,
+                                          const std::vector<RecentBookListRowData>& rowData, const size_t selectorIndex,
+                                          const int contentTop, const int contentHeight,
+                                          const ThemeMetrics& metrics) const {
+  if (rowData.empty()) {
+    return;
+  }
+  const int rowHeight = metrics.listWithSubtitleRowHeight;
+  const int pageItems = std::max(1, contentHeight / rowHeight);
+  const int pageStartIndex = static_cast<int>(selectorIndex) / pageItems * pageItems;
+  const int subtitleFont = UI_10_FONT_ID;
+
+  for (int i = pageStartIndex; i < static_cast<int>(rowData.size()) && i < pageStartIndex + pageItems; i++) {
+    renderer.drawText(subtitleFont, rowData[i].metricsRightX, contentTop + (i % pageItems) * rowHeight + 30,
+                      rowData[i].metricsRightText.c_str(), true);
+  }
+}
+
+int RecentBooksStore::getBookProgressPercent(const RecentBook& book) const {
+  return clampProgressPercent(book.progressPercent);
+}
+
+std::string RecentBooksStore::getBookProgressValue(const RecentBook& book) const { return book.progressValue; }
+
+std::string RecentBooksStore::getBookReadingTime(const RecentBook& book) const {
+  return formatDuration(book.readingSeconds);
+}
+
+std::string RecentBooksStore::getBookMetricsSubtitle(const RecentBook& book) const { return book.metricsSubtitle; }
 
 bool RecentBooksStore::saveToFile() const {
   Storage.mkdir("/.crosspoint");
@@ -74,19 +178,29 @@ RecentBook RecentBooksStore::getDataFromBook(std::string path) const {
   if (StringUtils::checkFileExtension(lastBookFileName, ".epub")) {
     Epub epub(path, "/.crosspoint");
     epub.load(false, true);
-    return RecentBook{path, epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
+    return RecentBook{path,
+                      epub.getTitle(),
+                      epub.getAuthor(),
+                      epub.getThumbBmpPath(),
+                      UNKNOWN_PROGRESS_PERCENT,
+                      INITIAL_READING_SECONDS};
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".xtch") ||
              StringUtils::checkFileExtension(lastBookFileName, ".xtc")) {
     // Handle XTC file
     Xtc xtc(path, "/.crosspoint");
     if (xtc.load()) {
-      return RecentBook{path, xtc.getTitle(), xtc.getAuthor(), xtc.getThumbBmpPath()};
+      return RecentBook{path,
+                        xtc.getTitle(),
+                        xtc.getAuthor(),
+                        xtc.getThumbBmpPath(),
+                        UNKNOWN_PROGRESS_PERCENT,
+                        INITIAL_READING_SECONDS};
     }
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".txt") ||
              StringUtils::checkFileExtension(lastBookFileName, ".md")) {
-    return RecentBook{path, lastBookFileName, "", ""};
+    return RecentBook{path, lastBookFileName, "", "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS};
   }
-  return RecentBook{path, "", "", ""};
+  return RecentBook{path, "", "", "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS};
 }
 
 bool RecentBooksStore::loadFromFile() {
@@ -94,7 +208,10 @@ bool RecentBooksStore::loadFromFile() {
   if (Storage.exists(RECENT_BOOKS_FILE_JSON)) {
     String json = Storage.readFile(RECENT_BOOKS_FILE_JSON);
     if (!json.isEmpty()) {
-      return JsonSettingsIO::loadRecentBooks(*this, json.c_str());
+      if (JsonSettingsIO::loadRecentBooks(*this, json.c_str())) {
+        refreshAllComputedFields();
+        return true;
+      }
     }
   }
 
@@ -136,7 +253,7 @@ bool RecentBooksStore::loadFromBinaryFile() {
         std::string title, author;
         serialization::readString(inputFile, title);
         serialization::readString(inputFile, author);
-        recentBooks.push_back({path, title, author, ""});
+        recentBooks.push_back({path, title, author, "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS});
       } else {
         recentBooks.push_back(book);
       }
@@ -162,7 +279,7 @@ bool RecentBooksStore::loadFromBinaryFile() {
         continue;
       }
 
-      recentBooks.push_back({path, title, author, coverBmpPath});
+      recentBooks.push_back({path, title, author, coverBmpPath, UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS});
     }
 
     if (omitted > 0) {
@@ -179,5 +296,52 @@ bool RecentBooksStore::loadFromBinaryFile() {
 
   inputFile.close();
   LOG_DBG("RBS", "Recent books loaded from binary file (%d entries)", static_cast<int>(recentBooks.size()));
+  refreshAllComputedFields();
   return true;
+}
+
+void RecentBooksStore::refreshComputedFields(RecentBook& book) {
+  if (book.progressPercent < 0) {
+    book.progressValue = "--%";
+  } else {
+    book.progressValue = std::to_string(clampProgressPercent(book.progressPercent)) + "%";
+  }
+  const std::string readText = formatDuration(book.readingSeconds);
+  const std::string remainingText = hasRemainingEstimate(book) ? formatDuration(getRemainingSeconds(book)) : "--";
+  book.metricsSubtitle = readText + " · " + remainingText;
+}
+
+void RecentBooksStore::refreshAllComputedFields() {
+  for (auto& book : recentBooks) {
+    refreshComputedFields(book);
+  }
+}
+
+std::string RecentBooksStore::formatDuration(const uint32_t totalSeconds) {
+  const uint32_t hours = totalSeconds / 3600U;
+  const uint32_t minutes = (totalSeconds % 3600U) / 60U;
+  return std::to_string(hours) + "h " + (minutes < 10 ? "0" : "") + std::to_string(minutes) + "m";
+}
+
+int RecentBooksStore::clampProgressPercent(const int progressPercent) {
+  return std::min(100, std::max(0, progressPercent));
+}
+
+bool RecentBooksStore::hasRemainingEstimate(const RecentBook& book) {
+  return book.progressPercent >= 100 || (book.progressPercent > 0 && book.readingSeconds > 0);
+}
+
+uint32_t RecentBooksStore::getRemainingSeconds(const RecentBook& book) {
+  if (book.progressPercent >= 100) {
+    return 0;
+  }
+
+  if (book.progressPercent <= 0 || book.readingSeconds == 0) {
+    return 0;
+  }
+
+  const float ratio = static_cast<float>(book.progressPercent) / 100.0f;
+  const float estimateTotal = static_cast<float>(book.readingSeconds) / ratio;
+  const uint32_t estimateTotalSeconds = static_cast<uint32_t>(estimateTotal + 0.5f);
+  return (estimateTotalSeconds > book.readingSeconds) ? (estimateTotalSeconds - book.readingSeconds) : 0;
 }

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -1,6 +1,7 @@
 #include "RecentBooksStore.h"
 
 #include <Epub.h>
+#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <JsonSettingsIO.h>
 #include <Logging.h>
@@ -9,6 +10,8 @@
 
 #include <algorithm>
 
+#include "components/themes/BaseTheme.h"
+#include "fontIds.h"
 #include "util/StringUtils.h"
 
 namespace {
@@ -17,27 +20,37 @@ constexpr char RECENT_BOOKS_FILE_BIN[] = "/.crosspoint/recent.bin";
 constexpr char RECENT_BOOKS_FILE_JSON[] = "/.crosspoint/recent.json";
 constexpr char RECENT_BOOKS_FILE_BAK[] = "/.crosspoint/recent.bin.bak";
 constexpr int MAX_RECENT_BOOKS = 10;
+constexpr int16_t UNKNOWN_PROGRESS_PERCENT = -1;
+constexpr uint32_t INITIAL_READING_SECONDS = 0;
+constexpr int BASE_CONTENT_WIDTH_OFFSET = 5;
+constexpr int SUBTITLE_RIGHT_GAP = 8;
 }  // namespace
 
 RecentBooksStore RecentBooksStore::instance;
 
 void RecentBooksStore::addBook(const std::string& path, const std::string& title, const std::string& author,
                                const std::string& coverBmpPath) {
+  int16_t progressPercent = UNKNOWN_PROGRESS_PERCENT;
+  uint32_t readingSeconds = INITIAL_READING_SECONDS;
+
   // Remove existing entry if present
   auto it =
       std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
   if (it != recentBooks.end()) {
+    progressPercent = it->progressPercent;
+    readingSeconds = it->readingSeconds;
     recentBooks.erase(it);
   }
 
   // Add to front
-  recentBooks.insert(recentBooks.begin(), {path, title, author, coverBmpPath});
+  recentBooks.insert(recentBooks.begin(), {path, title, author, coverBmpPath, progressPercent, readingSeconds});
 
   // Trim to max size
   if (recentBooks.size() > MAX_RECENT_BOOKS) {
     recentBooks.resize(MAX_RECENT_BOOKS);
   }
 
+  refreshComputedFields(recentBooks.front());
   saveToFile();
 }
 
@@ -50,8 +63,102 @@ void RecentBooksStore::updateBook(const std::string& path, const std::string& ti
     book.title = title;
     book.author = author;
     book.coverBmpPath = coverBmpPath;
+    refreshComputedFields(book);
     saveToFile();
   }
+}
+
+void RecentBooksStore::updateBookProgress(const std::string& path, const int16_t progressPercent) {
+  const int16_t clamped = std::max<int16_t>(0, std::min<int16_t>(100, progressPercent));
+  auto it =
+      std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
+  if (it == recentBooks.end() || it->progressPercent == clamped) {
+    return;
+  }
+
+  it->progressPercent = clamped;
+  refreshComputedFields(*it);
+  saveToFile();
+}
+
+void RecentBooksStore::addBookReadingTime(const std::string& path, const uint32_t elapsedSeconds) {
+  if (elapsedSeconds == 0) {
+    return;
+  }
+
+  auto it =
+      std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
+  if (it == recentBooks.end()) {
+    return;
+  }
+
+  const uint32_t previous = it->readingSeconds;
+  it->readingSeconds += elapsedSeconds;
+  if (it->readingSeconds < previous) {
+    it->readingSeconds = UINT32_MAX;
+  }
+  refreshComputedFields(*it);
+  saveToFile();
+}
+
+std::vector<RecentBookListRowData> RecentBooksStore::buildListRowData(const std::vector<RecentBook>& books,
+                                                                      const GfxRenderer& renderer,
+                                                                      const ThemeMetrics& metrics, const int pageWidth,
+                                                                      const int contentHeight) const {
+  std::vector<RecentBookListRowData> rows;
+  rows.reserve(books.size());
+  const int rowHeight = metrics.listWithSubtitleRowHeight;
+  const int pageItems = std::max(1, contentHeight / rowHeight);
+  const int totalPages = (static_cast<int>(books.size()) + pageItems - 1) / pageItems;
+  const int contentWidth = pageWidth - (totalPages > 1 ? (metrics.scrollBarWidth + metrics.scrollBarRightOffset)
+                                                        : BASE_CONTENT_WIDTH_OFFSET);
+  const int subtitleFont = UI_10_FONT_ID;
+  const int subtitleLeftX = metrics.contentSidePadding;
+
+  for (const auto& book : books) {
+    RecentBookListRowData row;
+    row.metricsRightText = book.metricsSubtitle;
+    const int rightWidth = renderer.getTextWidth(subtitleFont, row.metricsRightText.c_str());
+    row.metricsRightX = contentWidth - metrics.contentSidePadding - rightWidth;
+    const int maxAuthorWidth = std::max(0, row.metricsRightX - subtitleLeftX - SUBTITLE_RIGHT_GAP);
+    row.authorSubtitle = renderer.truncatedText(subtitleFont, book.author.c_str(), maxAuthorWidth);
+    rows.push_back(std::move(row));
+  }
+
+  return rows;
+}
+
+void RecentBooksStore::drawMetricsOverlay(const GfxRenderer& renderer, const std::vector<RecentBookListRowData>& rowData,
+                                          const size_t selectorIndex, const int contentTop, const int contentHeight,
+                                          const ThemeMetrics& metrics) const {
+  if (rowData.empty()) {
+    return;
+  }
+  const int rowHeight = metrics.listWithSubtitleRowHeight;
+  const int pageItems = std::max(1, contentHeight / rowHeight);
+  const int pageStartIndex = static_cast<int>(selectorIndex) / pageItems * pageItems;
+  const int subtitleFont = UI_10_FONT_ID;
+
+  for (int i = pageStartIndex; i < static_cast<int>(rowData.size()) && i < pageStartIndex + pageItems; i++) {
+    renderer.drawText(subtitleFont, rowData[i].metricsRightX, contentTop + (i % pageItems) * rowHeight + 30,
+                      rowData[i].metricsRightText.c_str(), true);
+  }
+}
+
+int RecentBooksStore::getBookProgressPercent(const RecentBook& book) const {
+  return clampProgressPercent(book.progressPercent);
+}
+
+std::string RecentBooksStore::getBookProgressValue(const RecentBook& book) const {
+  return book.progressValue;
+}
+
+std::string RecentBooksStore::getBookReadingTime(const RecentBook& book) const {
+  return formatDuration(book.readingSeconds);
+}
+
+std::string RecentBooksStore::getBookMetricsSubtitle(const RecentBook& book) const {
+  return book.metricsSubtitle;
 }
 
 bool RecentBooksStore::saveToFile() const {
@@ -74,19 +181,29 @@ RecentBook RecentBooksStore::getDataFromBook(std::string path) const {
   if (StringUtils::checkFileExtension(lastBookFileName, ".epub")) {
     Epub epub(path, "/.crosspoint");
     epub.load(false, true);
-    return RecentBook{path, epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
+    return RecentBook{path,
+                      epub.getTitle(),
+                      epub.getAuthor(),
+                      epub.getThumbBmpPath(),
+                      UNKNOWN_PROGRESS_PERCENT,
+                      INITIAL_READING_SECONDS};
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".xtch") ||
              StringUtils::checkFileExtension(lastBookFileName, ".xtc")) {
     // Handle XTC file
     Xtc xtc(path, "/.crosspoint");
     if (xtc.load()) {
-      return RecentBook{path, xtc.getTitle(), xtc.getAuthor(), xtc.getThumbBmpPath()};
+      return RecentBook{path,
+                        xtc.getTitle(),
+                        xtc.getAuthor(),
+                        xtc.getThumbBmpPath(),
+                        UNKNOWN_PROGRESS_PERCENT,
+                        INITIAL_READING_SECONDS};
     }
   } else if (StringUtils::checkFileExtension(lastBookFileName, ".txt") ||
              StringUtils::checkFileExtension(lastBookFileName, ".md")) {
-    return RecentBook{path, lastBookFileName, "", ""};
+    return RecentBook{path, lastBookFileName, "", "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS};
   }
-  return RecentBook{path, "", "", ""};
+  return RecentBook{path, "", "", "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS};
 }
 
 bool RecentBooksStore::loadFromFile() {
@@ -94,7 +211,10 @@ bool RecentBooksStore::loadFromFile() {
   if (Storage.exists(RECENT_BOOKS_FILE_JSON)) {
     String json = Storage.readFile(RECENT_BOOKS_FILE_JSON);
     if (!json.isEmpty()) {
-      return JsonSettingsIO::loadRecentBooks(*this, json.c_str());
+      if (JsonSettingsIO::loadRecentBooks(*this, json.c_str())) {
+        refreshAllComputedFields();
+        return true;
+      }
     }
   }
 
@@ -136,7 +256,7 @@ bool RecentBooksStore::loadFromBinaryFile() {
         std::string title, author;
         serialization::readString(inputFile, title);
         serialization::readString(inputFile, author);
-        recentBooks.push_back({path, title, author, ""});
+        recentBooks.push_back({path, title, author, "", UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS});
       } else {
         recentBooks.push_back(book);
       }
@@ -162,7 +282,7 @@ bool RecentBooksStore::loadFromBinaryFile() {
         continue;
       }
 
-      recentBooks.push_back({path, title, author, coverBmpPath});
+      recentBooks.push_back({path, title, author, coverBmpPath, UNKNOWN_PROGRESS_PERCENT, INITIAL_READING_SECONDS});
     }
 
     if (omitted > 0) {
@@ -179,5 +299,52 @@ bool RecentBooksStore::loadFromBinaryFile() {
 
   inputFile.close();
   LOG_DBG("RBS", "Recent books loaded from binary file (%d entries)", static_cast<int>(recentBooks.size()));
+  refreshAllComputedFields();
   return true;
+}
+
+void RecentBooksStore::refreshComputedFields(RecentBook& book) {
+  if (book.progressPercent < 0) {
+    book.progressValue = "--%";
+  } else {
+    book.progressValue = std::to_string(clampProgressPercent(book.progressPercent)) + "%";
+  }
+  const std::string readText = formatDuration(book.readingSeconds);
+  const std::string remainingText = hasRemainingEstimate(book) ? formatDuration(getRemainingSeconds(book)) : "--";
+  book.metricsSubtitle = readText + " · " + remainingText;
+}
+
+void RecentBooksStore::refreshAllComputedFields() {
+  for (auto& book : recentBooks) {
+    refreshComputedFields(book);
+  }
+}
+
+std::string RecentBooksStore::formatDuration(const uint32_t totalSeconds) {
+  const uint32_t hours = totalSeconds / 3600U;
+  const uint32_t minutes = (totalSeconds % 3600U) / 60U;
+  return std::to_string(hours) + "h " + (minutes < 10 ? "0" : "") + std::to_string(minutes) + "m";
+}
+
+int RecentBooksStore::clampProgressPercent(const int progressPercent) {
+  return std::min(100, std::max(0, progressPercent));
+}
+
+bool RecentBooksStore::hasRemainingEstimate(const RecentBook& book) {
+  return book.progressPercent >= 100 || (book.progressPercent > 0 && book.readingSeconds > 0);
+}
+
+uint32_t RecentBooksStore::getRemainingSeconds(const RecentBook& book) {
+  if (book.progressPercent >= 100) {
+    return 0;
+  }
+
+  if (book.progressPercent <= 0 || book.readingSeconds == 0) {
+    return 0;
+  }
+
+  const float ratio = static_cast<float>(book.progressPercent) / 100.0f;
+  const float estimateTotal = static_cast<float>(book.readingSeconds) / ratio;
+  const uint32_t estimateTotalSeconds = static_cast<uint32_t>(estimateTotal + 0.5f);
+  return (estimateTotalSeconds > book.readingSeconds) ? (estimateTotalSeconds - book.readingSeconds) : 0;
 }

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -111,11 +111,7 @@ std::vector<RecentBookListRowData> RecentBooksStore::buildListRowData(const std:
   const int pageItems = std::max(1, contentHeight / rowHeight);
   const int totalPages = (static_cast<int>(books.size()) + pageItems - 1) / pageItems;
   const int contentWidth = pageWidth - (totalPages > 1 ? (metrics.scrollBarWidth + metrics.scrollBarRightOffset)
-<<<<<<< HEAD
                                                        : BASE_CONTENT_WIDTH_OFFSET);
-=======
-                                                       : BASE_CONTENT_WIDTH_OFFSET);
->>>>>>> 6b345f057e004bcec21e9449b42300e8787ac48b
   const int subtitleFont = UI_10_FONT_ID;
   const int subtitleLeftX = metrics.contentSidePadding;
 
@@ -132,15 +128,9 @@ std::vector<RecentBookListRowData> RecentBooksStore::buildListRowData(const std:
   return rows;
 }
 
-<<<<<<< HEAD
 void RecentBooksStore::drawMetricsOverlay(const GfxRenderer& renderer,
                                           const std::vector<RecentBookListRowData>& rowData, const size_t selectorIndex,
                                           const int contentTop, const int contentHeight,
-=======
-void RecentBooksStore::drawMetricsOverlay(const GfxRenderer& renderer,
-                                          const std::vector<RecentBookListRowData>& rowData, const size_t selectorIndex,
-                                          const int contentTop, const int contentHeight,
->>>>>>> 6b345f057e004bcec21e9449b42300e8787ac48b
                                           const ThemeMetrics& metrics) const {
   if (rowData.empty()) {
     return;
@@ -160,21 +150,13 @@ int RecentBooksStore::getBookProgressPercent(const RecentBook& book) const {
   return clampProgressPercent(book.progressPercent);
 }
 
-<<<<<<< HEAD
 std::string RecentBooksStore::getBookProgressValue(const RecentBook& book) const { return book.progressValue; }
-=======
-std::string RecentBooksStore::getBookProgressValue(const RecentBook& book) const { return book.progressValue; }
->>>>>>> 6b345f057e004bcec21e9449b42300e8787ac48b
 
 std::string RecentBooksStore::getBookReadingTime(const RecentBook& book) const {
   return formatDuration(book.readingSeconds);
 }
 
-<<<<<<< HEAD
 std::string RecentBooksStore::getBookMetricsSubtitle(const RecentBook& book) const { return book.metricsSubtitle; }
-=======
-std::string RecentBooksStore::getBookMetricsSubtitle(const RecentBook& book) const { return book.metricsSubtitle; }
->>>>>>> 6b345f057e004bcec21e9449b42300e8787ac48b
 
 bool RecentBooksStore::saveToFile() const {
   Storage.mkdir("/.crosspoint");

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -1,14 +1,28 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
+
+class GfxRenderer;
+struct ThemeMetrics;
 
 struct RecentBook {
   std::string path;
   std::string title;
   std::string author;
   std::string coverBmpPath;
+  int16_t progressPercent = -1;
+  uint32_t readingSeconds = 0;
+  std::string progressValue = "--%";
+  std::string metricsSubtitle = "0h 00m / --";
 
   bool operator==(const RecentBook& other) const { return path == other.path; }
+};
+
+struct RecentBookListRowData {
+  std::string authorSubtitle;
+  std::string metricsRightText;
+  int metricsRightX = 0;
 };
 
 class RecentBooksStore;
@@ -36,6 +50,17 @@ class RecentBooksStore {
 
   void updateBook(const std::string& path, const std::string& title, const std::string& author,
                   const std::string& coverBmpPath);
+  void updateBookProgress(const std::string& path, int16_t progressPercent);
+  void addBookReadingTime(const std::string& path, uint32_t elapsedSeconds);
+  std::vector<RecentBookListRowData> buildListRowData(const std::vector<RecentBook>& books, const GfxRenderer& renderer,
+                                                      const ThemeMetrics& metrics, int pageWidth,
+                                                      int contentHeight) const;
+  void drawMetricsOverlay(const GfxRenderer& renderer, const std::vector<RecentBookListRowData>& rowData,
+                          size_t selectorIndex, int contentTop, int contentHeight, const ThemeMetrics& metrics) const;
+  int getBookProgressPercent(const RecentBook& book) const;
+  std::string getBookProgressValue(const RecentBook& book) const;
+  std::string getBookReadingTime(const RecentBook& book) const;
+  std::string getBookMetricsSubtitle(const RecentBook& book) const;
 
   // Get the list of recent books (most recent first)
   const std::vector<RecentBook>& getBooks() const { return recentBooks; }
@@ -49,6 +74,12 @@ class RecentBooksStore {
   RecentBook getDataFromBook(std::string path) const;
 
  private:
+  void refreshComputedFields(RecentBook& book);
+  void refreshAllComputedFields();
+  static std::string formatDuration(uint32_t totalSeconds);
+  static int clampProgressPercent(int progressPercent);
+  static bool hasRemainingEstimate(const RecentBook& book);
+  static uint32_t getRemainingSeconds(const RecentBook& book);
   bool loadFromBinaryFile();
 };
 

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -8,188 +8,10 @@
 #include <Txt.h>
 #include <Xtc.h>
 
-#include <algorithm>
-
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "util/StringUtils.h"
-
-namespace {
-constexpr uint32_t TXT_INDEX_MAGIC = 0x54585449;  // "TXTI"
-constexpr uint8_t TXT_INDEX_VERSION_MIN = 1;
-constexpr uint8_t TXT_INDEX_VERSION_MAX = 2;
-constexpr char READING_TIME_FILE_NAME[] = "/reading_time.bin";
-
-uint32_t readSecondsFromCachePath(const std::string& cachePath) {
-  uint32_t seconds = 0;
-  FsFile f;
-  if (!Storage.openFileForRead("RBA", cachePath + READING_TIME_FILE_NAME, f)) {
-    return 0;
-  }
-
-  uint8_t data[4];
-  if (f.read(data, sizeof(data)) == 4) {
-    seconds = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
-  }
-  f.close();
-  return seconds;
-}
-
-uint32_t loadReadSecondsForPath(const std::string& path) {
-  if (StringUtils::checkFileExtension(path, ".epub")) {
-    Epub epub(path, "/.crosspoint");
-    return readSecondsFromCachePath(epub.getCachePath());
-  }
-  if (StringUtils::checkFileExtension(path, ".xtch") || StringUtils::checkFileExtension(path, ".xtc")) {
-    Xtc xtc(path, "/.crosspoint");
-    return readSecondsFromCachePath(xtc.getCachePath());
-  }
-  if (StringUtils::checkFileExtension(path, ".txt") || StringUtils::checkFileExtension(path, ".md")) {
-    Txt txt(path, "/.crosspoint");
-    return readSecondsFromCachePath(txt.getCachePath());
-  }
-  return 0;
-}
-
-int loadEpubProgressPercent(const std::string& path) {
-  Epub epub(path, "/.crosspoint");
-  if (!epub.load(true, true)) {
-    return -1;
-  }
-
-  FsFile f;
-  if (!Storage.openFileForRead("RBA", epub.getCachePath() + "/progress.bin", f)) {
-    return -1;
-  }
-
-  uint8_t data[6];
-  const int dataSize = f.read(data, sizeof(data));
-  f.close();
-  if (dataSize < 4) {
-    return -1;
-  }
-
-  const int spineIndex = data[0] + (data[1] << 8);
-  const int currentPage = data[2] + (data[3] << 8);
-  int chapterPageCount = 0;
-  if (dataSize >= 6) {
-    chapterPageCount = data[4] + (data[5] << 8);
-  }
-
-  float sectionProgress = 0.0f;
-  if (chapterPageCount > 0) {
-    sectionProgress = static_cast<float>(currentPage) / static_cast<float>(chapterPageCount);
-  }
-
-  const float progress = epub.calculateProgress(spineIndex, sectionProgress);
-  int percent = static_cast<int>(progress * 100.0f + 0.5f);
-  if (percent < 0) percent = 0;
-  if (percent > 100) percent = 100;
-  return percent;
-}
-
-int loadXtcProgressPercent(const std::string& path) {
-  Xtc xtc(path, "/.crosspoint");
-  if (!xtc.load()) {
-    return -1;
-  }
-
-  const uint32_t totalPages = xtc.getPageCount();
-  if (totalPages == 0) {
-    return -1;
-  }
-
-  uint32_t currentPage = 0;
-  FsFile f;
-  if (Storage.openFileForRead("RBA", xtc.getCachePath() + "/progress.bin", f)) {
-    uint8_t data[4];
-    if (f.read(data, 4) == 4) {
-      currentPage = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
-    }
-    f.close();
-  }
-  if (currentPage >= totalPages) {
-    currentPage = totalPages - 1;
-  }
-
-  const int percent = static_cast<int>(((currentPage + 1U) * 100U) / totalPages);
-  return std::min(100, std::max(0, percent));
-}
-
-int loadTxtProgressPercent(const std::string& path) {
-  Txt txt(path, "/.crosspoint");
-  // load() ensures cache path generation semantics are consistent with reader.
-  if (!txt.load()) {
-    return -1;
-  }
-
-  uint32_t currentPage = 0;
-  FsFile progressFile;
-  if (Storage.openFileForRead("RBA", txt.getCachePath() + "/progress.bin", progressFile)) {
-    uint8_t data[4];
-    if (progressFile.read(data, 4) == 4) {
-      currentPage = data[0] + (data[1] << 8);
-    }
-    progressFile.close();
-  }
-
-  FsFile indexFile;
-  if (!Storage.openFileForRead("RBA", txt.getCachePath() + "/index.bin", indexFile)) {
-    return -1;
-  }
-
-  uint32_t magic = 0;
-  uint8_t version = 0;
-  serialization::readPod(indexFile, magic);
-  serialization::readPod(indexFile, version);
-  if (magic != TXT_INDEX_MAGIC || version < TXT_INDEX_VERSION_MIN || version > TXT_INDEX_VERSION_MAX) {
-    indexFile.close();
-    return -1;
-  }
-
-  // Skip remaining header fields until numPages.
-  uint32_t fileSize = 0;
-  int32_t viewportWidth = 0;
-  int32_t linesPerPage = 0;
-  int32_t fontId = 0;
-  int32_t margin = 0;
-  uint8_t alignment = 0;
-  uint32_t totalPages = 0;
-  serialization::readPod(indexFile, fileSize);
-  serialization::readPod(indexFile, viewportWidth);
-  serialization::readPod(indexFile, linesPerPage);
-  serialization::readPod(indexFile, fontId);
-  serialization::readPod(indexFile, margin);
-  serialization::readPod(indexFile, alignment);
-  serialization::readPod(indexFile, totalPages);
-  indexFile.close();
-
-  if (totalPages == 0) {
-    return -1;
-  }
-  if (currentPage >= totalPages) {
-    currentPage = totalPages - 1;
-  }
-
-  const int percent = static_cast<int>(((currentPage + 1U) * 100U) / totalPages);
-  return std::min(100, std::max(0, percent));
-}
-
-int loadProgressPercentForPath(const std::string& path) {
-  if (StringUtils::checkFileExtension(path, ".epub")) {
-    return loadEpubProgressPercent(path);
-  }
-  if (StringUtils::checkFileExtension(path, ".xtch") || StringUtils::checkFileExtension(path, ".xtc")) {
-    return loadXtcProgressPercent(path);
-  }
-  if (StringUtils::checkFileExtension(path, ".txt") || StringUtils::checkFileExtension(path, ".md")) {
-    return loadTxtProgressPercent(path);
-  }
-  return -1;
-}
-}  // namespace
 
 void RecentBooksActivity::loadRecentBooks() {
   recentBooks.clear();
@@ -210,7 +32,6 @@ void RecentBooksActivity::onEnter() {
 
   // Load data
   loadRecentBooks();
-  loadReadingMetrics();
 
   selectorIndex = 0;
   requestUpdate();
@@ -219,40 +40,7 @@ void RecentBooksActivity::onEnter() {
 void RecentBooksActivity::onExit() {
   Activity::onExit();
   recentBooks.clear();
-  readingMetrics.clear();
-}
-
-std::string RecentBooksActivity::formatDuration(const uint32_t totalSeconds) {
-  const uint32_t hours = totalSeconds / 3600U;
-  const uint32_t minutes = (totalSeconds % 3600U) / 60U;
-  return std::to_string(hours) + "h " + (minutes < 10 ? "0" : "") + std::to_string(minutes) + "m";
-}
-
-int RecentBooksActivity::clampProgressPercent(const int percent) { return std::min(100, std::max(0, percent)); }
-
-void RecentBooksActivity::loadReadingMetrics() {
-  readingMetrics.clear();
-  readingMetrics.reserve(recentBooks.size());
-
-  for (const auto& book : recentBooks) {
-    RecentBookReadingMetrics metrics;
-    metrics.progressPercent = loadProgressPercentForPath(book.path);
-    metrics.readSeconds = loadReadSecondsForPath(book.path);
-
-    if (metrics.progressPercent >= 100) {
-      metrics.remainingSeconds = 0;
-      metrics.hasRemainingEstimate = true;
-    } else if (metrics.progressPercent > 0 && metrics.readSeconds > 0) {
-      const float ratio = static_cast<float>(metrics.progressPercent) / 100.0f;
-      const float estimateTotal = static_cast<float>(metrics.readSeconds) / ratio;
-      const uint32_t estimateTotalSeconds = static_cast<uint32_t>(estimateTotal + 0.5f);
-      metrics.remainingSeconds =
-          (estimateTotalSeconds > metrics.readSeconds) ? (estimateTotalSeconds - metrics.readSeconds) : 0;
-      metrics.hasRemainingEstimate = true;
-    }
-
-    readingMetrics.push_back(metrics);
-  }
+  recentBookRows.clear();
 }
 
 void RecentBooksActivity::loop() {
@@ -309,42 +97,17 @@ void RecentBooksActivity::render(Activity::RenderLock&&) {
   if (recentBooks.empty()) {
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, contentTop + 20, tr(STR_NO_RECENT_BOOKS));
   } else {
+    recentBookRows = RECENT_BOOKS.buildListRowData(recentBooks, renderer, metrics, pageWidth, contentHeight);
+
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, recentBooks.size(), selectorIndex,
         [this](int index) { return recentBooks[index].title; },
-        [this](int index) {
-          if (index < 0 || static_cast<size_t>(index) >= readingMetrics.size()) return std::string();
-          const auto& m = readingMetrics[index];
-          const std::string percent =
-              (m.progressPercent >= 0) ? (std::to_string(clampProgressPercent(m.progressPercent)) + "%") : "--%";
-          const std::string readPart = formatDuration(m.readSeconds);
-          const std::string leftPart = m.hasRemainingEstimate ? formatDuration(m.remainingSeconds) : std::string("--");
-          return percent + " • " + readPart + " • " + leftPart;
-        },
-        [this](int index) { return UITheme::getFileIcon(recentBooks[index].path); });
+        [this](int index) { return recentBookRows[index].authorSubtitle; },
+        [this](int index) { return UITheme::getFileIcon(recentBooks[index].path); },
+        [this](int index) { return recentBooks[index].progressValue; }, false,
+        [this](int index) { return recentBooks[index].progressPercent; });
 
-    const int rowHeight = metrics.listWithSubtitleRowHeight;
-    const int pageItems = (rowHeight > 0) ? (contentHeight / rowHeight) : 0;
-    if (pageItems > 0) {
-      const int pageStartIndex = (static_cast<int>(selectorIndex) / pageItems) * pageItems;
-      const int visibleEnd = std::min(static_cast<int>(recentBooks.size()), pageStartIndex + pageItems);
-      const int barX = metrics.contentSidePadding + 18;
-      const int barWidth = pageWidth - barX - metrics.contentSidePadding - 26;
-      const int barHeight = 4;
-      for (int i = pageStartIndex; i < visibleEnd; ++i) {
-        const int itemY = contentTop + (i - pageStartIndex) * rowHeight;
-        const int barY = itemY + rowHeight - 10;
-        const int pct =
-            (i >= 0 && static_cast<size_t>(i) < readingMetrics.size() && readingMetrics[i].progressPercent >= 0)
-                ? clampProgressPercent(readingMetrics[i].progressPercent)
-                : 0;
-        const int filledWidth = (barWidth * pct) / 100;
-        renderer.drawRect(barX, barY, barWidth, barHeight, true);
-        if (filledWidth > 0) {
-          renderer.fillRect(barX + 1, barY + 1, std::max(1, filledWidth - 2), std::max(1, barHeight - 2), true);
-        }
-      }
-    }
+    RECENT_BOOKS.drawMetricsOverlay(renderer, recentBookRows, selectorIndex, contentTop, contentHeight, metrics);
   }
 
   // Help text

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -1,8 +1,12 @@
 #include "RecentBooksActivity.h"
 
+#include <Epub.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
+#include <Serialization.h>
+#include <Txt.h>
+#include <Xtc.h>
 
 #include <algorithm>
 
@@ -13,7 +17,178 @@
 #include "util/StringUtils.h"
 
 namespace {
-constexpr unsigned long GO_HOME_MS = 1000;
+constexpr uint32_t TXT_INDEX_MAGIC = 0x54585449;  // "TXTI"
+constexpr uint8_t TXT_INDEX_VERSION_MIN = 1;
+constexpr uint8_t TXT_INDEX_VERSION_MAX = 2;
+constexpr char READING_TIME_FILE_NAME[] = "/reading_time.bin";
+
+uint32_t readSecondsFromCachePath(const std::string& cachePath) {
+  uint32_t seconds = 0;
+  FsFile f;
+  if (!Storage.openFileForRead("RBA", cachePath + READING_TIME_FILE_NAME, f)) {
+    return 0;
+  }
+
+  uint8_t data[4];
+  if (f.read(data, sizeof(data)) == 4) {
+    seconds = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+  }
+  f.close();
+  return seconds;
+}
+
+uint32_t loadReadSecondsForPath(const std::string& path) {
+  if (StringUtils::checkFileExtension(path, ".epub")) {
+    Epub epub(path, "/.crosspoint");
+    return readSecondsFromCachePath(epub.getCachePath());
+  }
+  if (StringUtils::checkFileExtension(path, ".xtch") || StringUtils::checkFileExtension(path, ".xtc")) {
+    Xtc xtc(path, "/.crosspoint");
+    return readSecondsFromCachePath(xtc.getCachePath());
+  }
+  if (StringUtils::checkFileExtension(path, ".txt") || StringUtils::checkFileExtension(path, ".md")) {
+    Txt txt(path, "/.crosspoint");
+    return readSecondsFromCachePath(txt.getCachePath());
+  }
+  return 0;
+}
+
+int loadEpubProgressPercent(const std::string& path) {
+  Epub epub(path, "/.crosspoint");
+  if (!epub.load(true, true)) {
+    return -1;
+  }
+
+  FsFile f;
+  if (!Storage.openFileForRead("RBA", epub.getCachePath() + "/progress.bin", f)) {
+    return -1;
+  }
+
+  uint8_t data[6];
+  const int dataSize = f.read(data, sizeof(data));
+  f.close();
+  if (dataSize < 4) {
+    return -1;
+  }
+
+  const int spineIndex = data[0] + (data[1] << 8);
+  const int currentPage = data[2] + (data[3] << 8);
+  int chapterPageCount = 0;
+  if (dataSize >= 6) {
+    chapterPageCount = data[4] + (data[5] << 8);
+  }
+
+  float sectionProgress = 0.0f;
+  if (chapterPageCount > 0) {
+    sectionProgress = static_cast<float>(currentPage) / static_cast<float>(chapterPageCount);
+  }
+
+  const float progress = epub.calculateProgress(spineIndex, sectionProgress);
+  int percent = static_cast<int>(progress * 100.0f + 0.5f);
+  if (percent < 0) percent = 0;
+  if (percent > 100) percent = 100;
+  return percent;
+}
+
+int loadXtcProgressPercent(const std::string& path) {
+  Xtc xtc(path, "/.crosspoint");
+  if (!xtc.load()) {
+    return -1;
+  }
+
+  const uint32_t totalPages = xtc.getPageCount();
+  if (totalPages == 0) {
+    return -1;
+  }
+
+  uint32_t currentPage = 0;
+  FsFile f;
+  if (Storage.openFileForRead("RBA", xtc.getCachePath() + "/progress.bin", f)) {
+    uint8_t data[4];
+    if (f.read(data, 4) == 4) {
+      currentPage = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+    }
+    f.close();
+  }
+  if (currentPage >= totalPages) {
+    currentPage = totalPages - 1;
+  }
+
+  const int percent = static_cast<int>(((currentPage + 1U) * 100U) / totalPages);
+  return std::min(100, std::max(0, percent));
+}
+
+int loadTxtProgressPercent(const std::string& path) {
+  Txt txt(path, "/.crosspoint");
+  // load() ensures cache path generation semantics are consistent with reader.
+  if (!txt.load()) {
+    return -1;
+  }
+
+  uint32_t currentPage = 0;
+  FsFile progressFile;
+  if (Storage.openFileForRead("RBA", txt.getCachePath() + "/progress.bin", progressFile)) {
+    uint8_t data[4];
+    if (progressFile.read(data, 4) == 4) {
+      currentPage = data[0] + (data[1] << 8);
+    }
+    progressFile.close();
+  }
+
+  FsFile indexFile;
+  if (!Storage.openFileForRead("RBA", txt.getCachePath() + "/index.bin", indexFile)) {
+    return -1;
+  }
+
+  uint32_t magic = 0;
+  uint8_t version = 0;
+  serialization::readPod(indexFile, magic);
+  serialization::readPod(indexFile, version);
+  if (magic != TXT_INDEX_MAGIC || version < TXT_INDEX_VERSION_MIN || version > TXT_INDEX_VERSION_MAX) {
+    indexFile.close();
+    return -1;
+  }
+
+  // Skip remaining header fields until numPages.
+  uint32_t fileSize = 0;
+  int32_t viewportWidth = 0;
+  int32_t linesPerPage = 0;
+  int32_t fontId = 0;
+  int32_t margin = 0;
+  uint8_t alignment = 0;
+  uint32_t totalPages = 0;
+  serialization::readPod(indexFile, fileSize);
+  serialization::readPod(indexFile, viewportWidth);
+  serialization::readPod(indexFile, linesPerPage);
+  serialization::readPod(indexFile, fontId);
+  serialization::readPod(indexFile, margin);
+  serialization::readPod(indexFile, alignment);
+  serialization::readPod(indexFile, totalPages);
+  indexFile.close();
+
+  if (totalPages == 0) {
+    return -1;
+  }
+  if (currentPage >= totalPages) {
+    currentPage = totalPages - 1;
+  }
+
+  const int percent = static_cast<int>(((currentPage + 1U) * 100U) / totalPages);
+  return std::min(100, std::max(0, percent));
+}
+
+int loadProgressPercentForPath(const std::string& path) {
+  if (StringUtils::checkFileExtension(path, ".epub")) {
+    return loadEpubProgressPercent(path);
+  }
+  if (StringUtils::checkFileExtension(path, ".xtch") || StringUtils::checkFileExtension(path, ".xtc")) {
+    return loadXtcProgressPercent(path);
+  }
+  if (StringUtils::checkFileExtension(path, ".txt") || StringUtils::checkFileExtension(path, ".md")) {
+    return loadTxtProgressPercent(path);
+  }
+  return -1;
+}
 }  // namespace
 
 void RecentBooksActivity::loadRecentBooks() {
@@ -35,6 +210,7 @@ void RecentBooksActivity::onEnter() {
 
   // Load data
   loadRecentBooks();
+  loadReadingMetrics();
 
   selectorIndex = 0;
   requestUpdate();
@@ -43,6 +219,40 @@ void RecentBooksActivity::onEnter() {
 void RecentBooksActivity::onExit() {
   Activity::onExit();
   recentBooks.clear();
+  readingMetrics.clear();
+}
+
+std::string RecentBooksActivity::formatDuration(const uint32_t totalSeconds) {
+  const uint32_t hours = totalSeconds / 3600U;
+  const uint32_t minutes = (totalSeconds % 3600U) / 60U;
+  return std::to_string(hours) + "h " + (minutes < 10 ? "0" : "") + std::to_string(minutes) + "m";
+}
+
+int RecentBooksActivity::clampProgressPercent(const int percent) { return std::min(100, std::max(0, percent)); }
+
+void RecentBooksActivity::loadReadingMetrics() {
+  readingMetrics.clear();
+  readingMetrics.reserve(recentBooks.size());
+
+  for (const auto& book : recentBooks) {
+    RecentBookReadingMetrics metrics;
+    metrics.progressPercent = loadProgressPercentForPath(book.path);
+    metrics.readSeconds = loadReadSecondsForPath(book.path);
+
+    if (metrics.progressPercent >= 100) {
+      metrics.remainingSeconds = 0;
+      metrics.hasRemainingEstimate = true;
+    } else if (metrics.progressPercent > 0 && metrics.readSeconds > 0) {
+      const float ratio = static_cast<float>(metrics.progressPercent) / 100.0f;
+      const float estimateTotal = static_cast<float>(metrics.readSeconds) / ratio;
+      const uint32_t estimateTotalSeconds = static_cast<uint32_t>(estimateTotal + 0.5f);
+      metrics.remainingSeconds =
+          (estimateTotalSeconds > metrics.readSeconds) ? (estimateTotalSeconds - metrics.readSeconds) : 0;
+      metrics.hasRemainingEstimate = true;
+    }
+
+    readingMetrics.push_back(metrics);
+  }
 }
 
 void RecentBooksActivity::loop() {
@@ -101,8 +311,40 @@ void RecentBooksActivity::render(Activity::RenderLock&&) {
   } else {
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, recentBooks.size(), selectorIndex,
-        [this](int index) { return recentBooks[index].title; }, [this](int index) { return recentBooks[index].author; },
+        [this](int index) { return recentBooks[index].title; },
+        [this](int index) {
+          if (index < 0 || static_cast<size_t>(index) >= readingMetrics.size()) return std::string();
+          const auto& m = readingMetrics[index];
+          const std::string percent =
+              (m.progressPercent >= 0) ? (std::to_string(clampProgressPercent(m.progressPercent)) + "%") : "--%";
+          const std::string readPart = formatDuration(m.readSeconds);
+          const std::string leftPart = m.hasRemainingEstimate ? formatDuration(m.remainingSeconds) : std::string("--");
+          return percent + " • " + readPart + " • " + leftPart;
+        },
         [this](int index) { return UITheme::getFileIcon(recentBooks[index].path); });
+
+    const int rowHeight = metrics.listWithSubtitleRowHeight;
+    const int pageItems = (rowHeight > 0) ? (contentHeight / rowHeight) : 0;
+    if (pageItems > 0) {
+      const int pageStartIndex = (static_cast<int>(selectorIndex) / pageItems) * pageItems;
+      const int visibleEnd = std::min(static_cast<int>(recentBooks.size()), pageStartIndex + pageItems);
+      const int barX = metrics.contentSidePadding + 18;
+      const int barWidth = pageWidth - barX - metrics.contentSidePadding - 26;
+      const int barHeight = 4;
+      for (int i = pageStartIndex; i < visibleEnd; ++i) {
+        const int itemY = contentTop + (i - pageStartIndex) * rowHeight;
+        const int barY = itemY + rowHeight - 10;
+        const int pct =
+            (i >= 0 && static_cast<size_t>(i) < readingMetrics.size() && readingMetrics[i].progressPercent >= 0)
+                ? clampProgressPercent(readingMetrics[i].progressPercent)
+                : 0;
+        const int filledWidth = (barWidth * pct) / 100;
+        renderer.drawRect(barX, barY, barWidth, barHeight, true);
+        if (filledWidth > 0) {
+          renderer.fillRect(barX + 1, barY + 1, std::max(1, filledWidth - 2), std::max(1, barHeight - 2), true);
+        }
+      }
+    }
   }
 
   // Help text

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <I18n.h>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -8,6 +9,13 @@
 #include "../Activity.h"
 #include "RecentBooksStore.h"
 #include "util/ButtonNavigator.h"
+
+struct RecentBookReadingMetrics {
+  int progressPercent = -1;
+  uint32_t readSeconds = 0;
+  uint32_t remainingSeconds = 0;
+  bool hasRemainingEstimate = false;
+};
 
 class RecentBooksActivity final : public Activity {
  private:
@@ -17,6 +25,7 @@ class RecentBooksActivity final : public Activity {
 
   // Recent tab state
   std::vector<RecentBook> recentBooks;
+  std::vector<RecentBookReadingMetrics> readingMetrics;
 
   // Callbacks
   const std::function<void(const std::string& path)> onSelectBook;
@@ -24,6 +33,9 @@ class RecentBooksActivity final : public Activity {
 
   // Data loading
   void loadRecentBooks();
+  void loadReadingMetrics();
+  static std::string formatDuration(uint32_t totalSeconds);
+  static int clampProgressPercent(int percent);
 
  public:
   explicit RecentBooksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <I18n.h>
 
-#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -9,13 +8,6 @@
 #include "../Activity.h"
 #include "RecentBooksStore.h"
 #include "util/ButtonNavigator.h"
-
-struct RecentBookReadingMetrics {
-  int progressPercent = -1;
-  uint32_t readSeconds = 0;
-  uint32_t remainingSeconds = 0;
-  bool hasRemainingEstimate = false;
-};
 
 class RecentBooksActivity final : public Activity {
  private:
@@ -25,7 +17,7 @@ class RecentBooksActivity final : public Activity {
 
   // Recent tab state
   std::vector<RecentBook> recentBooks;
-  std::vector<RecentBookReadingMetrics> readingMetrics;
+  std::vector<RecentBookListRowData> recentBookRows;
 
   // Callbacks
   const std::function<void(const std::string& path)> onSelectBook;
@@ -33,9 +25,6 @@ class RecentBooksActivity final : public Activity {
 
   // Data loading
   void loadRecentBooks();
-  void loadReadingMetrics();
-  static std::string formatDuration(uint32_t totalSeconds);
-  static int clampProgressPercent(int percent);
 
  public:
   explicit RecentBooksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -143,7 +143,7 @@ void EpubReaderActivity::onExit() {
 
   if (epub && readingSessionStartMs != 0) {
     const uint32_t elapsedSeconds = (millis() - readingSessionStartMs) / 1000U;
-    addReadingTimeToCache(epub->getCachePath(), elapsedSeconds);
+    RECENT_BOOKS.addBookReadingTime(epub->getPath(), elapsedSeconds);
   }
   readingSessionStartMs = 0;
 
@@ -686,6 +686,13 @@ void EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageC
     LOG_DBG("ERS", "Progress saved: Chapter %d, Page %d", spineIndex, currentPage);
   } else {
     LOG_ERR("ERS", "Could not save progress!");
+  }
+
+  if (pageCount > 0) {
+    const float sectionProgress = static_cast<float>(currentPage) / static_cast<float>(pageCount);
+    const float bookProgress = epub->calculateProgress(spineIndex, sectionProgress);
+    const int percent = static_cast<int>(bookProgress * 100.0f + 0.5f);
+    RECENT_BOOKS.updateBookProgress(epub->getPath(), percent);
   }
 }
 void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int orientedMarginTop,

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -25,6 +25,7 @@ constexpr unsigned long skipChapterMs = 700;
 constexpr unsigned long goHomeMs = 1000;
 constexpr int statusBarMargin = 19;
 constexpr int progressBarMarginTop = 1;
+constexpr char READING_TIME_FILE_NAME[] = "/reading_time.bin";
 
 int clampPercent(int percent) {
   if (percent < 0) {
@@ -54,6 +55,36 @@ void applyReaderOrientation(GfxRenderer& renderer, const uint8_t orientation) {
       break;
     default:
       break;
+  }
+}
+
+void addReadingTimeToCache(const std::string& cachePath, const uint32_t elapsedSeconds) {
+  if (elapsedSeconds == 0) {
+    return;
+  }
+
+  uint32_t accumulatedSeconds = 0;
+  FsFile readFile;
+  if (Storage.openFileForRead("ERS", cachePath + READING_TIME_FILE_NAME, readFile)) {
+    uint8_t data[4];
+    if (readFile.read(data, sizeof(data)) == 4) {
+      accumulatedSeconds = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+    }
+    readFile.close();
+  }
+
+  uint32_t totalSeconds = accumulatedSeconds + elapsedSeconds;
+  if (totalSeconds < accumulatedSeconds) {
+    totalSeconds = UINT32_MAX;
+  }
+
+  FsFile writeFile;
+  if (Storage.openFileForWrite("ERS", cachePath + READING_TIME_FILE_NAME, writeFile)) {
+    const uint8_t out[4] = {static_cast<uint8_t>(totalSeconds & 0xFF), static_cast<uint8_t>((totalSeconds >> 8) & 0xFF),
+                            static_cast<uint8_t>((totalSeconds >> 16) & 0xFF),
+                            static_cast<uint8_t>((totalSeconds >> 24) & 0xFF)};
+    writeFile.write(out, sizeof(out));
+    writeFile.close();
   }
 }
 
@@ -101,6 +132,7 @@ void EpubReaderActivity::onEnter() {
   APP_STATE.openEpubPath = epub->getPath();
   APP_STATE.saveToFile();
   RECENT_BOOKS.addBook(epub->getPath(), epub->getTitle(), epub->getAuthor(), epub->getThumbBmpPath());
+  readingSessionStartMs = millis();
 
   // Trigger first update
   requestUpdate();
@@ -108,6 +140,12 @@ void EpubReaderActivity::onEnter() {
 
 void EpubReaderActivity::onExit() {
   ActivityWithSubactivity::onExit();
+
+  if (epub && readingSessionStartMs != 0) {
+    const uint32_t elapsedSeconds = (millis() - readingSessionStartMs) / 1000U;
+    addReadingTimeToCache(epub->getCachePath(), elapsedSeconds);
+  }
+  readingSessionStartMs = 0;
 
   // Reset orientation back to portrait for the rest of the UI
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -2,6 +2,8 @@
 #include <Epub.h>
 #include <Epub/Section.h>
 
+#include <cstdint>
+
 #include "EpubReaderMenuActivity.h"
 #include "activities/ActivityWithSubactivity.h"
 
@@ -22,6 +24,7 @@ class EpubReaderActivity final : public ActivityWithSubactivity {
   bool pendingGoHome = false;           // Defer go home to avoid race condition with display task
   bool pendingScreenshot = false;
   bool skipNextButtonCheck = false;  // Skip button processing for one frame after subactivity exit
+  uint32_t readingSessionStartMs = 0;
   const std::function<void()> onGoBack;
   const std::function<void()> onGoHome;
 

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -22,6 +22,37 @@ constexpr size_t CHUNK_SIZE = 8 * 1024;  // 8KB chunk for reading
 // Cache file magic and version
 constexpr uint32_t CACHE_MAGIC = 0x54585449;  // "TXTI"
 constexpr uint8_t CACHE_VERSION = 2;          // Increment when cache format changes
+constexpr char READING_TIME_FILE_NAME[] = "/reading_time.bin";
+
+void addReadingTimeToCache(const std::string& cachePath, const uint32_t elapsedSeconds) {
+  if (elapsedSeconds == 0) {
+    return;
+  }
+
+  uint32_t accumulatedSeconds = 0;
+  FsFile readFile;
+  if (Storage.openFileForRead("TRS", cachePath + READING_TIME_FILE_NAME, readFile)) {
+    uint8_t data[4];
+    if (readFile.read(data, sizeof(data)) == 4) {
+      accumulatedSeconds = data[0] | (data[1] << 8) | (data[2] << 16) | (data[3] << 24);
+    }
+    readFile.close();
+  }
+
+  uint32_t totalSeconds = accumulatedSeconds + elapsedSeconds;
+  if (totalSeconds < accumulatedSeconds) {
+    totalSeconds = UINT32_MAX;
+  }
+
+  FsFile writeFile;
+  if (Storage.openFileForWrite("TRS", cachePath + READING_TIME_FILE_NAME, writeFile)) {
+    const uint8_t out[4] = {static_cast<uint8_t>(totalSeconds & 0xFF), static_cast<uint8_t>((totalSeconds >> 8) & 0xFF),
+                            static_cast<uint8_t>((totalSeconds >> 16) & 0xFF),
+                            static_cast<uint8_t>((totalSeconds >> 24) & 0xFF)};
+    writeFile.write(out, sizeof(out));
+    writeFile.close();
+  }
+}
 }  // namespace
 
 void TxtReaderActivity::onEnter() {
@@ -57,6 +88,7 @@ void TxtReaderActivity::onEnter() {
   APP_STATE.openEpubPath = filePath;
   APP_STATE.saveToFile();
   RECENT_BOOKS.addBook(filePath, fileName, "", "");
+  readingSessionStartMs = millis();
 
   // Trigger first update
   requestUpdate();
@@ -64,6 +96,12 @@ void TxtReaderActivity::onEnter() {
 
 void TxtReaderActivity::onExit() {
   ActivityWithSubactivity::onExit();
+
+  if (txt && readingSessionStartMs != 0) {
+    const uint32_t elapsedSeconds = (millis() - readingSessionStartMs) / 1000U;
+    addReadingTimeToCache(txt->getCachePath(), elapsedSeconds);
+  }
+  readingSessionStartMs = 0;
 
   // Reset orientation back to portrait for the rest of the UI
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -98,8 +98,7 @@ void TxtReaderActivity::onExit() {
   ActivityWithSubactivity::onExit();
 
   if (txt && readingSessionStartMs != 0) {
-    const uint32_t elapsedSeconds = (millis() - readingSessionStartMs) / 1000U;
-    addReadingTimeToCache(txt->getCachePath(), elapsedSeconds);
+    RECENT_BOOKS.addBookReadingTime(txt->getPath(), (millis() - readingSessionStartMs) / 1000U);
   }
   readingSessionStartMs = 0;
 
@@ -578,6 +577,11 @@ void TxtReaderActivity::saveProgress() const {
     data[3] = 0;
     f.write(data, 4);
     f.close();
+  }
+
+  if (totalPages > 0) {
+    const int percent = static_cast<int>(((static_cast<uint32_t>(currentPage) + 1U) * 100U) / totalPages);
+    RECENT_BOOKS.updateBookProgress(txt->getPath(), percent);
   }
 }
 

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -2,6 +2,7 @@
 
 #include <Txt.h>
 
+#include <cstdint>
 #include <vector>
 
 #include "CrossPointSettings.h"
@@ -28,6 +29,7 @@ class TxtReaderActivity final : public ActivityWithSubactivity {
   int cachedFontId = 0;
   int cachedScreenMargin = 0;
   uint8_t cachedParagraphAlignment = CrossPointSettings::LEFT_ALIGN;
+  uint32_t readingSessionStartMs = 0;
 
   void renderPage();
   void renderStatusBar(int orientedMarginRight, int orientedMarginBottom, int orientedMarginLeft) const;

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -82,8 +82,7 @@ void XtcReaderActivity::onExit() {
   ActivityWithSubactivity::onExit();
 
   if (xtc && readingSessionStartMs != 0) {
-    const uint32_t elapsedSeconds = (millis() - readingSessionStartMs) / 1000U;
-    addReadingTimeToCache(xtc->getCachePath(), elapsedSeconds);
+    RECENT_BOOKS.addBookReadingTime(xtc->getPath(), (millis() - readingSessionStartMs) / 1000U);
   }
   readingSessionStartMs = 0;
 
@@ -381,6 +380,16 @@ void XtcReaderActivity::saveProgress() const {
     data[3] = (currentPage >> 24) & 0xFF;
     f.write(data, 4);
     f.close();
+  }
+
+  const uint32_t pageCount = xtc->getPageCount();
+  if (pageCount > 0) {
+    uint32_t clampedPage = currentPage;
+    if (clampedPage >= pageCount) {
+      clampedPage = pageCount - 1;
+    }
+    const int percent = static_cast<int>(((clampedPage + 1U) * 100U) / pageCount);
+    RECENT_BOOKS.updateBookProgress(xtc->getPath(), percent);
   }
 }
 

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -9,6 +9,8 @@
 
 #include <Xtc.h>
 
+#include <cstdint>
+
 #include "activities/ActivityWithSubactivity.h"
 
 class XtcReaderActivity final : public ActivityWithSubactivity {
@@ -16,6 +18,7 @@ class XtcReaderActivity final : public ActivityWithSubactivity {
 
   uint32_t currentPage = 0;
   int pagesUntilFullRefresh = 0;
+  uint32_t readingSessionStartMs = 0;
 
   const std::function<void()> onGoBack;
   const std::function<void()> onGoHome;

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -90,3 +90,17 @@ UIIcon UITheme::getFileIcon(std::string filename) {
   }
   return File;
 }
+
+void UITheme::drawListRowProgress(const GfxRenderer& renderer, const int progressPercent, const int x, const int y,
+                                  const int width, const int height) {
+  if (width <= 4 || height <= 2) {
+    return;
+  }
+
+  const int clamped = std::min(100, std::max(0, progressPercent));
+  const int filledWidth = (width * clamped) / 100;
+  renderer.drawRect(x, y, width, height, true);
+  if (filledWidth > 0) {
+    renderer.fillRect(x + 1, y + 1, std::max(1, filledWidth - 2), std::max(1, height - 2), true);
+  }
+}

--- a/src/components/UITheme.h
+++ b/src/components/UITheme.h
@@ -22,6 +22,8 @@ class UITheme {
                                      bool hasSubtitle);
   static std::string getCoverThumbPath(std::string coverBmpPath, int coverHeight);
   static UIIcon getFileIcon(std::string filename);
+  static void drawListRowProgress(const GfxRenderer& renderer, int progressPercent, int x, int y, int width,
+                                  int height);
 
  private:
   const ThemeMetrics* currentMetrics;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -6,6 +6,7 @@
 #include <Logging.h>
 #include <Utf8.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 
@@ -187,7 +188,8 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowTitle,
                          const std::function<std::string(int index)>& rowSubtitle,
                          const std::function<UIIcon(int index)>& rowIcon,
-                         const std::function<std::string(int index)>& rowValue, bool highlightValue) const {
+                         const std::function<std::string(int index)>& rowValue, bool highlightValue,
+                         const std::function<int(int index)>& rowProgress) const {
   int rowHeight =
       (rowSubtitle != nullptr) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
@@ -249,6 +251,14 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
       const auto valueTextWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str());
       renderer.drawText(UI_10_FONT_ID, rect.x + contentWidth - BaseMetrics::values.contentSidePadding - valueTextWidth,
                         itemY, valueText.c_str(), i != selectedIndex);
+    }
+
+    if (rowProgress != nullptr) {
+      const int barX = rect.x + BaseMetrics::values.contentSidePadding;
+      const int barWidth = contentWidth - BaseMetrics::values.contentSidePadding * 2;
+      const int barHeight = 4;
+      const int barY = itemY + rowHeight - (barHeight + 4);
+      UITheme::drawListRowProgress(renderer, rowProgress(i), barX, barY, barWidth, barHeight);
     }
   }
 }

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -115,11 +115,7 @@ class BaseTheme {
                         const std::function<std::string(int index)>& rowTitle,
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
                         const std::function<UIIcon(int index)>& rowIcon = nullptr,
-<<<<<<< HEAD
                         const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
-=======
-                        const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
->>>>>>> 6b345f057e004bcec21e9449b42300e8787ac48b
                         const std::function<int(int index)>& rowProgress = nullptr) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
                           const char* subtitle = nullptr) const;

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -115,8 +115,8 @@ class BaseTheme {
                         const std::function<std::string(int index)>& rowTitle,
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
                         const std::function<UIIcon(int index)>& rowIcon = nullptr,
-                        const std::function<std::string(int index)>& rowValue = nullptr,
-                        bool highlightValue = false) const;
+                        const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
+                        const std::function<int(int index)>& rowProgress = nullptr) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
                           const char* subtitle = nullptr) const;
   virtual void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -116,7 +116,8 @@ class BaseTheme {
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
                         const std::function<UIIcon(int index)>& rowIcon = nullptr,
                         const std::function<std::string(int index)>& rowValue = nullptr,
-                        bool highlightValue = false) const;
+                        bool highlightValue = false,
+                        const std::function<int(int index)>& rowProgress = nullptr) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
                           const char* subtitle = nullptr) const;
   virtual void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -6,6 +6,7 @@
 #include <I18n.h>
 #include <Utf8.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -250,7 +251,8 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowTitle,
                          const std::function<std::string(int index)>& rowSubtitle,
                          const std::function<UIIcon(int index)>& rowIcon,
-                         const std::function<std::string(int index)>& rowValue, bool highlightValue) const {
+                         const std::function<std::string(int index)>& rowValue, bool highlightValue,
+                         const std::function<int(int index)>& rowProgress) const {
   int rowHeight =
       (rowSubtitle != nullptr) ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
@@ -335,6 +337,14 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
       renderer.drawText(UI_10_FONT_ID, rect.x + contentWidth - LyraMetrics::values.contentSidePadding - valueWidth,
                         itemY + 6, valueText.c_str(), !(i == selectedIndex && highlightValue));
+    }
+
+    if (rowProgress != nullptr) {
+      const int barX = textX;
+      const int barWidth = textWidth;
+      const int barHeight = 3;
+      const int barY = itemY + rowHeight - (barHeight + 4);
+      UITheme::drawListRowProgress(renderer, rowProgress(i), barX, barY, barWidth, barHeight);
     }
   }
 }

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -51,7 +51,7 @@ class LyraTheme : public BaseTheme {
                 const std::function<std::string(int index)>& rowTitle,
                 const std::function<std::string(int index)>& rowSubtitle,
                 const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
-                bool highlightValue) const override;
+                bool highlightValue, const std::function<int(int index)>& rowProgress) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                        const char* btn4) const override;
   void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Improve "Recent books" view on all themes, adding a new progress bar per book, and reading time/estimated reading time remaining.

* **What changes are included?**
It changes the layout on RecentBooksActivity. Working with classic and Lyra.
It adds a new file on the cache for each book, where it stores the total reading time of each book.
Changes in EPUB-TXT-XTC-ReaderActivity to track time.

## Additional Context
It keeps track of time on the reading screen only, without background processes.
Only tracks time once the feature has been activated.
If no file is found (book never opened with this feature), shows 0h 00m - ..

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code?  YES 

![Imagen](https://github.com/user-attachments/assets/51cb9fc7-02ec-46f5-b3a3-93f1b6157831)

