### PR TITLE
feat: add 'opened' indicator to on-device file browser

### DIFF
--- a/src/activities/home/MyLibraryActivity.cpp
+++ b/src/activities/home/MyLibraryActivity.cpp
@@ -9,6 +9,7 @@
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/ReadProgressUtil.h"
 #include "util/StringUtils.h"
 
 namespace {
@@ -100,6 +101,19 @@ void MyLibraryActivity::loadFiles() {
   }
   root.close();
   sortFileList(files);
+
+  // Look up opened status for each file
+  fileOpened.clear();
+  for (const auto& filename : files) {
+    if (filename.back() == '/') {
+      fileOpened.push_back(false);  // Directories have no progress
+    } else {
+      std::string fullPath = basepath;
+      if (fullPath.back() != '/') fullPath += "/";
+      fullPath += filename;
+      fileOpened.push_back(ReadProgressUtil::hasBeenOpened(fullPath));
+    }
+  }
 }
 
 void MyLibraryActivity::onEnter() {
@@ -114,6 +128,7 @@ void MyLibraryActivity::onEnter() {
 void MyLibraryActivity::onExit() {
   Activity::onExit();
   files.clear();
+  fileOpened.clear();
 }
 
 void MyLibraryActivity::loop() {
@@ -214,7 +229,13 @@ void MyLibraryActivity::render(Activity::RenderLock&&) {
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, files.size(), selectorIndex,
         [this](int index) { return getFileName(files[index]); }, nullptr,
-        [this](int index) { return UITheme::getFileIcon(files[index]); });
+        [this](int index) { return UITheme::getFileIcon(files[index]); },
+        [this](int index) -> std::string {
+          if (index >= 0 && index < static_cast<int>(fileOpened.size()) && fileOpened[index]) {
+            return "\u2022";  // bullet: •
+          }
+          return "";
+        });
   }
 
   // Help text

--- a/src/activities/home/MyLibraryActivity.h
+++ b/src/activities/home/MyLibraryActivity.h
@@ -16,6 +16,7 @@ class MyLibraryActivity final : public Activity {
   // Files state
   std::string basepath = "/";
   std::vector<std::string> files;
+  std::vector<bool> fileOpened;  // true if book has been previously opened
 
   // Callbacks
   const std::function<void(const std::string& path)> onSelectBook;

--- a/src/util/ReadProgressUtil.cpp
+++ b/src/util/ReadProgressUtil.cpp
@@ -1,0 +1,36 @@
+#include "ReadProgressUtil.h"
+
+#include <HalStorage.h>
+
+#include <functional>
+
+#include "util/StringUtils.h"
+
+namespace ReadProgressUtil {
+
+bool hasBeenOpened(const std::string& filepath) {
+  // Determine the cache prefix based on file extension
+  const char* prefix = nullptr;
+  if (StringUtils::checkFileExtension(filepath, ".epub")) {
+    prefix = "epub_";
+  } else if (StringUtils::checkFileExtension(filepath, ".txt") ||
+             StringUtils::checkFileExtension(filepath, ".md")) {
+    prefix = "txt_";
+  } else if (StringUtils::checkFileExtension(filepath, ".xtc") ||
+             StringUtils::checkFileExtension(filepath, ".xtch")) {
+    prefix = "xtc_";
+  }
+
+  if (!prefix) {
+    return false;  // Unsupported file type
+  }
+
+  // Compute cache path using the same hash as Epub/Txt/Xtc constructors
+  const auto hash = std::hash<std::string>{}(filepath);
+  const std::string progressPath =
+      "/.crosspoint/" + std::string(prefix) + std::to_string(hash) + "/progress.bin";
+
+  return Storage.exists(progressPath.c_str());
+}
+
+}  // namespace ReadProgressUtil

--- a/src/util/ReadProgressUtil.h
+++ b/src/util/ReadProgressUtil.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace ReadProgressUtil {
+
+// Returns true if the book at `filepath` has been previously opened.
+// Checks for the existence of a progress.bin file in the book's cache directory.
+// Supports EPUB, TXT, MD, XTC, and XTCH file types.
+bool hasBeenOpened(const std::string& filepath);
+
+}  // namespace ReadProgressUtil


### PR DESCRIPTION
## Summary
Addresses #1191 (in part)
* **What is the goal of this PR?** 
  Adds a visual indicator to the on-device `MyLibraryActivity` file browser to show which books have been previously opened.

* **What changes are included?**
  * Created `ReadProgressUtil` to centralise cache path resolution (`.crosspoint/<type>_<hash>/progress.bin`).
  * Extended `MyLibraryActivity` to track opened status for files during directory scanning.
  * Passed a `rowValue` callback to `GUI.drawList()` to render a bullet (`•`) indicator on the right side of the list row for opened books.

## Additional Context

**Implementation Design / Missing Features**
* **Why no completion percentage?** Currently, it's not possible to accurately calculate a completion percentage without loading the full book metadata into memory. While `progress.bin` exists for all formats, the schema varies by reader (EPUB is 6 bytes holding chapter info, TXT/XTC are 4 bytes holding absolute pages). The EPUB reader needs to parse spine item sizes from `book.bin` to calculate a true book-level percentage. 
* **Why no "Finished" state?** Similarly, detecting a "completed" state purely from the file system isn't currently possible without either modifying the native reader activities to save a separate `finished` marker file when the end-of-book is reached, or modifying the core `progress.bin` schemas.
* **Why duplicate hash logic?** `ReadProgressUtil` duplicates the `std::hash<std::string>{}(filepath)` cache path generation logic found in the `Epub`, `Txt`, and `Xtc` constructors. This was done intentionally to keep the change footprint minimally invasive, allowing us to perform quick file-existence checks during directory scanning without requiring us to instantiate the heavier reader classes or refactor their internals.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
