### PR TITLE
fix: HTTP server crashes — reduce buffer size & limit connections

### DIFF
--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -23,7 +23,7 @@ constexpr const char* AP_SSID = "CrossPoint-Reader";
 constexpr const char* AP_PASSWORD = nullptr;  // Open network for ease of use
 constexpr const char* AP_HOSTNAME = "crosspoint";
 constexpr uint8_t AP_CHANNEL = 1;
-constexpr uint8_t AP_MAX_CONNECTIONS = 4;
+constexpr uint8_t AP_MAX_CONNECTIONS = 2;  // Reduced from 4 to reduce memory contention and improve stability
 constexpr int QR_CODE_WIDTH = 198;
 constexpr int QR_CODE_HEIGHT = 198;
 

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -39,9 +39,9 @@ class CrossPointWebServer {
     String error = "";
 
     // Upload write buffer - batches small writes into larger SD card operations
-    // 4KB is a good balance: large enough to reduce syscall overhead, small enough
-    // to keep individual write times short and avoid watchdog issues
-    static constexpr size_t UPLOAD_BUFFER_SIZE = 4096;  // 4KB buffer
+    // 2KB buffer reduces memory fragmentation on devices with limited heap
+    // Still large enough for SD card efficiency while keeping memory usage minimal
+    static constexpr size_t UPLOAD_BUFFER_SIZE = 2048;  // 2KB buffer (reduced from 4KB for stability)
     std::vector<uint8_t> buffer;
     size_t bufferPos = 0;
 


### PR DESCRIPTION
This PR fixes critical heap fragmentation crashes during HTTP operations.

## Changes
- Reduce UPLOAD_BUFFER_SIZE from 4KB to 2KB (memory pressure)
- Limit AP_MAX_CONNECTIONS from 4 to 2 (prevent heap exhaustion)

## Testing
- Reader now stable for 30+ minutes vs 5 minutes previously
- No regressions in HTTP functionality