### PR TITLE
feat: add cursor-based link navigation using Up/Down buttons

### DIFF
--- a/lib/Epub/Epub/LinkEntry.h
+++ b/lib/Epub/Epub/LinkEntry.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+
+struct LinkEntry {
+  char href[256];
+  int16_t x, y, w, h;
+
+  LinkEntry() : x(0), y(0), w(0), h(0) { href[0] = '\0'; }
+};

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -79,6 +79,21 @@ bool Page::serialize(FsFile& file) const {
     }
   }
 
+  // Serialize links
+  const uint16_t linkCount = std::min<uint16_t>(links.size(), MAX_LINKS_PER_PAGE);
+  serialization::writePod(file, linkCount);
+  for (uint16_t i = 0; i < linkCount; i++) {
+    const auto& lk = links[i];
+    if (file.write(lk.href, sizeof(lk.href)) != sizeof(lk.href)) {
+      LOG_ERR("PGE", "Failed to write link href");
+      return false;
+    }
+    serialization::writePod(file, lk.x);
+    serialization::writePod(file, lk.y);
+    serialization::writePod(file, lk.w);
+    serialization::writePod(file, lk.h);
+  }
+
   return true;
 }
 
@@ -121,6 +136,27 @@ std::unique_ptr<Page> Page::deserialize(FsFile& file) {
     }
     entry.number[sizeof(entry.number) - 1] = '\0';
     entry.href[sizeof(entry.href) - 1] = '\0';
+  }
+
+  // Deserialize links
+  uint16_t linkCount;
+  serialization::readPod(file, linkCount);
+  if (linkCount > Page::MAX_LINKS_PER_PAGE) {
+    LOG_ERR("PGE", "Invalid link count %u", linkCount);
+    return nullptr;
+  }
+  page->links.resize(linkCount);
+  for (uint16_t i = 0; i < linkCount; i++) {
+    auto& lk = page->links[i];
+    if (file.read(lk.href, sizeof(lk.href)) != sizeof(lk.href)) {
+      LOG_ERR("PGE", "Failed to read link %u", i);
+      return nullptr;
+    }
+    lk.href[sizeof(lk.href) - 1] = '\0';
+    serialization::readPod(file, lk.x);
+    serialization::readPod(file, lk.y);
+    serialization::readPod(file, lk.w);
+    serialization::readPod(file, lk.h);
   }
 
   return page;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "FootnoteEntry.h"
+#include "LinkEntry.h"
 #include "blocks/ImageBlock.h"
 #include "blocks/TextBlock.h"
 
@@ -62,6 +63,9 @@ class Page {
   std::vector<FootnoteEntry> footnotes;
   static constexpr uint16_t MAX_FOOTNOTES_PER_PAGE = 16;
 
+  std::vector<LinkEntry> links;
+  static constexpr uint16_t MAX_LINKS_PER_PAGE = 32;
+
   void addFootnote(const char* number, const char* href) {
     if (footnotes.size() >= MAX_FOOTNOTES_PER_PAGE) return;  // Cap per-page footnotes
     FootnoteEntry entry;
@@ -71,6 +75,21 @@ class Page {
     entry.href[sizeof(entry.href) - 1] = '\0';
     footnotes.push_back(entry);
   }
+
+  void addLink(const char* href, int16_t x, int16_t y, int16_t w, int16_t h) {
+    if (links.size() >= MAX_LINKS_PER_PAGE) return;
+    LinkEntry entry;
+    strncpy(entry.href, href, sizeof(entry.href) - 1);
+    entry.href[sizeof(entry.href) - 1] = '\0';
+    entry.x = x;
+    entry.y = y;
+    entry.w = w;
+    entry.h = h;
+    links.push_back(entry);
+  }
+
+  size_t getLinkCount() const { return links.size(); }
+  const LinkEntry& getLink(int i) const { return links[i]; }
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -78,9 +78,12 @@ class Page {
 
   void addLink(const char* href, int16_t x, int16_t y, int16_t w, int16_t h) {
     if (links.size() >= MAX_LINKS_PER_PAGE) return;
+    if (!href || strlen(href) >= sizeof(LinkEntry::href)) {
+      // Reject truncated or null hrefs to avoid unresolved navigation targets
+      return;
+    }
     LinkEntry entry;
-    strncpy(entry.href, href, sizeof(entry.href) - 1);
-    entry.href[sizeof(entry.href) - 1] = '\0';
+    strcpy(entry.href, href);  // Safe: length already validated
     entry.x = x;
     entry.y = y;
     entry.w = w;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -76,11 +76,11 @@ class Page {
     footnotes.push_back(entry);
   }
 
-  void addLink(const char* href, int16_t x, int16_t y, int16_t w, int16_t h) {
-    if (links.size() >= MAX_LINKS_PER_PAGE) return;
+  bool addLink(const char* href, int16_t x, int16_t y, int16_t w, int16_t h) {
+    if (links.size() >= MAX_LINKS_PER_PAGE) return false;
     if (!href || strlen(href) >= sizeof(LinkEntry::href)) {
       // Reject truncated or null hrefs to avoid unresolved navigation targets
-      return;
+      return false;
     }
     LinkEntry entry;
     strcpy(entry.href, href);  // Safe: length already validated
@@ -89,6 +89,7 @@ class Page {
     entry.w = w;
     entry.h = h;
     links.push_back(entry);
+    return true;
   }
 
   size_t getLinkCount() const { return links.size(); }

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -92,7 +92,10 @@ class Page {
   }
 
   size_t getLinkCount() const { return links.size(); }
-  const LinkEntry& getLink(int i) const { return links[i]; }
+  const LinkEntry& getLink(int i) const {
+    assert(i >= 0 && i < static_cast<int>(links.size()));
+    return links[i];
+  }
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -77,7 +77,7 @@ uint16_t measureWordWidth(const GfxRenderer& renderer, const int fontId, const s
 }  // namespace
 
 void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle, const bool underline,
-                         const bool attachToPrevious) {
+                         const bool attachToPrevious, const std::string& linkHref) {
   if (word.empty()) return;
 
   words.push_back(std::move(word));
@@ -87,6 +87,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   }
   wordStyles.push_back(combinedStyle);
   wordContinues.push_back(attachToPrevious);
+  wordLinkHrefs.push_back(linkHref);
 }
 
 // Consumes data to minimize memory usage
@@ -122,6 +123,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     words.erase(words.begin(), words.begin() + consumed);
     wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
+    wordLinkHrefs.erase(wordLinkHrefs.begin(), wordLinkHrefs.begin() + consumed);
   }
 }
 
@@ -402,9 +404,11 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
     words[wordIndex].push_back('-');
   }
 
-  // Insert the remainder word (with matching style and continuation flag) directly after the prefix.
+  // Insert the remainder word (with matching style, link href, and continuation flag) directly after the prefix.
+  std::string linkHref = wordLinkHrefs[wordIndex];  // copy before potential realloc
   words.insert(words.begin() + wordIndex + 1, remainder);
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
+  wordLinkHrefs.insert(wordLinkHrefs.begin() + wordIndex + 1, std::move(linkHref));
 
   // Continuation flag handling after splitting a word into prefix + remainder.
   //
@@ -529,6 +533,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
+  std::vector<std::string> lineLinkHrefs(std::make_move_iterator(wordLinkHrefs.begin() + lastBreakAt),
+                                         std::make_move_iterator(wordLinkHrefs.begin() + lineBreak));
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
@@ -536,6 +542,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
   }
 
-  processLine(
-      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle));
+  processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
+                                          blockStyle, std::move(lineLinkHrefs)));
 }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -15,7 +15,7 @@ class GfxRenderer;
 class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
-  std::vector<bool> wordContinues;  // true = word attaches to previous (no space before it)
+  std::vector<bool> wordContinues;         // true = word attaches to previous (no space before it)
   std::vector<std::string> wordLinkHrefs;  // parallel to words: non-empty = word is part of a link
   BlockStyle blockStyle;
   bool extraParagraphSpacing;

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -16,6 +16,7 @@ class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
   std::vector<bool> wordContinues;  // true = word attaches to previous (no space before it)
+  std::vector<std::string> wordLinkHrefs;  // parallel to words: non-empty = word is part of a link
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;
@@ -39,7 +40,8 @@ class ParsedText {
       : blockStyle(blockStyle), extraParagraphSpacing(extraParagraphSpacing), hyphenationEnabled(hyphenationEnabled) {}
   ~ParsedText() = default;
 
-  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false);
+  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false,
+               const std::string& linkHref = "");
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 18;
+constexpr uint8_t SECTION_FILE_VERSION = 19;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t);

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -26,7 +26,15 @@ class TextBlock final : public Block {
         wordXpos(std::move(word_xpos)),
         wordStyles(std::move(word_styles)),
         blockStyle(blockStyle),
-        wordLinkHrefs(std::move(word_link_hrefs)) {}
+        wordLinkHrefs(std::move(word_link_hrefs)) {
+    // Normalize wordLinkHrefs: if empty, treat as "no link metadata" and resize to match words
+    if (wordLinkHrefs.empty() && !this->words.empty()) {
+      this->wordLinkHrefs.resize(this->words.size(), "");
+    } else if (!wordLinkHrefs.empty()) {
+      // Ensure word-parallel invariant: wordLinkHrefs.size() == words.size()
+      assert(this->wordLinkHrefs.size() == this->words.size());
+    }
+  }
   ~TextBlock() override = default;
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   const BlockStyle& getBlockStyle() const { return blockStyle; }

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -16,18 +16,24 @@ class TextBlock final : public Block {
   std::vector<int16_t> wordXpos;
   std::vector<EpdFontFamily::Style> wordStyles;
   BlockStyle blockStyle;
+  std::vector<std::string> wordLinkHrefs;  // transient: not serialized, used during layout only
 
  public:
   explicit TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
-                     std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle())
+                     std::vector<EpdFontFamily::Style> word_styles, const BlockStyle& blockStyle = BlockStyle(),
+                     std::vector<std::string> word_link_hrefs = {})
       : words(std::move(words)),
         wordXpos(std::move(word_xpos)),
         wordStyles(std::move(word_styles)),
-        blockStyle(blockStyle) {}
+        blockStyle(blockStyle),
+        wordLinkHrefs(std::move(word_link_hrefs)) {}
   ~TextBlock() override = default;
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   const BlockStyle& getBlockStyle() const { return blockStyle; }
   const std::vector<std::string>& getWords() const { return words; }
+  const std::vector<int16_t>& getWordXpos() const { return wordXpos; }
+  const std::vector<EpdFontFamily::Style>& getWordStyles() const { return wordStyles; }
+  const std::vector<std::string>& getWordLinkHrefs() const { return wordLinkHrefs; }
   bool isEmpty() override { return words.empty(); }
   size_t wordCount() const { return words.size(); }
   // given a renderer works out where to break the words into lines

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1098,7 +1098,10 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
       const int16_t linkX = xpos[i] + xOffset;
       const int16_t lastWordW = renderer.getTextWidth(fontId, words[last].c_str(), styles[last]);
       const int16_t linkW = (xpos[last] + xOffset + lastWordW) - linkX;
-      currentPage->addLink(href.c_str(), linkX, currentPageNextY, linkW, static_cast<int16_t>(lineHeight));
+      if (!currentPage->addLink(href.c_str(), linkX, currentPageNextY, linkW, static_cast<int16_t>(lineHeight))) {
+        // Log if link was dropped due to page full or href too long
+        fprintf(stderr, "Warning: Link dropped (page full or href too long): %.50s\n", href.c_str());
+      }
       i = last + 1;
     }
   }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -119,7 +119,11 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 
   // flush the buffer
   partWordBuffer[partWordBufferIndex] = '\0';
-  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
+  if (insideFootnoteLink && currentFootnoteLinkHref[0] != '\0') {
+    currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, currentFootnoteLinkHref);
+  } else {
+    currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
+  }
   partWordBufferIndex = 0;
   nextWordContinues = false;
 }
@@ -1069,6 +1073,33 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
 
   // Apply horizontal left inset (margin + padding) as x position offset
   const int16_t xOffset = line->getBlockStyle().leftInset();
+
+  // Compute link bounding rects from per-word link hrefs
+  const auto& linkHrefs = line->getWordLinkHrefs();
+  if (!linkHrefs.empty()) {
+    const auto& words = line->getWords();
+    const auto& xpos = line->getWordXpos();
+    const auto& styles = line->getWordStyles();
+    size_t i = 0;
+    while (i < linkHrefs.size()) {
+      if (linkHrefs[i].empty()) {
+        ++i;
+        continue;
+      }
+      // Start of a link group: merge consecutive words with the same href
+      const std::string& href = linkHrefs[i];
+      size_t last = i;
+      while (last + 1 < linkHrefs.size() && linkHrefs[last + 1] == href) {
+        ++last;
+      }
+      const int16_t linkX = xpos[i] + xOffset;
+      const int16_t lastWordW = renderer.getTextWidth(fontId, words[last].c_str(), styles[last]);
+      const int16_t linkW = (xpos[last] + xOffset + lastWordW) - linkX;
+      currentPage->addLink(href.c_str(), linkX, currentPageNextY, linkW, static_cast<int16_t>(lineHeight));
+      i = last + 1;
+    }
+  }
+
   currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
   currentPageNextY += lineHeight;
 }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1080,6 +1080,9 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
     const auto& words = line->getWords();
     const auto& xpos = line->getWordXpos();
     const auto& styles = line->getWordStyles();
+    // Assert parallel word/link arrays are in sync
+    assert(linkHrefs.size() == words.size() && linkHrefs.size() == xpos.size() &&
+           linkHrefs.size() == styles.size());
     size_t i = 0;
     while (i < linkHrefs.size()) {
       if (linkHrefs[i].empty()) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -135,6 +135,41 @@ void EpubReaderActivity::loop() {
     }
   }
 
+  // Link cursor mode: Up/Down cycle through links, Confirm follows, Back exits
+  if (linkCursorIndex >= 0 && !currentPageLinks.empty()) {
+    if (mappedInput.wasReleased(MappedInputManager::Button::Up)) {
+      const int sz = static_cast<int>(currentPageLinks.size());
+      linkCursorIndex = (linkCursorIndex - 1 + sz) % sz;
+      requestUpdate();
+      return;
+    }
+    if (mappedInput.wasReleased(MappedInputManager::Button::Down)) {
+      linkCursorIndex = (linkCursorIndex + 1) % static_cast<int>(currentPageLinks.size());
+      requestUpdate();
+      return;
+    }
+    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+      std::string href = currentPageLinks[linkCursorIndex].href;
+      linkCursorIndex = -1;
+      navigateToHref(href, true);
+      return;
+    }
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back) &&
+        mappedInput.getHeldTime() < ReaderUtils::GO_HOME_MS) {
+      linkCursorIndex = -1;
+      requestUpdate();
+      return;
+    }
+  }
+
+  // Confirm: enter link cursor mode if links exist, otherwise open reader menu
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) && !currentPageLinks.empty() &&
+      linkCursorIndex < 0) {
+    linkCursorIndex = 0;
+    requestUpdate();
+    return;
+  }
+
   // Enter reader menu activity.
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const int currentPage = section ? section->currentPage + 1 : 0;
@@ -192,6 +227,7 @@ void EpubReaderActivity::loop() {
   const bool skipChapter = SETTINGS.longPressChapterSkip && mappedInput.getHeldTime() > skipChapterMs;
 
   if (skipChapter) {
+    linkCursorIndex = -1;
     lastPageTurnTime = millis();
     // We don't want to delete the section mid-render, so grab the semaphore
     {
@@ -457,6 +493,7 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
+  linkCursorIndex = -1;
   if (isForwardTurn) {
     if (section->currentPage < section->pageCount - 1) {
       section->currentPage++;
@@ -628,8 +665,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       return;
     }
 
-    // Collect footnotes from the loaded page
+    // Collect footnotes and link rects from the loaded page
     currentPageFootnotes = std::move(p->footnotes);
+    currentPageLinks = std::move(p->links);
 
     const auto start = millis();
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
@@ -683,6 +721,15 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   bool imagePageWithAA = page->hasImages() && SETTINGS.textAntiAliasing;
 
   page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+
+  // Draw link cursor highlight (border around the focused link)
+  if (linkCursorIndex >= 0 && static_cast<size_t>(linkCursorIndex) < currentPageLinks.size()) {
+    const auto& link = currentPageLinks[linkCursorIndex];
+    constexpr int pad = 2;
+    renderer.drawRect(link.x + orientedMarginLeft - pad, link.y + orientedMarginTop - pad, link.w + 2 * pad,
+                      link.h + 2 * pad, 2, true);
+  }
+
   renderStatusBar();
   fcm->logStats("bw_render");
   const auto tBwRender = millis();
@@ -798,6 +845,7 @@ void EpubReaderActivity::renderStatusBar() const {
 }
 
 void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool savePosition) {
+  linkCursorIndex = -1;
   if (!epub) return;
 
   // Push current position onto saved stack
@@ -842,6 +890,7 @@ void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool s
 }
 
 void EpubReaderActivity::restoreSavedPosition() {
+  linkCursorIndex = -1;
   if (footnoteDepth <= 0) return;
   footnoteDepth--;
   const auto& pos = savedPositions[footnoteDepth];

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
+#include <Epub/LinkEntry.h>
 #include <Epub/Section.h>
 
 #include "EpubReaderMenuActivity.h"
@@ -52,6 +53,10 @@ class EpubReaderActivity final : public Activity {
   // Footnote navigation
   void navigateToHref(const std::string& href, bool savePosition = false);
   void restoreSavedPosition();
+
+  // Link cursor navigation
+  int linkCursorIndex = -1;  // -1 = cursor mode inactive
+  std::vector<LinkEntry> currentPageLinks;
 
  public:
   explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub)


### PR DESCRIPTION
This PR adds on-device EPUB link navigation support.

## Features
- Press Confirm to enter link cursor mode (if page has links)
- Up/Down buttons cycle through links with highlight border
- Confirm follows the focused link
- Back exits cursor mode

## Implementation
- Link bounding rects computed during layout from per-word href tracking
- Bounding boxes persisted in section cache (SECTION_FILE_VERSION 18→19)
- Supports multiple links per page with clear visual feedback