### PR TITLE
feat: add XTC/XTCH file support to OPDS downloads

### DIFF
--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -154,7 +154,8 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
     if (href) {
       // Check for acquisition link with a supported book type
       if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0 || strcmp(type, "application/x-xtch+zip") == 0)) {
+          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0 ||
+           strcmp(type, "application/x-xtch+zip") == 0)) {
         self->currentEntry.type = OpdsEntryType::BOOK;
         self->currentEntry.href = href;
         self->currentEntry.mimeType = type;

--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -154,7 +154,7 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
     if (href) {
       // Check for acquisition link with a supported book type
       if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0)) {
+          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0 || strcmp(type, "application/x-xtch+zip") == 0)) {
         self->currentEntry.type = OpdsEntryType::BOOK;
         self->currentEntry.href = href;
         self->currentEntry.mimeType = type;

--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -154,8 +154,7 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
     if (href) {
       // Check for acquisition link with a supported book type
       if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-          (strcmp(type, "application/epub+zip") == 0 ||
-           strcmp(type, "application/x-xtc+zip") == 0)) {
+          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0)) {
         self->currentEntry.type = OpdsEntryType::BOOK;
         self->currentEntry.href = href;
         self->currentEntry.mimeType = type;

--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -152,11 +152,13 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
     const char* href = findAttribute(atts, "href");
 
     if (href) {
-      // Check for acquisition link with epub type (this is a downloadable book)
+      // Check for acquisition link with a supported book type
       if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-          strcmp(type, "application/epub+zip") == 0) {
+          (strcmp(type, "application/epub+zip") == 0 ||
+           strcmp(type, "application/x-xtc+zip") == 0)) {
         self->currentEntry.type = OpdsEntryType::BOOK;
         self->currentEntry.href = href;
+        self->currentEntry.mimeType = type;
       }
       // Check for navigation link (subsection or no rel specified with atom+xml type)
       else if (type && strstr(type, "application/atom+xml") != nullptr) {

--- a/lib/OpdsParser/OpdsParser.cpp
+++ b/lib/OpdsParser/OpdsParser.cpp
@@ -106,6 +106,19 @@ const char* OpdsParser::findAttribute(const XML_Char** atts, const char* name) {
   return nullptr;
 }
 
+static bool parseAcquisitionType(const char* mime, OpdsAcquisitionType& out) {
+  if (strcmp(mime, "application/epub+zip") == 0) {
+    out = OpdsAcquisitionType::EPUB;
+  } else if (strcmp(mime, "application/x-xtc+zip") == 0) {
+    out = OpdsAcquisitionType::XTC;
+  } else if (strcmp(mime, "application/x-xtch+zip") == 0) {
+    out = OpdsAcquisitionType::XTCH;
+  } else {
+    return false;
+  }
+  return true;
+}
+
 void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
   auto* self = static_cast<OpdsParser*>(userData);
 
@@ -154,11 +167,9 @@ void XMLCALL OpdsParser::startElement(void* userData, const XML_Char* name, cons
     if (href) {
       // Check for acquisition link with a supported book type
       if (rel && type && strstr(rel, "opds-spec.org/acquisition") != nullptr &&
-          (strcmp(type, "application/epub+zip") == 0 || strcmp(type, "application/x-xtc+zip") == 0 ||
-           strcmp(type, "application/x-xtch+zip") == 0)) {
+          parseAcquisitionType(type, self->currentEntry.acquisitionType)) {
         self->currentEntry.type = OpdsEntryType::BOOK;
         self->currentEntry.href = href;
-        self->currentEntry.mimeType = type;
       }
       // Check for navigation link (subsection or no rel specified with atom+xml type)
       else if (type && strstr(type, "application/atom+xml") != nullptr) {

--- a/lib/OpdsParser/OpdsParser.h
+++ b/lib/OpdsParser/OpdsParser.h
@@ -14,14 +14,23 @@ enum class OpdsEntryType {
 };
 
 /**
+ * Acquisition format for downloadable books.
+ */
+enum class OpdsAcquisitionType {
+  EPUB,  // application/epub+zip
+  XTC,   // application/x-xtc+zip
+  XTCH   // application/x-xtch+zip
+};
+
+/**
  * Represents an entry from an OPDS feed (either a navigation link or a book).
  */
 struct OpdsEntry {
   OpdsEntryType type = OpdsEntryType::NAVIGATION;
   std::string title;
-  std::string author;    // Only for books
-  std::string href;      // Navigation URL or book download URL
-  std::string mimeType;  // MIME type of the acquisition link (e.g. "application/epub+zip")
+  std::string author;  // Only for books
+  std::string href;    // Navigation URL or book download URL
+  OpdsAcquisitionType acquisitionType = OpdsAcquisitionType::EPUB;
   std::string id;
 };
 

--- a/lib/OpdsParser/OpdsParser.h
+++ b/lib/OpdsParser/OpdsParser.h
@@ -19,8 +19,9 @@ enum class OpdsEntryType {
 struct OpdsEntry {
   OpdsEntryType type = OpdsEntryType::NAVIGATION;
   std::string title;
-  std::string author;  // Only for books
-  std::string href;    // Navigation URL or epub download URL
+  std::string author;    // Only for books
+  std::string href;      // Navigation URL or book download URL
+  std::string mimeType;  // MIME type of the acquisition link (e.g. "application/epub+zip")
   std::string id;
 };
 

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -321,6 +321,8 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   std::string ext = ".epub";
   if (book.mimeType == "application/x-xtc+zip") {
     ext = ".xtc";
+  } else if (book.mimeType == "application/x-xtch+zip") {
+    ext = ".xtch";
   }
 
   // Create sanitized filename: "Title - Author.ext" or just "Title.ext" if no author
@@ -343,7 +345,7 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
     LOG_DBG("OPDS", "Download complete: %s", filename.c_str());
 
     // Invalidate cache for the corresponding format
-    if (ext == ".xtc") {
+    if (ext == ".xtc" || ext == ".xtch") {
       Xtc xtc(filename, "/.crosspoint");
       xtc.clearCache();
       LOG_DBG("OPDS", "Cleared XTC cache for: %s", filename.c_str());

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -317,12 +317,17 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // Build full download URL
   std::string downloadUrl = UrlUtils::buildUrl(SETTINGS.opdsServerUrl, book.href);
 
-  // Determine file extension from MIME type
-  std::string ext = ".epub";
-  if (book.mimeType == "application/x-xtc+zip") {
-    ext = ".xtc";
-  } else if (book.mimeType == "application/x-xtch+zip") {
-    ext = ".xtch";
+  // Determine file extension from acquisition type
+  const char* ext = ".epub";
+  switch (book.acquisitionType) {
+    case OpdsAcquisitionType::XTC:
+      ext = ".xtc";
+      break;
+    case OpdsAcquisitionType::XTCH:
+      ext = ".xtch";
+      break;
+    default:
+      break;
   }
 
   // Create sanitized filename: "Title - Author.ext" or just "Title.ext" if no author
@@ -345,20 +350,18 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
     LOG_DBG("OPDS", "Download complete: %s", filename.c_str());
 
     // Invalidate cache for the corresponding format
-    if (ext == ".xtc" || ext == ".xtch") {
+    bool cacheCleared;
+    if (book.acquisitionType == OpdsAcquisitionType::XTC || book.acquisitionType == OpdsAcquisitionType::XTCH) {
       Xtc xtc(filename, "/.crosspoint");
-      if (!xtc.clearCache()) {
-        LOG_ERR("OPDS", "Failed to clear XTC cache for: %s", filename.c_str());
-      } else {
-        LOG_DBG("OPDS", "Cleared XTC cache for: %s", filename.c_str());
-      }
+      cacheCleared = xtc.clearCache();
     } else {
       Epub epub(filename, "/.crosspoint");
-      if (!epub.clearCache()) {
-        LOG_ERR("OPDS", "Failed to clear EPUB cache for: %s", filename.c_str());
-      } else {
-        LOG_DBG("OPDS", "Cleared EPUB cache for: %s", filename.c_str());
-      }
+      cacheCleared = epub.clearCache();
+    }
+    if (!cacheCleared) {
+      LOG_ERR("OPDS", "Failed to clear cache for: %s", filename.c_str());
+    } else {
+      LOG_DBG("OPDS", "Cleared cache for: %s", filename.c_str());
     }
 
     state = BrowserState::BROWSING;

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1,6 +1,7 @@
 #include "OpdsBookBrowserActivity.h"
 
 #include <Epub.h>
+#include <Xtc.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <Logging.h>
@@ -341,10 +342,16 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   if (result == HttpDownloader::OK) {
     LOG_DBG("OPDS", "Download complete: %s", filename.c_str());
 
-    // Invalidate any existing cache for this file to prevent stale metadata issues
-    Epub epub(filename, "/.crosspoint");
-    epub.clearCache();
-    LOG_DBG("OPDS", "Cleared cache for: %s", filename.c_str());
+    // Invalidate cache for the corresponding format
+    if (ext == ".xtc") {
+      Xtc xtc(filename, "/.crosspoint");
+      xtc.clearCache();
+      LOG_DBG("OPDS", "Cleared XTC cache for: %s", filename.c_str());
+    } else {
+      Epub epub(filename, "/.crosspoint");
+      epub.clearCache();
+      LOG_DBG("OPDS", "Cleared EPUB cache for: %s", filename.c_str());
+    }
 
     state = BrowserState::BROWSING;
     requestUpdate();

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -316,12 +316,18 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // Build full download URL
   std::string downloadUrl = UrlUtils::buildUrl(SETTINGS.opdsServerUrl, book.href);
 
-  // Create sanitized filename: "Title - Author.epub" or just "Title.epub" if no author
+  // Determine file extension from MIME type
+  std::string ext = ".epub";
+  if (book.mimeType == "application/x-xtc+zip") {
+    ext = ".xtc";
+  }
+
+  // Create sanitized filename: "Title - Author.ext" or just "Title.ext" if no author
   std::string baseName = book.title;
   if (!book.author.empty()) {
     baseName += " - " + book.author;
   }
-  std::string filename = "/" + StringUtils::sanitizeFilename(baseName) + ".epub";
+  std::string filename = "/" + StringUtils::sanitizeFilename(baseName) + ext;
 
   LOG_DBG("OPDS", "Downloading: %s -> %s", downloadUrl.c_str(), filename.c_str());
 

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1,12 +1,12 @@
 #include "OpdsBookBrowserActivity.h"
 
 #include <Epub.h>
-#include <Xtc.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <Logging.h>
 #include <OpdsStream.h>
 #include <WiFi.h>
+#include <Xtc.h>
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
@@ -347,12 +347,18 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
     // Invalidate cache for the corresponding format
     if (ext == ".xtc" || ext == ".xtch") {
       Xtc xtc(filename, "/.crosspoint");
-      xtc.clearCache();
-      LOG_DBG("OPDS", "Cleared XTC cache for: %s", filename.c_str());
+      if (!xtc.clearCache()) {
+        LOG_ERR("OPDS", "Failed to clear XTC cache for: %s", filename.c_str());
+      } else {
+        LOG_DBG("OPDS", "Cleared XTC cache for: %s", filename.c_str());
+      }
     } else {
       Epub epub(filename, "/.crosspoint");
-      epub.clearCache();
-      LOG_DBG("OPDS", "Cleared EPUB cache for: %s", filename.c_str());
+      if (!epub.clearCache()) {
+        LOG_ERR("OPDS", "Failed to clear EPUB cache for: %s", filename.c_str());
+      } else {
+        LOG_DBG("OPDS", "Cleared EPUB cache for: %s", filename.c_str());
+      }
     }
 
     state = BrowserState::BROWSING;


### PR DESCRIPTION
## Summary

  * **What is the goal of this PR?** Enable OPDS download of XTC and XTCH files with the correct file extensions, so downloaded books open properly on the
  device.
  * **What changes are included?**
    - `OpdsParser` now recognizes `application/x-xtc+zip` and `application/x-xtch+zip` as valid acquisition MIME types alongside `application/epub+zip`
    - `OpdsEntry` stores the MIME type from the acquisition link
    - `OpdsBookBrowserActivity::downloadBook` derives the file extension from the MIME type instead of hardcoding `.epub` (`.xtc` for XTC, `.xtch` for XTCH)
    - Cache invalidation uses the correct class (`Xtc` for XTC/XTCH, `Epub` for EPUB)

  ## Additional Context

  Previously, OPDS servers serving XTC/XTCH files had to use `application/epub+zip` for entries to appear in the OPDS browser. This caused downloaded files to
  be saved with a `.epub` extension, and the device failed to open them since file type detection relies on the extension.

  This PR adds support for both `application/x-xtc+zip` and `application/x-xtch+zip` so OPDS servers can serve XTC/XTCH files with their correct MIME types, and
   the device saves them with the proper `.xtc` or `.xtch` extension.

  The change is backward-compatible — existing EPUB downloads are unaffected.

  ---

  ### AI Usage

  Did you use AI tools to help write this code? _**YES**_