### PR TITLE
fix: Honor CSS text-align

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -577,7 +577,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->startNewTextBlock(self->currentTextBlock->getBlockStyle());
     } else {
       self->currentCssStyle = cssStyle;
-      self->startNewTextBlock(userAlignmentBlockStyle);
+      auto blockStyle = userAlignmentBlockStyle;
+      if (self->embeddedStyle && cssStyle.hasTextAlign()) {
+        blockStyle.alignment = cssStyle.textAlign;
+        blockStyle.textAlignDefined = true;
+      }
+      self->startNewTextBlock(blockStyle);
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Respects explicit text-align css information, eg centered
* **What changes are included?**

## Additional Context

* When a global alignment setting (e.g. Justify, Left) was set, it unconditionally overrides the CSS text-align for all non-header block elements (<p>, <div>, etc.).
* The included fix now restores the CSS text-align for non-header block elements when the book's embedded stylesheet explicitly defines it — the same pattern already used for headers

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
