### PR TITLE
fix: Reset block style completely when leaving element

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -955,17 +955,29 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     self->currentCssStyle.reset();
     self->updateEffectiveInlineStyle();
 
-    // Reset alignment on empty text blocks to prevent stale alignment from bleeding
+    // Reset block style on empty text blocks to prevent stale styling from bleeding
     // into the next sibling element. This fixes issue #1026 where an empty <h1> (default
     // Center) followed by an image-only <p> causes Center to persist through the chain
     // of empty block reuse into subsequent text paragraphs.
-    // Margins/padding are preserved so parent element spacing still accumulates correctly.
+    // Margins/padding are also reset to prevent a closed block's horizontal margins from
+    // leaking to the next sibling (e.g. <div style="margin:1em 40%"><img/></div><p>text</p>
+    // would otherwise cause the <p> to inherit the div's 40% side margins).
+    // Parent-child margin accumulation is unaffected because it happens at child open time
+    // via getCombinedBlockStyle(), before the parent closes.
     if (self->currentTextBlock && self->currentTextBlock->isEmpty()) {
       auto style = self->currentTextBlock->getBlockStyle();
       style.textAlignDefined = false;
       style.alignment = (self->paragraphAlignment == static_cast<uint8_t>(CssTextAlign::None))
                             ? CssTextAlign::Justify
                             : static_cast<CssTextAlign>(self->paragraphAlignment);
+      style.marginLeft = 0;
+      style.marginRight = 0;
+      style.marginTop = 0;
+      style.marginBottom = 0;
+      style.paddingLeft = 0;
+      style.paddingRight = 0;
+      style.paddingTop = 0;
+      style.paddingBottom = 0;
       self->currentTextBlock->setBlockStyle(style);
     }
   }


### PR DESCRIPTION
## Summary

- Extends the empty text block style reset (introduced in #1026) to also clear all margins and padding, not just text alignment
- Prevents horizontal margins/padding from a closed block from bleeding into the next sibling element's empty text block

## Additional Context

Consider the following example:
```html
<div style="margin:1em 40%">
  <img/>
</div>
<p>text</p>
```

Before this fix, the `<p>` would inherit the div's 40% side margins, pushing text inward extremely far. After this fix, the div style is completely reset when leaving the element, preventing the bleed into the p element.

This does highlight an interesting issue where nested block elements with styles would leak incorrectly, but now no longer stack correctly. I think this is preferred, but happy for opinions.

e.g.

```html
<div class="c1">          <!-- marginLeft: 10px -->
  <div class="c2">        <!-- marginLeft: 20px -->
    <p class="c3">text</p>  <!-- marginLeft: 5px -->
  </div>
  <p class="c4">text2</p>   <!-- marginLeft: 5px -->
</div>
```

Expected: `c3` gets 10+20+5=35px, `c4` gets 10+5=15px.
Original code: `c2` closes with empty block (margins 30 preserved) →  `c4` merges styles → 35px. Wrong (should be 15).
This PR: `c2` closes with empty block → margins reset to 0 → c4 merges styles → 5px. Also wrong (should be 15).

The complete fix for this would be a full style stack. However this fix imo is slightly better than the old implementation. Throwing away styles feels like a better compromise rather than leaking them.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? Yes
