### PR TITLE
feat: Allow renaming and moving folders in web file manager (#864)

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -57,6 +57,8 @@ void clearEpubCacheIfNeeded(const String& filePath) {
 
 // Recursively clear epub caches for all EPUBs inside a directory
 void clearEpubCachesInDirectory(const String& dirPath) {
+  esp_task_wdt_reset();
+  yield();
   FsFile dir = Storage.open(dirPath.c_str());
   if (!dir || !dir.isDirectory()) {
     if (dir) dir.close();
@@ -65,6 +67,8 @@ void clearEpubCachesInDirectory(const String& dirPath) {
   char name[500];
   FsFile entry = dir.openNextFile();
   while (entry) {
+    esp_task_wdt_reset();
+    yield();
     entry.getName(name, sizeof(name));
     String childPath = dirPath;
     if (!childPath.endsWith("/")) childPath += "/";

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -49,11 +49,36 @@ unsigned long wsLastCompleteAt = 0;
 
 // Helper function to clear epub cache after upload
 void clearEpubCacheIfNeeded(const String& filePath) {
-  // Only clear cache for .epub files
   if (FsHelpers::hasEpubExtension(filePath)) {
     Epub(filePath.c_str(), "/.crosspoint").clearCache();
     LOG_DBG("WEB", "Cleared epub cache for: %s", filePath.c_str());
   }
+}
+
+// Recursively clear epub caches for all EPUBs inside a directory
+void clearEpubCachesInDirectory(const String& dirPath) {
+  FsFile dir = Storage.open(dirPath.c_str());
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return;
+  }
+  char name[500];
+  FsFile entry = dir.openNextFile();
+  while (entry) {
+    entry.getName(name, sizeof(name));
+    String childPath = dirPath;
+    if (!childPath.endsWith("/")) childPath += "/";
+    childPath += name;
+    if (entry.isDirectory()) {
+      entry.close();
+      clearEpubCachesInDirectory(childPath);
+    } else {
+      entry.close();
+      clearEpubCacheIfNeeded(childPath);
+    }
+    entry = dir.openNextFile();
+  }
+  dir.close();
 }
 
 String normalizeWebPath(const String& inputPath) {
@@ -854,11 +879,7 @@ void CrossPointWebServer::handleRename() const {
     server->send(500, "text/plain", "Failed to open file");
     return;
   }
-  if (file.isDirectory()) {
-    file.close();
-    server->send(400, "text/plain", "Only files can be renamed");
-    return;
-  }
+  const bool isDir = file.isDirectory();
 
   String parentPath = itemPath.substring(0, itemPath.lastIndexOf('/'));
   if (parentPath.isEmpty()) {
@@ -876,16 +897,20 @@ void CrossPointWebServer::handleRename() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  if (isDir) {
+    clearEpubCachesInDirectory(itemPath);
+  } else {
+    clearEpubCacheIfNeeded(itemPath);
+  }
   const bool success = file.rename(newPath.c_str());
   file.close();
 
   if (success) {
-    LOG_DBG("WEB", "Renamed file: %s -> %s", itemPath.c_str(), newPath.c_str());
+    LOG_DBG("WEB", "Renamed: %s -> %s", itemPath.c_str(), newPath.c_str());
     server->send(200, "text/plain", "Renamed successfully");
   } else {
-    LOG_ERR("WEB", "Failed to rename file: %s -> %s", itemPath.c_str(), newPath.c_str());
-    server->send(500, "text/plain", "Failed to rename file");
+    LOG_ERR("WEB", "Failed to rename: %s -> %s", itemPath.c_str(), newPath.c_str());
+    server->send(500, "text/plain", "Failed to rename");
   }
 }
 
@@ -930,10 +955,18 @@ void CrossPointWebServer::handleMove() const {
     server->send(500, "text/plain", "Failed to open file");
     return;
   }
-  if (file.isDirectory()) {
-    file.close();
-    server->send(400, "text/plain", "Only files can be moved");
-    return;
+  const bool isDir = file.isDirectory();
+
+  if (isDir) {
+    String destWithSlash = destPath;
+    if (!destWithSlash.endsWith("/")) destWithSlash += "/";
+    String itemWithSlash = itemPath;
+    if (!itemWithSlash.endsWith("/")) itemWithSlash += "/";
+    if (destPath == itemPath || destWithSlash.startsWith(itemWithSlash)) {
+      file.close();
+      server->send(400, "text/plain", "Cannot move folder into itself");
+      return;
+    }
   }
 
   if (!Storage.exists(destPath.c_str())) {
@@ -969,16 +1002,20 @@ void CrossPointWebServer::handleMove() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  if (isDir) {
+    clearEpubCachesInDirectory(itemPath);
+  } else {
+    clearEpubCacheIfNeeded(itemPath);
+  }
   const bool success = file.rename(newPath.c_str());
   file.close();
 
   if (success) {
-    LOG_DBG("WEB", "Moved file: %s -> %s", itemPath.c_str(), newPath.c_str());
+    LOG_DBG("WEB", "Moved: %s -> %s", itemPath.c_str(), newPath.c_str());
     server->send(200, "text/plain", "Moved successfully");
   } else {
-    LOG_ERR("WEB", "Failed to move file: %s -> %s", itemPath.c_str(), newPath.c_str());
-    server->send(500, "text/plain", "Failed to move file");
+    LOG_ERR("WEB", "Failed to move: %s -> %s", itemPath.c_str(), newPath.c_str());
+    server->send(500, "text/plain", "Failed to move");
   }
 }
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1915,8 +1915,8 @@
           fileTableContent += '<td><span class="folder-badge">FOLDER</span></td>';
           fileTableContent += '<td>-</td>';
           fileTableContent += `<td class="actions-col"><div class="action-icon-group">`;
-          fileTableContent += `<button class="move-btn" onclick="openMoveModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}')" title="Move folder">📂</button>`;
-          fileTableContent += `<button class="rename-btn" onclick="openRenameModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}')" title="Rename folder">✏️</button>`;
+          fileTableContent += `<button class="move-btn" onclick="openMoveModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Move folder">📂</button>`;
+          fileTableContent += `<button class="rename-btn" onclick="openRenameModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Rename folder">✏️</button>`;
           fileTableContent += `<button class="delete-btn" onclick="openDeleteModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Delete folder">🗑️</button>`;
           fileTableContent += `</div></td>`;
           fileTableContent += '</tr>';
@@ -5039,8 +5039,8 @@ function retryAllFailedUploads() {
   }
 
   // Rename functions
-  function openRenameModal(name, path) {
-    const icon = path.endsWith('/') ? '📁' : '📄';
+  function openRenameModal(name, path, isFolder = false) {
+    const icon = isFolder ? '📁' : '📄';
     document.getElementById('renameItemName').textContent = icon + ' ' + name;
     document.getElementById('renameItemPath').value = path;
     document.getElementById('renameNewName').value = name;
@@ -5155,8 +5155,8 @@ function retryAllFailedUploads() {
     });
   }
 
-  function openMoveModal(name, path) {
-    const icon = path.endsWith('/') ? '📁' : '📄';
+  function openMoveModal(name, path, isFolder = false) {
+    const icon = isFolder ? '📁' : '📄';
     document.getElementById('moveItemName').textContent = icon + ' ' + name;
     document.getElementById('moveItemPath').value = path;
     document.getElementById('moveDestPath').value = currentPath === '/' ? '/' : currentPath;

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1914,7 +1914,11 @@
           fileTableContent += `<td><span class="file-icon">📁</span><a href="/files?path=${encodeURIComponent(folderPath)}" class="folder-link">${escapeHtml(file.name)}</a></td>`;
           fileTableContent += '<td><span class="folder-badge">FOLDER</span></td>';
           fileTableContent += '<td>-</td>';
-          fileTableContent += `<td class="actions-col"><div class="action-icon-group"><button class="delete-btn" onclick="openDeleteModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Delete folder">🗑️</button></div></td>`;
+          fileTableContent += `<td class="actions-col"><div class="action-icon-group">`;
+          fileTableContent += `<button class="move-btn" onclick="openMoveModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}')" title="Move folder">📂</button>`;
+          fileTableContent += `<button class="rename-btn" onclick="openRenameModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}')" title="Rename folder">✏️</button>`;
+          fileTableContent += `<button class="delete-btn" onclick="openDeleteModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Delete folder">🗑️</button>`;
+          fileTableContent += `</div></td>`;
           fileTableContent += '</tr>';
         } else {
           let filePath = currentPath;
@@ -5036,7 +5040,8 @@ function retryAllFailedUploads() {
 
   // Rename functions
   function openRenameModal(name, path) {
-    document.getElementById('renameItemName').textContent = '📄 ' + name;
+    const icon = path.endsWith('/') ? '📁' : '📄';
+    document.getElementById('renameItemName').textContent = icon + ' ' + name;
     document.getElementById('renameItemPath').value = path;
     document.getElementById('renameNewName').value = name;
     document.getElementById('renameModal').classList.add('open');
@@ -5151,7 +5156,8 @@ function retryAllFailedUploads() {
   }
 
   function openMoveModal(name, path) {
-    document.getElementById('moveItemName').textContent = '📄 ' + name;
+    const icon = path.endsWith('/') ? '📁' : '📄';
+    document.getElementById('moveItemName').textContent = icon + ' ' + name;
     document.getElementById('moveItemPath').value = path;
     document.getElementById('moveDestPath').value = currentPath === '/' ? '/' : currentPath;
     document.getElementById('moveModal').classList.add('open');


### PR DESCRIPTION
Remove the directory restriction from rename and move handlers, add rename/move buttons to folder rows in the UI, and recursively clear EPUB caches when a folder is renamed or moved. Includes a safety check to prevent moving a folder into itself.

## Summary

* **What is the goal of this PR?** Fix for #864
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
