### PR TITLE
Make the keyboard a grid based entry instead of directional input

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -6,19 +6,6 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 
-// Keyboard layouts - lowercase
-const char* const KeyboardEntryActivity::keyboard[NUM_ROWS] = {
-    "`1234567890-=", "qwertyuiop[]\\", "asdfghjkl;'", "zxcvbnm,./",
-    "^  _____<OK"  // ^ = shift, _ = space, < = backspace, OK = done
-};
-
-// Keyboard layouts - uppercase/symbols
-const char* const KeyboardEntryActivity::keyboardShift[NUM_ROWS] = {"~!@#$%^&*()_+", "QWERTYUIOP{}|", "ASDFGHJKL:\"",
-                                                                    "ZXCVBNM<>?", "SPECIAL ROW"};
-
-// Shift state strings
-const char* const KeyboardEntryActivity::shiftString[3] = {"shift", "SHIFT", "LOCK"};
-
 void KeyboardEntryActivity::onEnter() {
   Activity::onEnter();
 
@@ -28,64 +15,43 @@ void KeyboardEntryActivity::onEnter() {
 
 void KeyboardEntryActivity::onExit() { Activity::onExit(); }
 
-int KeyboardEntryActivity::getRowLength(const int row) const {
-  if (row < 0 || row >= NUM_ROWS) return 0;
-
-  // Return actual length of each row based on keyboard layout
-  switch (row) {
-    case 0:
-      return 13;  // `1234567890-=
-    case 1:
-      return 13;  // qwertyuiop[]backslash
-    case 2:
-      return 11;  // asdfghjkl;'
-    case 3:
-      return 10;  // zxcvbnm,./
-    case 4:
-      return 11;  // shift (2 wide), space (5 wide), backspace (2 wide), OK (2 wide)
-    default:
-      return 0;
-  }
-}
+const char* KeyboardEntryActivity::keyboard[] = {
+  "abcd", "efgh", "ijkl", "mnop", "qrst", "uvwx", "yz12", "3456",
+  //"7890", "~!@#", "$%^&", "*()_", "+:<>", "?   "
+};
 
 char KeyboardEntryActivity::getSelectedChar() const {
-  const char* const* layout = shiftState ? keyboardShift : keyboard;
+  if (selectedTopLevel == 2 && selectedMidLevel == 2) {
+    return '\0';
+  }
 
-  if (selectedRow < 0 || selectedRow >= NUM_ROWS) return '\0';
-  if (selectedCol < 0 || selectedCol >= getRowLength(selectedRow)) return '\0';
+  int group = selectedTopLevel / 2 + selectedMidLevel; // Each page offsets the indices by one
 
-  return layout[selectedRow][selectedCol];
+  return keyboard[group][selectedBottomLevel];
 }
 
 bool KeyboardEntryActivity::handleKeyPress() {
   // Handle special row (bottom row with shift, space, backspace, done)
-  if (selectedRow == SPECIAL_ROW) {
-    if (selectedCol >= SHIFT_COL && selectedCol < SPACE_COL) {
-      // Shift toggle (0 = lower case, 1 = upper case, 2 = shift lock)
-      shiftState = (shiftState + 1) % 3;
-      return true;
-    }
-
-    if (selectedCol >= SPACE_COL && selectedCol < BACKSPACE_COL) {
-      // Space bar
-      if (maxLength == 0 || text.length() < maxLength) {
-        text += ' ';
-      }
-      return true;
-    }
-
-    if (selectedCol >= BACKSPACE_COL && selectedCol < DONE_COL) {
-      // Backspace
-      if (!text.empty()) {
-        text.pop_back();
-      }
-      return true;
-    }
-
-    if (selectedCol >= DONE_COL) {
-      // Done button
-      onComplete(text);
-      return false;
+  if (selectedTopLevel == 2 && selectedMidLevel == 2) {
+    switch (selectedBottomLevel) {
+      case 0:
+        // Shift toggle (0 = lower case, 1 = upper case, 2 = shift lock)
+        shiftState = (shiftState + 1) % 3;
+        return true;
+      case 1:
+        if (maxLength == 0 || text.length() < maxLength) {
+          text += ' ';
+        }
+        return true;
+      case 2:
+        // Backspace
+        if (!text.empty()) {
+          text.pop_back();
+        }
+        return true;
+      case 3:
+        onComplete(text);
+        return false;
     }
   }
 
@@ -106,71 +72,46 @@ bool KeyboardEntryActivity::handleKeyPress() {
   return true;
 }
 
+
+void KeyboardEntryActivity::setLevelOnPress(int level) {
+  if (selectedTopLevel == -1) {
+    selectedTopLevel = level;
+  } else if (selectedMidLevel == -1) {
+    selectedMidLevel = level;
+  } else {
+    selectedBottomLevel = level;
+  }
+}
+
 void KeyboardEntryActivity::loop() {
   // Handle navigation
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this] {
-    selectedRow = ButtonNavigator::previousIndex(selectedRow, NUM_ROWS);
-
-    const int maxCol = getRowLength(selectedRow) - 1;
-    if (selectedCol > maxCol) selectedCol = maxCol;
+    setLevelOnPress(0);
     requestUpdate();
   });
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down}, [this] {
-    selectedRow = ButtonNavigator::nextIndex(selectedRow, NUM_ROWS);
-
-    const int maxCol = getRowLength(selectedRow) - 1;
-    if (selectedCol > maxCol) selectedCol = maxCol;
+    //selectedRow = ButtonNavigator::nextIndex(selectedRow, NUM_ROWS);
+    setLevelOnPress(1);
     requestUpdate();
   });
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Left}, [this] {
-    const int maxCol = getRowLength(selectedRow) - 1;
-
-    // Special bottom row case
-    if (selectedRow == SPECIAL_ROW) {
-      // Bottom row has special key widths
-      if (selectedCol >= SHIFT_COL && selectedCol < SPACE_COL) {
-        // In shift key, wrap to end of row
-        selectedCol = maxCol;
-      } else if (selectedCol >= SPACE_COL && selectedCol < BACKSPACE_COL) {
-        // In space bar, move to shift
-        selectedCol = SHIFT_COL;
-      } else if (selectedCol >= BACKSPACE_COL && selectedCol < DONE_COL) {
-        // In backspace, move to space
-        selectedCol = SPACE_COL;
-      } else if (selectedCol >= DONE_COL) {
-        // At done button, move to backspace
-        selectedCol = BACKSPACE_COL;
-      }
-    } else {
-      selectedCol = ButtonNavigator::previousIndex(selectedCol, maxCol + 1);
-    }
-
+    setLevelOnPress(2);
     requestUpdate();
   });
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Right}, [this] {
-    const int maxCol = getRowLength(selectedRow) - 1;
-
-    // Special bottom row case
-    if (selectedRow == SPECIAL_ROW) {
-      // Bottom row has special key widths
-      if (selectedCol >= SHIFT_COL && selectedCol < SPACE_COL) {
-        // In shift key, move to space
-        selectedCol = SPACE_COL;
-      } else if (selectedCol >= SPACE_COL && selectedCol < BACKSPACE_COL) {
-        // In space bar, move to backspace
-        selectedCol = BACKSPACE_COL;
-      } else if (selectedCol >= BACKSPACE_COL && selectedCol < DONE_COL) {
-        // In backspace, move to done
-        selectedCol = DONE_COL;
-      } else if (selectedCol >= DONE_COL) {
-        // At done button, wrap to beginning of row
-        selectedCol = SHIFT_COL;
-      }
+    if (selectedBottomLevel == -1) {
+      setLevelOnPress(3);
     } else {
-      selectedCol = ButtonNavigator::nextIndex(selectedCol, maxCol + 1);
+      int oldLevel = selectedMidLevel;
+      if (selectedMidLevel != -1) {
+        selectedMidLevel = -1;
+      }
+      if (oldLevel != -1) {
+        selectedTopLevel = -1;
+      }
     }
     requestUpdate();
   });
@@ -185,7 +126,16 @@ void KeyboardEntryActivity::loop() {
 
   // Cancel
   if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-    onCancel();
+    if (selectedMidLevel != -1){
+      selectedMidLevel = -1;
+      selectedBottomLevel = -1;
+    } else if (selectedTopLevel != -1) {
+      selectedBottomLevel = -1;
+      selectedMidLevel = -1;
+      selectedTopLevel = -1;
+    } else {
+      onCancel();
+    }
   }
 }
 
@@ -240,76 +190,24 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   }
 
   GUI.drawTextField(renderer, Rect{0, inputStartY, pageWidth, inputHeight}, textWidth);
-
-  // Draw keyboard - use compact spacing to fit 5 rows on screen
   const int keyboardStartY = metrics.keyboardBottomAligned
-                                 ? pageHeight - metrics.buttonHintsHeight - metrics.verticalSpacing -
-                                       (metrics.keyboardKeyHeight + metrics.keyboardKeySpacing) * NUM_ROWS
-                                 : inputStartY + inputHeight + metrics.verticalSpacing * 4;
-  const int keyWidth = metrics.keyboardKeyWidth;
-  const int keyHeight = metrics.keyboardKeyHeight;
-  const int keySpacing = metrics.keyboardKeySpacing;
+                                   ? pageHeight - metrics.buttonHintsHeight - metrics.verticalSpacing -
+                                         (metrics.keyboardKeyHeight + metrics.keyboardKeySpacing) * 4
+                                   : inputStartY + inputHeight + metrics.verticalSpacing * 4;
 
-  const char* const* layout = shiftState ? keyboardShift : keyboard;
-
-  // Calculate left margin to center the longest row (13 keys)
-  const int maxRowWidth = KEYS_PER_ROW * (keyWidth + keySpacing);
-  const int leftMargin = (pageWidth - maxRowWidth) / 2;
-
-  for (int row = 0; row < NUM_ROWS; row++) {
-    const int rowY = keyboardStartY + row * (keyHeight + keySpacing);
-
-    // Left-align all rows for consistent navigation
-    const int startX = leftMargin;
-
-    // Handle bottom row (row 4) specially with proper multi-column keys
-    if (row == SPECIAL_ROW) {
-      // Bottom row layout: SHIFT (2 cols) | SPACE (5 cols) | <- (2 cols) | OK (2 cols)
-      // Total: 11 visual columns, but we use logical positions for selection
-
-      int currentX = startX;
-
-      // SHIFT key (logical col 0, spans 2 key widths)
-      const bool shiftSelected = (selectedRow == SPECIAL_ROW && selectedCol >= SHIFT_COL && selectedCol < SPACE_COL);
-      const int shiftWidth = SPACE_COL - SHIFT_COL;
-      const int shiftXWidth = shiftWidth * (keyWidth + keySpacing);
-      GUI.drawKeyboardKey(renderer, Rect{currentX, rowY, shiftXWidth, keyHeight}, shiftString[shiftState],
-                          shiftSelected);
-      currentX += shiftXWidth;
-
-      // Space bar (logical cols 2-6, spans 5 key widths)
-      const bool spaceSelected =
-          (selectedRow == SPECIAL_ROW && selectedCol >= SPACE_COL && selectedCol < BACKSPACE_COL);
-      const int spaceWidth = BACKSPACE_COL - SPACE_COL;
-      const int spaceXWidth = spaceWidth * (keyWidth + keySpacing);
-      GUI.drawKeyboardKey(renderer, Rect{currentX, rowY, spaceXWidth, keyHeight}, "_____", spaceSelected);
-      currentX += spaceXWidth;
-
-      // Backspace key (logical col 7, spans 2 key widths)
-      const bool bsSelected = (selectedRow == SPECIAL_ROW && selectedCol >= BACKSPACE_COL && selectedCol < DONE_COL);
-      const int backspaceWidth = DONE_COL - BACKSPACE_COL;
-      const int backspaceXWidth = backspaceWidth * (keyWidth + keySpacing);
-      GUI.drawKeyboardKey(renderer, Rect{currentX, rowY, backspaceXWidth, keyHeight}, "<-", bsSelected);
-      currentX += backspaceXWidth;
-
-      // OK button (logical col 9, spans 2 key widths)
-      const bool okSelected = (selectedRow == SPECIAL_ROW && selectedCol >= DONE_COL);
-      const int okWidth = getRowLength(row) - DONE_COL;
-      const int okXWidth = okWidth * (keyWidth + keySpacing);
-      GUI.drawKeyboardKey(renderer, Rect{currentX, rowY, okXWidth, keyHeight}, tr(STR_OK_BUTTON), okSelected);
-    } else {
-      // Regular rows: render each key individually
-      for (int col = 0; col < getRowLength(row); col++) {
-        // Get the character to display
-        const char c = layout[row][col];
-        std::string keyLabel(1, c);
-
-        const int keyX = startX + col * (keyWidth + keySpacing);
-        const bool isSelected = row == selectedRow && col == selectedCol;
-        GUI.drawKeyboardKey(renderer, Rect{keyX, rowY, keyWidth, keyHeight}, keyLabel.c_str(), isSelected);
-      }
+  if (selectedTopLevel == -1) {
+    for(int i = 0; i < 3; i++) {
+      int width = (metrics.keyboardKeyWidth * 4);
+      int offset = (pageWidth / 3);
+      int start = (pageWidth - offset) / 3 + i * offset;
+      renderer.drawRect(start, keyboardStartY, width, metrics.keyboardKeyHeight * 3);
+      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1, keyboard[i * 3]);
+      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1  + 1 * metrics.keyboardKeyHeight, keyboard[i * 3 + 1]);
+      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1  + 2 * metrics.keyboardKeyHeight, keyboard[i * 3 + 2]);
     }
   }
+
+
 
   // Draw help text
   const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT));

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -199,7 +199,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
     }
   } else {
     int requiredSpace = pageWidth - width * 3;
-    int x = (pageWidth - requiredSpace) / 4;
+    int x = (pageWidth - requiredSpace) / 3;
     for(int i = 0; i < 3; i++){
       renderer.drawRect(x, keyboardStartY, width, height * 2);
       buffer[0] = keyboard[selectedTopLevel].row[selectedMidLevel][i];

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -17,7 +17,7 @@ void KeyboardEntryActivity::onExit() { Activity::onExit(); }
 
 const char* KeyboardEntryActivity::keyboard[] = {
   "abcd", "efgh", "ijkl", "mnop", "qrst", "uvwx", "yz12", "3456",
-  //"7890", "~!@#", "$%^&", "*()_", "+:<>", "?   "
+  "7890", "~!@#", "$%^&", "*()_", "+:<>", "?   "
 };
 
 char KeyboardEntryActivity::getSelectedChar() const {
@@ -195,15 +195,36 @@ void KeyboardEntryActivity::render(RenderLock&&) {
                                          (metrics.keyboardKeyHeight + metrics.keyboardKeySpacing) * 4
                                    : inputStartY + inputHeight + metrics.verticalSpacing * 4;
 
+  char buffer[] = "A B C D\0";
+  int width = renderer.getTextWidth(UI_12_FONT_ID, buffer);
+  int height = renderer.getTextHeight(UI_12_FONT_ID);
+
   if (selectedTopLevel == -1) {
+    int requiredSpace = pageWidth - width * 3;
+    int x = (pageWidth - requiredSpace) / 3;
+
     for(int i = 0; i < 3; i++) {
-      int width = (metrics.keyboardKeyWidth * 4);
-      int offset = (pageWidth / 3);
-      int start = (pageWidth - offset) / 3 + i * offset;
-      renderer.drawRect(start, keyboardStartY, width, metrics.keyboardKeyHeight * 3);
-      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1, keyboard[i * 3]);
-      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1  + 1 * metrics.keyboardKeyHeight, keyboard[i * 3 + 1]);
-      renderer.drawText(UI_12_FONT_ID, start + 1, keyboardStartY + 1  + 2 * metrics.keyboardKeyHeight, keyboard[i * 3 + 2]);
+      renderer.drawRect(x, keyboardStartY, width, height * 3);
+      for(int row = 0; row < 3; row++){
+
+        for(int j = 0; j < 4; j++){
+          buffer[j * 2] = keyboard[i * 3 + row][j];
+        }
+        renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1 + row * height, buffer);
+      }
+      x += width + 10;
+    }
+  } else if (selectedMidLevel == -1){
+    int requiredSpace = pageWidth - width * 3;
+    int x = (pageWidth - requiredSpace) / 3;
+
+    for(int i = 0; i < 3; i++) {
+      renderer.drawRect(x, keyboardStartY, width, height * 2);
+      for(int j = 0; j < 4; j++){
+        buffer[j * 2] = keyboard[selectedTopLevel + i][j];
+      }
+      renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1, buffer);
+      x += width + 10;
     }
   }
 

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -197,6 +197,12 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   const int width = keyWidth * 3 + keySpacing * 2;
   const int requiredSpace = pageWidth - width * 3;
 
+  for(int i = 0; i < 3; i++){
+    int x = (pageWidth - requiredSpace) / 3 * (i + 1);
+    renderer.drawRect(x - 1, keyboardStartY, width, keyHeight * 3 + 1);
+  }
+
+
   if (selectedTopLevel == -1) {
     for(int i = 0; i < 3; i++) {
       int x = (pageWidth - requiredSpace) / 3 * (i + 1);
@@ -221,11 +227,10 @@ void KeyboardEntryActivity::render(RenderLock&&) {
     }
   } else {
     for(int i = 0; i < 3; i++){
-      int x = (pageWidth - requiredSpace) / 3 * (i + 1);
+      int x = (pageWidth - requiredSpace) / 3 * (i + 1) + keyWidth + keySpacing;
       buffer[0] = keyboard[selectedTopLevel + keyPage * 3].row[selectedMidLevel][i];
       buffer[1] = '\0';
       GUI.drawKeyboardKey(renderer, Rect{x, keyboardStartY, keyWidth, keyHeight}, buffer, false);
-      x += keyWidth + keySpacing;
     }
   }
 

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -16,12 +16,20 @@ void KeyboardEntryActivity::onEnter() {
 void KeyboardEntryActivity::onExit() { Activity::onExit(); }
 
 KeyboardEntryActivity::KeyBlock KeyboardEntryActivity::keyboard[] = {
-  {.row = {"abc", "def", "ghi"}}, {.row = {"jkl", "mno", "pqr"}}, {.row = {"stu", "vwx", "yz1"}},
-  {.row = {"234", "567", "890"}}, {.row = {"+:<", ">?!", "    "}}, {.row = {"   ", "   ", "   "}}
+  {.row = {"abc", "def", "ghi"}}, {.row = {"jkl", "mno", "pqr"}}, {.row = {"stu", "vwx", "yz`"}},
+  {.row = {"ABC", "DEF", "GHI"}}, {.row = {"JKL", "MNO", "PQR"}}, {.row = {"STU", "VWX", "YZ~"}},
+  {.row = {"123", "456", "789"}}, {.row = {"0!@", "#$%", "^&*"}}, {.row = {"()-", "_=+", "[]\\"}},
+  {.row = {"{}|", ";:'", "\",."}}, {.row = {"/<>", "   ", "   "}}, {.row = {"   ", "   ", "   "}}
 };
 
 char KeyboardEntryActivity::getSelectedChar() const {
-  return keyboard[selectedTopLevel].row[selectedMidLevel][selectedBottomLevel];
+  return keyboard[selectedTopLevel + keyPage * 3].row[selectedMidLevel][selectedBottomLevel];
+}
+
+void KeyboardEntryActivity::resetLevels(){
+  selectedTopLevel = -1;
+  selectedMidLevel = -1;
+  selectedBottomLevel = -1;
 }
 
 bool KeyboardEntryActivity::handleKeyPress() {
@@ -37,18 +45,11 @@ bool KeyboardEntryActivity::handleKeyPress() {
 
   if (maxLength == 0 || text.length() < maxLength) {
     text += c;
-    selectedTopLevel = -1;
-    selectedMidLevel = -1;
-    selectedBottomLevel = -1;
-    // Auto-disable shift after typing a character in non-lock mode
-    if (shiftState == 1) {
-      shiftState = 0;
-    }
+    resetLevels();
   }
 
   return true;
 }
-
 
 void KeyboardEntryActivity::setLevelOnPress(int level) {
   if (selectedTopLevel == -1) {
@@ -63,11 +64,14 @@ void KeyboardEntryActivity::setLevelOnPress(int level) {
 void KeyboardEntryActivity::loop() {
   // Handle navigation
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this] {
+    int pages = sizeof(KeyboardEntryActivity::keyboard) / (sizeof(KeyboardEntryActivity::KeyBlock) * 3);
+    keyPage = (keyPage - 1 + pages) % pages;
     requestUpdate();
   });
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down}, [this] {
-    //selectedRow = ButtonNavigator::nextIndex(selectedRow, NUM_ROWS);
+    int pages = sizeof(KeyboardEntryActivity::keyboard) / (sizeof(KeyboardEntryActivity::KeyBlock) * 3);
+    keyPage = (keyPage + 1 + pages) % pages;
     requestUpdate();
   });
 
@@ -96,9 +100,7 @@ void KeyboardEntryActivity::loop() {
       selectedBottomLevel = -1;
       selectedMidLevel = -1;
     } else if (selectedTopLevel != -1) {
-      selectedBottomLevel = -1;
-      selectedMidLevel = -1;
-      selectedTopLevel = -1;
+      resetLevels();
     } else {
       onCancel();
     }
@@ -106,7 +108,28 @@ void KeyboardEntryActivity::loop() {
   });
 
   buttonNavigator.onContinuous({MappedInputManager::Button::Back}, [this] {
+    onCancel();
+  });
 
+  buttonNavigator.onContinuous({MappedInputManager::Button::Confirm}, [this] {
+    onComplete(text);
+  });
+
+
+  buttonNavigator.onContinuous({MappedInputManager::Button::Left}, [this] {
+    if (!text.empty()) {
+        text.pop_back();
+        resetLevels();
+        requestUpdate();
+    }
+  });
+
+  buttonNavigator.onContinuous({MappedInputManager::Button::Right}, [this] {
+    if (maxLength == 0 || text.length() <maxLength) {
+        text += ' ';
+        resetLevels();
+        requestUpdate();
+    }
   });
 }
 
@@ -166,46 +189,43 @@ void KeyboardEntryActivity::render(RenderLock&&) {
                                          (metrics.keyboardKeyHeight + metrics.keyboardKeySpacing) * 4
                                    : inputStartY + inputHeight + metrics.verticalSpacing * 4;
 
-  char buffer[] = "A B C\0";
-  int width = renderer.getTextWidth(UI_12_FONT_ID, buffer);
-  int height = renderer.getTextHeight(UI_12_FONT_ID);
+  char buffer[] = "\0\0\0\0\0"; // Big enough for any single utf8 rune
+
+  const int keyWidth = metrics.keyboardKeyWidth;
+  const int keyHeight = metrics.keyboardKeyHeight;
+  const int keySpacing = metrics.keyboardKeySpacing;
+  const int width = keyWidth * 3 + keySpacing * 2;
+  const int requiredSpace = pageWidth - width * 3;
 
   if (selectedTopLevel == -1) {
-    int requiredSpace = pageWidth - width * 3;
-    int x = (pageWidth - requiredSpace) / 3;
-
     for(int i = 0; i < 3; i++) {
-      renderer.drawRect(x, keyboardStartY, width, height * 3);
+      int x = (pageWidth - requiredSpace) / 3 * (i + 1);
       for(int row = 0; row < 3; row++){
-
+        int startX = x;
         for(int j = 0; j < 3; j++){
-          buffer[j * 2] = keyboard[i].row[row][j];
+          buffer[0] = keyboard[i + keyPage * 3].row[row][j];
+          GUI.drawKeyboardKey(renderer, Rect{x, keyboardStartY + row * keyHeight, keyWidth, keyHeight}, buffer, false);
+          x += keyWidth + keySpacing;
         }
-        renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1 + row * height, buffer);
+        x = startX;
       }
-      x += width + 10;
     }
   } else if (selectedMidLevel == -1){
-    int requiredSpace = pageWidth - width * 3;
-    int x = (pageWidth - requiredSpace) / 3;
-
     for(int i = 0; i < 3; i++) {
-      renderer.drawRect(x, keyboardStartY, width, height * 2);
+      int x = (pageWidth - requiredSpace) / 3 * (i + 1);
       for(int j = 0; j < 3; j++){
-        buffer[j * 2] = keyboard[selectedTopLevel].row[i][j];
+        buffer[0] = keyboard[selectedTopLevel + keyPage * 3].row[i][j];
+        GUI.drawKeyboardKey(renderer, Rect{x, keyboardStartY, keyWidth, keyHeight}, buffer, false);
+        x += keyWidth + keySpacing;
       }
-      renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1, buffer);
-      x += width + 10;
     }
   } else {
-    int requiredSpace = pageWidth - width * 3;
-    int x = (pageWidth - requiredSpace) / 3;
     for(int i = 0; i < 3; i++){
-      renderer.drawRect(x, keyboardStartY, width, height * 2);
-      buffer[0] = keyboard[selectedTopLevel].row[selectedMidLevel][i];
+      int x = (pageWidth - requiredSpace) / 3 * (i + 1);
+      buffer[0] = keyboard[selectedTopLevel + keyPage * 3].row[selectedMidLevel][i];
       buffer[1] = '\0';
-      renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1, buffer);
-      x += width + 10;
+      GUI.drawKeyboardKey(renderer, Rect{x, keyboardStartY, keyWidth, keyHeight}, buffer, false);
+      x += keyWidth + keySpacing;
     }
   }
 

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -15,44 +15,18 @@ void KeyboardEntryActivity::onEnter() {
 
 void KeyboardEntryActivity::onExit() { Activity::onExit(); }
 
-const char* KeyboardEntryActivity::keyboard[] = {
-  "abcd", "efgh", "ijkl", "mnop", "qrst", "uvwx", "yz12", "3456",
-  "7890", "~!@#", "$%^&", "*()_", "+:<>", "?   "
+KeyboardEntryActivity::KeyBlock KeyboardEntryActivity::keyboard[] = {
+  {.row = {"abc", "def", "ghi"}}, {.row = {"jkl", "mno", "pqr"}}, {.row = {"stu", "vwx", "yz1"}},
+  {.row = {"234", "567", "890"}}, {.row = {"+:<", ">?!", "    "}}, {.row = {"   ", "   ", "   "}}
 };
 
 char KeyboardEntryActivity::getSelectedChar() const {
-  if (selectedTopLevel == 2 && selectedMidLevel == 2) {
-    return '\0';
-  }
-
-  int group = selectedTopLevel / 2 + selectedMidLevel; // Each page offsets the indices by one
-
-  return keyboard[group][selectedBottomLevel];
+  return keyboard[selectedTopLevel].row[selectedMidLevel][selectedBottomLevel];
 }
 
 bool KeyboardEntryActivity::handleKeyPress() {
-  // Handle special row (bottom row with shift, space, backspace, done)
-  if (selectedTopLevel == 2 && selectedMidLevel == 2) {
-    switch (selectedBottomLevel) {
-      case 0:
-        // Shift toggle (0 = lower case, 1 = upper case, 2 = shift lock)
-        shiftState = (shiftState + 1) % 3;
-        return true;
-      case 1:
-        if (maxLength == 0 || text.length() < maxLength) {
-          text += ' ';
-        }
-        return true;
-      case 2:
-        // Backspace
-        if (!text.empty()) {
-          text.pop_back();
-        }
-        return true;
-      case 3:
-        onComplete(text);
-        return false;
-    }
+  if(selectedBottomLevel == -1){
+    return false;
   }
 
   // Regular character
@@ -63,6 +37,9 @@ bool KeyboardEntryActivity::handleKeyPress() {
 
   if (maxLength == 0 || text.length() < maxLength) {
     text += c;
+    selectedTopLevel = -1;
+    selectedMidLevel = -1;
+    selectedBottomLevel = -1;
     // Auto-disable shift after typing a character in non-lock mode
     if (shiftState == 1) {
       shiftState = 0;
@@ -86,49 +63,38 @@ void KeyboardEntryActivity::setLevelOnPress(int level) {
 void KeyboardEntryActivity::loop() {
   // Handle navigation
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this] {
-    setLevelOnPress(0);
     requestUpdate();
   });
 
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down}, [this] {
     //selectedRow = ButtonNavigator::nextIndex(selectedRow, NUM_ROWS);
+    requestUpdate();
+  });
+
+  buttonNavigator.onPress({MappedInputManager::Button::Left}, [this] {
     setLevelOnPress(1);
+    handleKeyPress();
     requestUpdate();
   });
 
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Left}, [this] {
+  buttonNavigator.onPress({MappedInputManager::Button::Right}, [this] {
     setLevelOnPress(2);
-    requestUpdate();
-  });
-
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Right}, [this] {
-    if (selectedBottomLevel == -1) {
-      setLevelOnPress(3);
-    } else {
-      int oldLevel = selectedMidLevel;
-      if (selectedMidLevel != -1) {
-        selectedMidLevel = -1;
-      }
-      if (oldLevel != -1) {
-        selectedTopLevel = -1;
-      }
-    }
+    handleKeyPress();
     requestUpdate();
   });
 
   // Selection
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-    if (handleKeyPress()) {
-      requestUpdate();
-    }
-    // If handleKeyPress returns false, it means onComplete was triggered, no update needed
-  }
+  buttonNavigator.onPress({MappedInputManager::Button::Confirm}, [this] {
+    setLevelOnPress(0);
+    handleKeyPress();
+    requestUpdate();
+  });
 
   // Cancel
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+  buttonNavigator.onPress({MappedInputManager::Button::Back}, [this] {
     if (selectedMidLevel != -1){
-      selectedMidLevel = -1;
       selectedBottomLevel = -1;
+      selectedMidLevel = -1;
     } else if (selectedTopLevel != -1) {
       selectedBottomLevel = -1;
       selectedMidLevel = -1;
@@ -136,7 +102,12 @@ void KeyboardEntryActivity::loop() {
     } else {
       onCancel();
     }
-  }
+    requestUpdate();
+  });
+
+  buttonNavigator.onContinuous({MappedInputManager::Button::Back}, [this] {
+
+  });
 }
 
 void KeyboardEntryActivity::render(RenderLock&&) {
@@ -195,7 +166,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
                                          (metrics.keyboardKeyHeight + metrics.keyboardKeySpacing) * 4
                                    : inputStartY + inputHeight + metrics.verticalSpacing * 4;
 
-  char buffer[] = "A B C D\0";
+  char buffer[] = "A B C\0";
   int width = renderer.getTextWidth(UI_12_FONT_ID, buffer);
   int height = renderer.getTextHeight(UI_12_FONT_ID);
 
@@ -207,8 +178,8 @@ void KeyboardEntryActivity::render(RenderLock&&) {
       renderer.drawRect(x, keyboardStartY, width, height * 3);
       for(int row = 0; row < 3; row++){
 
-        for(int j = 0; j < 4; j++){
-          buffer[j * 2] = keyboard[i * 3 + row][j];
+        for(int j = 0; j < 3; j++){
+          buffer[j * 2] = keyboard[i].row[row][j];
         }
         renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1 + row * height, buffer);
       }
@@ -220,9 +191,19 @@ void KeyboardEntryActivity::render(RenderLock&&) {
 
     for(int i = 0; i < 3; i++) {
       renderer.drawRect(x, keyboardStartY, width, height * 2);
-      for(int j = 0; j < 4; j++){
-        buffer[j * 2] = keyboard[selectedTopLevel + i][j];
+      for(int j = 0; j < 3; j++){
+        buffer[j * 2] = keyboard[selectedTopLevel].row[i][j];
       }
+      renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1, buffer);
+      x += width + 10;
+    }
+  } else {
+    int requiredSpace = pageWidth - width * 3;
+    int x = (pageWidth - requiredSpace) / 4;
+    for(int i = 0; i < 3; i++){
+      renderer.drawRect(x, keyboardStartY, width, height * 2);
+      buffer[0] = keyboard[selectedTopLevel].row[selectedMidLevel][i];
+      buffer[1] = '\0';
       renderer.drawText(UI_12_FONT_ID, x + 1, keyboardStartY + 1, buffer);
       x += width + 10;
     }

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -47,29 +47,20 @@ class KeyboardEntryActivity : public Activity {
   ButtonNavigator buttonNavigator;
 
   // Keyboard state
-  int selectedRow = 0;
-  int selectedCol = 0;
+  int selectedTopLevel = -1;
+  int selectedMidLevel = -1;
+  int selectedBottomLevel = -1;
   int shiftState = 0;  // 0 = lower case, 1 = upper case, 2 = shift lock)
+
+  void setLevelOnPress(int level);
 
   // Handlers
   void onComplete(std::string text);
   void onCancel();
 
-  // Keyboard layout
-  static constexpr int NUM_ROWS = 5;
-  static constexpr int KEYS_PER_ROW = 13;  // Max keys per row (rows 0 and 1 have 13 keys)
-  static const char* const keyboard[NUM_ROWS];
-  static const char* const keyboardShift[NUM_ROWS];
-  static const char* const shiftString[3];
-
-  // Special key positions (bottom row)
-  static constexpr int SPECIAL_ROW = 4;
-  static constexpr int SHIFT_COL = 0;
-  static constexpr int SPACE_COL = 2;
-  static constexpr int BACKSPACE_COL = 7;
-  static constexpr int DONE_COL = 9;
-
   char getSelectedChar() const;
   bool handleKeyPress();  // false if onComplete was triggered
   int getRowLength(int row) const;
+
+  static const char* keyboard[];
 };

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -54,17 +54,20 @@ class KeyboardEntryActivity : public Activity {
   int selectedTopLevel = -1;
   int selectedMidLevel = -1;
   int selectedBottomLevel = -1;
-  int shiftState = 0;  // 0 = lower case, 1 = upper case, 2 = shift lock)
+  int keyPage = 0;
 
   void setLevelOnPress(int level);
+  void resetLevels();
 
   // Handlers
   void onComplete(std::string text);
   void onCancel();
+
 
   char getSelectedChar() const;
   bool handleKeyPress();  // false if onComplete was triggered
   int getRowLength(int row) const;
 
   static KeyBlock keyboard[];
+  static int pages;
 };

--- a/src/activities/util/KeyboardEntryActivity.h
+++ b/src/activities/util/KeyboardEntryActivity.h
@@ -13,6 +13,9 @@
  * Can be started from any activity that needs text entry via startActivityForResult()
  */
 class KeyboardEntryActivity : public Activity {
+  struct KeyBlock {
+    const char* row[3];
+  };
  public:
   /**
    * Constructor
@@ -39,6 +42,7 @@ class KeyboardEntryActivity : public Activity {
   void render(RenderLock&&) override;
 
  private:
+
   std::string title;
   std::string text;
   size_t maxLength;
@@ -62,5 +66,5 @@ class KeyboardEntryActivity : public Activity {
   bool handleKeyPress();  // false if onComplete was triggered
   int getRowLength(int row) const;
 
-  static const char* keyboard[];
+  static KeyBlock keyboard[];
 };


### PR DESCRIPTION
## Summary
This PR changes the keyboard to what I find is a more intuitive format. Instead of pretending the buttons are directional inputs it assumes they're choosing one of three options. The 'volume' buttons are used for moving between pages of keys be them uppercase, lowercase, or symbols.

## Additional Context

Mostly making this PR to see if anyone has any interest in this. If there is I could make it an option for the standard keyboard or this.

To show case how it is to interact.

The default state is the lower case keymap.
<img width="480" height="800" alt="screenshot-178549" src="https://github.com/user-attachments/assets/58bdb74f-7c64-4687-ad5e-64f7e6bd1f04" />



The user hit 'volume down' which moved down to the uppercase keymap.
<img width="480" height="800" alt="screenshot-184107" src="https://github.com/user-attachments/assets/14af327e-69cf-46b3-95f6-dee94905046f" />



The user hit the 'confirm' button, choosing the first block.
<img width="480" height="800" alt="screenshot-195108" src="https://github.com/user-attachments/assets/755771da-0818-45e9-839c-28c3a44c7b9c" />

The user hit the 'right button' choosing the last block.

<img width="480" height="800" alt="screenshot-209564" src="https://github.com/user-attachments/assets/234a0bcf-d632-40da-97f2-d2e20aa146a4" />





---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **NO**


