### PR TITLE
fix: distribute justifyExtra to non-breaking space tokens

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -469,6 +469,11 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
           renderer.getSpaceAdvance(fontId, lastCodepoint(words[lastBreakAt + wordIdx - 1]),
                                    firstCodepoint(words[lastBreakAt + wordIdx]), wordStyles[lastBreakAt + wordIdx - 1]);
     } else if (wordIdx > 0 && continuesVec[lastBreakAt + wordIdx]) {
+      // Non-breaking space tokens (" " with continues=true) are visible, stretchable spaces —
+      // count them as justifiable gaps so justifyExtra is distributed to them too.
+      if (words[lastBreakAt + wordIdx] == " ") {
+        actualGapCount++;
+      }
       // Cross-boundary kerning for continuation words (e.g. nonbreaking spaces, attached punctuation)
       totalNaturalGaps +=
           renderer.getKerning(fontId, lastCodepoint(words[lastBreakAt + wordIdx - 1]),
@@ -510,6 +515,11 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       advance +=
           renderer.getKerning(fontId, lastCodepoint(words[lastBreakAt + wordIdx]),
                               firstCodepoint(words[lastBreakAt + wordIdx + 1]), wordStyles[lastBreakAt + wordIdx]);
+      // Non-breaking space tokens are stretchable — expand them during justification like normal spaces.
+      if (words[lastBreakAt + wordIdx] == " " && continuesVec[lastBreakAt + wordIdx] &&
+          blockStyle.alignment == CssTextAlign::Justify && !isLastLine) {
+        advance += justifyExtra;
+      }
       xpos += advance;
     } else {
       int gap = 0;


### PR DESCRIPTION
## Summary

**What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* Fixes incorrect justification of non-breaking space characters. Previously, non-breaking space tokens were not counted as justifiable gaps, so justifyExtra was never distributed to them, causing uneven spacing on justified lines that contained them.

**What changes are included?**
* Two small changes to lib/Epub/Epub/ParsedText.cpp:
    a. Non-breaking space tokens with continues=true are now counted in actualGapCount so the extra justification space is distributed to them.
    b. During the advance calculation pass, non-breaking space tokens in justified non-final lines now receive justifyExtra the same way regular inter-word spaces do.

## Additional Context

- Fixes #1640 
- A test EPUB ([nbsp_test.zip](https://github.com/user-attachments/files/27230541/nbsp_test.zip)) can be used to verify the fix. It contains lines with non-breaking spaces in a justified paragraph (the space in each instance of "a počítejte"). Before the fix, spacing on those lines was uneven. After the fix, spacing is consistent with lines containing only regular spaces. 
- Unzip  linked file to find the test `epub` file that was used to verify the fix.
- No memory implications — the change adds two conditional checks with no allocations.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
