### PR TITLE
chore: Removed unused loc CHARACTER_SETS data

### DIFF
--- a/lib/I18n/I18n.cpp
+++ b/lib/I18n/I18n.cpp
@@ -108,12 +108,3 @@ void I18n::loadSettings() {
   }
 }
 
-// Generate character set for a specific language
-const char* I18n::getCharacterSet(Language lang) {
-  const auto langIndex = static_cast<size_t>(lang);
-  if (langIndex >= static_cast<size_t>(Language::_COUNT)) {
-    lang = Language::EN;  // Fallback to first language
-  }
-
-  return CHARACTER_SETS[static_cast<size_t>(lang)];
-}

--- a/lib/I18n/I18n.cpp
+++ b/lib/I18n/I18n.cpp
@@ -107,4 +107,3 @@ void I18n::loadSettings() {
     }
   }
 }
-

--- a/lib/I18n/I18n.h
+++ b/lib/I18n/I18n.h
@@ -28,10 +28,6 @@ class I18n {
   void saveSettings();
   void loadSettings();
 
-  // Get all unique characters used in a specific language
-  // Returns a sorted string of unique characters
-  static const char* getCharacterSet(Language lang);
-
  private:
   I18n() : _language(Language::EN) {}
 

--- a/scripts/gen_i18n.py
+++ b/scripts/gen_i18n.py
@@ -421,15 +421,6 @@ def format_cpp_string_literal(segments: List[str], indent: str = "    ") -> List
 # ---------------------------------------------------------------------------
 
 
-def compute_character_set(translations: Dict[str, List[str]], lang_index: int) -> str:
-    """Return a sorted string of every unique character used in a language."""
-    chars = set()
-    for values in translations.values():
-        for ch in values[lang_index]:
-            chars.add(ord(ch))
-    return "".join(chr(cp) for cp in sorted(chars))
-
-
 # ---------------------------------------------------------------------------
 # Code generators
 # ---------------------------------------------------------------------------
@@ -477,9 +468,6 @@ def generate_keys_header(
 
     lines.append("// Language display names (defined in I18nStrings.cpp)")
     lines.append("extern const char* const LANGUAGE_NAMES[];")
-    lines.append("")
-    lines.append("// Character sets for each language (defined in I18nStrings.cpp)")
-    lines.append("extern const char* const CHARACTER_SETS[];")
     lines.append("")
 
     # StrId enum
@@ -609,15 +597,6 @@ def generate_strings_cpp(
     lines.append("const char* const LANGUAGE_NAMES[] = {")
     for name in language_names:
         _append_string_entry(lines, name)
-    lines.append("};")
-    lines.append("")
-
-    # CHARACTER_SETS array
-    lines.append("// Character sets for each language")
-    lines.append("const char* const CHARACTER_SETS[] = {")
-    for lang_idx, name in enumerate(language_names):
-        charset = compute_character_set(translations, lang_idx)
-        _append_string_entry(lines, charset, comment=name)
     lines.append("};")
     lines.append("")
 


### PR DESCRIPTION
## Summary

Noticed while digging into other localization cleanup that CHARACTER_SETS is unused. Removing this clears 2,536 bytes of flash.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
