### PR TITLE
fix: rendering bug of scrollbar in RoundedRaff theme

### DIFF
--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -40,7 +40,8 @@ void drawScrollBar(const GfxRenderer& renderer, Rect rect, int itemCount, int pa
   const int thumbH = std::max(10, (barH * pageItems) / itemCount);
   const int maxStart = std::max(1, itemCount - pageItems);
   const int maxTravel = std::max(1, barH - thumbH);
-  const int thumbY = barY + (pageStartIndex * maxTravel) / maxStart;
+  const int clampedStart = std::clamp(pageStartIndex, 0, maxStart);
+  const int thumbY = barY + (clampedStart * maxTravel) / maxStart;
 
   renderer.fillRect(barX, thumbY, barW, thumbH);
 }


### PR DESCRIPTION
## Summary

Fix small bug I encounter when using RoundedRaff theme.
Without this the scrollbar positioning is a bit off sometimes, and on the serial output you get hundreds of lines like:
```
[22:31:00] [ERR] [GFX] !! Outside range (472, 834) -> (834, 7)
[22:31:00] [ERR] [GFX] !! Outside range (473, 834) -> (834, 6)
[22:31:00] [ERR] [GFX] !! Outside range (474, 834) -> (834, 5)
[22:31:00] [ERR] [GFX] !! Outside range (471, 835) -> (835, 8)
[22:31:00] [ERR] [GFX] !! Outside range (472, 835) -> (835, 7)
[22:31:00] [ERR] [GFX] !! Outside range (473, 835) -> (835, 6)
[22:31:00] [ERR] [GFX] !! Outside range (474, 835) -> (835, 5)
[22:31:00] [ERR] [GFX] !! Outside range (471, 836) -> (836, 8)
[22:31:00] [ERR] [GFX] !! Outside range (472, 836) -> (836, 7)
[22:31:00] [ERR] [GFX] !! Outside range (473, 836) -> (836, 6)
[22:31:00] [ERR] [GFX] !! Outside range (474, 836) -> (836, 5)
``` 
