### PR TITLE
feat: support background-color css parsing/rendering

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -22,6 +22,9 @@ std::unique_ptr<PageLine> PageLine::deserialize(FsFile& file, uint8_t sectionFil
   serialization::readPod(file, yPos);
 
   auto tb = TextBlock::deserialize(file, sectionFileVersion);
+  if (!tb) {
+    return nullptr;
+  }
   return std::unique_ptr<PageLine>(new PageLine(std::move(tb), xPos, yPos));
 }
 

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -15,13 +15,13 @@ bool PageLine::serialize(FsFile& file) {
   return block->serialize(file);
 }
 
-std::unique_ptr<PageLine> PageLine::deserialize(FsFile& file) {
+std::unique_ptr<PageLine> PageLine::deserialize(FsFile& file, uint8_t sectionFileVersion) {
   int16_t xPos;
   int16_t yPos;
   serialization::readPod(file, xPos);
   serialization::readPod(file, yPos);
 
-  auto tb = TextBlock::deserialize(file);
+  auto tb = TextBlock::deserialize(file, sectionFileVersion);
   return std::unique_ptr<PageLine>(new PageLine(std::move(tb), xPos, yPos));
 }
 
@@ -38,7 +38,7 @@ bool PageImage::serialize(FsFile& file) {
   return imageBlock->serialize(file);
 }
 
-std::unique_ptr<PageImage> PageImage::deserialize(FsFile& file) {
+std::unique_ptr<PageImage> PageImage::deserialize(FsFile& file, uint8_t /*sectionFileVersion*/) {
   int16_t xPos;
   int16_t yPos;
   serialization::readPod(file, xPos);
@@ -82,7 +82,7 @@ bool Page::serialize(FsFile& file) const {
   return true;
 }
 
-std::unique_ptr<Page> Page::deserialize(FsFile& file) {
+std::unique_ptr<Page> Page::deserialize(FsFile& file, uint8_t sectionFileVersion) {
   auto page = std::unique_ptr<Page>(new Page());
 
   uint16_t count;
@@ -93,10 +93,10 @@ std::unique_ptr<Page> Page::deserialize(FsFile& file) {
     serialization::readPod(file, tag);
 
     if (tag == TAG_PageLine) {
-      auto pl = PageLine::deserialize(file);
+      auto pl = PageLine::deserialize(file, sectionFileVersion);
       page->elements.push_back(std::move(pl));
     } else if (tag == TAG_PageImage) {
-      auto pi = PageImage::deserialize(file);
+      auto pi = PageImage::deserialize(file, sectionFileVersion);
       page->elements.push_back(std::move(pi));
     } else {
       LOG_ERR("PGE", "Deserialization failed: Unknown tag %u", tag);

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -38,7 +38,7 @@ class PageLine final : public PageElement {
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(FsFile& file) override;
   PageElementTag getTag() const override { return TAG_PageLine; }
-  static std::unique_ptr<PageLine> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
+  static std::unique_ptr<PageLine> deserialize(FsFile& file, uint8_t sectionFileVersion);
 };
 
 // New PageImage class
@@ -51,7 +51,7 @@ class PageImage final : public PageElement {
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(FsFile& file) override;
   PageElementTag getTag() const override { return TAG_PageImage; }
-  static std::unique_ptr<PageImage> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
+  static std::unique_ptr<PageImage> deserialize(FsFile& file, uint8_t sectionFileVersion);
   const ImageBlock& getImageBlock() const { return *imageBlock; }
 };
 
@@ -74,7 +74,7 @@ class Page {
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;
-  static std::unique_ptr<Page> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
+  static std::unique_ptr<Page> deserialize(FsFile& file, uint8_t sectionFileVersion);
 
   // Check if page contains any images (used to force full refresh)
   bool hasImages() const {

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -38,7 +38,7 @@ class PageLine final : public PageElement {
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(FsFile& file) override;
   PageElementTag getTag() const override { return TAG_PageLine; }
-  static std::unique_ptr<PageLine> deserialize(FsFile& file);
+  static std::unique_ptr<PageLine> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
 };
 
 // New PageImage class
@@ -51,7 +51,7 @@ class PageImage final : public PageElement {
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(FsFile& file) override;
   PageElementTag getTag() const override { return TAG_PageImage; }
-  static std::unique_ptr<PageImage> deserialize(FsFile& file);
+  static std::unique_ptr<PageImage> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
   const ImageBlock& getImageBlock() const { return *imageBlock; }
 };
 
@@ -74,7 +74,7 @@ class Page {
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;
-  static std::unique_ptr<Page> deserialize(FsFile& file);
+  static std::unique_ptr<Page> deserialize(FsFile& file, uint8_t sectionFileVersion = 0);
 
   // Check if page contains any images (used to force full refresh)
   bool hasImages() const {

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -4,6 +4,7 @@
 #include <Utf8.h>
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <functional>
 #include <limits>
@@ -407,12 +408,12 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   }
 
   // Insert the remainder word (with matching style and continuation flag) directly after the prefix.
+  // Invariant from addWord: words, wordStyles, wordBackgrounds must stay parallel and same size.
+  assert(wordIndex < wordBackgrounds.size());
   words.insert(words.begin() + wordIndex + 1, remainder);
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
   // Inherit background color from original word -> remainder gets same color
-  if (wordIndex < wordBackgrounds.size()) {
-    wordBackgrounds.insert(wordBackgrounds.begin() + wordIndex + 1, wordBackgrounds[wordIndex]);
-  }
+  wordBackgrounds.insert(wordBackgrounds.begin() + wordIndex + 1, wordBackgrounds[wordIndex]);
 
   // Continuation flag handling after splitting a word into prefix + remainder.
   //
@@ -537,10 +538,11 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
-  std::vector<uint8_t> lineWordBackgrounds(
-      wordBackgrounds.empty()
-          ? std::vector<uint8_t>()
-          : std::vector<uint8_t>(wordBackgrounds.begin() + lastBreakAt, wordBackgrounds.begin() + lineBreak));
+  // Guard against out-of-bounds slice if vectors desync (invariant: addWord keeps sizes equal)
+  std::vector<uint8_t> lineWordBackgrounds;
+  if (!wordBackgrounds.empty() && lastBreakAt <= wordBackgrounds.size() && wordBackgrounds.size() >= lineBreak) {
+    lineWordBackgrounds.assign(wordBackgrounds.begin() + lastBreakAt, wordBackgrounds.begin() + lineBreak);
+  }
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -77,7 +77,7 @@ uint16_t measureWordWidth(const GfxRenderer& renderer, const int fontId, const s
 }  // namespace
 
 void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle, const bool underline,
-                         const bool attachToPrevious) {
+                         const bool attachToPrevious, const uint8_t backgroundColor) {
   if (word.empty()) return;
 
   words.push_back(std::move(word));
@@ -87,6 +87,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   }
   wordStyles.push_back(combinedStyle);
   wordContinues.push_back(attachToPrevious);
+  wordBackgrounds.push_back(backgroundColor);
 }
 
 // Consumes data to minimize memory usage
@@ -122,6 +123,9 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     words.erase(words.begin(), words.begin() + consumed);
     wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
+    if (!wordBackgrounds.empty()) {
+      wordBackgrounds.erase(wordBackgrounds.begin(), wordBackgrounds.begin() + consumed);
+    }
   }
 }
 
@@ -405,6 +409,10 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   // Insert the remainder word (with matching style and continuation flag) directly after the prefix.
   words.insert(words.begin() + wordIndex + 1, remainder);
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
+  // Inherit background color from original word -> remainder gets same color
+  if (wordIndex < wordBackgrounds.size()) {
+    wordBackgrounds.insert(wordBackgrounds.begin() + wordIndex + 1, wordBackgrounds[wordIndex]);
+  }
 
   // Continuation flag handling after splitting a word into prefix + remainder.
   //
@@ -529,6 +537,9 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
+  std::vector<uint8_t> lineWordBackgrounds(
+      wordBackgrounds.empty() ? std::vector<uint8_t>() :
+      std::vector<uint8_t>(wordBackgrounds.begin() + lastBreakAt, wordBackgrounds.begin() + lineBreak));
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
@@ -536,6 +547,12 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
   }
 
-  processLine(
-      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle));
+  auto textBlock = std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
+                                               blockStyle);
+  if (!lineWordBackgrounds.empty()) {
+    for (size_t i = 0; i < lineWordBackgrounds.size(); i++) {
+      textBlock->setWordBackground(i, lineWordBackgrounds[i]);
+    }
+  }
+  processLine(std::move(textBlock));
 }

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -538,8 +538,9 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
   std::vector<uint8_t> lineWordBackgrounds(
-      wordBackgrounds.empty() ? std::vector<uint8_t>() :
-      std::vector<uint8_t>(wordBackgrounds.begin() + lastBreakAt, wordBackgrounds.begin() + lineBreak));
+      wordBackgrounds.empty()
+          ? std::vector<uint8_t>()
+          : std::vector<uint8_t>(wordBackgrounds.begin() + lastBreakAt, wordBackgrounds.begin() + lineBreak));
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
@@ -547,8 +548,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
   }
 
-  auto textBlock = std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
-                                               blockStyle);
+  auto textBlock =
+      std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles), blockStyle);
   if (!lineWordBackgrounds.empty()) {
     for (size_t i = 0; i < lineWordBackgrounds.size(); i++) {
       textBlock->setWordBackground(i, lineWordBackgrounds[i]);

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -15,7 +15,7 @@ class GfxRenderer;
 class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
-  std::vector<bool> wordContinues;  // true = word attaches to previous (no space before it)
+  std::vector<bool> wordContinues;       // true = word attaches to previous (no space before it)
   std::vector<uint8_t> wordBackgrounds;  // per-word background color (0 = none)
   BlockStyle blockStyle;
   bool extraParagraphSpacing;

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -39,11 +39,13 @@ class ParsedText {
       : blockStyle(blockStyle), extraParagraphSpacing(extraParagraphSpacing), hyphenationEnabled(hyphenationEnabled) {}
   ~ParsedText() = default;
 
-  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false);
+  void addWord(std::string word, EpdFontFamily::Style fontStyle, bool underline = false, bool attachToPrevious = false,
+               uint8_t backgroundColor = 0);
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
+  std::vector<uint8_t> wordBackgrounds;  // per-word background color (0 = none)
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
                              const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
                              bool includeLastLine = true);

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <EpdFontFamily.h>
 
 #include <functional>
@@ -47,7 +48,10 @@ class ParsedText {
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   const std::vector<uint8_t>& getWordBackgrounds() const { return wordBackgrounds; }
-  void setWordBackgrounds(std::vector<uint8_t> backgrounds) { wordBackgrounds = std::move(backgrounds); }
+  void setWordBackgrounds(std::vector<uint8_t> backgrounds) {
+    assert(backgrounds.size() == words.size());
+    wordBackgrounds = std::move(backgrounds);
+  }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
                              const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
                              bool includeLastLine = true);

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -16,6 +16,7 @@ class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
   std::vector<bool> wordContinues;  // true = word attaches to previous (no space before it)
+  std::vector<uint8_t> wordBackgrounds;  // per-word background color (0 = none)
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;
@@ -45,7 +46,8 @@ class ParsedText {
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
-  std::vector<uint8_t> wordBackgrounds;  // per-word background color (0 = none)
+  const std::vector<uint8_t>& getWordBackgrounds() const { return wordBackgrounds; }
+  void setWordBackgrounds(std::vector<uint8_t> backgrounds) { wordBackgrounds = std::move(backgrounds); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
                              const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
                              bool includeLastLine = true);

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cassert>
 #include <EpdFontFamily.h>
 
+#include <cassert>
 #include <functional>
 #include <memory>
 #include <string>

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -49,7 +49,7 @@ class ParsedText {
   bool isEmpty() const { return words.empty(); }
   const std::vector<uint8_t>& getWordBackgrounds() const { return wordBackgrounds; }
   void setWordBackgrounds(std::vector<uint8_t> backgrounds) {
-    assert(backgrounds.size() == words.size());
+    if (backgrounds.size() != words.size()) return;
     wordBackgrounds = std::move(backgrounds);
   }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 21;
+constexpr uint8_t SECTION_FILE_VERSION = 22;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(uint32_t) + sizeof(uint32_t) + sizeof(uint32_t);
@@ -80,6 +80,7 @@ bool Section::loadSectionFile(const int fontId, const float lineCompression, con
   {
     uint8_t version;
     serialization::readPod(file, version);
+    sectionFileVersion = version;  // store for downstream deserialization
     if (version != SECTION_FILE_VERSION) {
       // Explicit close() required: member variable persists beyond function scope
       file.close();
@@ -281,6 +282,7 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   if (cssParser) {
     cssParser->clear();
   }
+  sectionFileVersion = SECTION_FILE_VERSION;  // Mark as current version for downstream consumers
   return true;
 }
 
@@ -289,6 +291,7 @@ std::unique_ptr<Page> Section::loadPageFromSectionFile() {
     return nullptr;
   }
 
+  // We already validated version in loadSectionFile; sectionFileVersion is correct
   file.seek(HEADER_SIZE - sizeof(uint32_t) * 3);
   uint32_t lutOffset;
   serialization::readPod(file, lutOffset);
@@ -297,7 +300,7 @@ std::unique_ptr<Page> Section::loadPageFromSectionFile() {
   serialization::readPod(file, pagePos);
   file.seek(pagePos);
 
-  auto page = Page::deserialize(file);
+  auto page = Page::deserialize(file, sectionFileVersion);
   // Explicit close() required: member variable persists beyond function scope
   file.close();
   return page;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -15,6 +15,7 @@ class Section {
   GfxRenderer& renderer;
   std::string filePath;
   FsFile file;
+  uint8_t sectionFileVersion = 0;  // Loaded from file header for deserialization compatibility
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,
@@ -24,6 +25,7 @@ class Section {
  public:
   uint16_t pageCount = 0;
   int currentPage = 0;
+  uint8_t getSectionFileVersion() const { return sectionFileVersion; }
 
   explicit Section(const std::shared_ptr<Epub>& epub, const int spineIndex, GfxRenderer& renderer)
       : epub(epub),

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -144,8 +144,22 @@ std::unique_ptr<TextBlock> TextBlock::deserializeLegacy(FsFile& file) {
       LOG_ERR("TXB", "Deserialization failed: word length %u exceeds maximum", strLen);
       return nullptr;
     }
-    w.resize(strLen);
-    if (strLen > 0) file.read(&w[0], strLen);
+    if (strLen > 0) {
+      // Read into temporary buffer first to avoid partial fills on short reads
+      auto tempBuf = static_cast<char*>(malloc(strLen));
+      if (!tempBuf) {
+        LOG_ERR("TXB", "Deserialization failed: malloc failed for %u bytes", strLen);
+        return nullptr;
+      }
+      const size_t bytesRead = file.read(tempBuf, strLen);
+      if (bytesRead != strLen) {
+        free(tempBuf);
+        LOG_ERR("TXB", "Deserialization failed: short read (got %u, expected %u)", (uint32_t)bytesRead, strLen);
+        return nullptr;
+      }
+      w.assign(tempBuf, strLen);
+      free(tempBuf);
+    }
   }
   for (auto& x : wordXpos) serialization::readPod(file, x);
   for (auto& s : wordStyles) serialization::readPod(file, s);
@@ -198,8 +212,22 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file, uint8_t sectionV
       LOG_ERR("TXB", "Deserialization failed: word length %u exceeds maximum", strLen);
       return nullptr;
     }
-    w.resize(strLen);
-    if (strLen > 0) file.read(&w[0], strLen);
+    if (strLen > 0) {
+      // Read into temporary buffer first to avoid partial fills on short reads
+      auto tempBuf = static_cast<char*>(malloc(strLen));
+      if (!tempBuf) {
+        LOG_ERR("TXB", "Deserialization failed: malloc failed for %u bytes", strLen);
+        return nullptr;
+      }
+      const size_t bytesRead = file.read(tempBuf, strLen);
+      if (bytesRead != strLen) {
+        free(tempBuf);
+        LOG_ERR("TXB", "Deserialization failed: short read (got %u, expected %u)", (uint32_t)bytesRead, strLen);
+        return nullptr;
+      }
+      w.assign(tempBuf, strLen);
+      free(tempBuf);
+    }
   }
   for (auto& x : wordXpos) serialization::readPod(file, x);
   for (auto& s : wordStyles) serialization::readPod(file, s);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -9,8 +9,7 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
   if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
       (!wordBackgrounds.empty() && words.size() != wordBackgrounds.size())) {
     LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u, bg=%u)\n", (uint32_t)words.size(),
-            (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size(),
-            (uint32_t)wordBackgrounds.size());
+            (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size(), (uint32_t)wordBackgrounds.size());
     return;
   }
 

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -136,7 +136,17 @@ std::unique_ptr<TextBlock> TextBlock::deserializeLegacy(FsFile& file) {
   words.resize(wc);
   wordXpos.resize(wc);
   wordStyles.resize(wc);
-  for (auto& w : words) serialization::readString(file, w);
+  // Read words with bounded allocation to prevent corrupt disk data from causing unbounded memory allocation
+  for (auto& w : words) {
+    uint32_t strLen;
+    serialization::readPod(file, strLen);
+    if (strLen > 1024) {  // Maximum reasonable word length
+      LOG_ERR("TXB", "Deserialization failed: word length %u exceeds maximum", strLen);
+      return nullptr;
+    }
+    w.resize(strLen);
+    if (strLen > 0) file.read(&w[0], strLen);
+  }
   for (auto& x : wordXpos) serialization::readPod(file, x);
   for (auto& s : wordStyles) serialization::readPod(file, s);
 
@@ -180,7 +190,17 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file, uint8_t sectionV
   words.resize(wc);
   wordXpos.resize(wc);
   wordStyles.resize(wc);
-  for (auto& w : words) serialization::readString(file, w);
+  // Read words with bounded allocation to prevent corrupt disk data from causing unbounded memory allocation
+  for (auto& w : words) {
+    uint32_t strLen;
+    serialization::readPod(file, strLen);
+    if (strLen > 1024) {  // Maximum reasonable word length
+      LOG_ERR("TXB", "Deserialization failed: word length %u exceeds maximum", strLen);
+      return nullptr;
+    }
+    w.resize(strLen);
+    if (strLen > 0) file.read(&w[0], strLen);
+  }
   for (auto& x : wordXpos) serialization::readPod(file, x);
   for (auto& s : wordStyles) serialization::readPod(file, s);
 

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -6,16 +6,60 @@
 
 void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int x, const int y) const {
   // Validate iterator bounds before rendering
-  if (words.size() != wordXpos.size() || words.size() != wordStyles.size()) {
-    LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u)\n", (uint32_t)words.size(),
-            (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size());
+  if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
+      (!wordBackgrounds.empty() && words.size() != wordBackgrounds.size())) {
+    LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u, bg=%u)\n", (uint32_t)words.size(),
+            (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size(),
+            (uint32_t)wordBackgrounds.size());
     return;
   }
 
+  const int ascender = renderer.getFontAscenderSize(fontId);
+  const int lineHeight = renderer.getLineHeight(fontId);
+  const int pad = 2;
+
+  // Pass 1: Draw merged background fills for consecutive same-color runs
+  size_t i = 0;
+  while (i < words.size()) {
+    uint8_t runColor = wordBackgrounds.empty() ? 0 : wordBackgrounds[i];
+    if (runColor == 0) {
+      ++i;
+      continue;
+    }
+
+    // Start a run at word i
+    const size_t runStart = i;
+    int runLeft = wordXpos[runStart] + x;
+    int runRight = runLeft + renderer.getTextAdvanceX(fontId, words[runStart].c_str(), wordStyles[runStart]);
+
+    ++i;
+    while (i < words.size()) {
+      uint8_t nextColor = wordBackgrounds.empty() ? 0 : wordBackgrounds[i];
+      if (nextColor != runColor) break;
+
+      // Extend run to include word i (and everything between previous word and this word)
+      const int nextLeft = wordXpos[i] + x;
+      const int nextRight = nextLeft + renderer.getTextAdvanceX(fontId, words[i].c_str(), wordStyles[i]);
+      if (nextLeft < runLeft) runLeft = nextLeft;
+      if (nextRight > runRight) runRight = nextRight;
+      ++i;
+    }
+
+    const int bgX = runLeft - pad;
+    const int bgY = y - pad;
+    const int bgW = (runRight - runLeft) + pad * 2;
+    const int bgH = lineHeight + pad * 2;
+    renderer.fillRectDither(bgX, bgY, bgW, bgH, static_cast<Color>(runColor));
+  }
+
+  // Pass 2: Draw text (foreground)
   for (size_t i = 0; i < words.size(); i++) {
     const int wordX = wordXpos[i] + x;
     const EpdFontFamily::Style currentStyle = wordStyles[i];
-    renderer.drawText(fontId, wordX, y, words[i].c_str(), true, currentStyle);
+    // Choose text color based on word background: if background is dark (>8), draw white (false)
+    const uint8_t bgColor = wordBackgrounds.empty() ? 0 : wordBackgrounds[i];
+    const bool drawBlackText = (bgColor == 0) || (bgColor <= 8);
+    renderer.drawText(fontId, wordX, y, words[i].c_str(), drawBlackText, currentStyle);
 
     if ((currentStyle & EpdFontFamily::UNDERLINE) != 0) {
       const std::string& w = words[i];
@@ -68,10 +112,14 @@ bool TextBlock::serialize(FsFile& file) const {
   serialization::writePod(file, blockStyle.textIndent);
   serialization::writePod(file, blockStyle.textIndentDefined);
 
+  // Per-word background colors (length-prefixed: 0 words = legacy, 0xFFFF = sentinel if needed)
+  serialization::writePod(file, static_cast<uint16_t>(wordBackgrounds.size()));
+  for (auto bg : wordBackgrounds) serialization::writePod(file, bg);
+
   return true;
 }
 
-std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
+std::unique_ptr<TextBlock> TextBlock::deserializeLegacy(FsFile& file) {
   uint16_t wc;
   std::vector<std::string> words;
   std::vector<int16_t> wordXpos;
@@ -81,13 +129,11 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   // Word count
   serialization::readPod(file, wc);
 
-  // Sanity check: prevent allocation of unreasonably large vectors (max 10000 words per block)
   if (wc > 10000) {
     LOG_ERR("TXB", "Deserialization failed: word count %u exceeds maximum", wc);
     return nullptr;
   }
 
-  // Word data
   words.resize(wc);
   wordXpos.resize(wc);
   wordStyles.resize(wc);
@@ -95,7 +141,6 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   for (auto& x : wordXpos) serialization::readPod(file, x);
   for (auto& s : wordStyles) serialization::readPod(file, s);
 
-  // Style (alignment + margins/padding/indent)
   serialization::readPod(file, blockStyle.alignment);
   serialization::readPod(file, blockStyle.textAlignDefined);
   serialization::readPod(file, blockStyle.marginTop);
@@ -109,6 +154,69 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file) {
   serialization::readPod(file, blockStyle.textIndent);
   serialization::readPod(file, blockStyle.textIndentDefined);
 
-  return std::unique_ptr<TextBlock>(
+  auto tb = std::unique_ptr<TextBlock>(
       new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles), blockStyle));
+  LOG_DBG("TXB", "deserializeLegacy: wc=%u bg=all-zero", wc);
+  return tb;
+}
+
+std::unique_ptr<TextBlock> TextBlock::deserialize(FsFile& file, uint8_t sectionVersion) {
+  if (sectionVersion < 22) {
+    return deserializeLegacy(file);
+  }
+
+  uint16_t wc;
+  std::vector<std::string> words;
+  std::vector<int16_t> wordXpos;
+  std::vector<EpdFontFamily::Style> wordStyles;
+  BlockStyle blockStyle;
+
+  serialization::readPod(file, wc);
+
+  if (wc > 10000) {
+    LOG_ERR("TXB", "Deserialization failed: word count %u exceeds maximum", wc);
+    return nullptr;
+  }
+
+  words.resize(wc);
+  wordXpos.resize(wc);
+  wordStyles.resize(wc);
+  for (auto& w : words) serialization::readString(file, w);
+  for (auto& x : wordXpos) serialization::readPod(file, x);
+  for (auto& s : wordStyles) serialization::readPod(file, s);
+
+  serialization::readPod(file, blockStyle.alignment);
+  serialization::readPod(file, blockStyle.textAlignDefined);
+  serialization::readPod(file, blockStyle.marginTop);
+  serialization::readPod(file, blockStyle.marginBottom);
+  serialization::readPod(file, blockStyle.marginLeft);
+  serialization::readPod(file, blockStyle.marginRight);
+  serialization::readPod(file, blockStyle.paddingTop);
+  serialization::readPod(file, blockStyle.paddingBottom);
+  serialization::readPod(file, blockStyle.paddingLeft);
+  serialization::readPod(file, blockStyle.paddingRight);
+  serialization::readPod(file, blockStyle.textIndent);
+  serialization::readPod(file, blockStyle.textIndentDefined);
+
+  uint16_t bgCount;
+  serialization::readPod(file, bgCount);
+  LOG_DBG("TXB", "deserialize v22: wc=%u bgCount=%u", wc, bgCount);
+  std::vector<uint8_t> wordBackgrounds;
+  if (bgCount == wc) {
+    wordBackgrounds.resize(bgCount);
+    for (auto& bg : wordBackgrounds) serialization::readPod(file, bg);
+  } else {
+    wordBackgrounds.resize(wc, 0);  // mismatch: default to all transparent
+    if (bgCount > 0) {
+      for (uint16_t i = 0; i < bgCount; i++) {
+        uint8_t dummy;
+        serialization::readPod(file, dummy);
+      }
+    }
+  }
+
+  auto tb = std::unique_ptr<TextBlock>(
+      new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles), blockStyle));
+  tb->wordBackgrounds = std::move(wordBackgrounds);
+  return tb;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -15,6 +15,7 @@ class TextBlock final : public Block {
   std::vector<std::string> words;
   std::vector<int16_t> wordXpos;
   std::vector<EpdFontFamily::Style> wordStyles;
+  std::vector<uint8_t> wordBackgrounds;  // per-word background color (0=none, otherwise GfxRenderer::Color)
   BlockStyle blockStyle;
 
  public:
@@ -23,16 +24,24 @@ class TextBlock final : public Block {
       : words(std::move(words)),
         wordXpos(std::move(word_xpos)),
         wordStyles(std::move(word_styles)),
-        blockStyle(blockStyle) {}
+        blockStyle(blockStyle) {
+    // MUST use this->words.size() — parameter 'words' is empty after std::move above
+    wordBackgrounds.resize(this->words.size(), 0);
+  }
   ~TextBlock() override = default;
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   const BlockStyle& getBlockStyle() const { return blockStyle; }
   const std::vector<std::string>& getWords() const { return words; }
+  const std::vector<uint8_t>& getWordBackgrounds() const { return wordBackgrounds; }
+  void setWordBackground(size_t idx, uint8_t color) {
+    if (idx < wordBackgrounds.size()) wordBackgrounds[idx] = color;
+  }
   bool isEmpty() override { return words.empty(); }
   size_t wordCount() const { return words.size(); }
   // given a renderer works out where to break the words into lines
   void render(const GfxRenderer& renderer, int fontId, int x, int y) const;
   BlockType getType() override { return TEXT_BLOCK; }
   bool serialize(FsFile& file) const;
-  static std::unique_ptr<TextBlock> deserialize(FsFile& file);
+  static std::unique_ptr<TextBlock> deserialize(FsFile& file, uint8_t sectionVersion = 21);
+  static std::unique_ptr<TextBlock> deserializeLegacy(FsFile& file);
 };

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -104,7 +104,7 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
 
   if (normalized == "transparent" || normalized == "none") return 0;
 
-  // Named color path 
+  // Named color path
   int r = -1, g = -1, b = -1;
   if (normalized == "black") {
     return rgbToGrayscale(0, 0, 0);
@@ -171,13 +171,13 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
     }
 
     return rgbToGrayscale(r, g, b);
-  } 
-  
+  }
+
   // rgb parsing path (rgb(0, 0, 0), rgba(0, 0, 0))
   if (normalized.size() >= 4 && normalized.substr(0, 3) == "rgb") {
     size_t start = normalized.find('(');
     size_t end = normalized.find(')');
-    
+
     if (start == std::string::npos || end == std::string::npos || end < start) {
       return std::nullopt;
     }
@@ -185,12 +185,12 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
     std::string rgbPart = normalized.substr(start + 1, end - start - 1);
 
     size_t comma1 = rgbPart.find(',');
-    if(comma1 == std::string::npos) {
+    if (comma1 == std::string::npos) {
       return std::nullopt;
     }
 
     size_t comma2 = rgbPart.find(',', comma1 + 1);
-    if(comma2 == std::string::npos) {
+    if (comma2 == std::string::npos) {
       return std::nullopt;
     }
 

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cctype>
 #include <cerrno>
+#include <optional>
 #include <string_view>
 
 namespace {
@@ -79,9 +80,10 @@ std::string_view stripTrailingImportant(std::string_view value) {
 // Convert CSS color value to GfxRenderer::Color enum value (8-bit grayscale)
 // Supports hex colors (#000, #000000), named colors (black, white, gray),
 // and rgb/rgba values.
-static uint8_t interpretColor(const std::string& val) {
+// Returns std::nullopt if the color could not be parsed.
+static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
   std::string_view sv = stripTrailingImportant(val);
-  if (sv.empty()) return 0;
+  if (sv.empty()) return std::nullopt;
   while (!sv.empty() && isCssWhitespace(sv.front())) sv.remove_prefix(1);
   while (!sv.empty() && isCssWhitespace(sv.back())) sv.remove_suffix(1);
   std::string normalized(sv);
@@ -141,13 +143,13 @@ static uint8_t interpretColor(const std::string& val) {
       b = parseHexComponent(normalized, 5, 2);
     } else {
       LOG_DBG("CSS", "interpretColor: failed hex parse for '%s'", normalized.c_str());
-      return 0;
+      return std::nullopt;
     }
 
     // Validate parsing results
     if (r < 0 || g < 0 || b < 0 || r > 255 || g > 255 || b > 255) {
       LOG_DBG("CSS", "interpretColor: malformed hex color '%s'", normalized.c_str());
-      return 0;
+      return std::nullopt;
     }
 
     const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
@@ -199,6 +201,8 @@ static uint8_t interpretColor(const std::string& val) {
         }
       }
     }
+  } else {
+    return std::nullopt;
   }
   return result;
 }
@@ -386,6 +390,10 @@ bool CssParser::tryInterpretLength(const std::string& val, CssLength& out) {
   return true;
 }
 
+std::optional<uint8_t> CssParser::tryInterpretColor(const std::string& val) {
+  return ::tryInterpretColor(val);
+}
+
 // Declaration parsing
 
 void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& style, std::string& propNameBuf,
@@ -473,8 +481,10 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     style.display = (displayValue == "none") ? CssDisplay::None : CssDisplay::Block;
     style.defined.display = 1;
   } else if (propNameBuf == "background-color") {
-    style.backgroundColor = interpretColor(propValueBuf);
-    style.defined.backgroundColor = 1;
+    if (auto color = tryInterpretColor(propValueBuf)) {
+      style.backgroundColor = *color;
+      style.defined.backgroundColor = 1;
+    }
   }
 }
 

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -100,27 +100,43 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
     normalized[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized[i])));
   }
 
-  if (normalized == "transparent" || normalized == "none")
-    return 0;
+  if (normalized == "transparent" || normalized == "none") return 0;
 
   // Named colors — resolve to RGB then go through the shared grayscale helper
   int r = -1, g = -1, b = -1;
-  if (normalized == "black")
-    { r = 0;   g = 0;   b = 0;   }
-  else if (normalized == "white")
-    { r = 255; g = 255; b = 255; }
-  else if (normalized == "gray" || normalized == "grey")
-    { r = 128; g = 128; b = 128; }
-  else if (normalized == "lightgray")
-    { r = 211; g = 211; b = 211; }
-  else if (normalized == "darkgray")
-    { r = 169; g = 169; b = 169; }
-  else if (normalized == "red")
-    { r = 255; g = 0;   b = 0;   }
-  else if (normalized == "green")
-    { r = 0;   g = 255; b = 0;   }
-  else if (normalized == "blue")
-    { r = 0;   g = 0;   b = 255; }
+  if (normalized == "black") {
+    r = 0;
+    g = 0;
+    b = 0;
+  } else if (normalized == "white") {
+    r = 255;
+    g = 255;
+    b = 255;
+  } else if (normalized == "gray" || normalized == "grey") {
+    r = 128;
+    g = 128;
+    b = 128;
+  } else if (normalized == "lightgray") {
+    r = 211;
+    g = 211;
+    b = 211;
+  } else if (normalized == "darkgray") {
+    r = 169;
+    g = 169;
+    b = 169;
+  } else if (normalized == "red") {
+    r = 255;
+    g = 0;
+    b = 0;
+  } else if (normalized == "green") {
+    r = 0;
+    g = 255;
+    b = 0;
+  } else if (normalized == "blue") {
+    r = 0;
+    g = 0;
+    b = 255;
+  }
 
   if (r >= 0 && g >= 0 && b >= 0) {
     return rgbToGrayscale(r, g, b);
@@ -402,9 +418,7 @@ bool CssParser::tryInterpretLength(const std::string& val, CssLength& out) {
   return true;
 }
 
-std::optional<uint8_t> CssParser::tryInterpretColor(const std::string& val) {
-  return ::tryInterpretColor(val);
-}
+std::optional<uint8_t> CssParser::tryInterpretColor(const std::string& val) { return ::tryInterpretColor(val); }
 
 // Declaration parsing
 

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -88,15 +88,24 @@ static uint8_t interpretColor(const std::string& val) {
     normalized[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized[i])));
   }
   uint8_t result = 0;
-  if (normalized == "black" || normalized == "#000" || normalized == "#000000") result = 16;
-  else if (normalized == "white" || normalized == "#fff" || normalized == "#ffffff") result = 0;
-  else if (normalized == "gray" || normalized == "grey" || normalized == "#808080") result = 10;
-  else if (normalized == "lightgray" || normalized == "#d3d3d3") result = 5;
-  else if (normalized == "darkgray" || normalized == "#a9a9a9") result = 8;
-  else if (normalized == "red" || normalized == "#f00" || normalized == "#ff0000") result = 10;
-  else if (normalized == "blue" || normalized == "#00f" || normalized == "#0000ff") result = 10;
-  else if (normalized == "green" || normalized == "#0f0" || normalized == "#00ff00") result = 10;
-  else if (normalized == "transparent" || normalized == "none") result = 0;
+  if (normalized == "black" || normalized == "#000" || normalized == "#000000")
+    result = 16;
+  else if (normalized == "white" || normalized == "#fff" || normalized == "#ffffff")
+    result = 0;
+  else if (normalized == "gray" || normalized == "grey" || normalized == "#808080")
+    result = 10;
+  else if (normalized == "lightgray" || normalized == "#d3d3d3")
+    result = 5;
+  else if (normalized == "darkgray" || normalized == "#a9a9a9")
+    result = 8;
+  else if (normalized == "red" || normalized == "#f00" || normalized == "#ff0000")
+    result = 10;
+  else if (normalized == "blue" || normalized == "#00f" || normalized == "#0000ff")
+    result = 10;
+  else if (normalized == "green" || normalized == "#0f0" || normalized == "#00ff00")
+    result = 10;
+  else if (normalized == "transparent" || normalized == "none")
+    result = 0;
   else if (normalized.size() >= 4 && normalized[0] == '#') {
     int r = 0, g = 0, b = 0;
     if (normalized.size() == 4) {
@@ -128,20 +137,32 @@ static uint8_t interpretColor(const std::string& val) {
             const char* str = s.c_str();
             while (*str && isCssWhitespace(*str)) ++str;
             bool neg = false;
-            if (*str == '-') { neg = true; ++str; }
+            if (*str == '-') {
+              neg = true;
+              ++str;
+            }
             int val = 0;
-            while (*str >= '0' && *str <= '9') { val = val * 10 + (*str - '0'); ++str; }
+            while (*str >= '0' && *str <= '9') {
+              val = val * 10 + (*str - '0');
+              ++str;
+            }
             return neg ? -val : val;
           };
           r = parseInt(rgbPart.substr(0, comma1));
           g = parseInt(rgbPart.substr(comma1 + 1, comma2 - comma1 - 1));
           b = parseInt(rgbPart.substr(comma2 + 1));
-          if (r < 0) r = 0;
-          else if (r > 255) r = 255;
-          if (g < 0) g = 0;
-          else if (g > 255) g = 255;
-          if (b < 0) b = 0;
-          else if (b > 255) b = 255;
+          if (r < 0)
+            r = 0;
+          else if (r > 255)
+            r = 255;
+          if (g < 0)
+            g = 0;
+          else if (g > 255)
+            g = 255;
+          if (b < 0)
+            b = 0;
+          else if (b > 255)
+            b = 255;
           const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
           result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
           if (result > 16) result = 16;
@@ -874,9 +895,9 @@ bool CssParser::loadFromCache() {
 
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
-  constexpr size_t CSS_FIXED_STYLE_BYTES =
-      4 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) /* display */ +
-      sizeof(uint8_t) /* backgroundColor */ + sizeof(uint16_t) /* definedBits */ + sizeof(uint8_t) /* extraBits */;
+  constexpr size_t CSS_FIXED_STYLE_BYTES = 4 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) +
+                                           sizeof(uint8_t) /* display */ + sizeof(uint8_t) /* backgroundColor */ +
+                                           sizeof(uint16_t) /* definedBits */ + sizeof(uint8_t) /* extraBits */;
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <cerrno>
 #include <string_view>
 
 namespace {
@@ -108,18 +109,47 @@ static uint8_t interpretColor(const std::string& val) {
     result = 0;
   else if (normalized.size() >= 4 && normalized[0] == '#') {
     int r = 0, g = 0, b = 0;
+    auto parseHexComponent = [](const std::string& s, size_t pos, size_t len) -> int {
+      char* endPtr = nullptr;
+      // Copy the hex component to a buffer to ensure null termination
+      char buffer[3] = {0};
+      if (len == 1) {
+        // Short form: "f" -> duplicate to "ff"
+        buffer[0] = s[pos];
+        buffer[1] = s[pos];
+      } else {
+        buffer[0] = s[pos];
+        buffer[1] = s[pos + 1];
+      }
+      errno = 0;
+      long val = std::strtol(buffer, &endPtr, 16);
+      if (*endPtr != '\0' || errno == ERANGE) {
+        return -1;  // Parse failure
+      }
+      return static_cast<int>(val);
+    };
+
     if (normalized.size() == 4) {
-      r = std::stoi(std::string(2, normalized[1]), nullptr, 16);
-      g = std::stoi(std::string(2, normalized[2]), nullptr, 16);
-      b = std::stoi(std::string(2, normalized[3]), nullptr, 16);
+      // Short form #rgb
+      r = parseHexComponent(normalized, 1, 1);
+      g = parseHexComponent(normalized, 2, 1);
+      b = parseHexComponent(normalized, 3, 1);
     } else if (normalized.size() == 7) {
-      r = std::stoi(normalized.substr(1, 2), nullptr, 16);
-      g = std::stoi(normalized.substr(3, 2), nullptr, 16);
-      b = std::stoi(normalized.substr(5, 2), nullptr, 16);
+      // Long form #rrggbb
+      r = parseHexComponent(normalized, 1, 2);
+      g = parseHexComponent(normalized, 3, 2);
+      b = parseHexComponent(normalized, 5, 2);
     } else {
       LOG_DBG("CSS", "interpretColor: failed hex parse for '%s'", normalized.c_str());
       return 0;
     }
+
+    // Validate parsing results
+    if (r < 0 || g < 0 || b < 0 || r > 255 || g > 255 || b > 255) {
+      LOG_DBG("CSS", "interpretColor: malformed hex color '%s'", normalized.c_str());
+      return 0;
+    }
+
     const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
     result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
     if (result > 16) result = 16;
@@ -170,7 +200,6 @@ static uint8_t interpretColor(const std::string& val) {
       }
     }
   }
-  LOG_DBG("CSS", "interpretColor('%s') -> %d", normalized.c_str(), (int)result);
   return result;
 }
 
@@ -824,7 +853,8 @@ bool CssParser::saveToCache() const {
     file.write(static_cast<uint8_t>(style.display));
     file.write(style.backgroundColor);
 
-    // Write defined flags as uint16_t (extended to uint32_t for new bits)
+    // Write defined flags as uint16_t (definedBits) plus extra byte (extraBits) for overflow flags
+    // First 16 flags stored in definedBits; additional flags stored in extraBits appended separately
     uint16_t definedBits = 0;
     if (style.defined.textAlign) definedBits |= 1 << 0;
     if (style.defined.fontStyle) definedBits |= 1 << 1;

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -75,6 +75,84 @@ std::string_view stripTrailingImportant(std::string_view value) {
   return value;
 }
 
+// Convert CSS color value to GfxRenderer::Color enum value (8-bit grayscale)
+// Supports hex colors (#000, #000000), named colors (black, white, gray),
+// and rgb/rgba values.
+static uint8_t interpretColor(const std::string& val) {
+  std::string_view sv = stripTrailingImportant(val);
+  if (sv.empty()) return 0;
+  while (!sv.empty() && isCssWhitespace(sv.front())) sv.remove_prefix(1);
+  while (!sv.empty() && isCssWhitespace(sv.back())) sv.remove_suffix(1);
+  std::string normalized(sv);
+  for (size_t i = 0; i < normalized.size(); ++i) {
+    normalized[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized[i])));
+  }
+  uint8_t result = 0;
+  if (normalized == "black" || normalized == "#000" || normalized == "#000000") result = 16;
+  else if (normalized == "white" || normalized == "#fff" || normalized == "#ffffff") result = 0;
+  else if (normalized == "gray" || normalized == "grey" || normalized == "#808080") result = 10;
+  else if (normalized == "lightgray" || normalized == "#d3d3d3") result = 5;
+  else if (normalized == "darkgray" || normalized == "#a9a9a9") result = 8;
+  else if (normalized == "red" || normalized == "#f00" || normalized == "#ff0000") result = 10;
+  else if (normalized == "blue" || normalized == "#00f" || normalized == "#0000ff") result = 10;
+  else if (normalized == "green" || normalized == "#0f0" || normalized == "#00ff00") result = 10;
+  else if (normalized == "transparent" || normalized == "none") result = 0;
+  else if (normalized.size() >= 4 && normalized[0] == '#') {
+    int r = 0, g = 0, b = 0;
+    if (normalized.size() == 4) {
+      r = std::stoi(std::string(2, normalized[1]), nullptr, 16);
+      g = std::stoi(std::string(2, normalized[2]), nullptr, 16);
+      b = std::stoi(std::string(2, normalized[3]), nullptr, 16);
+    } else if (normalized.size() == 7) {
+      r = std::stoi(normalized.substr(1, 2), nullptr, 16);
+      g = std::stoi(normalized.substr(3, 2), nullptr, 16);
+      b = std::stoi(normalized.substr(5, 2), nullptr, 16);
+    } else {
+      LOG_DBG("CSS", "interpretColor: failed hex parse for '%s'", normalized.c_str());
+      return 0;
+    }
+    const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
+    result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
+    if (result > 16) result = 16;
+  } else if (normalized.size() >= 4 && normalized.substr(0, 3) == "rgb") {
+    size_t start = normalized.find('(');
+    size_t end = normalized.find(')');
+    if (start != std::string::npos && end != std::string::npos) {
+      std::string rgbPart = normalized.substr(start + 1, end - start - 1);
+      int r = 0, g = 0, b = 0;
+      size_t comma1 = rgbPart.find(',');
+      if (comma1 != std::string::npos) {
+        size_t comma2 = rgbPart.find(',', comma1 + 1);
+        if (comma2 != std::string::npos) {
+          auto parseInt = [](const std::string& s) -> int {
+            const char* str = s.c_str();
+            while (*str && isCssWhitespace(*str)) ++str;
+            bool neg = false;
+            if (*str == '-') { neg = true; ++str; }
+            int val = 0;
+            while (*str >= '0' && *str <= '9') { val = val * 10 + (*str - '0'); ++str; }
+            return neg ? -val : val;
+          };
+          r = parseInt(rgbPart.substr(0, comma1));
+          g = parseInt(rgbPart.substr(comma1 + 1, comma2 - comma1 - 1));
+          b = parseInt(rgbPart.substr(comma2 + 1));
+          if (r < 0) r = 0;
+          else if (r > 255) r = 255;
+          if (g < 0) g = 0;
+          else if (g > 255) g = 255;
+          if (b < 0) b = 0;
+          else if (b > 255) b = 255;
+          const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
+          result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
+          if (result > 16) result = 16;
+        }
+      }
+    }
+  }
+  LOG_DBG("CSS", "interpretColor('%s') -> %d", normalized.c_str(), (int)result);
+  return result;
+}
+
 }  // anonymous namespace
 
 // String utilities implementation
@@ -344,6 +422,9 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     const std::string_view displayValue = stripTrailingImportant(propValueBuf);
     style.display = (displayValue == "none") ? CssDisplay::None : CssDisplay::Block;
     style.defined.display = 1;
+  } else if (propNameBuf == "background-color") {
+    style.backgroundColor = interpretColor(propValueBuf);
+    style.defined.backgroundColor = 1;
   }
 }
 
@@ -720,8 +801,9 @@ bool CssParser::saveToCache() const {
     writeLength(style.imageHeight);
     writeLength(style.imageWidth);
     file.write(static_cast<uint8_t>(style.display));
+    file.write(style.backgroundColor);
 
-    // Write defined flags as uint16_t
+    // Write defined flags as uint16_t (extended to uint32_t for new bits)
     uint16_t definedBits = 0;
     if (style.defined.textAlign) definedBits |= 1 << 0;
     if (style.defined.fontStyle) definedBits |= 1 << 1;
@@ -739,7 +821,11 @@ bool CssParser::saveToCache() const {
     if (style.defined.imageHeight) definedBits |= 1 << 13;
     if (style.defined.imageWidth) definedBits |= 1 << 14;
     if (style.defined.display) definedBits |= 1 << 15;
+    // backgroundColor flag: extend beyond uint16_t; serialize extra byte
+    uint8_t extraBits = 0;
+    if (style.defined.backgroundColor) extraBits |= 1 << 0;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
+    file.write(extraBits);
   }
 
   LOG_DBG("CSS", "Saved %u rules to cache", ruleCount);
@@ -789,7 +875,8 @@ bool CssParser::loadFromCache() {
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
   constexpr size_t CSS_FIXED_STYLE_BYTES =
-      4 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) + sizeof(uint16_t);
+      4 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) /* display */ +
+      sizeof(uint8_t) /* backgroundColor */ + sizeof(uint16_t) /* definedBits */ + sizeof(uint8_t) /* extraBits */;
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
@@ -880,6 +967,14 @@ bool CssParser::loadFromCache() {
     }
     style.display = static_cast<CssDisplay>(displayVal);
 
+    // Read backgroundColor
+    uint8_t bgColor;
+    if (!hasRemainingBytes(1) || file.read(&bgColor, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.backgroundColor = bgColor;
+
     // Read defined flags
     uint16_t definedBits = 0;
     if (file.read(&definedBits, sizeof(definedBits)) != sizeof(definedBits)) {
@@ -902,6 +997,13 @@ bool CssParser::loadFromCache() {
     style.defined.imageHeight = (definedBits & 1 << 13) != 0;
     style.defined.imageWidth = (definedBits & 1 << 14) != 0;
     style.defined.display = (definedBits & 1 << 15) != 0;
+    // Read extra bits byte for extended flags
+    uint8_t extraBitsRead = 0;
+    if (file.read(&extraBitsRead, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.defined.backgroundColor = (extraBitsRead & 1 << 0) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -93,8 +93,10 @@ static uint8_t rgbToGrayscale(int r, int g, int b) {
 static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
   std::string_view sv = stripTrailingImportant(val);
   if (sv.empty()) return std::nullopt;
+
   while (!sv.empty() && isCssWhitespace(sv.front())) sv.remove_prefix(1);
   while (!sv.empty() && isCssWhitespace(sv.back())) sv.remove_suffix(1);
+
   std::string normalized(sv);
   for (size_t i = 0; i < normalized.size(); ++i) {
     normalized[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized[i])));
@@ -102,47 +104,27 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
 
   if (normalized == "transparent" || normalized == "none") return 0;
 
-  // Named colors — resolve to RGB then go through the shared grayscale helper
+  // Named color path 
   int r = -1, g = -1, b = -1;
   if (normalized == "black") {
-    r = 0;
-    g = 0;
-    b = 0;
+    return rgbToGrayscale(0, 0, 0);
   } else if (normalized == "white") {
-    r = 255;
-    g = 255;
-    b = 255;
+    return rgbToGrayscale(255, 255, 255);
   } else if (normalized == "gray" || normalized == "grey") {
-    r = 128;
-    g = 128;
-    b = 128;
+    return rgbToGrayscale(128, 128, 128);
   } else if (normalized == "lightgray") {
-    r = 211;
-    g = 211;
-    b = 211;
+    return rgbToGrayscale(211, 211, 211);
   } else if (normalized == "darkgray") {
-    r = 169;
-    g = 169;
-    b = 169;
+    return rgbToGrayscale(169, 169, 169);
   } else if (normalized == "red") {
-    r = 255;
-    g = 0;
-    b = 0;
+    return rgbToGrayscale(255, 0, 0);
   } else if (normalized == "green") {
-    r = 0;
-    g = 255;
-    b = 0;
+    return rgbToGrayscale(0, 255, 0);
   } else if (normalized == "blue") {
-    r = 0;
-    g = 0;
-    b = 255;
+    return rgbToGrayscale(0, 0, 255);
   }
 
-  if (r >= 0 && g >= 0 && b >= 0) {
-    return rgbToGrayscale(r, g, b);
-  }
-
-  uint8_t result = 0;
+  // Hex parsing path (#000)
   if (normalized.size() >= 4 && normalized[0] == '#') {
     auto parseHexComponent = [](const std::string& s, size_t pos, size_t len) -> int {
       char* endPtr = nullptr;
@@ -156,11 +138,14 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
         buffer[0] = s[pos];
         buffer[1] = s[pos + 1];
       }
+
       errno = 0;
       long val = std::strtol(buffer, &endPtr, 16);
+
       if (*endPtr != '\0' || errno == ERANGE) {
         return -1;  // Parse failure
       }
+
       return static_cast<int>(val);
     };
 
@@ -185,54 +170,72 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
       return std::nullopt;
     }
 
-    result = rgbToGrayscale(r, g, b);
-  } else if (normalized.size() >= 4 && normalized.substr(0, 3) == "rgb") {
+    return rgbToGrayscale(r, g, b);
+  } 
+  
+  // rgb parsing path (rgb(0, 0, 0), rgba(0, 0, 0))
+  if (normalized.size() >= 4 && normalized.substr(0, 3) == "rgb") {
     size_t start = normalized.find('(');
     size_t end = normalized.find(')');
-    if (start != std::string::npos && end != std::string::npos) {
-      std::string rgbPart = normalized.substr(start + 1, end - start - 1);
-      size_t comma1 = rgbPart.find(',');
-      if (comma1 != std::string::npos) {
-        size_t comma2 = rgbPart.find(',', comma1 + 1);
-        if (comma2 != std::string::npos) {
-          auto parseInt = [](const std::string& s) -> int {
-            const char* str = s.c_str();
-            while (*str && isCssWhitespace(*str)) ++str;
-            bool neg = false;
-            if (*str == '-') {
-              neg = true;
-              ++str;
-            }
-            int val = 0;
-            while (*str >= '0' && *str <= '9') {
-              val = val * 10 + (*str - '0');
-              ++str;
-            }
-            return neg ? -val : val;
-          };
-          r = parseInt(rgbPart.substr(0, comma1));
-          g = parseInt(rgbPart.substr(comma1 + 1, comma2 - comma1 - 1));
-          b = parseInt(rgbPart.substr(comma2 + 1));
-          if (r < 0)
-            r = 0;
-          else if (r > 255)
-            r = 255;
-          if (g < 0)
-            g = 0;
-          else if (g > 255)
-            g = 255;
-          if (b < 0)
-            b = 0;
-          else if (b > 255)
-            b = 255;
-          result = rgbToGrayscale(r, g, b);
-        }
-      }
+    
+    if (start == std::string::npos || end == std::string::npos || end < start) {
+      return std::nullopt;
     }
-  } else {
-    return std::nullopt;
+
+    std::string rgbPart = normalized.substr(start + 1, end - start - 1);
+
+    size_t comma1 = rgbPart.find(',');
+    if(comma1 == std::string::npos) {
+      return std::nullopt;
+    }
+
+    size_t comma2 = rgbPart.find(',', comma1 + 1);
+    if(comma2 == std::string::npos) {
+      return std::nullopt;
+    }
+
+    auto parseInt = [](const std::string& s) -> int {
+      const char* str = s.c_str();
+      while (*str && isCssWhitespace(*str)) ++str;
+
+      bool neg = false;
+      if (*str == '-') {
+        neg = true;
+        ++str;
+      }
+
+      int val = 0;
+      while (*str >= '0' && *str <= '9') {
+        val = val * 10 + (*str - '0');
+        ++str;
+      }
+
+      return neg ? -val : val;
+    };
+
+    r = parseInt(rgbPart.substr(0, comma1));
+    g = parseInt(rgbPart.substr(comma1 + 1, comma2 - comma1 - 1));
+    b = parseInt(rgbPart.substr(comma2 + 1));
+
+    if (r < 0)
+      r = 0;
+    else if (r > 255)
+      r = 255;
+
+    if (g < 0)
+      g = 0;
+    else if (g > 255)
+      g = 255;
+
+    if (b < 0)
+      b = 0;
+    else if (b > 255)
+      b = 255;
+
+    return rgbToGrayscale(r, g, b);
   }
-  return result;
+
+  return std::nullopt;
 }
 
 }  // anonymous namespace

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -77,6 +77,15 @@ std::string_view stripTrailingImportant(std::string_view value) {
   return value;
 }
 
+// Shared helper: convert RGB components to 8-bit grayscale using the same
+// luminance formula used for hex/rgb inputs.
+static uint8_t rgbToGrayscale(int r, int g, int b) {
+  const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
+  uint8_t result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
+  if (result > 16) result = 16;
+  return result;
+}
+
 // Convert CSS color value to GfxRenderer::Color enum value (8-bit grayscale)
 // Supports hex colors (#000, #000000), named colors (black, white, gray),
 // and rgb/rgba values.
@@ -90,27 +99,35 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
   for (size_t i = 0; i < normalized.size(); ++i) {
     normalized[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(normalized[i])));
   }
+
+  if (normalized == "transparent" || normalized == "none")
+    return 0;
+
+  // Named colors — resolve to RGB then go through the shared grayscale helper
+  int r = -1, g = -1, b = -1;
+  if (normalized == "black")
+    { r = 0;   g = 0;   b = 0;   }
+  else if (normalized == "white")
+    { r = 255; g = 255; b = 255; }
+  else if (normalized == "gray" || normalized == "grey")
+    { r = 128; g = 128; b = 128; }
+  else if (normalized == "lightgray")
+    { r = 211; g = 211; b = 211; }
+  else if (normalized == "darkgray")
+    { r = 169; g = 169; b = 169; }
+  else if (normalized == "red")
+    { r = 255; g = 0;   b = 0;   }
+  else if (normalized == "green")
+    { r = 0;   g = 255; b = 0;   }
+  else if (normalized == "blue")
+    { r = 0;   g = 0;   b = 255; }
+
+  if (r >= 0 && g >= 0 && b >= 0) {
+    return rgbToGrayscale(r, g, b);
+  }
+
   uint8_t result = 0;
-  if (normalized == "black" || normalized == "#000" || normalized == "#000000")
-    result = 16;
-  else if (normalized == "white" || normalized == "#fff" || normalized == "#ffffff")
-    result = 0;
-  else if (normalized == "gray" || normalized == "grey" || normalized == "#808080")
-    result = 10;
-  else if (normalized == "lightgray" || normalized == "#d3d3d3")
-    result = 5;
-  else if (normalized == "darkgray" || normalized == "#a9a9a9")
-    result = 8;
-  else if (normalized == "red" || normalized == "#f00" || normalized == "#ff0000")
-    result = 10;
-  else if (normalized == "blue" || normalized == "#00f" || normalized == "#0000ff")
-    result = 10;
-  else if (normalized == "green" || normalized == "#0f0" || normalized == "#00ff00")
-    result = 10;
-  else if (normalized == "transparent" || normalized == "none")
-    result = 0;
-  else if (normalized.size() >= 4 && normalized[0] == '#') {
-    int r = 0, g = 0, b = 0;
+  if (normalized.size() >= 4 && normalized[0] == '#') {
     auto parseHexComponent = [](const std::string& s, size_t pos, size_t len) -> int {
       char* endPtr = nullptr;
       // Copy the hex component to a buffer to ensure null termination
@@ -152,15 +169,12 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
       return std::nullopt;
     }
 
-    const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
-    result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
-    if (result > 16) result = 16;
+    result = rgbToGrayscale(r, g, b);
   } else if (normalized.size() >= 4 && normalized.substr(0, 3) == "rgb") {
     size_t start = normalized.find('(');
     size_t end = normalized.find(')');
     if (start != std::string::npos && end != std::string::npos) {
       std::string rgbPart = normalized.substr(start + 1, end - start - 1);
-      int r = 0, g = 0, b = 0;
       size_t comma1 = rgbPart.find(',');
       if (comma1 != std::string::npos) {
         size_t comma2 = rgbPart.find(',', comma1 + 1);
@@ -195,9 +209,7 @@ static std::optional<uint8_t> tryInterpretColor(const std::string& val) {
             b = 0;
           else if (b > 255)
             b = 255;
-          const int luminance = (19595 * r + 38470 * g + 7471 * b) >> 16;
-          result = static_cast<uint8_t>(((255 - luminance) * 16 + 127) / 255);
-          if (result > 16) result = 16;
+          result = rgbToGrayscale(r, g, b);
         }
       }
     }

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -31,7 +31,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 4;
+  static constexpr uint8_t CSS_CACHE_VERSION = 5;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -2,6 +2,7 @@
 
 #include <HalStorage.h>
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -123,6 +124,11 @@ class CssParser {
   static CssLength interpretLength(const std::string& val);
   /** Returns true only when a numeric length was parsed (e.g. 2em, 50%). False for auto/inherit/initial. */
   static bool tryInterpretLength(const std::string& val, CssLength& out);
+  /**
+   * Parse a CSS color value into an 8-bit grayscale color.
+   * Returns std::nullopt if the color could not be parsed.
+   */
+  static std::optional<uint8_t> tryInterpretColor(const std::string& val);
 
   // String utilities
   static std::string normalized(const std::string& s);

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -75,6 +75,7 @@ struct CssPropertyFlags {
   uint16_t imageHeight : 1;
   uint16_t imageWidth : 1;
   uint16_t display : 1;
+  uint16_t backgroundColor : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -92,19 +93,20 @@ struct CssPropertyFlags {
         paddingRight(0),
         imageHeight(0),
         imageWidth(0),
-        display(0) {}
+        display(0),
+        backgroundColor(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display;
+           imageWidth || display || backgroundColor;
   }
 
   void clearAll() {
     textAlign = fontStyle = fontWeight = textDecoration = textIndent = 0;
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
-    imageHeight = imageWidth = display = 0;
+    imageHeight = imageWidth = display = backgroundColor = 0;
   }
 };
 
@@ -129,6 +131,7 @@ struct CssStyle {
   CssLength imageHeight;    // Height for img (e.g. 2em) – width derived from aspect ratio when only height set
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;  // display property (Block or None)
+  uint8_t backgroundColor = 0;               // 0=none; otherwise maps to GfxRenderer::Color enum
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -199,6 +202,10 @@ struct CssStyle {
       display = base.display;
       defined.display = 1;
     }
+    if (base.hasBackgroundColor()) {
+      backgroundColor = base.backgroundColor;
+      defined.backgroundColor = 1;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -217,6 +224,7 @@ struct CssStyle {
   [[nodiscard]] bool hasImageHeight() const { return defined.imageHeight; }
   [[nodiscard]] bool hasImageWidth() const { return defined.imageWidth; }
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
+  [[nodiscard]] bool hasBackgroundColor() const { return defined.backgroundColor; }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -228,6 +236,7 @@ struct CssStyle {
     paddingTop = paddingBottom = paddingLeft = paddingRight = CssLength{};
     imageHeight = imageWidth = CssLength{};
     display = CssDisplay::Block;
+    backgroundColor = 0;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -131,7 +131,7 @@ struct CssStyle {
   CssLength imageHeight;    // Height for img (e.g. 2em) – width derived from aspect ratio when only height set
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;  // display property (Block or None)
-  uint8_t backgroundColor = 0;               // 0=none; otherwise maps to GfxRenderer::Color enum
+  uint8_t backgroundColor = 0;             // 0=none; otherwise maps to GfxRenderer::Color enum
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -84,6 +84,7 @@ void ChapterHtmlSlimParser::updateEffectiveInlineStyle() {
   effectiveItalic = currentCssStyle.hasFontStyle() && currentCssStyle.fontStyle == CssFontStyle::Italic;
   effectiveUnderline =
       currentCssStyle.hasTextDecoration() && currentCssStyle.textDecoration == CssTextDecoration::Underline;
+  effectiveBackgroundColor = currentCssStyle.hasBackgroundColor() ? currentCssStyle.backgroundColor : 0;
 
   // Apply inline style stack in order
   for (const auto& entry : inlineStyleStack) {
@@ -96,7 +97,13 @@ void ChapterHtmlSlimParser::updateEffectiveInlineStyle() {
     if (entry.hasUnderline) {
       effectiveUnderline = entry.underline;
     }
+    if (entry.hasBackgroundColor) {
+      effectiveBackgroundColor = entry.backgroundColor;
+    }
   }
+  LOG_DBG("EHP", "updateEffStyle: depth=%d b=%d i=%d u=%d bg=%d stack=%u", depth, (int)effectiveBold,
+          (int)effectiveItalic, (int)effectiveUnderline, (int)effectiveBackgroundColor,
+          (uint32_t)inlineStyleStack.size());
 }
 
 // flush the contents of partWordBuffer to currentTextBlock
@@ -120,7 +127,9 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 
   // flush the buffer
   partWordBuffer[partWordBufferIndex] = '\0';
-  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
+  LOG_DBG("EHP", "flush: effBg=%d buf='%s' len=%d continues=%d", (int)effectiveBackgroundColor, partWordBuffer,
+          partWordBufferIndex, (int)nextWordContinues);
+  currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues, effectiveBackgroundColor);
   partWordBufferIndex = 0;
   nextWordContinues = false;
 }
@@ -586,7 +595,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR, false, false,
+                                        self->effectiveBackgroundColor);
       }
     }
   } else if (matches(name, UNDERLINE_TAGS, NUM_UNDERLINE_TAGS)) {
@@ -657,12 +667,18 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->updateEffectiveInlineStyle();
   } else if (strcmp(name, "span") == 0 || !isHeaderOrBlock(name)) {
     // Handle span and other inline elements for CSS styling
-    if (cssStyle.hasFontWeight() || cssStyle.hasFontStyle() || cssStyle.hasTextDecoration()) {
+    if (cssStyle.hasFontWeight() || cssStyle.hasFontStyle() || cssStyle.hasTextDecoration() ||
+        cssStyle.hasBackgroundColor()) {
+      LOG_DBG("EHP", "span/inline: entering, hasBg=%d bg=%d class='%s'", cssStyle.hasBackgroundColor(),
+              (int)cssStyle.backgroundColor, classAttr.c_str());
       // Flush buffer before style change so preceding text gets current style
       if (self->partWordBufferIndex > 0) {
         self->flushPartWordBuffer();
         self->nextWordContinues = true;
       }
+      // Track that we're at a styled inline boundary - first content here should not
+      // continue from previous word (e.g., &nbsp; should create visible space, not attach)
+      self->atInlineStyleBoundary = true;
       StyleStackEntry entry;
       entry.depth = self->depth;  // Track depth for matching pop
       if (cssStyle.hasFontWeight()) {
@@ -677,8 +693,14 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         entry.hasUnderline = true;
         entry.underline = cssStyle.textDecoration == CssTextDecoration::Underline;
       }
+      if (cssStyle.hasBackgroundColor()) {
+        entry.hasBackgroundColor = true;
+        entry.backgroundColor = cssStyle.backgroundColor;
+      }
       self->inlineStyleStack.push_back(entry);
       self->updateEffectiveInlineStyle();
+    } else {
+      LOG_DBG("EHP", "span/inline: SKIPPED (no relevant style) class='%s'", classAttr.c_str());
     }
   }
 
@@ -765,10 +787,13 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordBuffer[0] = ' ';
       self->partWordBuffer[1] = '\0';
       self->partWordBufferIndex = 1;
-      self->nextWordContinues = true;  // Attach space to previous word (no break).
+      // If at styled inline boundary, space should not attach to previous word
+      // (creates visible separation between "Agent" and styled span content)
+      self->nextWordContinues = !self->atInlineStyleBoundary;
       self->flushPartWordBuffer();
 
       self->nextWordContinues = true;  // Next real word attaches to this space (no break).
+      self->atInlineStyleBoundary = false;  // Clear boundary flag after first content
 
       i++;  // Skip the second byte (0xA0)
       continue;
@@ -784,10 +809,12 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->partWordBuffer[0] = ' ';
       self->partWordBuffer[1] = '\0';
       self->partWordBufferIndex = 1;
-      self->nextWordContinues = true;
+      // If at styled inline boundary, space should not attach to previous word
+      self->nextWordContinues = !self->atInlineStyleBoundary;
       self->flushPartWordBuffer();
 
       self->nextWordContinues = true;
+      self->atInlineStyleBoundary = false;  // Clear boundary flag after first content
 
       i += 2;  // Skip the remaining two bytes (0x80 0xAF)
       continue;
@@ -832,6 +859,9 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
         self->flushPartWordBuffer();
       }
     }
+
+    // Clear inline style boundary flag once we process any real character content
+    self->atInlineStyleBoundary = false;
 
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -792,7 +792,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
       self->nextWordContinues = !self->atInlineStyleBoundary;
       self->flushPartWordBuffer();
 
-      self->nextWordContinues = true;  // Next real word attaches to this space (no break).
+      self->nextWordContinues = true;       // Next real word attaches to this space (no break).
       self->atInlineStyleBoundary = false;  // Clear boundary flag after first content
 
       i++;  // Skip the second byte (0xA0)

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -37,7 +37,8 @@ class ChapterHtmlSlimParser {
   char partWordBuffer[MAX_WORD_SIZE + 1] = {};
   int partWordBufferIndex = 0;
   bool nextWordContinues = false;  // true when next flushed word attaches to previous (inline element boundary)
-  bool atInlineStyleBoundary = false;  // true when entering styled inline element, cleared after first content processed
+  bool atInlineStyleBoundary =
+      false;  // true when entering styled inline element, cleared after first content processed
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
   std::unique_ptr<Page> currentPage = nullptr;
   int16_t currentPageNextY = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -37,6 +37,7 @@ class ChapterHtmlSlimParser {
   char partWordBuffer[MAX_WORD_SIZE + 1] = {};
   int partWordBufferIndex = 0;
   bool nextWordContinues = false;  // true when next flushed word attaches to previous (inline element boundary)
+  bool atInlineStyleBoundary = false;  // true when entering styled inline element, cleared after first content processed
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
   std::unique_ptr<Page> currentPage = nullptr;
   int16_t currentPageNextY = 0;
@@ -60,12 +61,15 @@ class ChapterHtmlSlimParser {
     bool hasBold = false, bold = false;
     bool hasItalic = false, italic = false;
     bool hasUnderline = false, underline = false;
+    bool hasBackgroundColor = false;
+    uint8_t backgroundColor = 0;
   };
   std::vector<StyleStackEntry> inlineStyleStack;
   CssStyle currentCssStyle;
   bool effectiveBold = false;
   bool effectiveItalic = false;
   bool effectiveUnderline = false;
+  uint8_t effectiveBackgroundColor = 0;
   int tableDepth = 0;
   int tableRowIndex = 0;
   int tableColIndex = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -64,6 +64,7 @@ class ChapterHtmlSlimParser {
     bool hasUnderline = false, underline = false;
     bool hasBackgroundColor = false;
     uint8_t backgroundColor = 0;
+    StyleStackEntry() : hasBackgroundColor(false), backgroundColor(0) {}
   };
   std::vector<StyleStackEntry> inlineStyleStack;
   CssStyle currentCssStyle;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1122,7 +1122,6 @@ int GfxRenderer::getFontAscenderSize(const int fontId) const {
   return fontIt->second.getData(EpdFontFamily::REGULAR)->ascender;
 }
 
-
 int GfxRenderer::getLineHeight(const int fontId) const {
   const auto fontIt = fontMap.find(fontId);
   if (fontIt == fontMap.end()) {

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -473,7 +473,6 @@ void GfxRenderer::drawPixelDither<Color::DarkGray>(const int x, const int y) con
 }
 
 void GfxRenderer::fillRectDither(const int x, const int y, const int width, const int height, Color color) const {
-  LOG_DBG("GFX", "fillRectDither: x=%d y=%d w=%d h=%d color=%d", x, y, width, height, (int)color);
   if (color == Color::Clear) {
   } else if (color == Color::Black) {
     fillRect(x, y, width, height, true);

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -473,6 +473,7 @@ void GfxRenderer::drawPixelDither<Color::DarkGray>(const int x, const int y) con
 }
 
 void GfxRenderer::fillRectDither(const int x, const int y, const int width, const int height, Color color) const {
+  LOG_DBG("GFX", "fillRectDither: x=%d y=%d w=%d h=%d color=%d", x, y, width, height, (int)color);
   if (color == Color::Clear) {
   } else if (color == Color::Black) {
     fillRect(x, y, width, height, true);
@@ -1120,6 +1121,7 @@ int GfxRenderer::getFontAscenderSize(const int fontId) const {
 
   return fontIt->second.getData(EpdFontFamily::REGULAR)->ascender;
 }
+
 
 int GfxRenderer::getLineHeight(const int fontId) const {
   const auto fontIt = fontMap.find(fontId);


### PR DESCRIPTION
## Summary

### Context & Motivation                                                                                                                                                                                                                
                                                                                                                                                                                                                                                             
This enhancement introduces support for reading and applying background colors to individual words within an EPUB section, enabling features like highlighting, block quotes, or stylistic emphasis. 
             
### Technical Implementation Details

 This feature required cascading updates across the core EPUB parsing and rendering pipeline:
                       
 #### 1. CSS Parsing & Model (lib/Epub/Epub/css/):                                                                                                                                                                                                           
                                                                                                                                                                                                                                                             
 - New Feature: Implemented interpretColor() in CssParser.cpp to robustly parse common CSS color formats (hex codes, named colors like black, and rgb(...)) and convert them into our 8-bit grayscale representation used for the e-reader display buffer.   
 - Cache Update: Incremented CSS_CACHE_VERSION from 4 to 5.                                                                                                                                                                                                  
 - Serialization: Updated the cache writing/reading mechanism in CssParser.cpp and .h to serialize and deserialize a dedicated backgroundColor flag (uint8_t) and store this data in the cached structure.                                                   
                                                                                                                                                                                                                                                             
 #### 2. EPUB Parsing & Structure:                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                             
 - HTML Parsing (ChapterHtmlSlimParser): Updated StyleStackEntry and logic within startElement()/characterData() to detect background colors set by inline HTML styles (e.g., <span style="background-color:...">). This color is now tracked in the         
 effectiveBackgroundColor.                                                                                                                                                                                                                                   
 - Content Model (ParsedText):                                                                                                                                                                                                                               
     - Updated addWord() signature in lib/Epub/Epub/ParsedText.h to accept an optional uint8_t backgroundColor parameter.                                                                                                                                    
     - Added and manage the wordBackgrounds vector within ParsedText to hold this per-word color information across the document structure.                                                                                                                  
     - Updated layout extraction (layoutAndExtractLines) and line construction (extractLine) to correctly populate and pass this background color data into the resulting TextBlock.                                                                         
                                                                                                                                                                                                                                                             
 #### 3. Content Serialization & Compatibility:                                                                                                                                                                                                              
                                                                                                                                                                                                                                                             
 - Block Level (TextBlock):                                                                                                                                                                                                                                  
     - Added std::vector<uint8_t> wordBackgrounds storage in TextBlock.h.                                                                                                                                                                                    
     - Overhauled serialization/deserialization (deserialize(FsFile& file, uint8_t sectionVersion)) to support the new background color payload for version $\ge$ 22.                                                                                        
     - Added a deserializeLegacy() fallback method to maintain compatibility with older EPUB sections lacking this data.                                                                                                                                     
 - Section Level (Section): Incremented SECTION_FILE_VERSION from 21 to 22. This change is required because the underlying content structure (TextBlock) has changed its serialized format significantly, necessitating cache invalidation on reading.       
                                                                                                                                                                                                                                                             
 #### 4. Rendering (GfxRenderer/TextBlock):                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                             
 - Rendering Logic: Heavily updated TextBlock::render() in lib/Epub/Epub/blocks/TextBlock.cpp. The renderer now executes two passes:                                                                                                                         
     1. Background Pass: Draws background colors using renderer.fillRectDither(), merging adjacent words with the same color into a single block for efficiency and accurate dithering.                                                                      
     2. Text Pass: Renders foreground text, intelligently choosing between black/white based on the detected word background color (assuming dark backgrounds require white text). 

## Screenshots

### Before
<img width="480" height="800" alt="before" src="https://github.com/user-attachments/assets/3fdc886e-6d7c-4642-a0e9-39eb34cc074c" />

### After
<img width="480" height="800" alt="after" src="https://github.com/user-attachments/assets/6a2cb661-1a7c-4e3b-b837-9f0351aae6e7" />


### Reference (KOReader)

<img width="596" height="319" alt="image" src="https://github.com/user-attachments/assets/87dae752-650f-4489-99e2-31f59b89e7cc" />

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**
