### PR TITLE
docs: RFC for multi-language plug-in font architecture (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,23 @@ file will use a new cache directory, resetting the reading progress.
 
 For more details on the internal file structures, see the [file formats document](./docs/file-formats.md).
 
+### Font system roadmap
+
+The current reader fonts (NotoSerif, NotoSans, OpenDyslexic at 12–18 pt) ship as `static const` Flash arrays sized
+for European-language coverage (~1070 glyphs each). This works for the 23 currently-supported languages but does not
+scale to CJK reading (~5000+ glyphs), Hebrew/Arabic, Indic, Thai, etc.
+
+A draft architecture (Font System v3) is in development to support **plug-in fonts via SD card** with multi-script
+fallback chains, while staying within the C3's 380 KB RAM budget (no PSRAM). Design documents:
+
+* [Architecture overview](./docs/architecture/font-system-v3.md) — long-form RFC
+* [ADR 0001 — `.cpf` paged glyph metadata](./docs/adr/0001-cpf-paged-metadata.md) — how we fit ~5000 CJK glyphs in 1 KB resident
+* [ADR 0002 — Multi-font fallback chain (`FontStack`)](./docs/adr/0002-font-fallback-chain.md) — the CSS-style fallback model
+* [ADR 0003 — Defer complex-script shaping](./docs/adr/0003-defer-harfbuzz-bidi.md) — why HarfBuzz / bidi / Indic / vector
+  rasterisation are out of scope for v3 and what triggers their re-entry
+
+These documents are RFCs, not implemented yet. Comments and pushback welcome on the corresponding GitHub discussion.
+
 ## Contributing
 
 Contributions are very welcome!

--- a/docs/adr/0001-cpf-paged-metadata.md
+++ b/docs/adr/0001-cpf-paged-metadata.md
@@ -1,0 +1,103 @@
+# ADR 0001 — `.cpf` Paged Glyph Metadata
+
+| Field        | Value                                                |
+| ---          | ---                                                  |
+| Status       | Proposed                                             |
+| Date         | 2026-05-06                                           |
+| Decision by  | TBD (RFC pending upstream review)                    |
+| Supersedes   | —                                                    |
+| Superseded by| —                                                    |
+
+## Context
+
+CrossPoint Reader currently supports 23 European languages plus Chinese as a UI translation. The reader-side fonts (`NotoSerif`, `NotoSans`, `OpenDyslexic` at 12–18 pt) ship as `static const` Flash arrays of ~1070 glyphs covering Latin, Cyrillic, and common symbols. This works because the worst-case 23-language coverage stays within ~1000 glyph metadata entries (16 B each = ~17 KB resident per font), which fits comfortably in Flash.
+
+**CJK changes the regime, not just the language.** Reading common Traditional Chinese requires ~5000 glyph metadata entries; covering the four classical novels in the project's test corpus (三国演义, 水浒传, 红楼梦, 西游记) requires **7830 unique CJK codepoints** including Simplified-to-Traditional variants. At 16 B per `EpdGlyph` row this is ~125 KB resident **per font style**, before any bitmap data. Instantiate four styles (Regular/Bold/Italic/BoldItalic) and the metadata alone overshoots the ESP32-C3's 380 KB total RAM after subtracting the 48 KB framebuffer, FreeRTOS overhead, and activity workspace.
+
+The companion exploration in `lib/EpdFont/SdFontLoader.{h,cpp}` already streams *bitmap* data from SD via a 32 KB LRU group cache, but **leaves glyph metadata fully resident** (`SdFont::epdGlyphs` vector). That single decision caps practical multi-language fallback chains at "one CJK font in RAM at a time", precluding the goal of dropping any TTF on SD and getting all-language coverage.
+
+## Decision
+
+Add a backward-compatible cpf v2.1 extension that **pages glyph metadata to SD** behind a small in-memory page index, keeping resident metadata cost at ~1 KB per font regardless of glyph count.
+
+### Format change
+
+The existing `cpf2::Header.flags` field (`lib/EpdFont/CpfV2Format.h:82`) reserves **bit 1 = "paged metadata"**. When set, the file layout becomes:
+
+```
+[Header 64 B]
+[Interval Table  12 B × intervalCount]    ← stays fully resident (~600 B for CJK)
+[GlyphPageIndex  4 B × ⌈glyphCount/256⌉]   ← stays fully resident (~80 B for 5000 CJK glyphs)
+[Glyph Pages     4 KB × pageCount]         ← demand-loaded into a metadata page LRU
+[Group Table     16 B × groupCount]
+[Compressed Glyph Groups]
+```
+
+Each glyph page holds 256 `cpf2::Glyph` rows (= 4 KB = exactly one SD sector × 8). Lookup of glyph index `idx` becomes:
+
+1. `pageId = idx >> 8`
+2. `pageOffset = GlyphPageIndex[pageId]`
+3. Fetch page from metadata page LRU (size: 4 pages × 4 KB = 16 KB, two-way at minimum)
+4. `&page[(idx & 0xFF) × 16]`
+
+Files without bit 1 keep the current resident-array layout, so existing `.cpf` files are not broken.
+
+### Resident memory accounting (CJK font, ~5000 glyphs, ~50 intervals)
+
+| Component                        | Pre-paged | Paged (this ADR) |
+| ---                              | ---       | ---              |
+| Interval Table                   | 600 B     | 600 B            |
+| GlyphPageIndex                   | —         | 80 B             |
+| Glyph metadata                   | 80 KB     | 0 (paged)        |
+| **Per-font resident**            | **~80 KB** | **~700 B**     |
+| Shared metadata page LRU         | —         | 16 KB (one-time) |
+
+A four-font fallback chain (Latin Serif primary + CJK Sans + Symbols + Emoji) drops from ~320 KB resident to ~3 KB + 16 KB shared LRU = **20× reduction** in resident metadata cost.
+
+## Consequences
+
+### Positive
+
+- **Multi-font fallback becomes feasible** within the C3's RAM budget; this ADR is the prerequisite for ADR 0002 (`FontStack`).
+- **Backward compatible**: existing `.cpf` files keep loading. Authoring tool (`scripts/export_fonts_v2.py`) gains a `--paged-metadata` flag; users opt in per-font.
+- **First-page latency stays bounded**: a typical reader page touches ~30 unique codepoints, each in its own 256-row page on average ≤ 2 unique pages × 1 SD sector read = ~5 ms additional vs the resident-array case.
+- **Aligns with the existing bitmap LRU pattern** in `SdDecompressor`. Same caching philosophy, same lock primitives (`HalStorage::StorageLock`), same eviction policy. No new architectural concept introduced.
+
+### Negative / risks
+
+- **Cold cache hit**: the very first glyph access after font registration always misses the page LRU. Mitigated by the prefetcher proposed in ADR 0002 (warming "first page after open" synchronously).
+- **Format-version drift**: future cpf changes must respect the bit-flag pattern to stay compatible. We document this convention in the format header and keep a changelog in `docs/file-formats.md`.
+- **Verifier complexity**: the round-trip verifier in `scripts/export_fonts_v2.py` must learn the paged layout, doubling its test surface.
+- **Loader paths fork**: `SdFontLoader` carries two code paths (resident vs paged) selected by the flag; the abstraction is `EpdFontData::glyphAt(idx)` returning `const EpdGlyph*`, which keeps the caller-side complexity at zero.
+
+## Alternatives considered
+
+### A1. "Fix it in fontconvert" — pre-shrink the glyph struct
+
+Reduce `EpdGlyph` from 16 B → 12 B by clipping `left`/`top` to int8 and dropping unused fields. Saves ~25%, brings 5000-glyph CJK from 80 KB → 60 KB. Still over budget for multi-font, and now the format diverges from `EpdFontData.h`'s public API. **Rejected**: a 25% reduction is a partial fix; this ADR's paged layout achieves >99% reduction and preserves API compatibility.
+
+### A2. Runtime TTF rasterisation (LVGL Tiny TTF / stb_truetype)
+
+The web's standard answer for "all languages from one font file". `lvgl/lvgl#tiny_ttf` and KOReader's FreeType+HarfBuzz stack both do this. Both **assume the entire TTF resides in RAM**: subset NotoSansCJK is 1.9 MB, full is 9 MB; neither fits on the C3 (380 KB total). Without a streaming TTF parser (which would need to be written from scratch — neither stb_truetype nor FreeType supports section-on-demand reads), this approach is not viable on the C3.
+
+**Re-entry trigger**: hardware variant adopts ESP32-S3 with ≥ 2 MB PSRAM. Until then, pre-rasterised + paged metadata is the only realistic path. Documented in ADR 0003.
+
+### A3. Compress the glyph metadata table itself
+
+Run-length or DEFLATE the metadata table and decompress on access. Saves ~50% on Latin (lots of repeated zero `left`/`top`), ~30% on CJK (more variation). Even at 50% saving the multi-font case is over budget, and the lookup hot-path now has decompression overhead. **Rejected**: paging gives better compression (resident → near-zero) and adds zero per-glyph compute.
+
+### A4. Two-tier "hot" + "cold" metadata
+
+Keep top-N most-frequently-used glyphs resident, page the rest. Saves a roundtrip for the hot 1000 glyphs but doubles the loader complexity. **Rejected**: the OS sector cache (`SdFat`) already provides this benefit transparently — frequently-fetched pages stay in the SDFat cache; we don't need a second tier.
+
+## References
+
+- **Web platform**: CSS3 Fonts Module Level 3 — `unicode-range` font subsetting (W3C Recommendation, 2018) — establishes the precedent that font metadata can be partitioned and lazily loaded.
+- **LVGL Tiny TTF docs**: https://docs.lvgl.io/9.1/libs/tiny_ttf.html — the PSRAM-assumption alternative explicitly discussed above.
+- **KOReader / crengine**: https://github.com/koreader/koreader — Linux-class precedent for runtime rasterisation; assumes ≥ 32 MB RAM.
+- **Pebble fontgen** (`pebble/sdk`): closest prior art for pre-rasterised font subsets on Cortex-M-class hardware, but no metadata paging.
+- **Bitbank "Building a Better Bitmap Font System" (2025)**: https://bitbanksoftware.blogspot.com/2025/07/building-better-bitmap-font-system.html — Latin-only embedded bitmap font design, validates per-glyph compression but doesn't address CJK metadata scale.
+
+## Implementation tracking
+
+This ADR's implementation plan lives in `docs/architecture/font-system-v3.md`. Phase 3 of that roadmap is the on-device land of paged metadata behind the `--paged-metadata` build flag, gated on Phase 2 (fallback chain) being merged.

--- a/docs/adr/0002-font-fallback-chain.md
+++ b/docs/adr/0002-font-fallback-chain.md
@@ -1,0 +1,172 @@
+# ADR 0002 — Multi-Font Fallback Chain (`FontStack`)
+
+| Field        | Value                                                |
+| ---          | ---                                                  |
+| Status       | Proposed                                             |
+| Date         | 2026-05-06                                           |
+| Decision by  | TBD (RFC pending upstream review)                    |
+| Supersedes   | —                                                    |
+| Superseded by| —                                                    |
+| Depends on   | ADR 0001 (paged glyph metadata)                      |
+
+## Context
+
+`EpdFontFamily` (`lib/EpdFont/EpdFontFamily.h:4-25`) groups four font *style* variants — Regular, Bold, Italic, Bold-Italic — under one logical "font family". When the renderer needs a glyph it calls `EpdFontFamily::getGlyph(cp, style)` which returns `nullptr` if that codepoint is absent from the chosen style.
+
+The renderer's current response to `nullptr` is to log an error and skip the glyph (`lib/GfxRenderer/GfxRenderer.cpp:85`):
+
+```cpp
+const EpdGlyph* glyph = fontFamily.getGlyph(cp, style);
+if (!glyph) {
+  LOG_ERR("GFX", "No glyph for codepoint %d", cp);
+  return;
+}
+```
+
+This is acceptable when one font covers everything the user can show. It breaks the moment we want **multi-script reading**:
+
+- A Latin-serif body font has no CJK glyphs.
+- A CJK font has no Hangul (well, NotoSansCJK does, but most CJK-only fonts don't).
+- An emoji font has no Latin.
+- An Arabic font has no Cyrillic.
+
+In every world-class text-rendering stack, the answer is the same — **ordered fallback**. A primary font is consulted first; missing glyphs fall through to a list of fallback fonts in priority order. CSS calls this `font-family` with `unicode-range`-subsetted webfonts. The OS calls this "font fallback chain" and ships per-language stacks. KOReader calls this "fallback fonts" and lets the user reorder them.
+
+CrossPoint's current single-font design is the outlier, not the norm.
+
+## Decision
+
+Replace `EpdFontFamily`'s 4-pointer struct with a `FontStack` of up to N **tiers**, where each tier is itself a (Regular, Bold, Italic, Bold-Italic) quartet. Glyph lookup walks the tiers in order, returning the first tier whose chosen style provides the codepoint.
+
+```cpp
+struct StyleSet {
+  const EpdFont* regular;
+  const EpdFont* bold;
+  const EpdFont* italic;
+  const EpdFont* boldItalic;
+};
+
+class FontStack {
+ public:
+  static constexpr uint8_t MAX_TIERS = 4;
+
+  FontStack(StyleSet primary);
+  FontStack& addFallback(StyleSet tier);
+
+  // Returns first tier whose `style` slot has the codepoint.
+  // Returns nullptr only if no tier covers it.
+  const EpdGlyph* getGlyph(uint32_t cp, EpdFontFamily::Style style) const;
+
+  // Returns the EpdFontData of the resolved tier so the renderer
+  // can pull metrics (advanceY, ascender, baseline) from the same
+  // tier as the glyph.
+  const EpdFontData* resolveData(uint32_t cp, EpdFontFamily::Style style) const;
+
+  // Returns the primary tier's EpdFontData for line-metrics queries
+  // that don't depend on a specific glyph (e.g. cursor blink height).
+  const EpdFontData* primaryData(EpdFontFamily::Style style) const;
+
+ private:
+  std::array<StyleSet, MAX_TIERS> tiers_;
+  uint8_t tierCount_ = 1;
+};
+```
+
+`MAX_TIERS = 4` is enough for the canonical reading stack:
+
+```
+tier 0: NotoSerif       (Latin + Cyrillic, primary body font)
+tier 1: NotoSansCJK     (CJK)
+tier 2: NotoSansSymbols (math, dingbats)
+tier 3: NotoEmoji-mono  (e-paper-friendly emoji)
+```
+
+Each tier holds 4 `const EpdFont*` (32 B per tier × 4 tiers = 128 B per FontStack — value-typed, no heap allocations).
+
+### Lookup behaviour
+
+```
+for tier in tiers_[0..tierCount_]:
+  font = tier.fontFor(style)
+  if font has cp:
+    return (font, tier.fontData)
+return primary.fontFor(style).getGlyph(.notdef)  // tofu, drawn with primary metrics
+```
+
+When all tiers miss, the primary font's `.notdef` glyph is drawn so vertical metrics and baseline stay consistent with surrounding text. This matches CSS's "tofu" rendering rather than skipping the codepoint entirely.
+
+### Style fallback within a tier
+
+Before falling through to the next tier, a tier with no Bold variant should try its own Regular (matching CSS `font-style` synthesis). This avoids "primary's Regular → fallback's Bold" weight inversions that would happen with a naive cross-tier walk:
+
+```
+for tier in tiers_:
+  for style in [requested, regular_synth_of(requested)]:
+    font = tier.fontFor(style)
+    if font and font has cp:
+      return ...
+```
+
+### Renderer integration
+
+The renderer's dispatch site (`lib/GfxRenderer/GfxRenderer.cpp:10-24` — `getGlyphBitmap`) takes `(EpdFontData*, EpdGlyph*)` pairs that are *already resolved* by the FontStack. **No renderer-internal change** is needed: the FontStack does the resolution one level up, in `renderCharImpl` (`GfxRenderer.cpp:80-169`).
+
+The seven sites that currently do `font->glyph[idx]` (`lib/EpdFont/EpdFont.cpp:170`, `lib/EpdFont/FontDecompressor.cpp:91, 98, 296, 371, 398, 450`) move to a new accessor `EpdFontData::glyphAt(idx)` that returns `const EpdGlyph*`. For resident-array fonts this is `&glyph[idx]`; for paged fonts (ADR 0001) it consults the metadata page LRU. The transition is mechanical and atomic.
+
+### Plug-in registration
+
+A new `FontRegistry` (proposed for Phase 4 of the roadmap) scans `/fonts/*.cpf` at boot, parses each header, and exposes the discovered fonts to the user as named handles. The user assigns each *role* — Body, Heading, Mono, UI — its own ordered FontStack via Settings, and the choices persist in NVS:
+
+```
+SETTINGS.fontStack.body = ["NotoSerifTC-14", "NotoSansCJK-14", "NotoSansSymbols-14"]
+```
+
+Drop a new `.cpf` on SD, reboot, the font appears in the chooser. **No firmware rebuild.**
+
+## Consequences
+
+### Positive
+
+- **All-language reading is finally possible** without per-language firmware builds. The user assembles their reading stack from `.cpf` files on SD.
+- **Mirrors web platform standards** (CSS Fonts Module Level 3) — reviewers familiar with web typography immediately understand the design.
+- **No renderer change**: the fallback logic lives entirely in `FontStack` and `EpdFontData::glyphAt`. `GfxRenderer.cpp:10-24` is unchanged.
+- **Style synthesis is built-in**: CJK fonts that lack italic variants don't break italic text — the layer falls back to Regular within the same tier, preserving font identity.
+- **Resident cost is bounded**: 128 B per FontStack × small number of stacks (Body, UI, …) = ~1 KB total. Well under any budget.
+
+### Negative / risks
+
+- **Performance**: glyph lookup is O(tiers × intervals) instead of O(intervals). For 4 tiers with binary-searched intervals this is ~4 × log₂(50) ≈ 22 comparisons; negligible vs the SD I/O on cache miss.
+- **Glyph-metadata heterogeneity**: the resolved tier's `EpdFontData::ascender/descender` may differ slightly from the primary's, causing baseline jitter mid-line. Mitigated by **always using the primary tier's vertical metrics for line layout**, only the tier's bitmap and horizontal advance for the glyph itself. Documented contract.
+- **Cross-tier kerning is unsupported**: kerning tables are intra-font; primary→fallback transitions skip kerning. Acceptable cost; web rendering does the same.
+- **More API surface**: `FontStack` adds methods over the simple `EpdFontFamily`. Mitigated by keeping `EpdFontFamily` as a thin wrapper for single-tier use, so existing call sites that don't need fallback can keep using the old API name.
+
+## Alternatives considered
+
+### A1. "One mega-font with everything baked in"
+
+Generate a single `.cpf` containing Latin + CJK + Symbols + Arabic + … Eliminates fallback machinery; the renderer just looks up. **Rejected**: combinatorial blow-up. Every new language requires re-running the toolchain and re-flashing or re-distributing one giant font file. Plug-and-play user experience disappears. Resident metadata grows linearly with coverage even with paging (ADR 0001) — paging spreads the cost over SD I/O, not eliminates it.
+
+### A2. Per-codepoint font dispatch table
+
+Build a `cp → fontIndex` lookup table at boot covering all loaded fonts. O(1) lookup, no fallback walk. **Rejected**: a 0x10000 BMP-coverage table costs 64 KB just for indices; sparse codepoints waste most of it. Hash tables solve the sparsity but add per-lookup overhead and complexity. The tier-walk's 22 comparisons are cheaper than a hash probe on the C3.
+
+### A3. Fallback as a renderer concern (not a font concern)
+
+Push the fallback logic into `GfxRenderer::renderCharImpl` directly: try font A, fail, try font B, … **Rejected**: violates separation of concerns. The renderer should ask one question — "give me the glyph and bitmap" — and get one answer. Fallback policy is a property of the *font collection*, not the rendering pipeline.
+
+### A4. CSS-style `unicode-range` per-tier subset specification
+
+Let each tier declare which Unicode ranges it claims, and skip tiers that don't claim the codepoint. **Deferred to future work**: useful when many fallback fonts cover overlapping ranges (e.g., emoji and CJK both have arrows). For our current 4-tier reading stack, simple "first tier with the codepoint wins" is adequate. Re-entry trigger: > 4 tiers, > 30% coverage overlap.
+
+## References
+
+- **CSS3 Fonts Module Level 3** § 4.3 ("Default fonts and font matching") — W3C Recommendation, defines the cascading fallback model.
+- **W3C `unicode-range` descriptor**: https://drafts.csswg.org/css-fonts/#unicode-range-desc — the canonical web-platform pattern.
+- **Apple Core Text Font Cascade Lists**: documented in Apple Developer's Core Text Programming Guide. macOS/iOS rendering pipeline since 2007.
+- **Microsoft DirectWrite Font Fallback**: https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwritefontfallback — Windows shipping API, mirrors CSS.
+- **KOReader Font Fallback** (`koreader/koreader`): user-orderable fallback font list, persisted per-language.
+- **Pango / FontConfig**: GNOME stack — substring-matching fallback resolver. Linux-class but widely studied.
+
+## Implementation tracking
+
+`FontStack` lands in Phase 2 of the roadmap (`docs/architecture/font-system-v3.md`). The 7 `glyph[idx]` callsites' migration to `glyphAt(idx)` lands as part of the same PR so the abstraction is consistent. `FontRegistry` plugin discovery lands in Phase 4 alongside the prefetcher.

--- a/docs/adr/0003-defer-harfbuzz-bidi.md
+++ b/docs/adr/0003-defer-harfbuzz-bidi.md
@@ -1,0 +1,92 @@
+# ADR 0003 — Defer Complex-Script Shaping (HarfBuzz / bidi / Indic / Vector Rasterisation)
+
+| Field        | Value                                                |
+| ---          | ---                                                  |
+| Status       | Proposed                                             |
+| Date         | 2026-05-06                                           |
+| Decision by  | TBD (RFC pending upstream review)                    |
+| Supersedes   | —                                                    |
+| Superseded by| —                                                    |
+
+## Context
+
+ADRs 0001 and 0002 enable CrossPoint to render arbitrary user-supplied `.cpf` fonts in an ordered fallback chain. That covers **all scripts whose written form is a sequence of independent, left-to-right glyphs with at most local ligatures and kerning** — i.e., everything currently in our 23-language i18n list plus CJK, Japanese kana, Hangul, and a number of African / Pacific Latin-derived scripts.
+
+It explicitly does **not** cover four classes of "complex" script behaviour:
+
+1. **Cursive shaping** (Arabic, N'Ko, Syriac, Mongolian) — a glyph's visible form depends on neighbours: isolated, initial, medial, final.
+2. **Reordering and conjunct formation** (Devanagari, Tamil, Bengali, Khmer, Thai, …) — the visual order of glyphs differs from logical text order; sub-cluster reordering is required.
+3. **Bidirectional layout** (Hebrew, Arabic, mixed-direction text) — runs of right-to-left text must be reversed at the line-layout level, and embedding levels managed per Unicode Bidirectional Algorithm (UAX #9).
+4. **Word-segmentation-dependent line breaking** (Thai, Lao, Khmer, Burmese) — these scripts don't use spaces; line breaks require dictionary or ML-based segmentation.
+
+Solving 1–3 in a renderer is the job of a **shaping engine**: HarfBuzz is the de facto open-source standard. Solving 4 is the job of **libthai** / **libunibreak** with appropriate dictionaries.
+
+## Decision
+
+**These four capabilities are out of scope for the v3 font architecture and any predecessor.** The v3 design is engineered to be a clean *floor* under which these can be added later, not a regression that has to be unwound.
+
+Each deferral has an explicit re-entry trigger documented below. When a trigger fires, the next architecture cycle revisits the deferred item; until then, content requiring these capabilities renders **visually wrong but does not crash**.
+
+### Specific deferrals
+
+#### D1. HarfBuzz shaping (cursive scripts + advanced typography)
+
+- **Cost to ship**: HarfBuzz core is ~200 KB compiled; per-shape-run buffers are 2–10 KB; depends on FreeType for glyph outlines (another ~150 KB).
+- **Why deferred**: total firmware Flash budget is 16 MB and currently 89% used; we cannot fit HarfBuzz + FreeType. RAM headroom on C3 (~98 KB free heap) cannot support per-run shaping buffers.
+- **Re-entry trigger**: hardware variant of the device adopts ESP32-S3 with **≥ 2 MB PSRAM**. Until then, cursive scripts render with **isolated-form glyphs only** — the user can read transliterated content but actual Arabic ebooks will look like disconnected letters.
+- **Workaround for v3**: pre-shape at PC authoring time into a font that bakes the shaped joining-form glyphs as separate codepoints in the Private Use Area. Documented in the cpf-mkfont CLI's future "shape-in-place" mode (Phase 5+).
+
+#### D2. Bidirectional layout (RTL text)
+
+- **Cost to ship**: `fribidi` is ~30 KB compiled, but the algorithmic complexity is in the line-breaking and selection layer, which would need significant rework. Our `LineLayout` (currently in `lib/Epub/Epub/parsers/`) assumes left-to-right runs throughout.
+- **Why deferred**: rewriting the line layout to be bidi-aware is a multi-week effort touching a path that's already CJK-fragile and SC→TC-fragile. Risk too high relative to current user demand (CrossPoint's i18n list has zero RTL languages).
+- **Re-entry trigger**: a translator commits the first Hebrew or Arabic `chinese.yaml`-equivalent translation file *and* there is a user request for RTL ebook reading. Both gates required: i18n alone is satisfiable with isolated forms; ebook reading needs full bidi.
+- **Workaround for v3**: Hebrew / Arabic content displays in logical (storage) order, which to a fluent reader is "backwards". UI strings in those languages would look reversed; we therefore decline to accept Hebrew / Arabic translations in i18n until this ADR is revisited.
+
+#### D3. Indic conjuncts and reordering
+
+- **Cost to ship**: depends on D1 (HarfBuzz). Conjuncts are Indic's specific shaping tables.
+- **Why deferred**: subset of D1.
+- **Re-entry trigger**: same as D1.
+- **Workaround for v3**: Indic content displays as a sequence of base + matra glyphs without conjunct formation. Native readers will recognise it as malformed but legible-ish.
+
+#### D4. Word-segmenting line breaking (Thai, Lao, Khmer, Burmese)
+
+- **Cost to ship**: `libthai` is ~50 KB code + 200 KB dictionary; libunibreak is smaller (~20 KB) but does not handle Thai well. Modern alternatives (ICU-LE, ML segmenters) are larger.
+- **Why deferred**: dictionary is the bulk of the cost and lives best on SD; the runtime cost is in the EPUB parser path, which already runs at the edge of timing budget for CJK chapters.
+- **Re-entry trigger**: Thai / Khmer translation contributed to i18n *and* the EPUB indexing path is no longer the bottleneck for chapter open time.
+- **Workaround for v3**: these scripts wrap on any whitespace (rare in their text), producing one extremely long line that scrolls off-screen. Renders correctly otherwise.
+
+#### D5. Runtime vector outline rasterisation (FreeType / stb_truetype)
+
+- **Cost to ship**: FreeType core ~150 KB + 50–100 KB per loaded face's working memory; stb_truetype is smaller (~15 KB code) but expects the entire TTF resident in RAM, and the smallest CJK TTFs are 1.9 MB after subsetting.
+- **Why deferred**: cannot fit a full CJK TTF on the C3's 380 KB total RAM. Streaming-TTF parsers (per-table on-demand reads) do not exist as off-the-shelf libraries; building one would be 1–2 weeks of work and add a parsing hot path on every glyph access.
+- **Re-entry trigger**: hardware variant adopts ESP32-S3 with ≥ 2 MB PSRAM **and** there is user demand for "drop a TTF on SD, render at any size on demand". Pre-rasterised `.cpf` covers all current size needs (12, 14, 16, 18 pt) at lower runtime cost.
+- **Workaround for v3**: users author `.cpf` files at their preferred size via the `cpf-mkfont` CLI; runtime size adjustment is constrained to the pre-generated set.
+
+## Consequences
+
+### Positive
+
+- **The v3 architecture stays small and ships within the C3's budget.** Every line of code in the v3 plan is justified against the resident memory and Flash budget; nothing speculative is included.
+- **Re-entry triggers are concrete and observable.** Future maintainers know exactly what to watch for: hardware refresh to S3+PSRAM, contributed RTL translations, etc.
+- **`IDecompressor` (`lib/EpdFont/IDecompressor.h`) already abstracts the glyph-data source.** A future `TtfDecompressor` (D5) can plug in alongside `FontDecompressor` and `SdDecompressor` without renderer changes — the architectural exit ramp is built in.
+- **Honest about scope**: explicitly listing what's *not* solved spares both contributors and end-users from debugging mismatches between expectation and delivery. ADR text doubles as a user-facing FAQ.
+
+### Negative / risks
+
+- **Complex-script communities will see CrossPoint as "not for them"** — accurate today but may slow contribution in those areas. Mitigated by the explicit re-entry triggers being public, so interested parties can advocate for the hardware refresh.
+- **Pre-shaped Arabic in the Private Use Area is a hack**: it works but breaks search and copy-paste correctness. Mitigated by clearly labelling such fonts as "display-only" in the cpf-mkfont CLI.
+
+## References
+
+- **Unicode Standard Annex #9** — UBA (Unicode Bidirectional Algorithm). The canonical specification deferred by D2.
+- **HarfBuzz**: https://harfbuzz.github.io/ — reference shaping engine; Linux/Android/Chrome/Firefox use it. Memory profile documented in their wiki.
+- **FreeType**: https://freetype.org/ — reference TTF rasteriser. Used by KOReader, Linux desktop, Android.
+- **fribidi**: https://github.com/fribidi/fribidi — reference UBA implementation, ~30 KB compiled.
+- **libthai**: https://linux.thai.net/projects/libthai — Thai dictionary-based segmenter.
+- **libunibreak**: https://github.com/adah1972/libunibreak — Unicode line-breaking; CrossPoint already uses similar logic in `lib/Epub/Epub/parsers/`.
+
+## Implementation tracking
+
+This ADR is informational; nothing is built. Each deferral's re-entry trigger, when it fires, will spawn a new ADR (ADR 0004 onwards) that supersedes the relevant section of this document.

--- a/docs/architecture/font-system-v3.md
+++ b/docs/architecture/font-system-v3.md
@@ -1,0 +1,324 @@
+# Font System v3 — Multi-Language Plug-in Architecture
+
+> **Status**: Request for Comments (RFC). This document accompanies the draft PR
+> "RFC: Multi-language plug-in font architecture (v3)" against `master`.
+> No code changes ship with this PR — the goal is to socialise the design before
+> implementation begins.
+
+## Table of contents
+
+1. [Why this exists](#why-this-exists)
+2. [Scope and goals](#scope-and-goals)
+3. [Constraints (ESP32-C3, no PSRAM)](#constraints-esp32-c3-no-psram)
+4. [Industry survey](#industry-survey)
+5. [Proposed architecture](#proposed-architecture)
+6. [Memory budget](#memory-budget)
+7. [Phased implementation roadmap](#phased-implementation-roadmap)
+8. [Verification plan](#verification-plan)
+9. [Out of scope (with re-entry triggers)](#out-of-scope-with-re-entry-triggers)
+10. [Appendix — measured numbers from the test corpus](#appendix--measured-numbers-from-the-test-corpus)
+
+---
+
+## Why this exists
+
+CrossPoint Reader currently supports 23 European languages plus Chinese as a UI translation. The reader-side fonts are pre-rasterised bitmap arrays in Flash, sized for European-language coverage (~1070 glyphs each at 14 pt). This works because European-language coverage stays inside ~1000 codepoints; the metadata + bitmaps fit in Flash without paging.
+
+CJK reading breaks the assumption. A typical Traditional Chinese book uses **~5000 unique codepoints**; covering the four classical novels in our test corpus (三国演义, 水浒传, 红楼梦, 西游记) requires **7830 unique codepoints** including Simplified-to-Traditional variants. The current `EpdFontFamily` (`lib/EpdFont/EpdFontFamily.h:4-25`) loads all glyph metadata into RAM (16 B per `EpdGlyph`) and has only four style slots (Regular / Bold / Italic / BoldItalic) — no fallback chain when a codepoint is missing from the chosen style.
+
+A working interim solution exists on a development branch: `.cpf v2` SD-streaming bitmaps via `SdFontLoader` and `SdDecompressor` with a 32 KB LRU group cache. That solves *bitmap* streaming but leaves **glyph metadata fully resident** (~144 KB just for one CJK font) and provides **no multi-font fallback**. Drop a Hebrew TTF on the SD card and the reader displays nothing for the Hebrew codepoints.
+
+This document proposes the next step: a re-architecture that removes those two limitations so any user can drop any pre-rasterised font on SD and read any script the bitmap pipeline can render. It is designed to be **a clean floor under future complex-script work** (HarfBuzz shaping, bidi, Indic conjuncts), not a regression that has to be unwound.
+
+## Scope and goals
+
+### In scope
+
+- **Plug-in fonts**: any user can drop a `.cpf` file on the SD card's `/fonts/` directory and the firmware picks it up at boot, with no rebuild.
+- **Multi-script reading**: an ordered fallback chain ("font stack") is consulted on glyph misses; users assemble their reading stack from available `.cpf` files via Settings.
+- **Any script representable as a sequence of independent left-to-right glyphs**, including all 23 currently-supported European languages plus CJK, Japanese kana, Hangul, Cyrillic, Greek, IPA, math symbols, and emoji (as monochrome bitmaps).
+- **First-page latency target**: 95th percentile under 150 ms after opening a book on a cold SD cache.
+- **Smooth flipping**: a background prefetcher warms 5–10 pages worth of glyphs ahead, so subsequent page flips stay under 60 ms p95.
+- **Authoring tools** so end users (not just developers) can convert their own TTFs to `.cpf` with a single CLI command.
+
+### Out of scope (rationale: ADR 0003)
+
+- HarfBuzz shaping (Arabic cursive forms, Indic conjuncts, advanced typography)
+- Bidirectional layout (Hebrew, Arabic ebook reading)
+- Word-segmenting line breaking for spaceless scripts (Thai, Khmer)
+- Runtime vector outline rasterisation (FreeType / stb_truetype) — pre-rasterised `.cpf` covers all current size needs
+
+Each has a documented re-entry trigger tied to a hardware milestone (typically: ESP32-S3 with ≥ 2 MB PSRAM).
+
+## Constraints (ESP32-C3, no PSRAM)
+
+The CrossPoint Reader hardware is the **Xteink X4** with an **ESP32-C3** at 160 MHz RISC-V, **380 KB total RAM**, **0 PSRAM**, **16 MB Flash** (currently 89% used in `default` build), **single-buffer 800 × 480 e-paper** (48 KB framebuffer), SD card via SPI.
+
+This rules out the standard "industry" approaches. Both LVGL Tiny TTF and KOReader's FreeType+HarfBuzz stack assume the entire TTF resides in RAM (subset NotoSansCJK is 1.9 MB; full is 9 MB). On the C3 we cannot fit either. That hardware reality forces a **pre-rasterise + stream** architecture rather than a runtime-rasteriser one.
+
+The numerical budget the v3 design must hit:
+
+| Resource          | Total       | Already used (baseline) | Available    |
+| ---               | ---         | ---                     | ---          |
+| Flash             | 16 MB       | 5.84 MB (89%)           | 720 KB       |
+| RAM (heap)        | 228 KB      | ~130 KB (FreeRTOS, network, activities) | ~98 KB |
+| RAM (min-free)    | —           | observed 22 KB during EPUB indexing | — |
+| SD                | 16 GB       | varies                  | gigabytes    |
+
+The v3 design targets ≤ 60 KB resident RAM for *all* loaded fonts in a four-tier fallback stack, leaving the rest for activity workspaces. ADR 0001 (paged metadata) is what makes this achievable.
+
+## Industry survey
+
+| Approach                              | Where it lives                        | Why it doesn't fit C3                                               |
+| ---                                   | ---                                   | ---                                                                 |
+| **LVGL Tiny TTF** (stb_truetype)      | LVGL libs, ESP32-S3-friendly         | Whole TTF in RAM; 256-glyph default cache; needs PSRAM for CJK.     |
+| **KOReader / crengine**               | Linux-class e-readers (Kobo, Kindle)  | FreeType + HarfBuzz; expects ≥ 32 MB RAM; mmap from filesystem.     |
+| **Bitbank Group5 / Group4 fax**       | Embedded, ATMega-class                | Latin-only RLE; no metadata-paging; no fallback chain.              |
+| **Pebble fontgen** (`pebble/sdk`)     | Cortex-M smartwatches                 | Pre-rasterised .pfo with subset selection — closest prior art.      |
+| **Adafruit GFX**                      | Arduino-class displays                | Per-font header file, fully resident; single-byte codepoints.       |
+| **CrossPoint v2 (`.cpf` on SD)**      | This repo's `feature/...` branch      | Bitmaps streamed, metadata resident — partial solution.             |
+| **CrossPoint v3 (this RFC)**          | This document                         | Bitmaps + metadata both paged + multi-font fallback chain.          |
+
+References for each entry are linked in [ADR 0001](../adr/0001-cpf-paged-metadata.md), [ADR 0002](../adr/0002-font-fallback-chain.md), and [ADR 0003](../adr/0003-defer-harfbuzz-bidi.md).
+
+The CrossPoint v3 architecture is **not a folk solution** — it mirrors the web platform's CSS3 `unicode-range` + font-fallback model faithfully (ADR 0002) and the metadata-paging pattern is how Pebble handled CJK on similar Cortex-M-class hardware. The deviation from LVGL/KOReader is forced by hardware (no PSRAM), not preference.
+
+## Proposed architecture
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              GfxRenderer                                     │
+│  (renderCharImpl, no behaviour change — calls FontStack::getGlyph)           │
+└──────────────────────────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                        FontStack (ADR 0002)                                  │
+│  tier 0: NotoSerif (Latin)   ─┐                                              │
+│  tier 1: NotoSansCJK         ─┤  ordered, missing-glyph falls through        │
+│  tier 2: NotoSansSymbols     ─┤                                              │
+│  tier 3: NotoEmoji-mono      ─┘                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+                       │ (per-tier)
+                       ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                   EpdFontData::glyphAt(idx) (ADR 0001)                       │
+│  resident-array fonts → &glyph[idx]                                          │
+│  paged-metadata fonts → metadata page LRU (16 KB shared)                     │
+└──────────────────────────────────────────────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                        IDecompressor (existing)                              │
+│  FontDecompressor (Flash fonts)  │  SdDecompressor (.cpf SD streaming)      │
+│                                  │  + 32 KB bitmap LRU                      │
+│                                  │  + warmGroup() called by FontPrefetcher  │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                                      ▲
+                                                      │ (warm)
+                       ┌──────────────────────────────┴────┐
+                       │       FontPrefetcher              │
+                       │   FreeRTOS task, 4 KB stack,      │
+                       │   warming next 5–10 pages of      │
+                       │   glyphs while user reads current │
+                       └───────────────────────────────────┘
+                       
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                         FontRegistry                                         │
+│  Boot scan of /fonts/*.cpf → named handles → user assigns to roles           │
+│  (Body, Heading, Mono, UI). NVS-persisted per-role FontStack ordering.       │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Layer responsibilities
+
+| Layer                  | Responsibility                                         | Owner / file (proposed)                                |
+| ---                    | ---                                                    | ---                                                    |
+| `FontStack`            | Ordered fallback resolution (ADR 0002)                 | `lib/EpdFont/FontStack.{h,cpp}`                        |
+| `FontRegistry`         | Boot-scan `/fonts/*.cpf`, NVS-persisted role mapping    | `lib/EpdFont/FontRegistry.{h,cpp}` (new)               |
+| `FontPrefetcher`       | FreeRTOS task warming next pages                       | `lib/EpdFont/FontPrefetcher.{h,cpp}` (new)             |
+| `EpdFontData::glyphAt` | Indirection over resident vs paged metadata (ADR 0001) | `lib/EpdFont/EpdFontData.h`                            |
+| `cpf v2.1`             | `flags` bit 1 = paged metadata                         | `lib/EpdFont/CpfV2Format.h`                            |
+| `SdFontLoader`         | Load `.cpf`, populate paged or resident metadata       | `lib/EpdFont/SdFontLoader.{h,cpp}`                     |
+| `SdDecompressor`       | Bitmap LRU + new metadata page LRU                     | `lib/EpdFont/SdDecompressor.{h,cpp}`                   |
+| `IDecompressor`        | Backend abstraction (no change)                        | `lib/EpdFont/IDecompressor.h`                          |
+| `cpf-mkfont` CLI       | TTF → `.cpf` for end users                             | `scripts/cpf-mkfont` (new), `scripts/export_fonts_v2.py` (extended) |
+
+`IDecompressor` already exists in upstream and provides the clean abstraction point at `lib/GfxRenderer/GfxRenderer.cpp:10-24`. A future `TtfDecompressor` (PSRAM-equipped hardware variant) could plug in alongside `FontDecompressor` and `SdDecompressor` with **no renderer changes** — the architectural exit ramp for ADR 0003 D5 is built in.
+
+## Memory budget
+
+Resident-RAM accounting at Phase 4 completion (worst case: 4-tier reading stack + 1-tier UI stack, all CJK-sized):
+
+| Component                           | Size       |
+| ---                                 | ---        |
+| Resident metadata, primary font     | 1 KB       |
+| Resident metadata, 3× fallback      | 3 KB       |
+| Resident metadata, 1× UI            | 1 KB       |
+| 32 KB LRU group cache               | 32 KB      |
+| Metadata page LRU (4 × 4 KB shared) | 16 KB      |
+| Prefetcher task stack               | 4 KB       |
+| FontRegistry + FontStack tiers      | < 1 KB     |
+| **Total resident**                  | **~58 KB** |
+| **Headroom remaining (of 98 KB)**   | **~40 KB** |
+
+Compare to the pre-paged equivalent (ADR 0001 not applied, one CJK font in RAM): **~190 KB → over budget**. ADR 0001 is what makes the multi-font case fit.
+
+## Phased implementation roadmap
+
+Each phase is an independently mergeable PR. Phases later than 0 do not block one another *technically* — they are ordered for review-cost minimisation.
+
+### Phase 0 — This RFC + ADRs (no code)
+
+- **Goal**: socialise the architecture with `crosspoint-reader/crosspoint-reader` upstream before any code lands.
+- **Deliverables**: this document, [ADR 0001](../adr/0001-cpf-paged-metadata.md), [ADR 0002](../adr/0002-font-fallback-chain.md), [ADR 0003](../adr/0003-defer-harfbuzz-bidi.md), README "Font System Roadmap" section.
+- **PR title**: "RFC: Multi-language plug-in font architecture (v3)".
+- **Test**: maintainer review feedback collected; ADRs accepted or amended.
+- **Scope**: docs only. ~1500 lines of markdown.
+
+### Phase 1 — Branch hygiene of existing development work
+
+- **Goal**: prepare the existing Phase 2 development work (currently on `feature/dark-theme-per-theme`) for independent upstream review.
+- **Action**: cherry-pick or re-create the relevant Phase 2 commits onto branches off `master`, one focused PR each:
+  - PR-1.A: extract `IDecompressor` interface
+  - PR-1.B: `cpf v2` format + `SdFontLoader` skeleton
+  - PR-1.C: `SdDecompressor` + `main.cpp` integration (the SD-streaming reader font loader)
+- **Test**: each PR builds and passes `pio check` + `pio run` standalone.
+- **Scope**: no new code; mechanical rebase / cherry-pick.
+
+### Phase 2 — `FontStack` fallback chain (ADR 0002)
+
+- **Goal**: missing glyph in primary font falls through to next font in stack.
+- **Files changed**:
+  - `lib/EpdFont/EpdFontFamily.h/.cpp` → `FontStack` (rename + extend)
+  - `lib/EpdFont/EpdFont.cpp` (1 site)
+  - `lib/EpdFont/FontDecompressor.cpp` (6 sites — `font->glyph[idx]` → `font->glyphAt(idx)`)
+  - `lib/EpdFont/EpdFontData.h` (add `glyphAt(idx)` shim — default impl returns `&glyph[idx]`)
+  - `lib/GfxRenderer/FontCacheManager.h/.cpp` (multi-font cache key)
+  - `src/main.cpp` (font registration)
+- **Test criteria**:
+  - Render "Hello 中文 abc" with primary NotoSerif + fallback NotoSansCJK; first-page render of 三国演义 succeeds with no `[ERR][GFX] No glyph` log lines.
+  - Existing Latin-only books render byte-identically vs `master`.
+- **Scope**: ~400 LOC.
+
+### Phase 3 — `cpf v2.1` paged metadata (ADR 0001)
+
+- **Goal**: cut resident metadata cost from `~16 B × N` to `< 1 KB` per font.
+- **Files changed**:
+  - `lib/EpdFont/CpfV2Format.h` (flag bit 1, GlyphPageIndex)
+  - `lib/EpdFont/SdFontLoader.{h,cpp}` (paged-mode loader path)
+  - `lib/EpdFont/SdDecompressor.{h,cpp}` (add metadata page LRU alongside bitmap LRU)
+  - `lib/EpdFont/EpdFontData.h` (`glyphAt` paged path)
+  - `scripts/export_fonts_v2.py` (`--paged-metadata` flag)
+- **Test criteria**:
+  - Round-trip verifier emits identical glyph metadata in flag-on and flag-off modes.
+  - Byte-identical bitmap output across the 4-book corpus, paged vs unpaged.
+  - Resident heap drops by ≥ 70 KB per CJK font.
+- **Scope**: ~700 LOC.
+
+### Phase 4 — Prefetcher + plugin discovery
+
+- **Goal**: 95th-percentile first-page latency < 150 ms; auto-discover `/fonts/*.cpf` for plug-in support.
+- **Files added**:
+  - `lib/EpdFont/FontPrefetcher.{h,cpp}` (FreeRTOS task)
+  - `lib/EpdFont/FontRegistry.{h,cpp}` (boot scan, NVS persistence)
+- **Files changed**:
+  - `lib/EpdFont/SdFontLoader.cpp` (boot-scan logic)
+  - `src/main.cpp` (task spawn, registry init)
+  - `src/activities/reader/...` (post next-page codepoint runs to prefetcher)
+- **Test criteria** (recorded in PR description):
+  - Cold-boot first-page latency: 95th-percentile < 150 ms across 100 trials per book × 4 books.
+  - 10-page flip burst: < 60 ms/page p95.
+  - Background CPU: < 5% via `uxTaskGetSystemState`.
+  - Heap free at idle, 4 fonts loaded: ≥ 35 KB.
+- **Scope**: ~600 LOC.
+
+### Phase 5 — `cpf-mkfont` CLI + user docs
+
+- **Goal**: end users (not just developers) can author fonts.
+- **Files**:
+  - `scripts/cpf-mkfont` — argparse wrapper with `convert / inspect / verify / merge-coverage` subcommands
+  - `scripts/export_fonts_v2.py` — CLI polish (`--name`, `--script`, `--coverage`)
+  - `docs/fonts/authoring.md` — walkthrough
+  - `USER_GUIDE.md` — "Adding fonts" section
+- **Test criteria**: documented walkthrough completes in < 5 minutes on a clean machine; round-tripped TTF renders correctly on device.
+- **Scope**: ~300 LOC.
+
+**Total**: ~2000 LOC across 5 functional PRs after the docs-only PR-0.
+
+## Verification plan
+
+### Per-phase gates
+
+| Phase | Gate                                                                               |
+| ---   | ---                                                                                |
+| 0     | ≥ 1 maintainer review; ADRs accepted or amended.                                   |
+| 1     | Each cherry-picked PR builds against `master` and passes `pio check` + `pio run`.  |
+| 2     | Golden-bitmap diff for 100 mixed-script sentences against pre-recorded fixtures.   |
+| 3     | Byte-identical render across paged and resident modes for the 4-book corpus.       |
+| 4     | First-page p95 < 150 ms, page-flip p95 < 60 ms, prefetch CPU < 5%, heap ≥ 35 KB.   |
+| 5     | Walkthrough completion < 5 min on clean machine; round-tripped TTF renders.        |
+
+### Ground-truth corpus
+
+Four classical Chinese novels in plain UTF-8, available locally during development:
+
+| Book                | Size (txt) | Unique CJK |
+| ---                 | ---        | ---        |
+| 三国演义.txt        | 2.2 MB     | 4121       |
+| 水浒传.txt          | 2.5 MB     | 4251       |
+| 红楼梦.txt          | 3.2 MB     | 4817       |
+| 西游记.txt          | 2.3 MB     | 4531       |
+| **Combined unique** | —          | **5920**   |
+
+The validated full reading set after applying the existing SC→TC mapping (`lib/I18n/Sc2TcTable.h`) is **7830 unique codepoints**.
+
+### Performance benchmarks
+
+Recorded in each PR description for traceability:
+
+- **First-page latency, cold SD**: target < 150 ms p95
+- **Page-flip latency, warm**: target < 60 ms p95
+- **Prefetch background CPU**: < 5% measured via `uxTaskGetSystemState`
+- **Heap free at idle, 4 fonts loaded**: ≥ 35 KB
+
+## Out of scope (with re-entry triggers)
+
+See [ADR 0003](../adr/0003-defer-harfbuzz-bidi.md) for the full rationale on each item.
+
+| Capability                                | Re-entry trigger                                                                             |
+| ---                                       | ---                                                                                          |
+| HarfBuzz cursive shaping (Arabic, …)      | Hardware refresh to ESP32-S3 + ≥ 2 MB PSRAM                                                  |
+| Bidirectional layout (Hebrew, Arabic)     | Contributed RTL i18n translation + user request for RTL ebook reading                        |
+| Indic conjuncts and reordering            | Same trigger as HarfBuzz (coupled)                                                           |
+| Word-segmenting line breaking (Thai, …)   | Contributed translation + EPUB indexing path is no longer the chapter-open bottleneck        |
+| Runtime vector outline rasterisation      | Hardware refresh to PSRAM-equipped variant; user demand for arbitrary runtime size           |
+
+## Appendix — measured numbers from the test corpus
+
+These numbers come from running `python3 -c "..."` snippets against the four-book corpus. They establish the design's quantitative basis.
+
+```
+Book                     Unique CJK  ASCII chars    Total chars
+三国演义.txt             4121        796247         800368
+水浒传.txt               4251        852362         856613
+红楼梦.txt               4817        1097783        1102600
+西游记.txt               4531        797069         801600
+                                                   ─────────
+Combined unique CJK:     5920
+After SC→TC variants:    7830
+```
+
+Coverage curve for top-N most-frequent codepoints across the corpus:
+
+```
+top  2000 (2700 after +TC variants):  96.29% coverage,  42 KB resident metadata
+top  2500 (3371 after +TC):           97.95% coverage,  53 KB
+top  3000 (4062 after +TC):           98.89% coverage,  63 KB
+top  3500 (4736 after +TC):           99.41% coverage,  74 KB
+top  4000 (5401 after +TC):           99.69% coverage,  84 KB
+top  5000 (6692 after +TC):           99.94% coverage, 105 KB
+all   7830:                          100.00% coverage, 125 KB
+```
+
+Without paged metadata (ADR 0001), even **top 3500 (74 KB)** exceeds the realistic per-style budget for a four-tier fallback stack. With paged metadata, **all 7830 (= 100% coverage)** costs ~700 B per font + 16 KB shared LRU. That order-of-magnitude difference is the technical core of this proposal.


### PR DESCRIPTION
## Status

**Draft / Request for Comments. No code ships in this PR — only design documents.** The goal is to socialise the proposed architecture before any implementation lands so we can incorporate maintainer feedback at design time rather than after the fact.

## TL;DR

CrossPoint currently supports 23 European languages plus Chinese as a UI translation, but reading actual Chinese ebooks doesn't work — the reader fonts (NotoSerif/NotoSans/OpenDyslexic 12–18 pt) ship as Flash arrays sized for European-language coverage (~1070 glyphs each), with no CJK glyphs.

This RFC proposes **Font System v3** — a re-architecture that:

1. **Pages glyph metadata to SD** ([ADR 0001](../blob/feature/font-system-v3/docs/adr/0001-cpf-paged-metadata.md)) — cuts per-CJK-font resident cost from ~125 KB to ~1 KB. Backward compatible via a `cpf2::Header.flags` bit; existing `.cpf` files keep loading.

2. **Replaces \`EpdFontFamily\` with \`FontStack\`** ([ADR 0002](../blob/feature/font-system-v3/docs/adr/0002-font-fallback-chain.md)) — an ordered tier list with missing-glyph fallback, mirroring CSS3 \`unicode-range\` semantics. Lets users stack \`Latin + CJK + Symbols + Emoji\` fonts without per-language firmware builds.

3. **Adds a FreeRTOS prefetcher** that warms 5–10 pages of glyphs in the background, hitting the user's first-page-latency target of < 150 ms p95.

4. **Auto-discovers \`/fonts/*.cpf\`** at boot via a new \`FontRegistry\`, with NVS-persisted role-to-stack mapping and a Settings UI for reordering.

5. **Defers complex-script work** ([ADR 0003](../blob/feature/font-system-v3/docs/adr/0003-defer-harfbuzz-bidi.md)) — HarfBuzz cursive shaping, bidi, Indic conjuncts, Thai word-segmenting, runtime vector rasterisation — explicitly out of scope, with documented re-entry triggers (mostly tied to a future ESP32-S3 + PSRAM hardware refresh).

The full plan, memory budget, phased roadmap, and verification gates are in [docs/architecture/font-system-v3.md](../blob/feature/font-system-v3/docs/architecture/font-system-v3.md).

## Why this is needed

Concrete numbers from the four classical Chinese novels in our local test corpus (三国演义, 水浒传, 红楼梦, 西游记):

| Book              | Unique CJK |
| ---               | ---        |
| 三国演义           | 4121       |
| 水浒传             | 4251       |
| 红楼梦             | 4817       |
| 西游记             | 4531       |
| **Combined unique** | **5920** |
| **+ SC→TC variants** | **7830** |

At 16 B per `EpdGlyph` row, fully-resident metadata for full-coverage CJK is **~125 KB per font style**, before any bitmap data. Four styles (R/B/I/BI) won't fit in the C3's 380 KB total RAM after subtracting the 48 KB framebuffer, FreeRTOS overhead, and activity workspace (observed min-free during EPUB indexing: 22 KB).

Existing in-flight work (`feature/sd-font-loading` and successors on a forked branch) has SD-streamed bitmap data (working) but left glyph metadata fully resident. v3 makes the multi-font fallback case fit by paging the metadata too.

## Why these design choices, not LVGL Tiny TTF or KOReader's stack

Both the LVGL Tiny TTF integration and KOReader's FreeType + HarfBuzz approach are the canonical answers to "all languages from one font file" elsewhere in the embedded / e-reader space. **They both assume the entire TTF fits in RAM**: a subset NotoSansCJK is 1.9 MB, full is 9 MB. On the C3 (380 KB total RAM, no PSRAM) neither fits. Without a streaming TTF parser — which would need to be written from scratch since neither stb_truetype nor FreeType supports section-on-demand reads — that path is not viable on this chip.

The architectural exit ramp is preserved: \`IDecompressor\` (already in upstream at \`lib/EpdFont/IDecompressor.h\`) abstracts the glyph-data source. A future \`TtfDecompressor\` for a PSRAM-equipped hardware variant would plug in alongside \`FontDecompressor\` and \`SdDecompressor\` without renderer changes.

## Why open this RFC before code lands

Each subsequent PR (Phases 1 through 5 in the architecture doc) modifies a small, focused area of the codebase (~300–700 LOC each). Reviewing them individually without shared context on the overall direction is harder for both sides. This RFC sets the context once.

If maintainers see fundamental issues with the direction, catching them now is much cheaper than after Phase 4 lands.

## Asks of the reviewer

- Does the architecture make sense as the next step beyond the existing `.cpf v2` SD-streaming work?
- Is the deferral list in [ADR 0003](../blob/feature/font-system-v3/docs/adr/0003-defer-harfbuzz-bidi.md) what you expect, or is there scope you'd like added/removed?
- Are there specific phases you'd like to see split or combined?
- Any preference on ADR location / format (currently `docs/adr/`)?

I'll mark each follow-up PR as a draft against the same branch until this RFC's main points are resolved. No code merging is requested in this PR.

## Files in this PR

- `docs/architecture/font-system-v3.md` (324 lines)
- `docs/adr/0001-cpf-paged-metadata.md` (103 lines)
- `docs/adr/0002-font-fallback-chain.md` (172 lines)
- `docs/adr/0003-defer-harfbuzz-bidi.md` (92 lines)
- `README.md` — adds "Font system roadmap" section under Internals, linking the four documents

Total: ~700 lines of markdown.

## Test plan

- [x] Markdown links are valid (manually verified — relative paths against the branch tree)
- [x] All four Chinese-corpus benchmark numbers in the appendix were computed against the actual book files (`三国演义.txt`, `水浒传.txt`, `红楼梦.txt`, `西游记.txt`)
- [N/A] No code changes; `pio run` / `pio check` parity with master is by definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)