### PR TITLE
fix: fix KOSync text overlapping buttons in Landscape CW orientation

### DIFF
--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -281,46 +281,51 @@ void KOReaderSyncActivity::render(RenderLock&&) {
         (localTocIndex >= 0) ? epub->getTocItem(localTocIndex).title
                              : (std::string(tr(STR_SECTION_PREFIX)) + std::to_string(currentSpineIndex + 1));
 
+    // In LandscapeClockwise, button hints appear on the left edge; reserve a gutter matching the reader menu.
+    const int contentX = (renderer.getOrientation() == GfxRenderer::Orientation::LandscapeClockwise) ? 30 : 0;
+    const int leftX = contentX + 20;
+    const int contentWidth = pageWidth - contentX;
+
     // Remote progress - chapter and page
-    renderer.drawText(UI_10_FONT_ID, 20, 160, tr(STR_REMOTE_LABEL), true);
+    renderer.drawText(UI_10_FONT_ID, leftX, 160, tr(STR_REMOTE_LABEL), true);
     char remoteChapterStr[128];
     snprintf(remoteChapterStr, sizeof(remoteChapterStr), "  %s", remoteChapter.c_str());
-    renderer.drawText(UI_10_FONT_ID, 20, 185, remoteChapterStr);
+    renderer.drawText(UI_10_FONT_ID, leftX, 185, remoteChapterStr);
     char remotePageStr[64];
     snprintf(remotePageStr, sizeof(remotePageStr), tr(STR_PAGE_OVERALL_FORMAT), remotePosition.pageNumber + 1,
              remoteProgress.percentage * 100);
-    renderer.drawText(UI_10_FONT_ID, 20, 210, remotePageStr);
+    renderer.drawText(UI_10_FONT_ID, leftX, 210, remotePageStr);
 
     if (!remoteProgress.device.empty()) {
       char deviceStr[64];
       snprintf(deviceStr, sizeof(deviceStr), tr(STR_DEVICE_FROM_FORMAT), remoteProgress.device.c_str());
-      renderer.drawText(UI_10_FONT_ID, 20, 235, deviceStr);
+      renderer.drawText(UI_10_FONT_ID, leftX, 235, deviceStr);
     }
 
     // Local progress - chapter and page
-    renderer.drawText(UI_10_FONT_ID, 20, 270, tr(STR_LOCAL_LABEL), true);
+    renderer.drawText(UI_10_FONT_ID, leftX, 270, tr(STR_LOCAL_LABEL), true);
     char localChapterStr[128];
     snprintf(localChapterStr, sizeof(localChapterStr), "  %s", localChapter.c_str());
-    renderer.drawText(UI_10_FONT_ID, 20, 295, localChapterStr);
+    renderer.drawText(UI_10_FONT_ID, leftX, 295, localChapterStr);
     char localPageStr[64];
     snprintf(localPageStr, sizeof(localPageStr), tr(STR_PAGE_TOTAL_OVERALL_FORMAT), currentPage + 1, totalPagesInSpine,
              localProgress.percentage * 100);
-    renderer.drawText(UI_10_FONT_ID, 20, 320, localPageStr);
+    renderer.drawText(UI_10_FONT_ID, leftX, 320, localPageStr);
 
     const int optionY = 350;
     const int optionHeight = 30;
 
     // Apply option
     if (selectedOption == 0) {
-      renderer.fillRect(0, optionY - 2, pageWidth - 1, optionHeight);
+      renderer.fillRect(contentX, optionY - 2, contentWidth - 1, optionHeight);
     }
-    renderer.drawText(UI_10_FONT_ID, 20, optionY, tr(STR_APPLY_REMOTE), selectedOption != 0);
+    renderer.drawText(UI_10_FONT_ID, leftX, optionY, tr(STR_APPLY_REMOTE), selectedOption != 0);
 
     // Upload option
     if (selectedOption == 1) {
-      renderer.fillRect(0, optionY + optionHeight - 2, pageWidth - 1, optionHeight);
+      renderer.fillRect(contentX, optionY + optionHeight - 2, contentWidth - 1, optionHeight);
     }
-    renderer.drawText(UI_10_FONT_ID, 20, optionY + optionHeight, tr(STR_UPLOAD_LOCAL), selectedOption != 1);
+    renderer.drawText(UI_10_FONT_ID, leftX, optionY + optionHeight, tr(STR_UPLOAD_LOCAL), selectedOption != 1);
 
     // Bottom button hints
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_SELECT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));


### PR DESCRIPTION
## Summary

* In LandscapeClockwise orientation, the KOReader sync result screen rendered all text at hardcoded `x=20` and selection highlights at `x=0`, causing content to appear behind the front button hint labels (~40px wide on the left edge).
* Applied the same `contentX` gutter pattern already used by `EpubReaderMenuActivity`: 30px gutter in LandscapeClockwise (0 otherwise), with text at `contentX + 20` and selection highlights starting at `contentX`.

## Additional Context

* No change to behaviour in Portrait, PortraitInverted, or LandscapeCounterClockwise orientations.
* Pattern is consistent with `EpubReaderMenuActivity::render()` which handles the same problem for the reader menu.

---

### AI Usage

Did you use AI tools to help write this code? **YES**


### Before:
<img width="3430" height="2173" alt="before" src="https://github.com/user-attachments/assets/9252da19-f89e-4ad1-b51e-4f795aa4ea9d" />

### After:
<img width="3402" height="2179" alt="after" src="https://github.com/user-attachments/assets/edf99bcd-e1ec-44a0-a656-3f2eed554643" />
