### PR TITLE
feat: add numeric chapter prefix to reader menus

### DIFF
--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -124,8 +124,14 @@ void EpubReaderChapterSelectionActivity::render(RenderLock&&) {
 
     // Indent per TOC level while keeping content within the gutter-safe region.
     const int indentSize = contentX + 20 + (item.level - 1) * 15;
+
+    char prefix[32];
+    snprintf(prefix, sizeof(prefix), "%d. ", itemIndex + 1);
+    std::string fullTitle = prefix;
+    fullTitle += item.title;
+
     const std::string chapterName =
-        renderer.truncatedText(UI_10_FONT_ID, item.title.c_str(), contentWidth - 40 - indentSize);
+        renderer.truncatedText(UI_10_FONT_ID, fullTitle.c_str(), contentWidth - 40 - (indentSize - contentX));
 
     renderer.drawText(UI_10_FONT_ID, indentSize, displayY, chapterName.c_str(), !isSelected);
   }

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
@@ -127,7 +127,15 @@ void XtcReaderChapterSelectionActivity::render(RenderLock&&) {
   for (int i = pageStartIndex; i < static_cast<int>(chapters.size()) && i < pageStartIndex + pageItems; i++) {
     const auto& chapter = chapters[i];
     const char* title = chapter.name.empty() ? tr(STR_UNNAMED) : chapter.name.c_str();
-    renderer.drawText(UI_10_FONT_ID, contentX + 20, 60 + contentY + (i % pageItems) * 30, title, i != selectorIndex);
+
+    char prefix[32];
+    snprintf(prefix, sizeof(prefix), "%d. ", i + 1);
+    std::string fullTitle = prefix;
+    fullTitle += title;
+
+    const std::string displayedTitle = renderer.truncatedText(UI_10_FONT_ID, fullTitle.c_str(), contentWidth - 40);
+    renderer.drawText(UI_10_FONT_ID, contentX + 20, 60 + contentY + (i % pageItems) * 30, displayedTitle.c_str(),
+                      i != selectorIndex);
   }
 
   // Skip button hints in landscape CW mode (they overlap content)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
The goal of this PR is to improve the usability and accessibility of the chapter selection menu, particularly for users reading content in languages or fonts that are not fully supported by the current system fonts.

* **What changes are included?**
- Added a numeric prefix (`X.`) to all TOC entries in the **EPUB** chapter selection activity.
- Added the same numeric prefix to the **XTC** (pre-rendered) chapter selection activity.
- Implemented consistent text truncation to ensure the prefix remains visible even for very long chapter titles.

## Additional Context

Currently, if a chapter title contains characters that the current font cannot render (e.g., specific UTF-8 symbols or unsupported scripts), the entry appears completely blank in the menu. This makes navigation impossible for affected books.

By adding a numeric prefix in a standard supported font, users can always identify the chapter index even if the rest of the title is unreadable. This is a low-risk, high-impact UX improvement that makes the reader more robust for international users.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_