### PR TITLE
refactor: unify book cache clearing for epub, txt, and xtc files

### DIFF
--- a/lib/Txt/Txt.cpp
+++ b/lib/Txt/Txt.cpp
@@ -155,6 +155,21 @@ bool Txt::generateCoverBmp() const {
   return false;
 }
 
+bool Txt::clearCache() const {
+  if (!Storage.exists(cachePath.c_str())) {
+    LOG_DBG("TXT", "Cache does not exist, no action needed");
+    return true;
+  }
+
+  if (!Storage.removeDir(cachePath.c_str())) {
+    LOG_ERR("TXT", "Failed to clear cache");
+    return false;
+  }
+
+  LOG_DBG("TXT", "Cache cleared successfully");
+  return true;
+}
+
 bool Txt::readContent(uint8_t* buffer, size_t offset, size_t length) const {
   if (!loaded) {
     return false;

--- a/lib/Txt/Txt.h
+++ b/lib/Txt/Txt.h
@@ -22,6 +22,7 @@ class Txt {
   [[nodiscard]] size_t getFileSize() const { return fileSize; }
 
   void setupCacheDir() const;
+  bool clearCache() const;
 
   // Cover image support - looks for cover.bmp/jpg/jpeg/png in same folder as txt file
   [[nodiscard]] std::string getCoverBmpPath() const;

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1,6 +1,5 @@
 #include "OpdsBookBrowserActivity.h"
 
-#include <Epub.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <Logging.h>
@@ -13,6 +12,7 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "network/HttpDownloader.h"
+#include "util/BookCacheUtils.h"
 #include "util/StringUtils.h"
 #include "util/UrlUtils.h"
 
@@ -277,7 +277,7 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
       server.username, server.password);
 
   if (result == HttpDownloader::OK) {
-    Epub(filename, "/.crosspoint").clearCache();
+    clearBookCache(filename);
     state = BrowserState::BROWSING;
   } else {
     state = BrowserState::ERROR;

--- a/src/activities/settings/ClearCacheActivity.cpp
+++ b/src/activities/settings/ClearCacheActivity.cpp
@@ -8,6 +8,7 @@
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/BookCacheUtils.h"
 
 void ClearCacheActivity::onEnter() {
   Activity::onEnter();
@@ -94,9 +95,8 @@ void ClearCacheActivity::clearCache() {
     file.getName(name, sizeof(name));
     String itemName(name);
 
-    // Only delete directories starting with epub_, txt_, or xtc_
-    if (file.isDirectory() &&
-        (itemName.startsWith("epub_") || itemName.startsWith("txt_") || itemName.startsWith("xtc_"))) {
+    // Only delete directories matching known book cache names.
+    if (file.isDirectory() && isBookCacheDirectoryName(itemName.c_str())) {
       String fullPath = "/.crosspoint/" + itemName;
       LOG_DBG("CLEAR_CACHE", "Removing cache: %s", fullPath.c_str());
 

--- a/src/activities/settings/ClearCacheActivity.cpp
+++ b/src/activities/settings/ClearCacheActivity.cpp
@@ -94,8 +94,9 @@ void ClearCacheActivity::clearCache() {
     file.getName(name, sizeof(name));
     String itemName(name);
 
-    // Only delete directories starting with epub_ or xtc_
-    if (file.isDirectory() && (itemName.startsWith("epub_") || itemName.startsWith("xtc_"))) {
+    // Only delete directories starting with epub_, txt_, or xtc_
+    if (file.isDirectory() &&
+        (itemName.startsWith("epub_") || itemName.startsWith("txt_") || itemName.startsWith("xtc_"))) {
       String fullPath = "/.crosspoint/" + itemName;
       LOG_DBG("CLEAR_CACHE", "Removing cache: %s", fullPath.c_str());
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1,7 +1,6 @@
 #include "CrossPointWebServer.h"
 
 #include <ArduinoJson.h>
-#include <Epub.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
@@ -23,6 +22,7 @@
 #include "html/HomePageHtml.generated.h"
 #include "html/SettingsPageHtml.generated.h"
 #include "html/js/jszip_minJs.generated.h"
+#include "util/BookCacheUtils.h"
 
 namespace {
 // Folders/files to hide from the web interface file browser
@@ -47,15 +47,6 @@ size_t wsLastProgressSent = 0;
 String wsLastCompleteName;
 size_t wsLastCompleteSize = 0;
 unsigned long wsLastCompleteAt = 0;
-
-// Helper function to clear epub cache after upload
-void clearEpubCacheIfNeeded(const String& filePath) {
-  // Only clear cache for .epub files
-  if (FsHelpers::hasEpubExtension(filePath)) {
-    Epub(filePath.c_str(), "/.crosspoint").clearCache();
-    LOG_DBG("WEB", "Cleared epub cache for: %s", filePath.c_str());
-  }
-}
 
 String normalizeWebPath(const String& inputPath) {
   if (inputPath.isEmpty() || inputPath == "/") {
@@ -731,7 +722,7 @@ void CrossPointWebServer::handleUpload(UploadState& state) const {
         String filePath = state.path;
         if (!filePath.endsWith("/")) filePath += "/";
         filePath += state.fileName;
-        clearEpubCacheIfNeeded(filePath);
+        clearBookCache(filePath.c_str());
       }
     }
   } else if (upload.status == UPLOAD_FILE_ABORTED) {
@@ -877,7 +868,7 @@ void CrossPointWebServer::handleRename() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  clearBookCache(itemPath.c_str());
   const bool success = file.rename(newPath.c_str());
   file.close();
 
@@ -970,7 +961,7 @@ void CrossPointWebServer::handleMove() const {
     return;
   }
 
-  clearEpubCacheIfNeeded(itemPath);
+  clearBookCache(itemPath.c_str());
   const bool success = file.rename(newPath.c_str());
   file.close();
 
@@ -1089,7 +1080,7 @@ void CrossPointWebServer::handleDelete() const {
       // It's a file (or couldn't open as dir) — remove file
       if (f) f.close();
       success = Storage.remove(itemPath.c_str());
-      clearEpubCacheIfNeeded(itemPath);
+      clearBookCache(itemPath.c_str());
     }
 
     if (!success) {
@@ -1634,7 +1625,7 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
             wsLastCompleteSize = 0;
             wsLastCompleteAt = millis();
             LOG_DBG("WS", "Zero-byte upload complete: %s", filePath.c_str());
-            clearEpubCacheIfNeeded(filePath);
+            clearBookCache(filePath.c_str());
             wsServer->sendTXT(num, "DONE");
             wsLastProgressSent = 0;
             break;
@@ -1703,7 +1694,7 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
         String filePath = wsUploadPath;
         if (!filePath.endsWith("/")) filePath += "/";
         filePath += wsUploadFileName;
-        clearEpubCacheIfNeeded(filePath);
+        clearBookCache(filePath.c_str());
 
         wsServer->sendTXT(num, "DONE");
         wsLastProgressSent = 0;

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -1,10 +1,11 @@
 #include "WebDAVHandler.h"
 
-#include <Epub.h>
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <esp_task_wdt.h>
+
+#include "util/BookCacheUtils.h"
 
 namespace {
 constexpr const char* HIDDEN_ITEMS[] = {"System Volume Information", "XTCache"};
@@ -384,7 +385,7 @@ void WebDAVHandler::handlePut(WebServer& s) {
     return;
   }
 
-  clearEpubCacheIfNeeded(path);
+  clearBookCache(path.c_str());
   s.send(_putExisted ? 204 : 201);
   LOG_DBG("DAV", "PUT complete: %s", path.c_str());
 }
@@ -433,7 +434,7 @@ void WebDAVHandler::handleDelete(WebServer& s) {
     }
   } else {
     file.close();
-    clearEpubCacheIfNeeded(path);
+    clearBookCache(path.c_str());
     if (Storage.remove(path.c_str())) {
       s.send(204);
     } else {
@@ -542,7 +543,7 @@ void WebDAVHandler::handleMove(WebServer& s) {
     return;
   }
 
-  clearEpubCacheIfNeeded(srcPath);
+  clearBookCache(srcPath.c_str());
   bool success = file.rename(dstPath.c_str());
   file.close();
 
@@ -795,13 +796,6 @@ bool WebDAVHandler::getOverwrite(WebServer& s) const {
   String ow = s.header("Overwrite");
   if (ow == "F" || ow == "f") return false;
   return true;  // Default is T
-}
-
-void WebDAVHandler::clearEpubCacheIfNeeded(const String& path) const {
-  if (FsHelpers::hasEpubExtension(path)) {
-    Epub(path.c_str(), "/.crosspoint").clearCache();
-    LOG_DBG("DAV", "Cleared epub cache for: %s", path.c_str());
-  }
 }
 
 String WebDAVHandler::getMimeType(const String& path) const {

--- a/src/network/WebDAVHandler.h
+++ b/src/network/WebDAVHandler.h
@@ -38,7 +38,6 @@ class WebDAVHandler : public RequestHandler {
   bool isProtectedPath(const String& path) const;
   int getDepth(WebServer& s) const;
   bool getOverwrite(WebServer& s) const;
-  void clearEpubCacheIfNeeded(const String& path) const;
   void sendPropEntry(WebServer& s, const String& href, bool isDir, size_t size, const String& lastModified) const;
   String getMimeType(const String& path) const;
 };

--- a/src/util/BookCacheUtils.cpp
+++ b/src/util/BookCacheUtils.cpp
@@ -1,0 +1,20 @@
+#include "BookCacheUtils.h"
+
+#include <Epub.h>
+#include <FsHelpers.h>
+#include <Logging.h>
+#include <Txt.h>
+#include <Xtc.h>
+
+void clearBookCache(const std::string& path) {
+  if (FsHelpers::hasEpubExtension(path)) {
+    Epub(path, "/.crosspoint").clearCache();
+  } else if (FsHelpers::hasXtcExtension(path)) {
+    Xtc(path, "/.crosspoint").clearCache();
+  } else if (FsHelpers::hasTxtExtension(path)) {
+    Txt(path, "/.crosspoint").clearCache();
+  } else {
+    return;
+  }
+  LOG_DBG("BookCache", "Cleared metadata cache for: %s", path.c_str());
+}

--- a/src/util/BookCacheUtils.cpp
+++ b/src/util/BookCacheUtils.cpp
@@ -16,5 +16,5 @@ void clearBookCache(const std::string& path) {
   } else {
     return;
   }
-  LOG_DBG("BookCache", "Cleared metadata cache for: %s", path.c_str());
+  LOG_DBG("BookCache", "Done checking metadata cache for: %s", path.c_str());
 }

--- a/src/util/BookCacheUtils.cpp
+++ b/src/util/BookCacheUtils.cpp
@@ -6,6 +6,20 @@
 #include <Txt.h>
 #include <Xtc.h>
 
+bool isBookCacheDirectoryName(const char* name) {
+  if (!name) {
+    return false;
+  }
+
+  constexpr char EPUB_PREFIX[] = "epub_";
+  constexpr char TXT_PREFIX[] = "txt_";
+  constexpr char XTC_PREFIX[] = "xtc_";
+
+  return strncmp(name, EPUB_PREFIX, std::size(EPUB_PREFIX) - 1) == 0 ||
+         strncmp(name, TXT_PREFIX, std::size(TXT_PREFIX) - 1) == 0 ||
+         strncmp(name, XTC_PREFIX, std::size(XTC_PREFIX) - 1) == 0;
+}
+
 void clearBookCache(const std::string& path) {
   if (FsHelpers::hasEpubExtension(path)) {
     Epub(path, "/.crosspoint").clearCache();

--- a/src/util/BookCacheUtils.h
+++ b/src/util/BookCacheUtils.h
@@ -5,3 +5,6 @@
 // Clears the reading cache for a book file if its extension is recognised
 // (EPUB, XTC, or TXT). Does nothing for other file types.
 void clearBookCache(const std::string& path);
+
+// Returns true if the directory name matches a book cache entry.
+bool isBookCacheDirectoryName(const char* name);

--- a/src/util/BookCacheUtils.h
+++ b/src/util/BookCacheUtils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+// Clears the reading cache for a book file if its extension is recognised
+// (EPUB, XTC, or TXT). Does nothing for other file types.
+void clearBookCache(const std::string& path);


### PR DESCRIPTION
## Summary

* What is the goal of this PR?  
  Implements unified book cache invalidation method for text, epub, and xtc files content paths to ensure cache is cleared whenever files are uploaded, renamed, moved, or deleted.

* What changes are included?  
  - Added `Txt::clearCache()` support in `Txt.cpp` / `Txt.h`
  - Added `clearBookCache()` helper in `BookCacheUtils.cpp` / `BookCacheUtils.h`
  - Replaced EPUB-specific cache clearing calls with the generic helper in:
    - OpdsBookBrowserActivity.cpp
    - CrossPointWebServer.cpp
    - WebDAVHandler.cpp
  - Extended settings cache cleanup in ClearCacheActivity.cpp to handle `txt_` cache directories as well

## Additional Context

I will work on `FileBrowserActivity.cpp` as part of #1803's follow-up after this pr.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
