### PR TITLE
feat(epub): basic table support for row/colspan and for solid/none border style

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -30,6 +30,30 @@ void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffse
   imageBlock->render(renderer, xPos + xOffset, yPos + yOffset);
 }
 
+void PageTable::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
+  tableBlock->render(renderer, fontId, xPos + xOffset, yPos + yOffset);
+}
+
+bool PageTable::serialize(FsFile& file) {
+  serialization::writePod(file, xPos);
+  serialization::writePod(file, yPos);
+  serialization::writePod(file, tableHeight);
+  return tableBlock->serialize(file);
+}
+
+std::unique_ptr<PageTable> PageTable::deserialize(FsFile& file) {
+  int16_t xPos = 0, yPos = 0, tableHeight = 0;
+  serialization::readPod(file, xPos);
+  serialization::readPod(file, yPos);
+  serialization::readPod(file, tableHeight);
+  auto tb = TableBlock::deserialize(file);
+  if (!tb) {
+    LOG_ERR("PGE", "Failed to deserialize TableBlock");
+    return nullptr;
+  }
+  return std::unique_ptr<PageTable>(new PageTable(std::move(tb), xPos, yPos, tableHeight));
+}
+
 bool PageImage::serialize(FsFile& file) {
   serialization::writePod(file, xPos);
   serialization::writePod(file, yPos);
@@ -98,6 +122,10 @@ std::unique_ptr<Page> Page::deserialize(FsFile& file) {
     } else if (tag == TAG_PageImage) {
       auto pi = PageImage::deserialize(file);
       page->elements.push_back(std::move(pi));
+    } else if (tag == TAG_PageTable) {
+      auto pt = PageTable::deserialize(file);
+      if (!pt) return nullptr;
+      page->elements.push_back(std::move(pt));
     } else {
       LOG_ERR("PGE", "Deserialization failed: Unknown tag %u", tag);
       return nullptr;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -8,11 +8,13 @@
 
 #include "FootnoteEntry.h"
 #include "blocks/ImageBlock.h"
+#include "blocks/TableBlock.h"
 #include "blocks/TextBlock.h"
 
 enum PageElementTag : uint8_t {
   TAG_PageLine = 1,
-  TAG_PageImage = 2,  // New tag
+  TAG_PageImage = 2,
+  TAG_PageTable = 3,
 };
 
 // represents something that has been added to a page
@@ -53,6 +55,21 @@ class PageImage final : public PageElement {
   PageElementTag getTag() const override { return TAG_PageImage; }
   static std::unique_ptr<PageImage> deserialize(FsFile& file);
   const ImageBlock& getImageBlock() const { return *imageBlock; }
+};
+
+// A pre-laid-out table placed at a fixed position on the page.
+class PageTable final : public PageElement {
+  std::unique_ptr<TableBlock> tableBlock;
+  int16_t tableHeight;  // pre-computed total pixel height
+
+ public:
+  PageTable(std::unique_ptr<TableBlock> block, const int16_t xPos, const int16_t yPos, const int16_t height)
+      : PageElement(xPos, yPos), tableBlock(std::move(block)), tableHeight(height) {}
+  void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
+  bool serialize(FsFile& file) override;
+  PageElementTag getTag() const override { return TAG_PageTable; }
+  int16_t getHeight() const { return tableHeight; }
+  static std::unique_ptr<PageTable> deserialize(FsFile& file);
 };
 
 class Page {

--- a/lib/Epub/Epub/blocks/Block.h
+++ b/lib/Epub/Epub/blocks/Block.h
@@ -2,7 +2,7 @@
 
 class GfxRenderer;
 
-typedef enum { TEXT_BLOCK, IMAGE_BLOCK } BlockType;
+typedef enum { TEXT_BLOCK, IMAGE_BLOCK, TABLE_BLOCK } BlockType;
 
 // a block of content in the html - either a paragraph or an image
 class Block {

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -212,8 +212,13 @@ std::unique_ptr<TableBlock> TableBlock::deserialize(FsFile& file) {
         cell.colspan = 1;  // phantom cells always span 1 column
       else if (cell.colspan == 0)
         cell.colspan = 1;  // guard against corrupt data
+      constexpr uint16_t kMaxCellLines = 4096;
       uint16_t numLines = 0;
       serialization::readPod(file, numLines);
+      if (numLines > kMaxCellLines) {
+        LOG_ERR("TBL", "Sanity check failed: cell lines=%u", numLines);
+        return nullptr;
+      }
       cell.lines.reserve(numLines);
       for (uint16_t l = 0; l < numLines; l++) {
         auto line = TextBlock::deserialize(file);

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -106,7 +106,7 @@ void TableBlock::render(GfxRenderer& renderer, int fontId, int x, int y) const {
           uint8_t lc = 0;
           for (const auto& nc : rows[ri + 1].cells) {
             if (nc.rowspan == 0 && lc < 64) phantomAt[lc] = true;
-            lc++;
+            lc = static_cast<uint8_t>(lc + ((nc.rowspan == 0) ? 1 : nc.colspan));
           }
         }
         int segStart = x;

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -1,0 +1,229 @@
+#include "TableBlock.h"
+
+#include <GfxRenderer.h>
+#include <Logging.h>
+#include <Serialization.h>
+
+// Layout:
+//   1px top border
+//   For each row:
+//     maxPaddingTop + row.maxLines * lineHeight + maxPaddingBottom  pixels of content
+//     1px bottom border (doubles as top border of next row)
+int16_t TableBlock::totalHeight() const {
+  if (rows.empty()) return 0;
+  int16_t h = static_cast<int16_t>(rows.size() + 1);  // (numRows+1) 1px borders
+  for (const auto& row : rows) {
+    h = static_cast<int16_t>(h + row.maxLines * lineHeight + row.maxPaddingTop + row.maxPaddingBottom);
+  }
+  return h;
+}
+
+void TableBlock::render(GfxRenderer& renderer, int fontId, int x, int y) const {
+  if (rows.empty() || numCols == 0) return;
+
+  // Build cumulative column X positions (numCols+1 values: left edge of each col + right edge of last).
+  std::vector<int16_t> colX;
+  colX.reserve(numCols + 1);
+  auto cx = static_cast<int16_t>(x);
+  for (uint8_t c = 0; c <= numCols; c++) {
+    colX.push_back(cx);
+    if (c < numCols) cx = static_cast<int16_t>(cx + getColWidth(c));
+  }
+  const int tableWidth = static_cast<int>(colX[numCols]) - x;
+
+  int curY = y;
+  if (drawBorderTop) renderer.drawLine(x, curY, x + tableWidth, curY, true);  // top border
+  curY += 1;
+
+  // A vertical divider is the right edge of one column and the left edge of the next.
+  // Draw it if either the left or right side has borders enabled.
+  const bool drawVerticals = drawBorderLeft || drawBorderRight;
+  // A horizontal row separator is both the bottom of one row and the top of the next.
+  // Draw it if either the top or bottom side has borders enabled.
+  const bool drawHorizontals = drawBorderTop || drawBorderBottom;
+
+  for (size_t ri = 0; ri < rows.size(); ri++) {
+    const auto& row = rows[ri];
+    const int rowContentH = row.maxLines * lineHeight + row.maxPaddingTop + row.maxPaddingBottom;
+
+    // Vertical column lines — skip interior boundaries of spanning cells.
+    // Phantom cells (rowspan==0) are single-column and do not suppress any borders.
+    {
+      // drawBorderAt[i] == true means draw a vertical line at colX[i].
+      // numCols <= 64, so stack array is safe.
+      bool drawBorderAt[65] = {};
+      // Left edge, interior dividers, and right edge each use their respective flags.
+      for (int i = 0; i <= static_cast<int>(numCols); i++) {
+        if (i == 0)
+          drawBorderAt[i] = drawBorderLeft;
+        else if (i == static_cast<int>(numCols))
+          drawBorderAt[i] = drawBorderRight;
+        else
+          drawBorderAt[i] = drawVerticals;  // interior column: draw if either side active
+      }
+      if (drawVerticals) {
+        uint8_t logCol = 0;
+        for (size_t ci = 0; ci < row.cells.size() && logCol < numCols; ci++) {
+          const auto& cell = row.cells[ci];
+          const uint8_t span = (cell.rowspan == 0) ? 1 : cell.colspan;
+          // Interior column positions within this span must not have a divider.
+          for (uint8_t k = 1; k < span && (logCol + k) <= numCols; k++) {
+            drawBorderAt[logCol + k] = false;
+          }
+          logCol = static_cast<uint8_t>(logCol + span);
+        }
+        for (int col = 0; col <= static_cast<int>(numCols); col++) {
+          if (drawBorderAt[col]) {
+            renderer.drawLine(colX[col], curY, colX[col], curY + rowContentH, true);
+          }
+        }
+      }
+    }
+
+    // Cell text — advance logical column by each cell's colspan.
+    // Phantom cells (rowspan==0) have no lines, so the inner loop is a no-op for them.
+    {
+      uint8_t logCol = 0;
+      for (size_t ci = 0; ci < row.cells.size() && logCol < numCols; ci++) {
+        const auto& cell = row.cells[ci];
+        const int cellTextX = static_cast<int>(colX[logCol]) + 1 + cell.paddingLeft;  // +1 for left border
+        int lineY = curY + row.maxPaddingTop;
+        for (const auto& line : cell.lines) {
+          line->render(renderer, fontId, cellTextX, lineY);
+          lineY += lineHeight;
+        }
+        logCol = static_cast<uint8_t>(logCol + ((cell.rowspan == 0) ? 1 : cell.colspan));
+      }
+    }
+
+    curY += rowContentH;
+    if (drawHorizontals) {
+      // Suppress the bottom border at columns where the next row has phantom cells
+      // (those columns are visually spanned by a rowspan cell continuing from this row).
+      if (ri + 1 < rows.size()) {
+        bool phantomAt[64] = {};
+        {
+          uint8_t lc = 0;
+          for (const auto& nc : rows[ri + 1].cells) {
+            if (nc.rowspan == 0 && lc < 64) phantomAt[lc] = true;
+            lc++;
+          }
+        }
+        int segStart = x;
+        for (int col = 0; col < static_cast<int>(numCols); col++) {
+          if (col < 64 && phantomAt[col]) {
+            if (segStart < colX[col]) renderer.drawLine(segStart, curY, colX[col], curY, true);
+            segStart = colX[col + 1];
+          }
+        }
+        if (segStart < colX[numCols]) renderer.drawLine(segStart, curY, colX[numCols], curY, true);
+      } else {
+        renderer.drawLine(x, curY, x + tableWidth, curY, true);  // row bottom / next row top
+      }
+    }
+    curY += 1;
+  }
+}
+
+bool TableBlock::serialize(FsFile& file) const {
+  serialization::writePod(file, numCols);
+  serialization::writePod(file, colWidth);
+  serialization::writePod(file, lineHeight);
+  const uint8_t flags = drawBorderTop << 0 | drawBorderBottom << 1 | drawBorderLeft << 2 | drawBorderRight << 3;
+  serialization::writePod(file, flags);
+
+  // Per-column widths
+  const auto numColWidths = static_cast<uint8_t>(std::min(colWidths.size(), size_t(255)));
+  serialization::writePod(file, numColWidths);
+  for (uint8_t c = 0; c < numColWidths; c++) serialization::writePod(file, colWidths[c]);
+
+  const auto numRows = static_cast<uint16_t>(rows.size());
+  serialization::writePod(file, numRows);
+
+  for (const auto& row : rows) {
+    serialization::writePod(file, row.maxLines);
+    serialization::writePod(file, row.maxPaddingTop);
+    serialization::writePod(file, row.maxPaddingBottom);
+    const auto numCells = static_cast<uint8_t>(std::min(row.cells.size(), size_t(255)));
+    serialization::writePod(file, numCells);
+    for (uint8_t c = 0; c < numCells; c++) {
+      const auto& cell = row.cells[c];
+      serialization::writePod(file, cell.paddingLeft);
+      serialization::writePod(file, cell.paddingRight);
+      serialization::writePod(file, cell.paddingTop);
+      serialization::writePod(file, cell.paddingBottom);
+      serialization::writePod(file, cell.colspan);
+      serialization::writePod(file, cell.rowspan);
+      const auto numLines = static_cast<uint16_t>(std::min(cell.lines.size(), size_t(65535)));
+      serialization::writePod(file, numLines);
+      for (uint16_t l = 0; l < numLines; l++) {
+        if (!cell.lines[l]->serialize(file)) {
+          LOG_ERR("TBL", "Failed to serialize cell[%u] line %u", c, l);
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+std::unique_ptr<TableBlock> TableBlock::deserialize(FsFile& file) {
+  auto tb = std::unique_ptr<TableBlock>(new TableBlock());
+  serialization::readPod(file, tb->numCols);
+  serialization::readPod(file, tb->colWidth);
+  serialization::readPod(file, tb->lineHeight);
+  uint8_t flags = 0;
+  serialization::readPod(file, flags);
+  tb->drawBorderTop = (flags & 1) != 0;
+  tb->drawBorderBottom = (flags & 2) != 0;
+  tb->drawBorderLeft = (flags & 4) != 0;
+  tb->drawBorderRight = (flags & 8) != 0;
+
+  // Per-column widths
+  uint8_t numColWidths = 0;
+  serialization::readPod(file, numColWidths);
+  tb->colWidths.resize(numColWidths);
+  for (auto& w : tb->colWidths) serialization::readPod(file, w);
+
+  uint16_t numRows = 0;
+  serialization::readPod(file, numRows);
+
+  if (numRows > 1000 || tb->numCols > 64) {
+    LOG_ERR("TBL", "Sanity check failed: rows=%u cols=%u", numRows, tb->numCols);
+    return nullptr;
+  }
+
+  tb->rows.resize(numRows);
+  for (auto& row : tb->rows) {
+    serialization::readPod(file, row.maxLines);
+    serialization::readPod(file, row.maxPaddingTop);
+    serialization::readPod(file, row.maxPaddingBottom);
+    uint8_t numCells = 0;
+    serialization::readPod(file, numCells);
+    row.cells.resize(numCells);
+    for (auto& cell : row.cells) {
+      serialization::readPod(file, cell.paddingLeft);
+      serialization::readPod(file, cell.paddingRight);
+      serialization::readPod(file, cell.paddingTop);
+      serialization::readPod(file, cell.paddingBottom);
+      serialization::readPod(file, cell.colspan);
+      serialization::readPod(file, cell.rowspan);
+      if (cell.rowspan == 0)
+        cell.colspan = 1;  // phantom cells always span 1 column
+      else if (cell.colspan == 0)
+        cell.colspan = 1;  // guard against corrupt data
+      uint16_t numLines = 0;
+      serialization::readPod(file, numLines);
+      cell.lines.reserve(numLines);
+      for (uint16_t l = 0; l < numLines; l++) {
+        auto line = TextBlock::deserialize(file);
+        if (!line) {
+          LOG_ERR("TBL", "Failed to deserialize cell line");
+          return nullptr;
+        }
+        cell.lines.push_back(std::move(line));
+      }
+    }
+  }
+  return tb;
+}

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -20,6 +20,10 @@ int16_t TableBlock::totalHeight() const {
 
 void TableBlock::render(GfxRenderer& renderer, int fontId, int x, int y) const {
   if (rows.empty() || numCols == 0) return;
+  if (numCols > 64) {
+    LOG_ERR("TBL", "Skipping table render: too many cols=%u", numCols);
+    return;
+  }
 
   // Build cumulative column X positions (numCols+1 values: left edge of each col + right edge of last).
   std::vector<int16_t> colX;

--- a/lib/Epub/Epub/blocks/TableBlock.h
+++ b/lib/Epub/Epub/blocks/TableBlock.h
@@ -16,7 +16,8 @@ struct TableCell {
   int16_t paddingTop = 1;  // default: TableBlock::CELL_PADDING_Y
   int16_t paddingBottom = 1;
   uint8_t colspan = 1;  // number of logical columns this cell spans
-  uint8_t rowspan = 1;  // 0 = phantom (column occupied by rowspan from above), 1 = normal, >1 = spans rows
+  uint8_t rowspan =
+      1;  // 0 = phantom (column occupied by rowspan from above), 1 = normal, >1 = spans rows; HTML "0" mapped to 64
 };
 
 // One row in a table — holds cells and aggregated height metrics.

--- a/lib/Epub/Epub/blocks/TableBlock.h
+++ b/lib/Epub/Epub/blocks/TableBlock.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <memory>
+#include <vector>
+
+#include "Block.h"
+#include "TextBlock.h"
+
+// One cell in a table row — holds pre-laid-out text lines and its own CSS-resolved padding.
+struct TableCell {
+  std::vector<std::shared_ptr<TextBlock>> lines;
+  int16_t paddingLeft = 2;  // default: TableBlock::CELL_PADDING_X
+  int16_t paddingRight = 2;
+  int16_t paddingTop = 1;  // default: TableBlock::CELL_PADDING_Y
+  int16_t paddingBottom = 1;
+  uint8_t colspan = 1;  // number of logical columns this cell spans
+  uint8_t rowspan = 1;  // 0 = phantom (column occupied by rowspan from above), 1 = normal, >1 = spans rows
+};
+
+// One row in a table — holds cells and aggregated height metrics.
+struct TableRow {
+  std::vector<TableCell> cells;
+  uint8_t maxLines = 0;          // max text lines across all cells in this row
+  int16_t maxPaddingTop = 1;     // max paddingTop  across all cells
+  int16_t maxPaddingBottom = 1;  // max paddingBottom across all cells
+};
+
+class GfxRenderer;
+
+// A fully pre-laid-out table. Column widths can be per-column (CSS) or uniform.
+// Line heights are pre-computed and stored so rendering does not need to re-query the font.
+class TableBlock final : public Block {
+ public:
+  static constexpr int16_t CELL_PADDING_X = 2;  // horizontal padding default
+  static constexpr int16_t CELL_PADDING_Y = 1;  // vertical padding default
+
+  std::vector<TableRow> rows;
+  uint8_t numCols = 0;
+  int16_t colWidth = 0;            // equal-width fallback (used when colWidths is empty)
+  std::vector<int16_t> colWidths;  // per-column pixel widths; if size()==numCols overrides colWidth
+  int16_t lineHeight = 0;
+  bool drawBorderTop = false;     // draw top edge of table; also gates interior row-separator lines
+  bool drawBorderBottom = false;  // draw bottom edge of table; also gates interior row-separator lines
+  bool drawBorderLeft = false;    // draw left edge of table; also gates interior column-divider lines
+  bool drawBorderRight = false;   // draw right edge of table; also gates interior column-divider lines
+
+  // Returns true if any border side is enabled.
+  bool drawAnyBorder() const { return drawBorderTop || drawBorderBottom || drawBorderLeft || drawBorderRight; }
+
+  BlockType getType() override { return TABLE_BLOCK; }
+  bool isEmpty() override { return rows.empty(); }
+
+  // Pixel width of column `col` (0-based).
+  int16_t getColWidth(uint8_t col) const {
+    if (col < static_cast<uint8_t>(colWidths.size())) return colWidths[col];
+    return colWidth;
+  }
+
+  // Total pixel height occupied by this table (borders + padding + text lines).
+  int16_t totalHeight() const;
+
+  void render(GfxRenderer& renderer, int fontId, int x, int y) const;
+  bool serialize(FsFile& file) const;
+  static std::unique_ptr<TableBlock> deserialize(FsFile& file);
+};

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -211,6 +211,12 @@ CssTextDecoration CssParser::interpretDecoration(const std::string& val) {
   return CssTextDecoration::None;
 }
 
+CssBorderStyle CssParser::interpretBorderStyle(const std::string& val) {
+  const std::string v = normalized(val);
+  if (v == "none" || v == "hidden") return CssBorderStyle::None;
+  return CssBorderStyle::Solid;
+}
+
 CssLength CssParser::interpretLength(const std::string& val) {
   CssLength result;
   tryInterpretLength(val, result);
@@ -344,6 +350,63 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     const std::string_view displayValue = stripTrailingImportant(propValueBuf);
     style.display = (displayValue == "none") ? CssDisplay::None : CssDisplay::Block;
     style.defined.display = 1;
+  } else if (propNameBuf == "border-top-style") {
+    style.borderTopStyle = interpretBorderStyle(propValueBuf);
+    style.defined.borderTopStyle = 1;
+  } else if (propNameBuf == "border-bottom-style") {
+    style.borderBottomStyle = interpretBorderStyle(propValueBuf);
+    style.defined.borderBottomStyle = 1;
+  } else if (propNameBuf == "border-left-style") {
+    style.borderLeftStyle = interpretBorderStyle(propValueBuf);
+    style.defined.borderLeftStyle = 1;
+  } else if (propNameBuf == "border-right-style") {
+    style.borderRightStyle = interpretBorderStyle(propValueBuf);
+    style.defined.borderRightStyle = 1;
+  } else if (propNameBuf == "border-top-width") {
+    // Track zero-width independently from style; combined at check time via isBorderTopVisible().
+    CssLength len;
+    if (tryInterpretLength(propValueBuf, len)) {
+      style.defined.borderTopWidthZero = (len.value == 0.0f) ? 1 : 0;
+    }
+  } else if (propNameBuf == "border-bottom-width") {
+    CssLength len;
+    if (tryInterpretLength(propValueBuf, len)) {
+      style.defined.borderBottomWidthZero = (len.value == 0.0f) ? 1 : 0;
+    }
+  } else if (propNameBuf == "border-left-width") {
+    CssLength len;
+    if (tryInterpretLength(propValueBuf, len)) {
+      style.defined.borderLeftWidthZero = (len.value == 0.0f) ? 1 : 0;
+    }
+  } else if (propNameBuf == "border-right-width") {
+    CssLength len;
+    if (tryInterpretLength(propValueBuf, len)) {
+      style.defined.borderRightWidthZero = (len.value == 0.0f) ? 1 : 0;
+    }
+  } else if (propNameBuf == "border-width") {
+    // Shorthand: 1–4 values (top right bottom left). Track zero-width per side.
+    const auto values = splitWhitespace(propValueBuf);
+    if (!values.empty()) {
+      const std::string& top = values[0];
+      const std::string& right = values.size() >= 2 ? values[1] : values[0];
+      const std::string& bottom = values.size() >= 3 ? values[2] : values[0];
+      const std::string& left = values.size() >= 4 ? values[3] : right;
+      CssLength len;
+      if (tryInterpretLength(top, len)) style.defined.borderTopWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (tryInterpretLength(right, len)) style.defined.borderRightWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (tryInterpretLength(bottom, len)) style.defined.borderBottomWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (tryInterpretLength(left, len)) style.defined.borderLeftWidthZero = (len.value == 0.0f) ? 1 : 0;
+    }
+  } else if (propNameBuf == "border-style") {
+    const auto values = splitWhitespace(propValueBuf);
+    if (!values.empty()) {
+      style.borderTopStyle = interpretBorderStyle(values[0]);
+      style.borderRightStyle = values.size() >= 2 ? interpretBorderStyle(values[1]) : style.borderTopStyle;
+      style.borderBottomStyle = values.size() >= 3 ? interpretBorderStyle(values[2]) : style.borderTopStyle;
+      style.borderLeftStyle = values.size() >= 4 ? interpretBorderStyle(values[3]) : style.borderRightStyle;
+      style.defined.borderTopStyle = style.defined.borderRightStyle = style.defined.borderBottomStyle =
+          style.defined.borderLeftStyle = 1;
+    }
   }
 }
 
@@ -720,9 +783,13 @@ bool CssParser::saveToCache() const {
     writeLength(style.imageHeight);
     writeLength(style.imageWidth);
     file.write(static_cast<uint8_t>(style.display));
+    file.write(static_cast<uint8_t>(style.borderTopStyle));
+    file.write(static_cast<uint8_t>(style.borderBottomStyle));
+    file.write(static_cast<uint8_t>(style.borderLeftStyle));
+    file.write(static_cast<uint8_t>(style.borderRightStyle));
 
-    // Write defined flags as uint16_t
-    uint16_t definedBits = 0;
+    // Write defined flags as uint32_t
+    uint32_t definedBits = 0;
     if (style.defined.textAlign) definedBits |= 1 << 0;
     if (style.defined.fontStyle) definedBits |= 1 << 1;
     if (style.defined.fontWeight) definedBits |= 1 << 2;
@@ -739,6 +806,14 @@ bool CssParser::saveToCache() const {
     if (style.defined.imageHeight) definedBits |= 1 << 13;
     if (style.defined.imageWidth) definedBits |= 1 << 14;
     if (style.defined.display) definedBits |= 1 << 15;
+    if (style.defined.borderTopStyle) definedBits |= 1 << 16;
+    if (style.defined.borderBottomStyle) definedBits |= 1 << 17;
+    if (style.defined.borderLeftStyle) definedBits |= 1 << 18;
+    if (style.defined.borderRightStyle) definedBits |= 1 << 19;
+    if (style.defined.borderTopWidthZero) definedBits |= 1 << 20;
+    if (style.defined.borderBottomWidthZero) definedBits |= 1 << 21;
+    if (style.defined.borderLeftWidthZero) definedBits |= 1 << 22;
+    if (style.defined.borderRightWidthZero) definedBits |= 1 << 23;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
   }
 
@@ -788,8 +863,11 @@ bool CssParser::loadFromCache() {
 
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
-  constexpr size_t CSS_FIXED_STYLE_BYTES =
-      4 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) + sizeof(uint16_t);
+  constexpr size_t CSS_FIXED_STYLE_BYTES = sizeof(CssTextAlign) + sizeof(CssFontStyle) + sizeof(CssFontWeight) +
+                                           sizeof(CssTextDecoration) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) +
+                                           sizeof(CssDisplay) +
+                                           4 * sizeof(CssBorderStyle) +  // border{Top,Bottom,Left,Right}Style
+                                           sizeof(uint32_t);             // definedBits
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
@@ -880,8 +958,30 @@ bool CssParser::loadFromCache() {
     }
     style.display = static_cast<CssDisplay>(displayVal);
 
+    uint8_t borderStyleVal;
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderTopStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderBottomStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderLeftStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderRightStyle = static_cast<CssBorderStyle>(borderStyleVal);
+
     // Read defined flags
-    uint16_t definedBits = 0;
+    uint32_t definedBits = 0;
     if (file.read(&definedBits, sizeof(definedBits)) != sizeof(definedBits)) {
       rulesBySelector_.clear();
       return false;
@@ -902,6 +1002,14 @@ bool CssParser::loadFromCache() {
     style.defined.imageHeight = (definedBits & 1 << 13) != 0;
     style.defined.imageWidth = (definedBits & 1 << 14) != 0;
     style.defined.display = (definedBits & 1 << 15) != 0;
+    style.defined.borderTopStyle = (definedBits & 1 << 16) != 0;
+    style.defined.borderBottomStyle = (definedBits & 1 << 17) != 0;
+    style.defined.borderLeftStyle = (definedBits & 1 << 18) != 0;
+    style.defined.borderRightStyle = (definedBits & 1 << 19) != 0;
+    style.defined.borderTopWidthZero = (definedBits & 1 << 20) != 0;
+    style.defined.borderBottomWidthZero = (definedBits & 1 << 21) != 0;
+    style.defined.borderLeftWidthZero = (definedBits & 1 << 22) != 0;
+    style.defined.borderRightWidthZero = (definedBits & 1 << 23) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -369,28 +369,53 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     style.borderRightStyle = interpretBorderStyle(propValueBuf);
     style.defined.borderRightStyle = 1;
   } else if (propNameBuf == "border-top-width") {
-    // Track zero-width independently from style; combined at check time via isBorderTopVisible().
+    // Track zero-width vs non-zero-width independently from style;
+    // combined at check time via isBorderTopVisible().
     CssLength len;
     if (tryInterpretLength(propValueBuf, len)) {
-      style.defined.borderTopWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (len.value == 0.0f) {
+        style.defined.borderTopWidthZero = 1;
+        style.defined.borderTopWidthSet = 0;
+      } else {
+        style.defined.borderTopWidthSet = 1;
+        style.defined.borderTopWidthZero = 0;
+      }
     }
   } else if (propNameBuf == "border-bottom-width") {
     CssLength len;
     if (tryInterpretLength(propValueBuf, len)) {
-      style.defined.borderBottomWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (len.value == 0.0f) {
+        style.defined.borderBottomWidthZero = 1;
+        style.defined.borderBottomWidthSet = 0;
+      } else {
+        style.defined.borderBottomWidthSet = 1;
+        style.defined.borderBottomWidthZero = 0;
+      }
     }
   } else if (propNameBuf == "border-left-width") {
     CssLength len;
     if (tryInterpretLength(propValueBuf, len)) {
-      style.defined.borderLeftWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (len.value == 0.0f) {
+        style.defined.borderLeftWidthZero = 1;
+        style.defined.borderLeftWidthSet = 0;
+      } else {
+        style.defined.borderLeftWidthSet = 1;
+        style.defined.borderLeftWidthZero = 0;
+      }
     }
   } else if (propNameBuf == "border-right-width") {
     CssLength len;
     if (tryInterpretLength(propValueBuf, len)) {
-      style.defined.borderRightWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (len.value == 0.0f) {
+        style.defined.borderRightWidthZero = 1;
+        style.defined.borderRightWidthSet = 0;
+      } else {
+        style.defined.borderRightWidthSet = 1;
+        style.defined.borderRightWidthZero = 0;
+      }
     }
   } else if (propNameBuf == "border-width") {
-    // Shorthand: 1–4 values (top right bottom left). Track zero-width per side.
+    // Shorthand: 1–4 values (top right bottom left). Track zero vs non-zero width per side.
     const auto values = splitWhitespace(propValueBuf);
     if (!values.empty()) {
       const std::string& top = values[0];
@@ -398,10 +423,42 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
       const std::string& bottom = values.size() >= 3 ? values[2] : values[0];
       const std::string& left = values.size() >= 4 ? values[3] : right;
       CssLength len;
-      if (tryInterpretLength(top, len)) style.defined.borderTopWidthZero = (len.value == 0.0f) ? 1 : 0;
-      if (tryInterpretLength(right, len)) style.defined.borderRightWidthZero = (len.value == 0.0f) ? 1 : 0;
-      if (tryInterpretLength(bottom, len)) style.defined.borderBottomWidthZero = (len.value == 0.0f) ? 1 : 0;
-      if (tryInterpretLength(left, len)) style.defined.borderLeftWidthZero = (len.value == 0.0f) ? 1 : 0;
+      if (tryInterpretLength(top, len)) {
+        if (len.value == 0.0f) {
+          style.defined.borderTopWidthZero = 1;
+          style.defined.borderTopWidthSet = 0;
+        } else {
+          style.defined.borderTopWidthSet = 1;
+          style.defined.borderTopWidthZero = 0;
+        }
+      }
+      if (tryInterpretLength(right, len)) {
+        if (len.value == 0.0f) {
+          style.defined.borderRightWidthZero = 1;
+          style.defined.borderRightWidthSet = 0;
+        } else {
+          style.defined.borderRightWidthSet = 1;
+          style.defined.borderRightWidthZero = 0;
+        }
+      }
+      if (tryInterpretLength(bottom, len)) {
+        if (len.value == 0.0f) {
+          style.defined.borderBottomWidthZero = 1;
+          style.defined.borderBottomWidthSet = 0;
+        } else {
+          style.defined.borderBottomWidthSet = 1;
+          style.defined.borderBottomWidthZero = 0;
+        }
+      }
+      if (tryInterpretLength(left, len)) {
+        if (len.value == 0.0f) {
+          style.defined.borderLeftWidthZero = 1;
+          style.defined.borderLeftWidthSet = 0;
+        } else {
+          style.defined.borderLeftWidthSet = 1;
+          style.defined.borderLeftWidthZero = 0;
+        }
+      }
     }
   } else if (propNameBuf == "border-style") {
     const auto values = splitWhitespace(propValueBuf);
@@ -442,22 +499,67 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
     if (propNameBuf == "border-top" || propNameBuf == "border") {
       style.borderTopStyle = parsedStyle;
       style.defined.borderTopStyle = 1;
-      if (hasWidth) style.defined.borderTopWidthZero = widthIsZero ? 1 : 0;
+      if (hasWidth) {
+        if (widthIsZero) {
+          style.defined.borderTopWidthZero = 1;
+          style.defined.borderTopWidthSet = 0;
+        } else {
+          style.defined.borderTopWidthSet = 1;
+          style.defined.borderTopWidthZero = 0;
+        }
+      } else if (hasStyle) {
+        // CSS shorthand default width is medium (non-zero)
+        style.defined.borderTopWidthSet = 1;
+        style.defined.borderTopWidthZero = 0;
+      }
     }
     if (propNameBuf == "border-bottom" || propNameBuf == "border") {
       style.borderBottomStyle = parsedStyle;
       style.defined.borderBottomStyle = 1;
-      if (hasWidth) style.defined.borderBottomWidthZero = widthIsZero ? 1 : 0;
+      if (hasWidth) {
+        if (widthIsZero) {
+          style.defined.borderBottomWidthZero = 1;
+          style.defined.borderBottomWidthSet = 0;
+        } else {
+          style.defined.borderBottomWidthSet = 1;
+          style.defined.borderBottomWidthZero = 0;
+        }
+      } else if (hasStyle) {
+        style.defined.borderBottomWidthSet = 1;
+        style.defined.borderBottomWidthZero = 0;
+      }
     }
     if (propNameBuf == "border-left" || propNameBuf == "border") {
       style.borderLeftStyle = parsedStyle;
       style.defined.borderLeftStyle = 1;
-      if (hasWidth) style.defined.borderLeftWidthZero = widthIsZero ? 1 : 0;
+      if (hasWidth) {
+        if (widthIsZero) {
+          style.defined.borderLeftWidthZero = 1;
+          style.defined.borderLeftWidthSet = 0;
+        } else {
+          style.defined.borderLeftWidthSet = 1;
+          style.defined.borderLeftWidthZero = 0;
+        }
+      } else if (hasStyle) {
+        style.defined.borderLeftWidthSet = 1;
+        style.defined.borderLeftWidthZero = 0;
+      }
     }
     if (propNameBuf == "border-right" || propNameBuf == "border") {
       style.borderRightStyle = parsedStyle;
       style.defined.borderRightStyle = 1;
-      if (hasWidth) style.defined.borderRightWidthZero = widthIsZero ? 1 : 0;
+      if (hasWidth) {
+        if (widthIsZero) {
+          style.defined.borderRightWidthZero = 1;
+          style.defined.borderRightWidthSet = 0;
+        } else {
+          style.defined.borderRightWidthSet = 1;
+          style.defined.borderRightWidthZero = 0;
+        }
+      } else if (hasStyle) {
+        style.defined.borderRightWidthSet = 1;
+        style.defined.borderRightWidthZero = 0;
+      }
     }
   }
 }
@@ -866,6 +968,10 @@ bool CssParser::saveToCache() const {
     if (style.defined.borderBottomWidthZero) definedBits |= 1 << 21;
     if (style.defined.borderLeftWidthZero) definedBits |= 1 << 22;
     if (style.defined.borderRightWidthZero) definedBits |= 1 << 23;
+    if (style.defined.borderTopWidthSet) definedBits |= 1 << 24;
+    if (style.defined.borderBottomWidthSet) definedBits |= 1 << 25;
+    if (style.defined.borderLeftWidthSet) definedBits |= 1 << 26;
+    if (style.defined.borderRightWidthSet) definedBits |= 1 << 27;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
   }
 
@@ -1062,6 +1168,10 @@ bool CssParser::loadFromCache() {
     style.defined.borderBottomWidthZero = (definedBits & 1 << 21) != 0;
     style.defined.borderLeftWidthZero = (definedBits & 1 << 22) != 0;
     style.defined.borderRightWidthZero = (definedBits & 1 << 23) != 0;
+    style.defined.borderTopWidthSet = (definedBits & 1 << 24) != 0;
+    style.defined.borderBottomWidthSet = (definedBits & 1 << 25) != 0;
+    style.defined.borderLeftWidthSet = (definedBits & 1 << 26) != 0;
+    style.defined.borderRightWidthSet = (definedBits & 1 << 27) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -75,6 +75,12 @@ std::string_view stripTrailingImportant(std::string_view value) {
   return value;
 }
 
+// Checks if a normalized token is a known CSS border-style keyword.
+bool isBorderStyleKeyword(const std::string& token) {
+  return token == "none" || token == "hidden" || token == "solid" || token == "dotted" || token == "dashed" ||
+         token == "double" || token == "groove" || token == "ridge" || token == "inset" || token == "outset";
+}
+
 }  // anonymous namespace
 
 // String utilities implementation
@@ -406,6 +412,52 @@ void CssParser::parseDeclarationIntoStyle(const std::string& decl, CssStyle& sty
       style.borderLeftStyle = values.size() >= 4 ? interpretBorderStyle(values[3]) : style.borderRightStyle;
       style.defined.borderTopStyle = style.defined.borderRightStyle = style.defined.borderBottomStyle =
           style.defined.borderLeftStyle = 1;
+    }
+  } else if (propNameBuf == "border" || propNameBuf == "border-top" || propNameBuf == "border-bottom" ||
+             propNameBuf == "border-left" || propNameBuf == "border-right") {
+    // Parse compound border shorthand: <width> <style> <color> in any order.
+    // Width keywords (thin/medium/thick) and color values are recognized but ignored beyond
+    // determining whether the width is non-zero.
+    const auto tokens = splitWhitespace(propValueBuf);
+    CssBorderStyle parsedStyle = CssBorderStyle::None;
+    bool hasStyle = false;
+    bool widthIsZero = false;
+    bool hasWidth = false;
+
+    for (const auto& token : tokens) {
+      CssLength len;
+      if (tryInterpretLength(token, len)) {
+        hasWidth = true;
+        widthIsZero = (len.value == 0.0f);
+      } else if (token == "thin" || token == "medium" || token == "thick") {
+        hasWidth = true;
+        widthIsZero = false;
+      } else if (isBorderStyleKeyword(token)) {
+        hasStyle = true;
+        parsedStyle = interpretBorderStyle(token);
+      }
+      // Any remaining tokens are colors — ignored for monochrome e-ink rendering.
+    }
+
+    if (propNameBuf == "border-top" || propNameBuf == "border") {
+      style.borderTopStyle = parsedStyle;
+      style.defined.borderTopStyle = 1;
+      if (hasWidth) style.defined.borderTopWidthZero = widthIsZero ? 1 : 0;
+    }
+    if (propNameBuf == "border-bottom" || propNameBuf == "border") {
+      style.borderBottomStyle = parsedStyle;
+      style.defined.borderBottomStyle = 1;
+      if (hasWidth) style.defined.borderBottomWidthZero = widthIsZero ? 1 : 0;
+    }
+    if (propNameBuf == "border-left" || propNameBuf == "border") {
+      style.borderLeftStyle = parsedStyle;
+      style.defined.borderLeftStyle = 1;
+      if (hasWidth) style.defined.borderLeftWidthZero = widthIsZero ? 1 : 0;
+    }
+    if (propNameBuf == "border-right" || propNameBuf == "border") {
+      style.borderRightStyle = parsedStyle;
+      style.defined.borderRightStyle = 1;
+      if (hasWidth) style.defined.borderRightWidthZero = widthIsZero ? 1 : 0;
     }
   }
 }

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -31,7 +31,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 4;
+  static constexpr uint8_t CSS_CACHE_VERSION = 5;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;
@@ -120,6 +120,7 @@ class CssParser {
   static CssFontStyle interpretFontStyle(const std::string& val);
   static CssFontWeight interpretFontWeight(const std::string& val);
   static CssTextDecoration interpretDecoration(const std::string& val);
+  static CssBorderStyle interpretBorderStyle(const std::string& val);
   static CssLength interpretLength(const std::string& val);
   /** Returns true only when a numeric length was parsed (e.g. 2em, 50%). False for auto/inherit/initial. */
   static bool tryInterpretLength(const std::string& val, CssLength& out);

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -88,6 +88,12 @@ struct CssPropertyFlags {
   uint32_t borderBottomWidthZero : 1;
   uint32_t borderLeftWidthZero : 1;
   uint32_t borderRightWidthZero : 1;
+  // Set when the corresponding border-*-width was explicitly parsed as non-zero.
+  // Used during cascade to clear a lower-priority WidthZero flag.
+  uint32_t borderTopWidthSet : 1;
+  uint32_t borderBottomWidthSet : 1;
+  uint32_t borderLeftWidthSet : 1;
+  uint32_t borderRightWidthSet : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -113,13 +119,18 @@ struct CssPropertyFlags {
         borderTopWidthZero(0),
         borderBottomWidthZero(0),
         borderLeftWidthZero(0),
-        borderRightWidthZero(0) {}
+        borderRightWidthZero(0),
+        borderTopWidthSet(0),
+        borderBottomWidthSet(0),
+        borderLeftWidthSet(0),
+        borderRightWidthSet(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
            imageWidth || display || borderTopStyle || borderBottomStyle || borderLeftStyle || borderRightStyle ||
-           borderTopWidthZero || borderBottomWidthZero || borderLeftWidthZero || borderRightWidthZero;
+           borderTopWidthZero || borderBottomWidthZero || borderLeftWidthZero || borderRightWidthZero ||
+           borderTopWidthSet || borderBottomWidthSet || borderLeftWidthSet || borderRightWidthSet;
   }
 
   void clearAll() {
@@ -129,6 +140,7 @@ struct CssPropertyFlags {
     imageHeight = imageWidth = display = 0;
     borderTopStyle = borderBottomStyle = borderLeftStyle = borderRightStyle = 0;
     borderTopWidthZero = borderBottomWidthZero = borderLeftWidthZero = borderRightWidthZero = 0;
+    borderTopWidthSet = borderBottomWidthSet = borderLeftWidthSet = borderRightWidthSet = 0;
   }
 };
 
@@ -243,11 +255,36 @@ struct CssStyle {
       borderRightStyle = base.borderRightStyle;
       defined.borderRightStyle = 1;
     }
-    // Width-zero flags: propagate from base (inline/overriding style) when explicitly set.
-    if (base.defined.borderTopWidthZero) defined.borderTopWidthZero = 1;
-    if (base.defined.borderBottomWidthZero) defined.borderBottomWidthZero = 1;
-    if (base.defined.borderLeftWidthZero) defined.borderLeftWidthZero = 1;
-    if (base.defined.borderRightWidthZero) defined.borderRightWidthZero = 1;
+    // Width flags: propagate from base (inline/overriding style) when explicitly set.
+    // WidthSet (non-zero) and WidthZero are mutually exclusive; the incoming style wins.
+    if (base.defined.borderTopWidthSet) {
+      defined.borderTopWidthSet = 1;
+      defined.borderTopWidthZero = 0;
+    } else if (base.defined.borderTopWidthZero) {
+      defined.borderTopWidthZero = 1;
+      defined.borderTopWidthSet = 0;
+    }
+    if (base.defined.borderBottomWidthSet) {
+      defined.borderBottomWidthSet = 1;
+      defined.borderBottomWidthZero = 0;
+    } else if (base.defined.borderBottomWidthZero) {
+      defined.borderBottomWidthZero = 1;
+      defined.borderBottomWidthSet = 0;
+    }
+    if (base.defined.borderLeftWidthSet) {
+      defined.borderLeftWidthSet = 1;
+      defined.borderLeftWidthZero = 0;
+    } else if (base.defined.borderLeftWidthZero) {
+      defined.borderLeftWidthZero = 1;
+      defined.borderLeftWidthSet = 0;
+    }
+    if (base.defined.borderRightWidthSet) {
+      defined.borderRightWidthSet = 1;
+      defined.borderRightWidthZero = 0;
+    } else if (base.defined.borderRightWidthZero) {
+      defined.borderRightWidthZero = 1;
+      defined.borderRightWidthSet = 0;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -270,6 +307,10 @@ struct CssStyle {
   [[nodiscard]] bool hasBorderBottomStyle() const { return defined.borderBottomStyle; }
   [[nodiscard]] bool hasBorderLeftStyle() const { return defined.borderLeftStyle; }
   [[nodiscard]] bool hasBorderRightStyle() const { return defined.borderRightStyle; }
+  [[nodiscard]] bool hasBorderTopWidthSet() const { return defined.borderTopWidthSet; }
+  [[nodiscard]] bool hasBorderBottomWidthSet() const { return defined.borderBottomWidthSet; }
+  [[nodiscard]] bool hasBorderLeftWidthSet() const { return defined.borderLeftWidthSet; }
+  [[nodiscard]] bool hasBorderRightWidthSet() const { return defined.borderRightWidthSet; }
   // Returns true if the border side is both styled solid AND has a non-zero width.
   [[nodiscard]] bool isBorderTopVisible() const {
     return borderTopStyle != CssBorderStyle::None && !defined.borderTopWidthZero;

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -57,24 +57,37 @@ enum class CssTextDecoration : uint8_t { None = 0, Underline = 1 };
 // Display options - only None and Block are relevant for e-ink rendering
 enum class CssDisplay : uint8_t { Block = 0, None = 1 };
 
+// Border style options - controls table border rendering
+enum class CssBorderStyle : uint8_t { Solid = 0, None = 1 };
+
 // Bitmask for tracking which properties have been explicitly set
 struct CssPropertyFlags {
-  uint16_t textAlign : 1;
-  uint16_t fontStyle : 1;
-  uint16_t fontWeight : 1;
-  uint16_t textDecoration : 1;
-  uint16_t textIndent : 1;
-  uint16_t marginTop : 1;
-  uint16_t marginBottom : 1;
-  uint16_t marginLeft : 1;
-  uint16_t marginRight : 1;
-  uint16_t paddingTop : 1;
-  uint16_t paddingBottom : 1;
-  uint16_t paddingLeft : 1;
-  uint16_t paddingRight : 1;
-  uint16_t imageHeight : 1;
-  uint16_t imageWidth : 1;
-  uint16_t display : 1;
+  uint32_t textAlign : 1;
+  uint32_t fontStyle : 1;
+  uint32_t fontWeight : 1;
+  uint32_t textDecoration : 1;
+  uint32_t textIndent : 1;
+  uint32_t marginTop : 1;
+  uint32_t marginBottom : 1;
+  uint32_t marginLeft : 1;
+  uint32_t marginRight : 1;
+  uint32_t paddingTop : 1;
+  uint32_t paddingBottom : 1;
+  uint32_t paddingLeft : 1;
+  uint32_t paddingRight : 1;
+  uint32_t imageHeight : 1;
+  uint32_t imageWidth : 1;
+  uint32_t display : 1;
+  uint32_t borderTopStyle : 1;
+  uint32_t borderBottomStyle : 1;
+  uint32_t borderLeftStyle : 1;
+  uint32_t borderRightStyle : 1;
+  // Set when the corresponding border-*-width was explicitly parsed as 0.
+  // A side is invisible when style==Solid but this bit is set.
+  uint32_t borderTopWidthZero : 1;
+  uint32_t borderBottomWidthZero : 1;
+  uint32_t borderLeftWidthZero : 1;
+  uint32_t borderRightWidthZero : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -92,12 +105,21 @@ struct CssPropertyFlags {
         paddingRight(0),
         imageHeight(0),
         imageWidth(0),
-        display(0) {}
+        display(0),
+        borderTopStyle(0),
+        borderBottomStyle(0),
+        borderLeftStyle(0),
+        borderRightStyle(0),
+        borderTopWidthZero(0),
+        borderBottomWidthZero(0),
+        borderLeftWidthZero(0),
+        borderRightWidthZero(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display;
+           imageWidth || display || borderTopStyle || borderBottomStyle || borderLeftStyle || borderRightStyle ||
+           borderTopWidthZero || borderBottomWidthZero || borderLeftWidthZero || borderRightWidthZero;
   }
 
   void clearAll() {
@@ -105,6 +127,8 @@ struct CssPropertyFlags {
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
     imageHeight = imageWidth = display = 0;
+    borderTopStyle = borderBottomStyle = borderLeftStyle = borderRightStyle = 0;
+    borderTopWidthZero = borderBottomWidthZero = borderLeftWidthZero = borderRightWidthZero = 0;
   }
 };
 
@@ -129,6 +153,10 @@ struct CssStyle {
   CssLength imageHeight;    // Height for img (e.g. 2em) – width derived from aspect ratio when only height set
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;  // display property (Block or None)
+  CssBorderStyle borderTopStyle = CssBorderStyle::None;
+  CssBorderStyle borderBottomStyle = CssBorderStyle::None;
+  CssBorderStyle borderLeftStyle = CssBorderStyle::None;
+  CssBorderStyle borderRightStyle = CssBorderStyle::None;
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -199,6 +227,27 @@ struct CssStyle {
       display = base.display;
       defined.display = 1;
     }
+    if (base.hasBorderTopStyle()) {
+      borderTopStyle = base.borderTopStyle;
+      defined.borderTopStyle = 1;
+    }
+    if (base.hasBorderBottomStyle()) {
+      borderBottomStyle = base.borderBottomStyle;
+      defined.borderBottomStyle = 1;
+    }
+    if (base.hasBorderLeftStyle()) {
+      borderLeftStyle = base.borderLeftStyle;
+      defined.borderLeftStyle = 1;
+    }
+    if (base.hasBorderRightStyle()) {
+      borderRightStyle = base.borderRightStyle;
+      defined.borderRightStyle = 1;
+    }
+    // Width-zero flags: propagate from base (inline/overriding style) when explicitly set.
+    if (base.defined.borderTopWidthZero) defined.borderTopWidthZero = 1;
+    if (base.defined.borderBottomWidthZero) defined.borderBottomWidthZero = 1;
+    if (base.defined.borderLeftWidthZero) defined.borderLeftWidthZero = 1;
+    if (base.defined.borderRightWidthZero) defined.borderRightWidthZero = 1;
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -217,6 +266,26 @@ struct CssStyle {
   [[nodiscard]] bool hasImageHeight() const { return defined.imageHeight; }
   [[nodiscard]] bool hasImageWidth() const { return defined.imageWidth; }
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
+  [[nodiscard]] bool hasBorderTopStyle() const { return defined.borderTopStyle; }
+  [[nodiscard]] bool hasBorderBottomStyle() const { return defined.borderBottomStyle; }
+  [[nodiscard]] bool hasBorderLeftStyle() const { return defined.borderLeftStyle; }
+  [[nodiscard]] bool hasBorderRightStyle() const { return defined.borderRightStyle; }
+  // Returns true if the border side is both styled solid AND has a non-zero width.
+  [[nodiscard]] bool isBorderTopVisible() const {
+    return borderTopStyle != CssBorderStyle::None && !defined.borderTopWidthZero;
+  }
+  [[nodiscard]] bool isBorderBottomVisible() const {
+    return borderBottomStyle != CssBorderStyle::None && !defined.borderBottomWidthZero;
+  }
+  [[nodiscard]] bool isBorderLeftVisible() const {
+    return borderLeftStyle != CssBorderStyle::None && !defined.borderLeftWidthZero;
+  }
+  [[nodiscard]] bool isBorderRightVisible() const {
+    return borderRightStyle != CssBorderStyle::None && !defined.borderRightWidthZero;
+  }
+  [[nodiscard]] bool hasBorderStyle() const {
+    return defined.borderTopStyle || defined.borderBottomStyle || defined.borderLeftStyle || defined.borderRightStyle;
+  }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -228,6 +297,7 @@ struct CssStyle {
     paddingTop = paddingBottom = paddingLeft = paddingRight = CssLength{};
     imageHeight = imageWidth = CssLength{};
     display = CssDisplay::Block;
+    borderTopStyle = borderBottomStyle = borderLeftStyle = borderRightStyle = CssBorderStyle::None;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -301,7 +301,13 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
           if (cs > 1 && cs <= 64) cellColspan = static_cast<uint8_t>(cs);
         } else if (strcmp(atts[i], "rowspan") == 0) {
           const int rs = atoi(atts[i + 1]);
-          if (rs > 1 && rs <= 64) cellRowspan = static_cast<uint8_t>(rs);
+          if (rs == 0)
+            cellRowspan = 64;  // HTML rowspan="0" = span to end of table group
+          else if (rs > 1 && rs <= 64)
+            // Reject colspan values outside the range of [1, 64] to
+            // prevent the phantom-cell loop in layout from running out of memory or looping excessively.
+            // (64 is somewhat arbitrary but should be more than enough for any reasonable table;)
+            cellRowspan = static_cast<uint8_t>(rs);
         }
       }
     }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -340,7 +340,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     newCell.colspan = cellColspan;
     newCell.rowspan = cellRowspan;
 
-    self->currentTextBlock.reset(new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled, cellBlockStyle));
+    self->currentTextBlock.reset(new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled,
+                                                self->focusReadingEnabled, cellBlockStyle));
     self->inTableCellMode = true;
 
     // Bold/italic from CSS or <th> default.
@@ -1098,7 +1099,8 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     }
     self->inTableCellMode = false;
     // Reset currentTextBlock for any content between </td> and next <td>/<tr>
-    self->currentTextBlock.reset(new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled));
+    self->currentTextBlock.reset(
+        new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled, self->focusReadingEnabled));
     self->nextWordContinues = false;
   }
 
@@ -1344,7 +1346,8 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
         placeholderStyle.alignment = CssTextAlign::Center;
 
         auto placeholder =
-            std::make_shared<TextBlock>(std::move(words), std::move(xpos), std::move(styles), placeholderStyle);
+            std::make_shared<TextBlock>(std::move(words), std::move(xpos), std::move(styles), std::vector<uint8_t>{},
+                                        std::vector<uint16_t>{}, placeholderStyle);
         self->currentPage->elements.push_back(std::make_shared<PageLine>(placeholder, 0, self->currentPageNextY));
         self->currentPageNextY += lh;
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1330,6 +1330,27 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
           static_cast<int16_t>(numCols > 0 ? self->viewportWidth / numCols : self->viewportWidth);
       const auto lh = static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
 
+      if (numCols > 64) {
+        LOG_ERR("EHP", "Table too wide (%u cols), rendering placeholder", numCols);
+        if (!self->currentPage) {
+          self->currentPage.reset(new Page());
+          self->currentPageNextY = 0;
+        }
+        std::vector<std::string> words = {"[Table too wide]"};
+        std::vector<int16_t> xpos = {0};
+        std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::REGULAR};
+        BlockStyle placeholderStyle;
+        placeholderStyle.textAlignDefined = true;
+        placeholderStyle.alignment = CssTextAlign::Center;
+
+        auto placeholder =
+            std::make_shared<TextBlock>(std::move(words), std::move(xpos), std::move(styles), placeholderStyle);
+        self->currentPage->elements.push_back(std::make_shared<PageLine>(placeholder, 0, self->currentPageNextY));
+        self->currentPageNextY += lh;
+
+        self->tableAccumRows.clear();
+      }
+
       // Emit rows across one or more pages, splitting when the remaining rows don't fit.
       size_t rowStart = 0;
       size_t totalRows = self->tableAccumRows.size();  // non-const: may grow if a row is split

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1166,8 +1166,11 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
           for (const auto& ca : row.cells) {
             if (ca.colspan == 1 && ca.requestedWidth > 0) {
               if (logCol < numCols) {
-                slotWidths[logCol] = ca.requestedWidth;
-                totalExplicit += ca.requestedWidth;
+                // CSS width is content-box; column width must include horizontal padding
+                // so that textWidth = cellColWidth - 1 - padL - padR ≈ requestedWidth - 1
+                const int16_t colW = static_cast<int16_t>(ca.requestedWidth + ca.paddingLeft + ca.paddingRight);
+                slotWidths[logCol] = colW;
+                totalExplicit += colW;
               }
             } else {
               // Spanning or unspecified: leave slots as 0 (unspecified).
@@ -1184,6 +1187,16 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
           self->tableColWidths.reserve(numCols);
           for (auto w : slotWidths) {
             self->tableColWidths.push_back(w > 0 ? w : fallback);
+          }
+          // Scale columns proportionally to fit viewport
+          // (must happen here so text layout uses the scaled widths)
+          int16_t totalColW = 0;
+          for (auto w : self->tableColWidths) totalColW += w;
+          if (totalColW > 0 && totalColW != self->viewportWidth) {
+            const float scale = static_cast<float>(self->viewportWidth) / totalColW;
+            for (auto& w : self->tableColWidths) {
+              w = static_cast<int16_t>(std::max(1.0f, w * scale));
+            }
           }
         }
       }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1364,7 +1364,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
         // Flush if the page is already full.
         if (self->currentPageNextY >= self->viewportHeight) {
-          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
           self->completedPageCount++;
           self->currentPage.reset(new Page());
           self->currentPageNextY = 0;
@@ -1391,7 +1391,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
         // If no rows fit on a non-empty page, flush and retry from a fresh page.
         if (rowEnd == rowStart && self->currentPageNextY > 0) {
-          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
           self->completedPageCount++;
           self->currentPage.reset(new Page());
           self->currentPageNextY = 0;
@@ -1484,7 +1484,7 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
 
         // Flush the page if more rows still need to be placed.
         if (rowStart < totalRows) {
-          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
           self->completedPageCount++;
           self->currentPage.reset();
           self->currentPageNextY = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1259,6 +1259,70 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     self->nextWordContinues = false;
 
     if (!self->tableAccumRows.empty() && self->tableTotalCols > 0) {
+      // Distribute spanning cell lines evenly across the rows they span.
+      // Without this, all content sits in the first row, making it extremely
+      // tall while spanned rows are tiny — causing uneven heights in adjacent
+      // columns and poor page splits.
+      for (size_t ri = 0; ri < self->tableAccumRows.size(); ri++) {
+        uint8_t logCol = 0;
+        for (auto& ca : self->tableAccumRows[ri].cells) {
+          if (ca.rowspan > 1 && ca.colspan == 1) {
+            const size_t endRow = std::min(ri + static_cast<size_t>(ca.rowspan), self->tableAccumRows.size());
+            const size_t numSpanned = endRow - ri;
+            if (!ca.lines.empty() && numSpanned > 1) {
+              const uint8_t linesPerRow =
+                  std::max(uint8_t(1), static_cast<uint8_t>((ca.lines.size() + numSpanned - 1) / numSpanned));
+              const uint8_t targetLogCol = logCol;
+              std::vector<std::shared_ptr<TextBlock>> allLines = std::move(ca.lines);
+              std::vector<std::shared_ptr<TextBlock>> chunk;
+              chunk.reserve(linesPerRow);
+              size_t srcIdx = 0;
+              for (size_t i = 0; i < numSpanned && srcIdx < allLines.size(); i++) {
+                const size_t r = ri + i;
+                const uint8_t count = std::min(linesPerRow, static_cast<uint8_t>(allLines.size() - srcIdx));
+                chunk.clear();
+                for (uint8_t j = 0; j < count; j++) {
+                  chunk.push_back(std::move(allLines[srcIdx++]));
+                }
+                if (i == 0) {
+                  ca.lines = std::move(chunk);
+                } else {
+                  uint8_t plc = 0;
+                  for (auto& pca : self->tableAccumRows[r].cells) {
+                    if (plc == targetLogCol && pca.rowspan == 0) {
+                      pca.lines = std::move(chunk);
+                      pca.paddingLeft = ca.paddingLeft;
+                      pca.paddingRight = ca.paddingRight;
+                      pca.paddingTop = ca.paddingTop;
+                      pca.paddingBottom = ca.paddingBottom;
+                      break;
+                    }
+                    plc = static_cast<uint8_t>(plc + ((pca.rowspan == 0) ? 1 : pca.colspan));
+                  }
+                }
+              }
+            }
+          }
+          logCol = static_cast<uint8_t>(logCol + ((ca.rowspan == 0) ? 1 : ca.colspan));
+        }
+      }
+
+      // Recompute row metrics after distribution.
+      for (auto& row : self->tableAccumRows) {
+        uint8_t maxLines = 0;
+        int16_t maxPadTop = TableBlock::CELL_PADDING_Y;
+        int16_t maxPadBot = TableBlock::CELL_PADDING_Y;
+        for (auto& ca : row.cells) {
+          const auto lineCount = static_cast<uint8_t>(std::min(ca.lines.size(), size_t(255)));
+          if (lineCount > maxLines) maxLines = lineCount;
+          if (ca.paddingTop > maxPadTop) maxPadTop = ca.paddingTop;
+          if (ca.paddingBottom > maxPadBot) maxPadBot = ca.paddingBottom;
+        }
+        row.maxLines = maxLines;
+        row.maxPaddingTop = maxPadTop;
+        row.maxPaddingBottom = maxPadBot;
+      }
+
       const auto numCols = static_cast<uint8_t>(self->tableTotalCols);
       // Use established per-column widths, or fall back to equal distribution.
       const bool hasPerColWidths = (static_cast<int>(self->tableColWidths.size()) == numCols);

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -12,6 +12,7 @@
 
 #include "Epub.h"
 #include "Epub/Page.h"
+#include "Epub/blocks/TableBlock.h"
 #include "Epub/converters/ImageDecoderFactory.h"
 #include "Epub/converters/ImageToFramebufferDecoder.h"
 #include "Epub/htmlEntities.h"
@@ -27,6 +28,29 @@ constexpr const char* ITALIC_TAGS[] = {"i", "em"};
 constexpr const char* UNDERLINE_TAGS[] = {"u", "ins"};
 constexpr const char* IMAGE_TAGS[] = {"img"};
 constexpr const char* SKIP_TAGS[] = {"head"};
+
+// Parse an HTML width attribute value to pixels.
+// Returns 0 if the value is empty or unparseable.
+static int16_t parseHtmlWidthAttr(const char* s, int16_t viewportWidth, float emSize) {
+  if (!s || !*s) return 0;
+  char* end;
+  const float val = strtof(s, &end);
+  if (end == s) return 0;  // no numeric part
+  while (*end == ' ') ++end;
+  if (*end == '%') {
+    return static_cast<int16_t>(val * viewportWidth / 100.0f);
+  }
+  if (strncmp(end, "em", 2) == 0) {
+    return static_cast<int16_t>(val * emSize);
+  }
+  if (strncmp(end, "rem", 3) == 0) {
+    return static_cast<int16_t>(val * emSize);
+  }
+  if (strncmp(end, "pt", 2) == 0) {
+    return static_cast<int16_t>(val * 1.33f);
+  }
+  return static_cast<int16_t>(val);  // treat bare number or px as pixels
+}
 
 bool isWhitespace(const char c) { return c == ' ' || c == '\r' || c == '\n' || c == '\t'; }
 
@@ -116,6 +140,10 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 // start a new text block if needed
 void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
   nextWordContinues = false;  // New block = new paragraph, no continuation
+  if (inTableCellMode) {
+    // Inside a table cell: merge all content into the single cell ParsedText without resetting.
+    return;
+  }
   if (currentTextBlock) {
     // already have a text block running and it is empty - just reuse it
     if (currentTextBlock->isEmpty()) {
@@ -199,9 +227,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     return;
   }
 
-  // Special handling for tables/cells: flatten into per-cell paragraphs with a prefixed header.
+  // Table handling: accumulate cells per row, lay out at </tr>, emit PageTable at </table>.
   if (strcmp(name, "table") == 0) {
-    // skip nested tables
+    // Nested tables are not supported — skip their content
     if (self->tableDepth > 0) {
       self->tableDepth += 1;
       return;
@@ -210,16 +238,28 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
     }
+    // Flush any pre-table text block to the page before starting accumulation
+    if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
+      self->makePages();
+    }
     self->tableDepth += 1;
-    self->tableRowIndex = 0;
-    self->tableColIndex = 0;
+    self->tableAccumRows.clear();
+    self->tableAccumRows.reserve(8);  // conservative estimate; avoids reallocation for typical tables
+    self->tableTotalCols = 0;
+    self->tableRowspanTracker.clear();
+    // Border declared on the <table> element itself.
+    // Handles e.g. <table style="border: 1px solid"> or a CSS rule like
+    // "table { border-style: solid }" that targets the table directly.
+    self->tableDrawBorderTop = cssStyle.isBorderTopVisible();
+    self->tableDrawBorderBottom = cssStyle.isBorderBottomVisible();
+    self->tableDrawBorderLeft = cssStyle.isBorderLeftVisible();
+    self->tableDrawBorderRight = cssStyle.isBorderRightVisible();
     self->depth += 1;
     return;
   }
 
   if (self->tableDepth == 1 && strcmp(name, "tr") == 0) {
-    self->tableRowIndex += 1;
-    self->tableColIndex = 0;
+    self->tableAccumRows.emplace_back();
     self->depth += 1;
     return;
   }
@@ -228,35 +268,105 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
     }
-    self->tableColIndex += 1;
 
-    auto tableCellBlockStyle = BlockStyle();
-    tableCellBlockStyle.textAlignDefined = true;
-    const auto align = (self->paragraphAlignment == static_cast<uint8_t>(CssTextAlign::None))
-                           ? CssTextAlign::Justify
-                           : static_cast<CssTextAlign>(self->paragraphAlignment);
-    tableCellBlockStyle.alignment = align;
-    self->startNewTextBlock(tableCellBlockStyle);
-
-    const std::string headerText =
-        "Tab Row " + std::to_string(self->tableRowIndex) + ", Cell " + std::to_string(self->tableColIndex) + ":";
-    StyleStackEntry headerStyle;
-    headerStyle.depth = self->depth;
-    headerStyle.hasBold = true;
-    headerStyle.bold = false;
-    headerStyle.hasItalic = true;
-    headerStyle.italic = true;
-    headerStyle.hasUnderline = true;
-    headerStyle.underline = false;
-    self->inlineStyleStack.push_back(headerStyle);
-    self->updateEffectiveInlineStyle();
-    self->characterData(userData, headerText.c_str(), static_cast<int>(headerText.length()));
-    if (self->partWordBufferIndex > 0) {
-      self->flushPartWordBuffer();
+    // Guard against malformed HTML where <td> appears without a prior <tr>
+    if (self->tableAccumRows.empty()) {
+      self->tableAccumRows.emplace_back();
     }
-    self->nextWordContinues = false;
-    self->inlineStyleStack.pop_back();
-    self->updateEffectiveInlineStyle();
+
+    // --- CSS / attribute resolution for this cell ---
+    // `cssStyle` was already computed at the top of startElement (name+classAttr+styleAttr).
+    const float emSize = static_cast<float>(self->renderer.getFontAscenderSize(self->fontId));
+    const float vw = static_cast<float>(self->viewportWidth);
+
+    // Cell padding: CSS > default
+    const int16_t defPadX = TableBlock::CELL_PADDING_X;
+    const int16_t defPadY = TableBlock::CELL_PADDING_Y;
+    const int16_t padLeft = cssStyle.hasPaddingLeft() ? cssStyle.paddingLeft.toPixelsInt16(emSize, vw) : defPadX;
+    const int16_t padRight = cssStyle.hasPaddingRight() ? cssStyle.paddingRight.toPixelsInt16(emSize, vw) : defPadX;
+    const int16_t padTop = cssStyle.hasPaddingTop() ? cssStyle.paddingTop.toPixelsInt16(emSize, vw) : defPadY;
+    const int16_t padBottom = cssStyle.hasPaddingBottom() ? cssStyle.paddingBottom.toPixelsInt16(emSize, vw) : defPadY;
+
+    // Cell column width: HTML width attr > CSS width > 0 (unspecified)
+    // Also parse colspan.
+    int16_t reqWidth = 0;
+    uint8_t cellColspan = 1;
+    uint8_t cellRowspan = 1;
+    if (atts != nullptr) {
+      for (int i = 0; atts[i]; i += 2) {
+        if (strcmp(atts[i], "width") == 0) {
+          reqWidth = parseHtmlWidthAttr(atts[i + 1], static_cast<int16_t>(self->viewportWidth), emSize);
+        } else if (strcmp(atts[i], "colspan") == 0) {
+          const int cs = atoi(atts[i + 1]);
+          if (cs > 1 && cs <= 64) cellColspan = static_cast<uint8_t>(cs);
+        } else if (strcmp(atts[i], "rowspan") == 0) {
+          const int rs = atoi(atts[i + 1]);
+          if (rs > 1 && rs <= 64) cellRowspan = static_cast<uint8_t>(rs);
+        }
+      }
+    }
+    if (reqWidth == 0 && cssStyle.hasImageWidth()) {
+      reqWidth = cssStyle.imageWidth.toPixelsInt16(emSize, vw);
+    }
+
+    // Text alignment: CSS > user preference > justify
+    CssTextAlign cellAlign;
+    if (cssStyle.hasTextAlign()) {
+      cellAlign = cssStyle.textAlign;
+    } else if (self->paragraphAlignment != static_cast<uint8_t>(CssTextAlign::None)) {
+      cellAlign = static_cast<CssTextAlign>(self->paragraphAlignment);
+    } else {
+      cellAlign = CssTextAlign::Justify;
+    }
+
+    BlockStyle cellBlockStyle;
+    cellBlockStyle.textAlignDefined = true;
+    cellBlockStyle.alignment = cellAlign;
+
+    // Push a new cell and populate its padding + width.
+    self->tableAccumRows.back().cells.emplace_back();
+    auto& newCell = self->tableAccumRows.back().cells.back();
+    newCell.paddingLeft = padLeft;
+    newCell.paddingRight = padRight;
+    newCell.paddingTop = padTop;
+    newCell.paddingBottom = padBottom;
+    newCell.requestedWidth = reqWidth;
+    newCell.colspan = cellColspan;
+    newCell.rowspan = cellRowspan;
+
+    self->currentTextBlock.reset(new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled, cellBlockStyle));
+    self->inTableCellMode = true;
+
+    // Bold/italic from CSS or <th> default.
+    if (cssStyle.hasFontWeight()) {
+      StyleStackEntry entry;
+      entry.depth = self->depth;
+      entry.hasBold = true;
+      entry.bold = (cssStyle.fontWeight == CssFontWeight::Bold);
+      self->inlineStyleStack.push_back(entry);
+      self->updateEffectiveInlineStyle();
+    } else if (strcmp(name, "th") == 0) {
+      // <th> default: bold
+      self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
+      self->updateEffectiveInlineStyle();
+    }
+    if (cssStyle.hasFontStyle()) {
+      StyleStackEntry entry;
+      entry.depth = self->depth;
+      entry.hasItalic = true;
+      entry.italic = (cssStyle.fontStyle == CssFontStyle::Italic);
+      self->inlineStyleStack.push_back(entry);
+      self->updateEffectiveInlineStyle();
+    }
+
+    // Border declared on individual <td>/<th> cells rather than on <table>.
+    // Some EPUBs use border-collapse:collapse on the table
+    // with no border-style on the table element; the actual borders live on each cell.
+    // OR in each cell's per-side flags to accumulate the full set of visible borders.
+    self->tableDrawBorderTop |= cssStyle.isBorderTopVisible();
+    self->tableDrawBorderBottom |= cssStyle.isBorderBottomVisible();
+    self->tableDrawBorderLeft |= cssStyle.isBorderLeftVisible();
+    self->tableDrawBorderRight |= cssStyle.isBorderRightVisible();
 
     self->depth += 1;
     return;
@@ -879,11 +989,9 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
 
-  // If we have > 750 words buffered up, perform the layout and consume out all but the last line
-  // There should be enough here to build out 1-2 full pages and doing this will free up a lot of
-  // memory.
-  // Spotted when reading Intermezzo, there are some really long text blocks in there.
-  if (self->currentTextBlock->size() > 750) {
+  // If we have > 750 words buffered up, perform the layout and consume out all but the last line.
+  // Skip this optimisation inside table cells — cells are laid out in bulk at </tr>.
+  if (!self->inTableCellMode && self->currentTextBlock->size() > 750) {
     LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
     const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
     const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
@@ -977,18 +1085,317 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 
   if (self->tableDepth == 1 && (strcmp(name, "td") == 0 || strcmp(name, "th") == 0)) {
+    // Move the accumulated cell ParsedText into the cell accumulator for later layout
+    if (!self->tableAccumRows.empty()) {
+      auto& cell = self->tableAccumRows.back().cells.back();
+      cell.text = std::move(self->currentTextBlock);
+    }
+    self->inTableCellMode = false;
+    // Reset currentTextBlock for any content between </td> and next <td>/<tr>
+    self->currentTextBlock.reset(new ParsedText(self->extraParagraphSpacing, self->hyphenationEnabled));
     self->nextWordContinues = false;
   }
 
-  if (self->tableDepth == 1 && (strcmp(name, "tr") == 0)) {
+  if (self->tableDepth == 1 && strcmp(name, "tr") == 0) {
+    // Layout all cells in this row now that we know the column count
+    if (!self->tableAccumRows.empty()) {
+      auto& row = self->tableAccumRows.back();
+
+      // Interleave phantom cells for columns occupied by rowspan cells from previous rows.
+      {
+        std::vector<TableCellAccum> interleaved;
+        interleaved.reserve(row.cells.size() + self->tableRowspanTracker.size());
+        uint8_t lc = 0;
+        for (auto& ca : row.cells) {
+          // Insert a phantom for each occupied column before this cell.
+          while (lc < static_cast<uint8_t>(self->tableRowspanTracker.size()) && self->tableRowspanTracker[lc] > 0) {
+            TableCellAccum phantom;
+            phantom.rowspan = 0;
+            interleaved.push_back(std::move(phantom));
+            self->tableRowspanTracker[lc]--;
+            lc++;
+          }
+          // If this cell has rowspan > 1, mark covered columns for future rows.
+          if (ca.rowspan > 1) {
+            for (uint8_t k = 0; k < ca.colspan; k++) {
+              const uint8_t c = static_cast<uint8_t>(lc + k);
+              if (c >= static_cast<uint8_t>(self->tableRowspanTracker.size()))
+                self->tableRowspanTracker.resize(c + 1, 0);
+              self->tableRowspanTracker[c] = ca.rowspan - 1;
+            }
+          }
+          lc = static_cast<uint8_t>(std::min(255, lc + ca.colspan));
+          interleaved.push_back(std::move(ca));
+        }
+        // Trailing phantom columns after all actual cells.
+        while (lc < static_cast<uint8_t>(self->tableRowspanTracker.size()) && self->tableRowspanTracker[lc] > 0) {
+          TableCellAccum phantom;
+          phantom.rowspan = 0;
+          interleaved.push_back(std::move(phantom));
+          self->tableRowspanTracker[lc]--;
+          lc++;
+        }
+        row.cells = std::move(interleaved);
+      }
+
+      // Count logical columns by summing colspan values across cells.
+      int logicalColCount = 0;
+      for (const auto& ca : row.cells) logicalColCount += ca.colspan;
+      const auto numCols = static_cast<uint8_t>(std::min(logicalColCount, 255));
+      if (numCols > self->tableTotalCols) {
+        self->tableTotalCols = numCols;
+      }
+
+      // Determine per-column widths for this row.
+      // Only colspan=1 cells with an explicit requestedWidth contribute to column width establishment;
+      // spanning cells' widths are ambiguous and skipped.
+      if (self->tableColWidths.empty() && numCols > 0) {
+        bool anyExplicit = false;
+        for (const auto& ca : row.cells) {
+          if (ca.colspan == 1 && ca.requestedWidth > 0) {
+            anyExplicit = true;
+            break;
+          }
+        }
+        if (anyExplicit) {
+          // Build per-logical-column widths, distributing remainder to unspecified slots.
+          std::vector<int16_t> slotWidths(numCols, 0);
+          int16_t totalExplicit = 0;
+          int unspecifiedCount = 0;
+          uint8_t logCol = 0;
+          for (const auto& ca : row.cells) {
+            if (ca.colspan == 1 && ca.requestedWidth > 0) {
+              if (logCol < numCols) {
+                slotWidths[logCol] = ca.requestedWidth;
+                totalExplicit += ca.requestedWidth;
+              }
+            } else {
+              // Spanning or unspecified: leave slots as 0 (unspecified).
+              for (uint8_t k = 0; k < ca.colspan && (logCol + k) < numCols; k++) {
+                ++unspecifiedCount;
+              }
+            }
+            logCol = static_cast<uint8_t>(std::min(255, logCol + ca.colspan));
+          }
+          const int16_t remaining = static_cast<int16_t>(self->viewportWidth - totalExplicit);
+          const int16_t fallback = (unspecifiedCount > 0)
+                                       ? static_cast<int16_t>(std::max(1, remaining / unspecifiedCount))
+                                       : static_cast<int16_t>(self->viewportWidth / numCols);
+          self->tableColWidths.reserve(numCols);
+          for (auto w : slotWidths) {
+            self->tableColWidths.push_back(w > 0 ? w : fallback);
+          }
+        }
+      }
+
+      // Layout each cell; cells spanning multiple columns get the summed column widths.
+      uint8_t maxLines = 0;
+      int16_t maxPadTop = TableBlock::CELL_PADDING_Y;
+      int16_t maxPadBot = TableBlock::CELL_PADDING_Y;
+      {
+        uint8_t logCol = 0;
+        for (auto& ca : row.cells) {
+          // Phantom cells (rowspan==0) occupy one column with no content — skip layout.
+          if (ca.rowspan == 0) {
+            logCol++;
+            continue;
+          }
+          // Sum widths of all columns in this cell's span.
+          int16_t cellColWidth = 0;
+          for (uint8_t k = 0; k < ca.colspan; k++) {
+            const uint8_t c = logCol + k;
+            if (c < static_cast<uint8_t>(self->tableColWidths.size())) {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->tableColWidths[c]);
+            } else if (numCols > 0) {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->viewportWidth / numCols);
+            } else {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->viewportWidth);
+            }
+          }
+          // Subtract left border (1px) + horizontal padding; ensure at least 1px.
+          const int16_t textWidth =
+              static_cast<int16_t>(std::max(1, cellColWidth - 1 - ca.paddingLeft - ca.paddingRight));
+
+          if (ca.text && !ca.text->isEmpty()) {
+            ca.text->layoutAndExtractLines(self->renderer, self->fontId, textWidth,
+                                           [&ca](const std::shared_ptr<TextBlock>& line) { ca.lines.push_back(line); });
+          }
+          const auto lineCount = static_cast<uint8_t>(std::min(ca.lines.size(), size_t(255)));
+          if (lineCount > maxLines) maxLines = lineCount;
+          if (ca.paddingTop > maxPadTop) maxPadTop = ca.paddingTop;
+          if (ca.paddingBottom > maxPadBot) maxPadBot = ca.paddingBottom;
+
+          logCol = static_cast<uint8_t>(std::min(255, logCol + ca.colspan));
+        }
+      }
+      row.maxLines = maxLines;
+      row.maxPaddingTop = maxPadTop;
+      row.maxPaddingBottom = maxPadBot;
+    }
     self->nextWordContinues = false;
   }
 
   if (self->tableDepth == 1 && strcmp(name, "table") == 0) {
     self->tableDepth -= 1;
-    self->tableRowIndex = 0;
-    self->tableColIndex = 0;
     self->nextWordContinues = false;
+
+    if (!self->tableAccumRows.empty() && self->tableTotalCols > 0) {
+      const auto numCols = static_cast<uint8_t>(self->tableTotalCols);
+      // Use established per-column widths, or fall back to equal distribution.
+      const bool hasPerColWidths = (static_cast<int>(self->tableColWidths.size()) == numCols);
+      const auto colWidthFallback =
+          static_cast<int16_t>(numCols > 0 ? self->viewportWidth / numCols : self->viewportWidth);
+      const auto lh = static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
+
+      // Emit rows across one or more pages, splitting when the remaining rows don't fit.
+      size_t rowStart = 0;
+      size_t totalRows = self->tableAccumRows.size();  // non-const: may grow if a row is split
+
+      while (rowStart < totalRows) {
+        // Ensure we have a current page to place content on.
+        if (!self->currentPage) {
+          self->currentPage.reset(new Page());
+          self->currentPageNextY = 0;
+        }
+
+        // Flush if the page is already full.
+        if (self->currentPageNextY >= self->viewportHeight) {
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completedPageCount++;
+          self->currentPage.reset(new Page());
+          self->currentPageNextY = 0;
+        }
+
+        const int16_t available = static_cast<int16_t>(self->viewportHeight - self->currentPageNextY);
+
+        // Greedily fit as many rows as possible into `available` pixels.
+        // The first row is always included even if it doesn't fit (avoids infinite loop).
+        // Height accounting matches TableBlock::totalHeight():
+        //   (numRows + 1) border px  +  sum(maxPaddingTop + maxLines * lh + maxPaddingBottom)
+        int16_t accumulated = 1;  // top border of the slice
+        size_t rowEnd = rowStart;
+        while (rowEnd < totalRows) {
+          const auto& ra = self->tableAccumRows[rowEnd];
+          const int16_t rowCost = static_cast<int16_t>(1 + ra.maxLines * lh + ra.maxPaddingTop + ra.maxPaddingBottom);
+          // Only break if at least one row has already been included.
+          if (rowEnd > rowStart && accumulated + rowCost > available) {
+            break;
+          }
+          accumulated += rowCost;
+          rowEnd++;
+        }
+
+        // If no rows fit on a non-empty page, flush and retry from a fresh page.
+        if (rowEnd == rowStart && self->currentPageNextY > 0) {
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completedPageCount++;
+          self->currentPage.reset(new Page());
+          self->currentPageNextY = 0;
+          continue;  // re-evaluate available on the new page
+        }
+
+        // If the sole row to emit is taller than the full page, split it line by line
+        // so the overflow continues on the next page rather than rendering off-screen.
+        if (rowEnd == rowStart + 1 && accumulated > available) {
+          auto& accumRow = self->tableAccumRows[rowStart];
+          const int16_t contentAvail =
+              static_cast<int16_t>(available - 2 - accumRow.maxPaddingTop - accumRow.maxPaddingBottom);
+          const int16_t fittableLines =
+              static_cast<int16_t>(std::max(int16_t(1), static_cast<int16_t>(contentAvail / lh)));
+
+          if (fittableLines < static_cast<int16_t>(accumRow.maxLines)) {
+            // Build a remainder row with the leftover lines.
+            TableRowAccum remainder;
+            remainder.maxPaddingTop = accumRow.maxPaddingTop;
+            remainder.maxPaddingBottom = accumRow.maxPaddingBottom;
+            uint8_t remMaxLines = 0;
+
+            for (auto& ca : accumRow.cells) {
+              TableCellAccum remCell;
+              remCell.colspan = ca.colspan;
+              remCell.rowspan = ca.rowspan;
+              remCell.paddingLeft = ca.paddingLeft;
+              remCell.paddingRight = ca.paddingRight;
+              remCell.paddingTop = ca.paddingTop;
+              remCell.paddingBottom = ca.paddingBottom;
+
+              const auto splitAt = static_cast<size_t>(fittableLines);
+              if (ca.lines.size() > splitAt) {
+                remCell.lines.assign(std::make_move_iterator(ca.lines.begin() + static_cast<ptrdiff_t>(splitAt)),
+                                     std::make_move_iterator(ca.lines.end()));
+                ca.lines.resize(splitAt);
+              }
+              const auto remCount = static_cast<uint8_t>(std::min(remCell.lines.size(), size_t(255)));
+              if (remCount > remMaxLines) remMaxLines = remCount;
+              remainder.cells.push_back(std::move(remCell));
+            }
+            remainder.maxLines = remMaxLines;
+            accumRow.maxLines = static_cast<uint8_t>(fittableLines);
+
+            // Insert remainder immediately after the current row.
+            self->tableAccumRows.insert(self->tableAccumRows.begin() + static_cast<ptrdiff_t>(rowStart + 1),
+                                        std::move(remainder));
+            totalRows++;  // one more row to process
+            // rowEnd stays at rowStart+1; fall through to emit the trimmed row.
+          }
+        }
+
+        // Build a TableBlock for rows [rowStart, rowEnd).
+        auto tableBlock = std::make_unique<TableBlock>();
+        tableBlock->numCols = numCols;
+        tableBlock->colWidth = colWidthFallback;
+        tableBlock->lineHeight = lh;
+        tableBlock->drawBorderTop = self->tableDrawBorderTop;
+        tableBlock->drawBorderBottom = self->tableDrawBorderBottom;
+        tableBlock->drawBorderLeft = self->tableDrawBorderLeft;
+        tableBlock->drawBorderRight = self->tableDrawBorderRight;
+        if (hasPerColWidths) tableBlock->colWidths = self->tableColWidths;
+        tableBlock->rows.reserve(rowEnd - rowStart);
+        for (size_t r = rowStart; r < rowEnd; r++) {
+          TableRow row;
+          row.maxLines = self->tableAccumRows[r].maxLines;
+          row.maxPaddingTop = self->tableAccumRows[r].maxPaddingTop;
+          row.maxPaddingBottom = self->tableAccumRows[r].maxPaddingBottom;
+          row.cells.reserve(self->tableAccumRows[r].cells.size());
+          for (auto& ca : self->tableAccumRows[r].cells) {
+            TableCell cell;
+            cell.lines = std::move(ca.lines);
+            cell.paddingLeft = ca.paddingLeft;
+            cell.paddingRight = ca.paddingRight;
+            cell.paddingTop = ca.paddingTop;
+            cell.paddingBottom = ca.paddingBottom;
+            cell.colspan = ca.colspan;
+            cell.rowspan = ca.rowspan;
+            row.cells.push_back(std::move(cell));
+          }
+          tableBlock->rows.push_back(std::move(row));
+        }
+
+        const int16_t tableHeight = tableBlock->totalHeight();
+        self->currentPage->elements.push_back(
+            std::make_shared<PageTable>(std::move(tableBlock), 0, self->currentPageNextY, tableHeight));
+        self->currentPageNextY += tableHeight;
+
+        rowStart = rowEnd;
+
+        // Flush the page if more rows still need to be placed.
+        if (rowStart < totalRows) {
+          self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex);
+          self->completedPageCount++;
+          self->currentPage.reset();
+          self->currentPageNextY = 0;
+        }
+      }
+    }
+
+    self->tableAccumRows.clear();
+    self->tableTotalCols = 0;
+    self->tableColWidths.clear();
+    self->tableRowspanTracker.clear();
+    self->tableDrawBorderTop = false;
+    self->tableDrawBorderBottom = false;
+    self->tableDrawBorderLeft = false;
+    self->tableDrawBorderRight = false;
   }
 
   // Leaving bold tag

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -11,6 +11,7 @@
 #include "Epub/FootnoteEntry.h"
 #include "Epub/ParsedText.h"
 #include "Epub/blocks/ImageBlock.h"
+#include "Epub/blocks/TableBlock.h"
 #include "Epub/blocks/TextBlock.h"
 #include "Epub/css/CssParser.h"
 #include "Epub/css/CssStyle.h"
@@ -69,8 +70,34 @@ class ChapterHtmlSlimParser {
   bool effectiveItalic = false;
   bool effectiveUnderline = false;
   int tableDepth = 0;
-  int tableRowIndex = 0;
-  int tableColIndex = 0;
+
+  // Table accumulation: cells are collected per-row, laid out at </tr>.
+  struct TableCellAccum {
+    std::unique_ptr<ParsedText> text;               // raw words; laid out at </tr>
+    std::vector<std::shared_ptr<TextBlock>> lines;  // filled after layout
+    int16_t paddingLeft = TableBlock::CELL_PADDING_X;
+    int16_t paddingRight = TableBlock::CELL_PADDING_X;
+    int16_t paddingTop = TableBlock::CELL_PADDING_Y;
+    int16_t paddingBottom = TableBlock::CELL_PADDING_Y;
+    int16_t requestedWidth = 0;  // 0 = unspecified (equal distribution)
+    uint8_t colspan = 1;         // number of logical columns this cell spans
+    uint8_t rowspan = 1;         // 0 = phantom (occupied by rowspan above), 1 = normal, >1 = rowspan cell
+  };
+  struct TableRowAccum {
+    std::vector<TableCellAccum> cells;
+    uint8_t maxLines = 0;
+    int16_t maxPaddingTop = TableBlock::CELL_PADDING_Y;
+    int16_t maxPaddingBottom = TableBlock::CELL_PADDING_Y;
+  };
+  bool inTableCellMode = false;
+  std::vector<TableRowAccum> tableAccumRows;
+  int tableTotalCols = 0;                    // max columns seen across all rows
+  std::vector<int16_t> tableColWidths;       // per-column widths once established (first row with explicit widths)
+  std::vector<uint8_t> tableRowspanTracker;  // remaining rowspan rows per logical column
+  bool tableDrawBorderTop = false;           // accumulated from <table>/<td>/<th> CSS: draw top edge
+  bool tableDrawBorderBottom = false;        // accumulated from <table>/<td>/<th> CSS: draw bottom edge
+  bool tableDrawBorderLeft = false;          // accumulated from <table>/<td>/<th> CSS: draw left edge
+  bool tableDrawBorderRight = false;         // accumulated from <table>/<td>/<th> CSS: draw right edge
 
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -81,7 +81,8 @@ class ChapterHtmlSlimParser {
     int16_t paddingBottom = TableBlock::CELL_PADDING_Y;
     int16_t requestedWidth = 0;  // 0 = unspecified (equal distribution)
     uint8_t colspan = 1;         // number of logical columns this cell spans
-    uint8_t rowspan = 1;         // 0 = phantom (occupied by rowspan above), 1 = normal, >1 = rowspan cell
+    uint8_t rowspan =
+        1;  // 0 = phantom (occupied by rowspan above), 1 = normal, >1 = rowspan cell; HTML "0" mapped to 64
   };
   struct TableRowAccum {
     std::vector<TableCellAccum> cells;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Implements basic EPUB table rendering support in the reader, including row/colspan handling and border rendering for `solid`/`none` border styles.

* **What changes are included?**  
  * Added `TableBlock` and `PageTable` support for table rendering and page serialization.
  * Extended `ChapterHtmlSlimParser` to parse `<table>`, `<tr>`, `<td>`, and `<th>` with cell padding, width, colspan, rowspan, and border style accumulation.
  * Added CSS parsing for `border-style`, `border-width`, and shorthand `border`/`border-top`/`border-bottom`/`border-left`/`border-right`.
  * Added `CssBorderStyle` support and visibility checks in `CssStyle`.
  * Added table serialization/deserialization and page element tagging in Page.cpp / `Page.h`.

## Additional Context

1. Basic two-column table
<img width="914" height="758" alt="image" src="https://github.com/user-attachments/assets/3593a7b0-4185-49ad-8755-0158ed51cf98" />

| Screenshot 1 | Screenshot 2 | 
|--------|--------|
| <img width="480" height="796" alt="image" src="https://github.com/user-attachments/assets/d3982fcc-dcb7-4e18-869b-faa5e78c5c7e" /> | <img width="483" height="804" alt="image" src="https://github.com/user-attachments/assets/c382d881-acad-4895-a78e-b6d7e06f8764" /> |

2. Basic three-column table

| Table | Screenshot | 
|--------|--------|
| <img width="921" height="472" alt="image" src="https://github.com/user-attachments/assets/6a64afca-008a-4cc3-b31b-49bcf056d45d" /> | <img width="474" height="792" alt="image" src="https://github.com/user-attachments/assets/2bfe48ca-b6fc-451b-8592-97a1b1fbfcf9" />|

3. Center-aligned table with no border
<img width="911" height="471" alt="image" src="https://github.com/user-attachments/assets/dfae3d64-9d32-49d3-8ac8-2cbea5d601b6" />

| Screenshot 1 | Screenshot 2 | 
|--------|--------|
| <img width="480" height="802" alt="image" src="https://github.com/user-attachments/assets/031b48f5-ff3c-46bb-b08b-adc1364fdbcd" /> | <img width="481" height="801" alt="image" src="https://github.com/user-attachments/assets/8bce49a1-412c-4773-aecc-0a3b34ec65c3" /> |

4. Table with no border

| Table | Screenshot | 
|--------|--------|
|<img width="920" height="473" alt="image" src="https://github.com/user-attachments/assets/6d7b9a5f-ed4b-43a3-8734-9f2590f296a6" /> | <img width="481" height="803" alt="image" src="https://github.com/user-attachments/assets/4ffa1ff4-cdc8-4c52-97f9-379ec9f42930" />|

5. Table with border-{top,bottom} style

| Table | Screenshot | 
|--------|--------|
| <img width="733" height="549" alt="image" src="https://github.com/user-attachments/assets/bc8a8ac5-acac-4617-a14e-4a56ced6c9bb" /> | <img width="485" height="806" alt="image" src="https://github.com/user-attachments/assets/bcd51b48-4440-49fc-bc48-ef917177910a" /> |

6. Table with border-{top,bottom} style and center-aligned text

<img width="740" height="573" alt="image" src="https://github.com/user-attachments/assets/2c5123b8-7f2b-49a0-8427-9ddb89960b3d" /> 

| Screenshot 1 | Screenshot 2 | 
|--------|--------|
| <img width="484" height="799" alt="image" src="https://github.com/user-attachments/assets/98766f57-fd39-4c05-9a22-ea658b20f66d" /> | <img width="481" height="800" alt="image" src="https://github.com/user-attachments/assets/0bce385c-1d94-4355-87b9-51d81e79af46" />|

7. Table with row/colspan

| Table | Screenshot | 
|--------|--------|
| <img width="734" height="665" alt="image" src="https://github.com/user-attachments/assets/703a6049-307e-4a12-8cbf-0a25d2b72adc" /> | <img width="487" height="807" alt="image" src="https://github.com/user-attachments/assets/228073c5-0da9-44d3-b968-3fd0b23acc56" /> |

8. Table with border shorthands style
<img width="737" height="1016" alt="image" src="https://github.com/user-attachments/assets/2eb261e0-3f53-494f-a477-ca1c9cee7f4d" />

| Screenshot 1 | Screenshot 2 |
|--------|--------|
| <img width="479" height="799" alt="image" src="https://github.com/user-attachments/assets/8ccbe5b0-8791-41b1-a2a5-0558451a111b" /> | <img width="482" height="801" alt="image" src="https://github.com/user-attachments/assets/427e90c4-d646-4a3a-b665-b32a31515bd7" /> | 

| Screenshot 3 | Screenshot 4 |
|--------|--------|
| <img width="479" height="801" alt="image" src="https://github.com/user-attachments/assets/2dc0d849-7e35-438f-88d4-defd19d8a38e" /> |  <img width="478" height="806" alt="image" src="https://github.com/user-attachments/assets/f49d7846-a0e7-41c0-9c8d-0b4ae39cbef6" /> |

9. Table with border shorthands style (postive pixels + none)

<img width="746" height="1017" alt="image" src="https://github.com/user-attachments/assets/0c9c566c-b059-42c0-b1d3-9924ef826c66" />

| Screenshot 1 | Screenshot 2 |
|--------|--------|
| <img width="479" height="804" alt="image" src="https://github.com/user-attachments/assets/b9deaf32-34b8-46d2-84d2-a5c7b955a354" /> |<img width="472" height="794" alt="image" src="https://github.com/user-attachments/assets/44c2c1ea-a80e-4e47-8754-a1826657215d" /> |

| Screenshot 3 | Screenshot 4 |
|--------|--------|
| <img width="472" height="791" alt="image" src="https://github.com/user-attachments/assets/d01b4216-8df9-4d10-9296-e066c3ec7e00" /> | <img width="473" height="804" alt="image" src="https://github.com/user-attachments/assets/f039bef7-ea64-4522-ae5e-d7479ebb1b70" /> |

10. Table with border shorthands style (none + postive pixels)

<img width="739" height="1009" alt="image" src="https://github.com/user-attachments/assets/bd1408fc-b5ac-4f5c-a636-88b70d965d73" />

| Screenshot 1 | Screenshot 2 |
|--------|--------|
| <img width="477" height="797" alt="image" src="https://github.com/user-attachments/assets/4f624de4-e2bc-4c2f-a938-d51ac365be49" /> |  <img width="483" height="797" alt="image" src="https://github.com/user-attachments/assets/ba428ab7-f37e-4df5-b615-067374617bb7" /> |

| Screenshot 3 | Screenshot 4 |
|--------|--------|
| <img width="482" height="800" alt="image" src="https://github.com/user-attachments/assets/a1deb672-03e3-4abd-a3f2-249d7b1b63c6" /> | <img width="478" height="799" alt="image" src="https://github.com/user-attachments/assets/7d59d07e-ae74-49f5-a640-2fd711c67fd6" /> |

11. Table with special case of rowspan="0"

Note: colspan must be a positive number, only rowspan can be zero or a positive number.

<img width="748" height="1082" alt="image" src="https://github.com/user-attachments/assets/93f29319-deda-4771-adb2-c45e074fc1c2" />

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|--------|--------|--------|
| <img width="479" height="794" alt="image" src="https://github.com/user-attachments/assets/c30f9b4b-72a5-42f1-943b-68b32a71da76" /> | <img width="479" height="804" alt="image" src="https://github.com/user-attachments/assets/e6767753-e373-4513-9755-4b630de898a8" /> | <img width="481" height="802" alt="image" src="https://github.com/user-attachments/assets/8f7cf374-482c-4549-a627-05cb0af0e699" />|

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
