### PR TITLE
fix: use power button held time for shutdown logic

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -223,6 +223,8 @@ bool HalGPIO::wasAnyReleased() const { return inputMgr.wasAnyReleased(); }
 
 unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 
+unsigned long HalGPIO::getPowerButtonHeldTime() const { return inputMgr.getPowerButtonHeldTime(); }
+
 void HalGPIO::startDeepSleep() {
   // Ensure that the power button has been released to avoid immediately turning back on if you're holding it
   while (inputMgr.isPressed(BTN_POWER)) {
@@ -258,8 +260,8 @@ void HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPre
     do {
       delay(10);
       inputMgr.update();
-    } while (inputMgr.isPressed(BTN_POWER) && inputMgr.getHeldTime() < calibratedDuration);
-    if (inputMgr.getHeldTime() < calibratedDuration) {
+    } while (inputMgr.isPressed(BTN_POWER) && inputMgr.getPowerButtonHeldTime() < calibratedDuration);
+    if (inputMgr.getPowerButtonHeldTime() < calibratedDuration) {
       startDeepSleep();
     }
   } else {

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -70,6 +70,7 @@ class HalGPIO {
   bool wasReleased(uint8_t buttonIndex) const;
   bool wasAnyReleased() const;
   unsigned long getHeldTime() const;
+  unsigned long getPowerButtonHeldTime() const;
 
   // Setup wake up GPIO and enter deep sleep
   void startDeepSleep();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,8 +162,8 @@ void verifyPowerButtonDuration() {
     do {
       delay(10);
       gpio.update();
-    } while (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() < calibratedPressDuration);
-    abort = gpio.getHeldTime() < calibratedPressDuration;
+    } while (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getPowerButtonHeldTime() < calibratedPressDuration);
+    abort = gpio.getPowerButtonHeldTime() < calibratedPressDuration;
   } else {
     abort = true;
   }
@@ -418,7 +418,7 @@ void loop() {
     return;
   }
 
-  if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getHeldTime() > SETTINGS.getPowerButtonDuration()) {
+  if (gpio.isPressed(HalGPIO::BTN_POWER) && gpio.getPowerButtonHeldTime() > SETTINGS.getPowerButtonDuration()) {
     // If the screenshot combination is potentially being pressed, don't sleep
     if (gpio.isPressed(HalGPIO::BTN_DOWN)) {
       return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
Fix incorrect power button long-press detection during shutdown/wake verification by introducing dedicated power button timing logic.
* **What changes are included?**
  * Added getPowerButtonHeldTime() to HalGPIO as a wrapper over input manager logic
  * Replaced generic getHeldTime() usage with power-button-specific timing in verifyPowerButtonWakeup()
  * Ensures shutdown/wake decision is based only on actual power button hold duration, not any-button timing
  * Minor header update for new API exposure in HalGPIO.h
## Additional Context

This fixes a bug where holding another button while briefly pressing the power button could incorrectly trigger shutdown behavior due to shared timing state (getHeldTime()).

The change isolates power button timing to prevent cross-button interference and makes shutdown logic reliable during multi-button interactions.

No behavioral changes are expected outside of power-button handling logic.

**Dependencies**
- SDK PR: https://github.com/crosspoint-reader/community-sdk/pull/3

This PR requires the `community-sdk` submodule to be updated after the SDK change is merged.

- Fixes: #1881

---

### AI Usage
Did you use AI tools to help write this code? _**PARTIALLY**_
