### PR TITLE
fix: Missing navigation button labels in Roundedraff theme

### DIFF
--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -5,7 +5,6 @@
 #include <I18n.h>
 
 #include <algorithm>
-#include <cctype>
 #include <string>
 #include <vector>
 
@@ -42,18 +41,6 @@ void drawScrollBar(const GfxRenderer& renderer, Rect rect, int itemCount, int pa
   const int thumbY = barY + (clampedStart * maxTravel) / maxStart;
 
   renderer.fillRect(barX, thumbY, barW, thumbH);
-}
-
-std::string sanitizeButtonLabel(std::string label) {
-  // Remove common directional prefixes/symbols (e.g. "<< Home", unsupported icon glyphs).
-  while (!label.empty() && !std::isalnum(static_cast<unsigned char>(label[0]))) {
-    label.erase(0, 1);
-  }
-  // Trim any extra left spaces.
-  while (!label.empty() && label[0] == ' ') {
-    label.erase(0, 1);
-  }
-  return label;
 }
 
 }  // namespace
@@ -341,11 +328,11 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const bool backDisabled = (btn1 == nullptr || btn1[0] == '\0');
   const int leftGroupX = sidePadding;
   const int rightGroupX = leftGroupX + groupWidth + groupGap;
-  const std::string backLabel = backDisabled ? "" : sanitizeButtonLabel(std::string(btn1));
+  const std::string backLabel = backDisabled ? "" : std::string(btn1);
   // Callers should provide the button labels. If a label is not specified, it should render empty.
-  const std::string selectText = (btn2 && btn2[0] != '\0') ? sanitizeButtonLabel(std::string(btn2)) : "";
-  const std::string upText = (btn3 && btn3[0] != '\0') ? sanitizeButtonLabel(std::string(btn3)) : "";
-  const std::string downText = (btn4 && btn4[0] != '\0') ? sanitizeButtonLabel(std::string(btn4)) : "";
+  const std::string selectText = (btn2 && btn2[0] != '\0') ? std::string(btn2) : "";
+  const std::string upText = (btn3 && btn3[0] != '\0') ? std::string(btn3) : "";
+  const std::string downText = (btn4 && btn4[0] != '\0') ? std::string(btn4) : "";
 
   // Ensure button hints always "win" visually even if other elements accidentally render into this area.
   renderer.fillRect(leftGroupX, hintY, groupWidth, hintHeight, false);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** fix bug in Roundedraff theme when used with non-acsii languages. See https://github.com/uxjulia/CrossInk/issues/94 

## Additional Context

Basically just removed `sanitizeButtonLabel()` - which removed completely the russian strings. I'm really not sure why it was there in the first place. @bunsoootchi can you shed some light here?

---

### AI Usage

Did you use AI tools to help write this code? _**< NO >**_
