### PR TITLE
fix: capture instantiateVariableFont return value

### DIFF
--- a/lib/EpdFont/scripts/build-sd-fonts.py
+++ b/lib/EpdFont/scripts/build-sd-fonts.py
@@ -87,7 +87,18 @@ def extract_static_instance(source_path: Path, axes: dict, family_name: str, sty
     tmp_path = Path(tmp_name)
     font = TTFont(str(source_path))
     try:
-        instantiateVariableFont(font, axes)
+        # instantiateVariableFont returns a *new* TTFont with the axes pinned;
+        # without capturing the return value, font.save() below would write the
+        # original (still-variable) font and the requested axis values would be
+        # silently ignored.
+        #
+        # updateFontNames=True   — rewrite the name table so the saved font
+        #                          reports its weight/style accurately rather
+        #                          than retaining the variable-font names.
+        # optimize=False         — skip the gvar interpolation optimisation;
+        #                          fully pinning every axis drops gvar anyway,
+        #                          so the work would be wasted.
+        font = instantiateVariableFont(font, axes, updateFontNames=True, optimize=False)
         font.save(str(tmp_path))
     except Exception:
         tmp_path.unlink(missing_ok=True)

--- a/lib/EpdFont/scripts/build-sd-fonts.py
+++ b/lib/EpdFont/scripts/build-sd-fonts.py
@@ -85,26 +85,29 @@ def extract_static_instance(source_path: Path, axes: dict, family_name: str, sty
     tmp_fd, tmp_name = tempfile.mkstemp(suffix=".ttf", dir=cached.parent)
     os.close(tmp_fd)
     tmp_path = Path(tmp_name)
-    font = TTFont(str(source_path))
+    # Keep separate handles for the source variable font and the static
+    # instance: instantiateVariableFont with default inplace=False returns a
+    # *new* TTFont, so rebinding `font` would otherwise strand the source's
+    # file handle open until GC runs.
+    #
+    # updateFontNames=True   — rewrite the name table so the saved font
+    #                          reports its weight/style accurately rather
+    #                          than retaining the variable-font names.
+    # optimize=False         — skip the gvar interpolation optimisation;
+    #                          fully pinning every axis drops gvar anyway,
+    #                          so the work would be wasted.
+    source_font = TTFont(str(source_path))
     try:
-        # instantiateVariableFont returns a *new* TTFont with the axes pinned;
-        # without capturing the return value, font.save() below would write the
-        # original (still-variable) font and the requested axis values would be
-        # silently ignored.
-        #
-        # updateFontNames=True   — rewrite the name table so the saved font
-        #                          reports its weight/style accurately rather
-        #                          than retaining the variable-font names.
-        # optimize=False         — skip the gvar interpolation optimisation;
-        #                          fully pinning every axis drops gvar anyway,
-        #                          so the work would be wasted.
-        font = instantiateVariableFont(font, axes, updateFontNames=True, optimize=False)
-        font.save(str(tmp_path))
+        font = instantiateVariableFont(source_font, axes, updateFontNames=True, optimize=False)
+        try:
+            font.save(str(tmp_path))
+        finally:
+            font.close()
     except Exception:
         tmp_path.unlink(missing_ok=True)
         raise
     finally:
-        font.close()
+        source_font.close()
     tmp_path.replace(cached)
 
     return cached


### PR DESCRIPTION
instantiateVariableFont() returns a *new* TTFont with the requested axes pinned; the existing call discards that return and proceeds to font.save() the original (still-variable) font. The "static instance" written to disk is therefore identical to the source variable font and the requested axis values are silently ignored.

For sd-fonts.yaml entries that use the `variable: {wght: 400}` form (e.g. Bitter, Lora) this means every weight ends up rasterised from the same default-weight glyphs — bold and regular look the same.

Capture the return value, and pass two diagnostically useful kwargs while we're touching the call:

* updateFontNames=True  — rewrite the name table so the saved TTF reports its actual weight/style instead of retaining the source variable-font names.
* optimize=False        — skip the gvar interpolation optimisation;
                          fully pinning every axis drops gvar anyway,
                          so the work would be wasted.

The atomic-write scaffolding around the call is left untouched.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
