### PR TITLE
feat: bounded per-codepoint miss diagnostics

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -84,7 +84,25 @@ void SdCardFont::freeStyleAll(PerStyle& s) {
   delete[] s.fullIntervals;
   s.fullIntervals = nullptr;
   freeStyleKernLigatureData(s);
+  s.reportedMissCount = 0;
   s.present = false;
+}
+
+// Log a missing codepoint at LOG_DBG once per style since the last cache
+// clear. Returns true if the cp was newly seen (and either logged or
+// recorded as overflow), false if it was already on the ring. Bounded to
+// PerStyle::MAX_REPORTED_MISSES distinct entries; once full, further misses
+// silently increment the count without re-logging — the cps still fall back
+// to the replacement glyph cleanly in EpdFont::getGlyph().
+bool SdCardFont::reportMissOnce(PerStyle& s, uint32_t codepoint, uint8_t styleIdx, const char* origin) {
+  for (uint8_t r = 0; r < s.reportedMissCount; r++) {
+    if (s.reportedMisses[r] == codepoint) return false;
+  }
+  if (s.reportedMissCount < PerStyle::MAX_REPORTED_MISSES) {
+    s.reportedMisses[s.reportedMissCount++] = codepoint;
+    LOG_DBG("SDCF", "%s: missing glyph U+%04X style %u", origin, codepoint, styleIdx);
+  }
+  return true;
 }
 
 // --- Global free/cleanup ---
@@ -708,6 +726,8 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
       mappings[validCount].codepoint = codepoints[i];
       mappings[validCount].globalIndex = idx;
       validCount++;
+    } else {
+      reportMissOnce(s, codepoints[i], styleIdx, "prewarm");
     }
   }
   int missed = static_cast<int>(cpCount - validCount);
@@ -920,6 +940,10 @@ void SdCardFont::clearCache() {
   for (uint8_t i = 0; i < MAX_STYLES; i++) {
     if (!styles_[i].present) continue;
     freeStyleMiniData(styles_[i]);
+    // Forget which cps we've already logged as missing. clearCache() marks a
+    // section / chapter boundary, so a missing-glyph diagnostic from the
+    // *next* section is genuinely new information worth re-logging.
+    styles_[i].reportedMissCount = 0;
     applyGlyphMissCallback(i);
   }
 }
@@ -1102,6 +1126,7 @@ int SdCardFont::buildAdvanceTable(const char* utf8Text, uint8_t styleMask) {
       if (advanceTableLookup(si, cp, nullptr)) continue;  // already cached
       int32_t idx = findGlobalGlyphIndex(s, cp);
       if (idx < 0) {
+        reportMissOnce(styles_[si], cp, si, "advance");
         missedThisStyle++;
         continue;
       }

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -171,6 +171,18 @@ class SdCardFont {
     EpdFont epdFont{&stubData};
 
     bool present = false;
+
+    // Bounded ring of codepoints already logged as missing for this style
+    // since the last cache clear. prewarmStyle()/buildAdvanceTable() count
+    // every miss but only LOG_DBG the first MAX_REPORTED_MISSES distinct
+    // codepoints — without this, a document containing a non-supported
+    // script (e.g. a Greek quotation in a Latin-only font) spams the log
+    // at every layout pass with the same dozen codepoints. Reset by
+    // freeStyleAll() and clearCache(); cps that fall off the ring still
+    // resolve correctly via the replacement glyph.
+    static constexpr uint8_t MAX_REPORTED_MISSES = 32;
+    uint32_t reportedMisses[MAX_REPORTED_MISSES] = {};
+    uint8_t reportedMissCount = 0;
   };
 
   PerStyle styles_[MAX_STYLES] = {};
@@ -230,6 +242,8 @@ class SdCardFont {
   void applyGlyphMissCallback(uint8_t styleIdx);
   int32_t findGlobalGlyphIndex(const PerStyle& s, uint32_t codepoint) const;
   int prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint32_t cpCount, bool metadataOnly);
+  // Bounded per-style miss reporter (see PerStyle::MAX_REPORTED_MISSES).
+  static bool reportMissOnce(PerStyle& s, uint32_t codepoint, uint8_t styleIdx, const char* origin);
 
   // Global helpers
   void freeAll();


### PR DESCRIPTION
Add a small per-style ring of codepoints already logged as missing for this style since the last cache clear. prewarmStyle() and buildAdvanceTable() count every miss as before but now LOG_DBG only the first MAX_REPORTED_MISSES (32) distinct codepoints per style.

Currently both paths silently drop missing codepoints — useful for the fast path but unhelpful for diagnosing why an SD font looks wrong on a particular document. Logging every miss the first time around is fine, but layout pagination calls prewarm/buildAdvanceTable repeatedly with the same text, so naive logging spams the log with the same handful of codepoints at every pass.

The ring is reset on freeStyleAll() (font teardown) and on clearCache() (section/chapter boundary, where a missing-glyph diagnostic from the next section is genuinely new information). Codepoints that fall off the ring still resolve correctly via the replacement glyph.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES | PARTIALLY | NO >**_
