### PR TITLE
feat: add new font families to sd-fonts.yaml

### DIFF
--- a/lib/EpdFont/scripts/fontconvert_sdcard.py
+++ b/lib/EpdFont/scripts/fontconvert_sdcard.py
@@ -43,7 +43,24 @@ INTERVAL_PRESETS = {
     "latin-ext":   [(0x0020, 0x007E), (0x0080, 0x00FF), (0x0100, 0x024F),
                     (0x1E00, 0x1EFF), (0x2000, 0x206F), (0xFB00, 0xFB06)],
     "greek":       [(0x0370, 0x03FF), (0x1F00, 0x1FFF)],
+    # Greek monotonic letters only — drops the polytonic block (0x1F00-0x1FFF)
+    # that "greek" includes. Useful for fonts that ship modern Greek but no
+    # polytonic glyphs, where requesting "greek" would just produce empty
+    # glyph slots for everything in 0x1F00-0x1FFF.
+    "greek-letters": [(0x0370, 0x03FF)],
     "cyrillic":    [(0x0400, 0x04FF), (0x0500, 0x052F)],
+    # Latin (incl. core punctuation) + extended Cyrillic in one preset, for
+    # families that ship both scripts. The Cyrillic side picks up the three
+    # extended blocks (0x1C80-0x1C8F, 0x2DE0-0x2DFF, 0xA640-0xA69F) on top of
+    # what plain "cyrillic" covers, since fonts wide enough to bundle Latin +
+    # Cyrillic generally also cover those.
+    "latin-cyrillic": [(0x0020, 0x007E), (0x0080, 0x00FF), (0x0100, 0x024F),
+                       (0x1E00, 0x1EFF), (0x2000, 0x206F),
+                       (0x0400, 0x04FF), (0x0500, 0x052F),
+                       (0x1C80, 0x1C8F), (0x2DE0, 0x2DFF), (0xA640, 0xA69F)],
+    # Music symbols (card suits + Western notation block). Small block, useful
+    # to enable globally without bloating fonts much.
+    "musical-symbols": [(0x2660, 0x266F), (0x1D100, 0x1D1FF)],
     "georgian":    [(0x10A0, 0x10FF), (0x2D00, 0x2D2F)],
     "armenian":    [(0x0530, 0x058F)],
     "ethiopic":    [(0x1200, 0x137F), (0x1380, 0x139F), (0x2D80, 0x2DDF)],

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -35,8 +35,8 @@ families:
 
   - name: Literata
     description: "Screen-optimized serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/googlefonts/literata/main/fonts/ttf/Literata-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/googlefonts/literata/main/fonts/ttf/Literata-Bold.ttf"}
@@ -45,8 +45,8 @@ families:
 
   - name: SourceSerif4
     description: "Adobe transitional serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/adobe-fonts/source-serif/release/TTF/SourceSerif4-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/adobe-fonts/source-serif/release/TTF/SourceSerif4-Bold.ttf"}
@@ -55,8 +55,8 @@ families:
 
   - name: NotoSerifExtended
     description: "Serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/notofonts/NotoSerif/main/fonts/ttf/unhinted/instance_ttf/NotoSerif-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/notofonts/NotoSerif/main/fonts/ttf/unhinted/instance_ttf/NotoSerif-Bold.ttf"}
@@ -65,8 +65,8 @@ families:
 
   - name: Merriweather
     description: "Warm serif for long-form reading (Latin, Cyrillic)"
-    intervals: latin-ext,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/SorkinType/Merriweather/master/fonts/ttf/Merriweather-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/SorkinType/Merriweather/master/fonts/ttf/Merriweather-Bold.ttf"}
@@ -75,8 +75,8 @@ families:
 
   - name: Lora
     description: "Calligraphic serif for literary reading (Latin, Cyrillic)"
-    intervals: latin-ext,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/cyrealtype/Lora-Cyrillic/main/fonts/ttf/Lora-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/cyrealtype/Lora-Cyrillic/main/fonts/ttf/Lora-Bold.ttf"}
@@ -85,8 +85,8 @@ families:
 
   - name: GentiumBookPlus
     description: "Scholarly serif with wide Unicode coverage (Latin, Greek, Cyrillic, IPA)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gentiumbookplus/GentiumBookPlus-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gentiumbookplus/GentiumBookPlus-Bold.ttf"}
@@ -95,8 +95,8 @@ families:
 
   - name: IBMPlexSerif
     description: "Professional serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/ibmplexserif/IBMPlexSerif-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/ibmplexserif/IBMPlexSerif-Bold.ttf"}
@@ -105,8 +105,8 @@ families:
 
   - name: Bitter
     description: "Slab serif designed for e-ink (Latin, Cyrillic)"
-    intervals: latin-ext,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter%5Bwght%5D.ttf", variable: {wght: 400}}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter%5Bwght%5D.ttf", variable: {wght: 700}}
@@ -117,8 +117,8 @@ families:
 
   - name: NotoSansExtended
     description: "Sans-serif (Latin, Greek, Cyrillic, Georgian, Armenian, Ethiopic)"
-    intervals: latin-ext,greek,cyrillic,georgian,armenian,ethiopic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,georgian,armenian,ethiopic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {path: "builtinFonts/source/NotoSans/NotoSans-Regular.ttf"}
       bold:       {path: "builtinFonts/source/NotoSans/NotoSans-Bold.ttf"}
@@ -127,8 +127,8 @@ families:
 
   - name: Inter
     description: "Modern sans-serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/inter/Inter%5Bopsz%2Cwght%5D.ttf", variable: {wght: 400, opsz: 14}}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/inter/Inter%5Bopsz%2Cwght%5D.ttf", variable: {wght: 700, opsz: 14}}
@@ -137,8 +137,8 @@ families:
 
   - name: SourceSans3
     description: "Adobe humanist sans-serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/adobe-fonts/source-sans/release/TTF/SourceSans3-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/adobe-fonts/source-sans/release/TTF/SourceSans3-Bold.ttf"}
@@ -147,8 +147,8 @@ families:
 
   - name: IBMPlexSans
     description: "IBM corporate sans-serif (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/IBM/plex/master/packages/plex-sans/fonts/complete/ttf/IBMPlexSans-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/IBM/plex/master/packages/plex-sans/fonts/complete/ttf/IBMPlexSans-Bold.ttf"}
@@ -157,8 +157,8 @@ families:
 
   - name: Alegreya
     description: "Calligraphic serif/display (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alegreya/Alegreya%5Bwght%5D.ttf", variable: {wght: 400}}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alegreya/Alegreya%5Bwght%5D.ttf", variable: {wght: 700}}
@@ -169,8 +169,8 @@ families:
 
   - name: IBMPlexMono
     description: "Monospace for code and technical reading (Latin, Greek, Cyrillic)"
-    intervals: latin-ext,greek,cyrillic
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-cyrillic,greek-letters,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/ibmplexmono/IBMPlexMono-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/ibmplexmono/IBMPlexMono-Bold.ttf"}
@@ -179,8 +179,8 @@ families:
 
   - name: SourceCodePro
     description: "Adobe monospace with excellent hinting (Latin)"
-    intervals: latin-ext
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-ext
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/adobe-fonts/source-code-pro/release/TTF/SourceCodePro-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/adobe-fonts/source-code-pro/release/TTF/SourceCodePro-Bold.ttf"}
@@ -191,8 +191,8 @@ families:
 
   - name: AtkinsonHyperlegibleNext
     description: "Accessibility font for low vision (Latin)"
-    intervals: latin-ext
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-ext
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/googlefonts/atkinson-hyperlegible-next/main/fonts/ttf/AtkinsonHyperlegibleNext-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/googlefonts/atkinson-hyperlegible-next/main/fonts/ttf/AtkinsonHyperlegibleNext-Bold.ttf"}
@@ -201,8 +201,8 @@ families:
 
   - name: LexicaUltralegible
     description: "Accessibility font for low vision / dyslexia (Latin)"
-    intervals: latin-ext
-    sizes: [12, 14, 16, 18]
+    intervals: builtin,latin-ext
+    sizes: [10, 12, 14, 16, 18]
     styles:
       regular:    {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -278,30 +278,3 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-BoldItalic.ttf"}
-
-  # ── CJK & Hangul ───────────────────────────────────────────────────────
-  # Single-style only: CJK families ship the regular weight as a multi-MB
-  # OTF; bundling four styles per size would blow past reasonable SD-card
-  # footprints for users who only read English with occasional CJK.
-
-  - name: NotoSansCJK
-    description: "Sans-serif (Chinese, Japanese, Korean)"
-    intervals: builtin,cjk
-    sizes: [10, 12, 14, 16, 18]
-    styles:
-      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"}
-
-  - name: NotoSerifCJK
-    description: "Serif (Chinese, Japanese, Korean)"
-    intervals: builtin,cjk
-    sizes: [10, 12, 14, 16, 18]
-    styles:
-      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-Regular.otf"}
-
-  - name: NotoSansHangul
-    description: "Sans-serif (Korean Hangul)"
-    intervals: builtin,hangul
-    sizes: [10, 12, 14, 16, 18]
-    styles:
-      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"}
-

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -113,6 +113,66 @@ families:
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
 
+  - name: Gelasio
+    description: "Readable old-style serif (Latin, Cyrillic)"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gelasio/Gelasio%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gelasio/Gelasio%5Bwght%5D.ttf", variable: {wght: 700}}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gelasio/Gelasio-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/gelasio/Gelasio-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
+
+  - name: Readerly
+    description: "Similar to Bookerly (Latin, Cyrillic)"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Readerly-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Readerly-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Readerly-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Readerly-BoldItalic.ttf"}
+
+  - name: Charis
+    description: "Great universal pick"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/NV_Charis-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/NV_Charis-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/NV_Charis-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/NV_Charis-BoldItalic.ttf"}
+
+  - name: Sourcerer
+    description: "Thicker version of Source Serif"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Sourcerer-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Sourcerer-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Sourcerer-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/nicoverbruggen/ebook-fonts/main/fonts/core/Sourcerer-BoldItalic.ttf"}
+
+  - name: Spectral
+    description: "A new and versatile serif face (Latin, Cyrillic)"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/spectral/Spectral-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/spectral/Spectral-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/spectral/Spectral-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/spectral/Spectral-BoldItalic.ttf"}
+
+  - name: Vollkorn
+    description: "The free and healthy typeface for bread and butter use (Latin, Cyrillic)"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/vollkorn/Vollkorn%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/vollkorn/Vollkorn%5Bwght%5D.ttf", variable: {wght: 700}}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/vollkorn/Vollkorn-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/vollkorn/Vollkorn-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
+
   # ── Sans-serif ─────────────────────────────────────────────────────────
 
   - name: NotoSansExtended
@@ -165,6 +225,16 @@ families:
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alegreya/Alegreya-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alegreya/Alegreya-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
 
+  - name: Arimo
+    description: "Metric-compatible with Arial (Latin, Cyrillic)"
+    intervals: builtin,latin-cyrillic,musical-symbols
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/arimo/Arimo%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/arimo/Arimo%5Bwght%5D.ttf", variable: {wght: 700}}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/arimo/Arimo-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/arimo/Arimo-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
+
   # ── Monospace ──────────────────────────────────────────────────────────
 
   - name: IBMPlexMono
@@ -208,4 +278,30 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-BoldItalic.ttf"}
+
+  # ── CJK & Hangul ───────────────────────────────────────────────────────
+  # Single-style only: CJK families ship the regular weight as a multi-MB
+  # OTF; bundling four styles per size would blow past reasonable SD-card
+  # footprints for users who only read English with occasional CJK.
+
+  - name: NotoSansCJK
+    description: "Sans-serif (Chinese, Japanese, Korean)"
+    intervals: builtin,ascii,latin1,punctuation,cjk
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"}
+
+  - name: NotoSerifCJK
+    description: "Serif (Chinese, Japanese, Korean)"
+    intervals: builtin,ascii,latin1,punctuation,cjk
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-Regular.otf"}
+
+  - name: NotoSansHangul
+    description: "Sans-serif (Korean Hangul)"
+    intervals: builtin,ascii,latin1,punctuation,hangul
+    sizes: [10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"}
 

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -286,21 +286,21 @@ families:
 
   - name: NotoSansCJK
     description: "Sans-serif (Chinese, Japanese, Korean)"
-    intervals: builtin,ascii,latin1,punctuation,cjk
+    intervals: builtin,cjk
     sizes: [10, 12, 14, 16, 18]
     styles:
       regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/SimplifiedChinese/NotoSansCJKsc-Regular.otf"}
 
   - name: NotoSerifCJK
     description: "Serif (Chinese, Japanese, Korean)"
-    intervals: builtin,ascii,latin1,punctuation,cjk
+    intervals: builtin,cjk
     sizes: [10, 12, 14, 16, 18]
     styles:
       regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Serif/OTF/SimplifiedChinese/NotoSerifCJKsc-Regular.otf"}
 
   - name: NotoSansHangul
     description: "Sans-serif (Korean Hangul)"
-    intervals: builtin,ascii,latin1,punctuation,hangul
+    intervals: builtin,hangul
     sizes: [10, 12, 14, 16, 18]
     styles:
       regular: {url: "https://github.com/notofonts/noto-cjk/raw/main/Sans/OTF/Korean/NotoSansCJKkr-Regular.otf"}


### PR DESCRIPTION
## Summary
Extend the SD-card font catalogue with 10 families across serif and sans-serif scripts. All entries use stable upstream sources (Google Fonts,  nicoverbruggen/ebook-fonts).

| Category | Family | Source | Variable? |
|---|---|---|---|
| Serif | Gelasio | google/fonts | ✓ wght |
| Serif | Readerly | nicoverbruggen/ebook-fonts | – |
| Serif | Charis | nicoverbruggen/ebook-fonts | – |
| Serif | Sourcerer | nicoverbruggen/ebook-fonts | – |
| Serif | Spectral | google/fonts | – |
| Serif | Vollkorn | google/fonts | ✓ wght |
| Sans | Arimo | google/fonts | ✓ wght |

## Dependency
Eight of the ten families use the `latin-cyrillic` and `musical-symbols` presets introduced in #N (`sdfont-yaml-presets`). This PR will fail to build until that one merges.
