### PR TITLE
feat: increase default weight of Bitter font for improved rendering

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -108,9 +108,9 @@ families:
     intervals: latin-ext,cyrillic
     sizes: [12, 14, 16, 18]
     styles:
-      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter%5Bwght%5D.ttf", variable: {wght: 400}}
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter%5Bwght%5D.ttf", variable: {wght: 500}}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter%5Bwght%5D.ttf", variable: {wght: 700}}
-      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 400}}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 500}}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
 
   # ── Sans-serif ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**What is the goal of this PR?**
* Provide a better default weight of Bitter font for improved rendering

**What changes are included?**
* Changes the default weight for Bitter font that is defined in the custom font catalog to medium (500) from regular (400) for improved rendering on e-ink, especially when font anti-aliasing is turned on

## Additional Context

* Bitter font at regular weight can become washed out when AA is on due to some of the thinner stems and posts of the font. Bumping the weight up to medium makes it sturdier and holds up better when AA is turned on.


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
