### PR TITLE
fix: jump page on hold in font family and language selection

### DIFF
--- a/src/activities/settings/FontSelectionActivity.cpp
+++ b/src/activities/settings/FontSelectionActivity.cpp
@@ -60,13 +60,26 @@ void FontSelectionActivity::loop() {
     return;
   }
 
-  buttonNavigator_.onNextRelease([this] {
-    selectedIndex_ = ButtonNavigator::nextIndex(selectedIndex_, static_cast<int>(fonts_.size()));
+  const int listSize = static_cast<int>(fonts_.size());
+  const int pageItems = UITheme::getNumberOfItemsPerPage(renderer, true, false, true, false);
+
+  buttonNavigator_.onNextRelease([this, listSize] {
+    selectedIndex_ = ButtonNavigator::nextIndex(selectedIndex_, listSize);
     requestUpdate();
   });
 
-  buttonNavigator_.onPreviousRelease([this] {
-    selectedIndex_ = ButtonNavigator::previousIndex(selectedIndex_, static_cast<int>(fonts_.size()));
+  buttonNavigator_.onPreviousRelease([this, listSize] {
+    selectedIndex_ = ButtonNavigator::previousIndex(selectedIndex_, listSize);
+    requestUpdate();
+  });
+
+  buttonNavigator_.onNextContinuous([this, listSize, pageItems] {
+    selectedIndex_ = ButtonNavigator::nextPageIndex(selectedIndex_, listSize, pageItems);
+    requestUpdate();
+  });
+
+  buttonNavigator_.onPreviousContinuous([this, listSize, pageItems] {
+    selectedIndex_ = ButtonNavigator::previousPageIndex(selectedIndex_, listSize, pageItems);
     requestUpdate();
   });
 }

--- a/src/activities/settings/LanguageSelectActivity.cpp
+++ b/src/activities/settings/LanguageSelectActivity.cpp
@@ -37,6 +37,8 @@ void LanguageSelectActivity::loop() {
     return;
   }
 
+  const int pageItems = UITheme::getNumberOfItemsPerPage(renderer, true, false, true, false);
+
   // Handle navigation
   buttonNavigator.onNextRelease([this] {
     selectedIndex = ButtonNavigator::nextIndex(static_cast<int>(selectedIndex), totalItems);
@@ -45,6 +47,16 @@ void LanguageSelectActivity::loop() {
 
   buttonNavigator.onPreviousRelease([this] {
     selectedIndex = ButtonNavigator::previousIndex(static_cast<int>(selectedIndex), totalItems);
+    requestUpdate();
+  });
+
+  buttonNavigator.onNextContinuous([this, pageItems] {
+    selectedIndex = ButtonNavigator::nextPageIndex(static_cast<int>(selectedIndex), totalItems, pageItems);
+    requestUpdate();
+  });
+
+  buttonNavigator.onPreviousContinuous([this, pageItems] {
+    selectedIndex = ButtonNavigator::previousPageIndex(static_cast<int>(selectedIndex), totalItems, pageItems);
     requestUpdate();
   });
 }


### PR DESCRIPTION
## Summary
- Holding the navigation button in **Settings → Reader → Font family** now advances the selection by a full visible page instead of one item at a time.
- Same fix applied to **Settings → Language**, which had the same one-item-only behavior.
- Mirrors the pattern already used in font download (ceb3fed) and chapter selection screens.

## Test plan
- [ ] Settings → Reader → Font family: tap moves by one item; hold jumps a page (wraps at ends)
- [ ] Settings → Language: tap moves by one item; hold jumps a page (wraps at ends)