### PR TITLE
docs: fix KOReader sync guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project is **not affiliated with Xteink**; it's built as a community projec
 Multi-language support: Read EPUBs in various languages, including English, Spanish, French, German, Italian, Portuguese, Russian, Ukrainian, Polish, Swedish, Norwegian, [and more](./USER_GUIDE.md#supported-languages).
 
 See [the user guide](./USER_GUIDE.md) for instructions on operating CrossPoint, including the
-[KOReader Sync quick setup](./USER_GUIDE.md#365-koreader-sync-quick-setup).
+[KOReader Sync quick setup](./USER_GUIDE.md#367-koreader-sync-quick-setup).
 
 For more details about the scope of the project, see the [SCOPE.md](SCOPE.md) document.
 


### PR DESCRIPTION
## Summary

* Fix the README link to the KOReader Sync quick setup section in the user guide.
* Update the fragment from the old 3.6.5 anchor to the current 3.6.7 anchor.

## Additional Context

The README pointed to `#365-koreader-sync-quick-setup`, but `USER_GUIDE.md` defines this section as `3.6.7 KOReader Sync Quick Setup`, with the matching anchor `#367-koreader-sync-quick-setup`.

Verified with `rg` that the README now points to the existing heading. PlatformIO checks were not run because this is a Markdown-only link fix and `pio` is not installed in this environment.