### PR TITLE
docs: fix activity manager reference

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -47,7 +47,7 @@ In each loop iteration, the firmware updates input, runs the active activity, ha
 ## Activity model
 
 Activities are screen-level controllers deriving from `src/activities/Activity.h`.
-Some flows use `src/activities/ActivityWithSubactivity.h` to host nested activities.
+Some flows use the stack in `src/activities/ActivityManager.h` to host nested activities and return results.
 
 - `onEnter()` and `onExit()` manage setup/teardown
 - `loop()` handles per-frame behavior


### PR DESCRIPTION
## Summary

* Update the contributor architecture guide to reference the current ActivityManager stack for nested activities.
* Remove the stale reference to `src/activities/ActivityWithSubactivity.h`, which no longer exists.

## Additional Context

`docs/contributing/architecture.md` still pointed contributors to the removed `ActivityWithSubactivity` helper. The current activity stack lives in `src/activities/ActivityManager.h`, with helpers exposed through `Activity`.

Verified that `src/activities/ActivityManager.h` exists, `src/activities/ActivityWithSubactivity.h` does not exist, and the contributor architecture guide no longer references the removed header.