### PR TITLE
fix: show convert icon usage without optional deps

### DIFF
--- a/scripts/convert_icon.py
+++ b/scripts/convert_icon.py
@@ -1,18 +1,20 @@
-import sys
 import os
-from PIL import Image
-import cairosvg
 import io
+import sys
 
 threshold = 128
 
 def svg_to_png_bytes(svg_path, width, height):
+    import cairosvg
+
     with open(svg_path, 'rb') as f:
         svg_data = f.read()
     png_bytes = cairosvg.svg2png(bytestring=svg_data, output_width=width, output_height=height)
     return png_bytes
 
 def load_image(path, width, height):
+    from PIL import Image
+
     ext = os.path.splitext(path)[1].lower()
     if ext == '.svg':
         png_bytes = svg_to_png_bytes(path, width, height)
@@ -59,7 +61,7 @@ def image_to_c_array(img, array_name):
 
 def main():
     if len(sys.argv) < 5:
-        print('Usage: python convert_image.py input.png output_name width height')
+        print('Usage: python scripts/convert_icon.py input.png output_name width height')
         sys.exit(1)
     input_path, output_name, width, height = sys.argv[1:5]
     array_name = output_name.capitalize() + 'Icon'


### PR DESCRIPTION
## Summary

* Let `scripts/convert_icon.py` print its usage message before importing optional image conversion dependencies.
* Correct the usage text to reference `scripts/convert_icon.py` instead of the non-existent `convert_image.py`.

## Additional Context

Running `python3 scripts/convert_icon.py` without arguments should show usage, but it could fail first if `cairosvg` was not installed. Moving the image library imports into the conversion paths keeps the basic CLI help available before installing script dependencies.

Verified with:

```sh
python3 scripts/convert_icon.py
python3 -m py_compile scripts/convert_icon.py
```