### PR TITLE
fix: support font manifest script on Python 3.9

### DIFF
--- a/scripts/generate-font-manifest.py
+++ b/scripts/generate-font-manifest.py
@@ -16,6 +16,8 @@ The input directory may be flat (all .cpfont files in one dir) or nested
 convention <FamilyName>_<size>.cpfont.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os


### PR DESCRIPTION
## Summary

Fix `scripts/generate-font-manifest.py` so it can start under Python 3.9, matching the documented Python 3.8+ contributor requirement.

## Details

The script used modern union type annotations in a way that Python 3.9 evaluates during import. As a result, even `--help` failed before argparse could run. Postponing annotation evaluation keeps the existing hints while avoiding runtime evaluation on older supported Python versions.

## Validation

- `python3 scripts/generate-font-manifest.py --help`
- `python3 -m py_compile scripts/generate-font-manifest.py`
