### PR TITLE
fix: show debug monitor help without runtime deps

### DIFF
--- a/scripts/debugging_monitor.py
+++ b/scripts/debugging_monitor.py
@@ -35,6 +35,43 @@ import threading
 from collections import deque
 from datetime import datetime
 
+DEFAULT_BAUDRATE = 115200
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="ESP32 Serial Monitor with Memory Graph - Real-time monitoring, graphing, and command interface"
+    )
+    parser.add_argument(
+        "port",
+        nargs="?",
+        default=None,
+        help="Serial port (leave empty for autodetection)",
+    )
+    parser.add_argument(
+        "--baud",
+        type=int,
+        default=DEFAULT_BAUDRATE,
+        help=f"Baud rate (default: {DEFAULT_BAUDRATE})",
+    )
+    parser.add_argument(
+        "--filter",
+        type=str,
+        default="",
+        help="Only display lines containing this keyword (case-insensitive)",
+    )
+    parser.add_argument(
+        "--suppress",
+        type=str,
+        default="",
+        help="Suppress lines containing this keyword (case-insensitive)",
+    )
+    return parser
+
+
+if any(arg in ("-h", "--help") for arg in sys.argv[1:]):
+    build_arg_parser().parse_args()
+
 # Try to import potentially missing packages
 PACKAGE_MAPPING: dict[str, str] = {
     "serial": "pyserial",
@@ -401,34 +438,7 @@ def main() -> None:
     - Screenshot capture capability
     - Graceful shutdown on Ctrl-C or window close
     """
-    parser = argparse.ArgumentParser(
-        description="ESP32 Serial Monitor with Memory Graph - Real-time monitoring, graphing, and command interface"
-    )
-    default_baudrate = 115200
-    parser.add_argument(
-        "port",
-        nargs="?",
-        default=None,
-        help="Serial port (leave empty for autodetection)",
-    )
-    parser.add_argument(
-        "--baud",
-        type=int,
-        default=default_baudrate,
-        help=f"Baud rate (default: {default_baudrate})",
-    )
-    parser.add_argument(
-        "--filter",
-        type=str,
-        default="",
-        help="Only display lines containing this keyword (case-insensitive)",
-    )
-    parser.add_argument(
-        "--suppress",
-        type=str,
-        default="",
-        help="Suppress lines containing this keyword (case-insensitive)",
-    )
+    parser = build_arg_parser()
     args = parser.parse_args()
     port = args.port
     if port is None:


### PR DESCRIPTION
## Summary

Allow `scripts/debugging_monitor.py --help` to display CLI help before third-party runtime packages are installed.

## Details

The monitor script imported serial, matplotlib, and related packages before argparse had a chance to process `--help`. On a fresh checkout without those packages installed, even the help command exited with the dependency installation message instead of showing the available options.

This moves parser construction into a shared helper and handles `-h` / `--help` before importing the runtime-only packages. Normal execution still reports missing dependencies when they are required.

## Validation

- `python3 scripts/debugging_monitor.py --help`
- `python3 -m py_compile scripts/debugging_monitor.py`
- `python3 scripts/debugging_monitor.py` still reports the missing package message when pyserial is unavailable
