### PR TITLE
fix: prevent card overflow on screens

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -47,6 +47,7 @@
       margin: 0;
     }
     .card {
+      width: 100%;
       background: var(--card-bg);
       border-radius: 8px;
       padding: 20px;
@@ -1216,6 +1217,7 @@
         font-size: 14px;
       }
       .card {
+        line-break: anywhere;
         padding: 12px;
         margin: 10px 0;
       }

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -47,7 +47,6 @@
       margin: 0;
     }
     .card {
-      width: 100%;
       background: var(--card-bg);
       border-radius: 8px;
       padding: 20px;
@@ -262,6 +261,7 @@
     }
     .folder-link,
     .file-link {
+      word-break: break-word;
       color: var(--accent-color);
       text-decoration: none;
       cursor: pointer;


### PR DESCRIPTION
## Summary

prevent card overflow

## Additional Context

<img width="1920" height="1080" alt="bug" src="https://github.com/user-attachments/assets/df84e233-908e-4ce1-8289-d0e9b579bc13" />
<img width="1920" height="1080" alt="Bug" src="https://github.com/user-attachments/assets/cfd20f51-6421-4271-9a62-9c1987cc0dd0" />
<img width="1920" height="1080" alt="fix" src="https://github.com/user-attachments/assets/4fbe83fe-5376-4393-bd45-a825f24e19e3" />
<img width="1920" height="1080" alt="fix2" src="https://github.com/user-attachments/assets/4397848e-d8fa-4c51-ab4d-c32b2fcf33d1" />


---

### AI Usage

Did you use AI tools to help write this code? _**NO**_
