### PR TITLE
fix: sd font folder paths in documentation

### DIFF
--- a/docs/sd-card-fonts.md
+++ b/docs/sd-card-fonts.md
@@ -25,16 +25,29 @@ There are three ways to install fonts:
 
 1. Download font files from the
    [Releases page](https://github.com/crosspoint-reader/crosspoint-reader/releases/tag/sd-fonts)
-2. Copy font family folders to `/.crosspoint/fonts/` on your SD card:
+2. Copy font family folders to one of two locations on your SD card:
+
+   - `/.fonts/` — hidden directory (preferred; keeps the SD root tidy
+     when mounted on a desktop)
+   - `/fonts/` — visible directory (use this if your OS hides dot-files
+     and you'd rather see the folder in your file manager)
+
+   Both roots are always scanned at boot and the results are merged: a
+   family installed in `/fonts/` shows up even when `/.fonts/` also
+   exists, and vice versa. The two roots only collide if the same family
+   name appears in both — in that case the copy in `/.fonts/` wins and
+   the duplicate in `/fonts/` is ignored.
 
        SD Card Root/
-       └── .crosspoint/
-           └── fonts/
-               ├── Bookerly-SD/
-               │   ├── Bookerly-SD_12.cpfont
-               │   ├── Bookerly-SD_14.cpfont
-               │   ├── Bookerly-SD_16.cpfont
-               │   └── Bookerly-SD_18.cpfont
+       ├── .fonts/                     ← Hidden root (preferred)
+       │   └── Literata/
+       │       ├── Literata_12.cpfont
+       │       ├── Literata_14.cpfont
+       │       ├── Literata_16.cpfont
+       │       └── Literata_18.cpfont
+       └── fonts/                      ← Visible root (equally valid)
+           └── Merriweather/
+               ├── Merriweather_12.cpfont
                └── ...
 
 3. Insert the SD card and power on your CrossPoint reader


### PR DESCRIPTION
## Summary

The paths in the sd font documentation were never updated to match the code's use of `/fonts` and `/.fonts`. This fixes the paths in the docs.

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **Yes, Claude**
