### PR TITLE
fix: harden EPUB optimiser UI gating, size reporting, and picker teardown

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -3,6 +3,7 @@
 #include <ArduinoJson.h>
 #include <Epub.h>
 #include <FsHelpers.h>
+#include <HalGPIO.h>
 #include <HalStorage.h>
 #include <Logging.h>
 #include <WiFi.h>
@@ -375,6 +376,7 @@ void CrossPointWebServer::handleStatus() const {
   doc["rssi"] = apMode ? 0 : WiFi.RSSI();
   doc["freeHeap"] = ESP.getFreeHeap();
   doc["uptime"] = millis() / 1000;
+  doc["device"] = gpio.deviceIsX3() ? "X3" : "X4";
 
   String json;
   serializeJson(doc, json);

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4903,7 +4903,9 @@ function uploadFile() {
       // Save failed file log to batch if in batch mode
       if (useBatchLog && needsConversion) {
         logError(`Upload failed: ${error}`);
-        saveToFileBatchLog(file.name, false, 0, 0);
+        // Preserve conversion size totals when the convert step succeeded but
+        // the upload failed; otherwise nothing was produced and 0/0 is correct.
+        saveToFileBatchLog(file.name, false, convOriginalSize, convNewSize);
       }
 
       failedFiles.push({ name: file.name, error: error, file: originalFile });

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -3190,7 +3190,7 @@ function startBatchLog(fileCount) {
 }
 
 // Save current file's log to batch entries
-function saveToFileBatchLog(fileName, succeeded) {
+function saveToFileBatchLog(fileName, succeeded, originalSize = 0, newSize = 0) {
   if (!isBatchMode) return;
 
   const entries = Array.from(logContainer.querySelectorAll('.log-entry'));
@@ -3212,6 +3212,10 @@ function saveToFileBatchLog(fileName, succeeded) {
   batchStats.totalSplits += conversionStats.splits;
   batchStats.totalFixes += conversionStats.fixes;
   batchStats.totalErrors += conversionStats.errors;
+  // Defaults of 0 keep failure-path callers safe — files that never
+  // produced a converted blob contribute nothing to the totals.
+  batchStats.totalOriginalSize += originalSize;
+  batchStats.totalNewSize += newSize;
 
   // Clear for next file
   logContainer.innerHTML = '';
@@ -3244,6 +3248,22 @@ function finalizeBatchLog() {
     });
   });
 
+  // Aggregate size totals: only emit rows when at least one file was successfully
+  // converted (totalOriginalSize stays 0 for batches where conversion was off or
+  // every file fell back to original upload).
+  const totalSaved = batchStats.totalOriginalSize - batchStats.totalNewSize;
+  const totalSavedPct = batchStats.totalOriginalSize > 0
+    ? ((totalSaved / batchStats.totalOriginalSize) * 100).toFixed(1)
+    : '0.0';
+  const sizeRowsHtml = batchStats.totalOriginalSize > 0 ? `
+        <tr><td>Total original</td><td>${formatBytes(batchStats.totalOriginalSize)}</td></tr>
+        <tr><td>Total optimised</td><td>${formatBytes(batchStats.totalNewSize)}</td></tr>
+        <tr><td>Total saved</td><td class="${totalSaved > 0 ? 'saved' : 'increased'}">${
+          totalSaved > 0
+            ? `${formatBytes(totalSaved)} (${totalSavedPct}%)`
+            : `+${formatBytes(-totalSaved)}`
+        }</td></tr>` : '';
+
   // Add batch summary
   const batchSummaryHtml = `
     <div class="log-summary">
@@ -3255,7 +3275,7 @@ function finalizeBatchLog() {
         <tr><td>Total images processed</td><td>${batchStats.totalImages}</td></tr>
         <tr><td>Total splits</td><td>${batchStats.totalSplits}</td></tr>
         <tr><td>Total fixes applied</td><td>${batchStats.totalFixes}</td></tr>
-        ${batchStats.totalErrors > 0 ? `<tr><td>Total errors</td><td style="color:#e74c3c">${batchStats.totalErrors}</td></tr>` : ''}
+        ${batchStats.totalErrors > 0 ? `<tr><td>Total errors</td><td style="color:#e74c3c">${batchStats.totalErrors}</td></tr>` : ''}${sizeRowsHtml}
         <tr><td>Total time</td><td>${batchTime.toFixed(1)}s</td></tr>
       </table>
     </div>
@@ -4779,6 +4799,8 @@ function uploadFile() {
     const needsConversion = isEpub && convertEnabled;
     let conversionSucceeded = false;
     let conversionFailed = false;  // Track if conversion actually failed
+    let convOriginalSize = 0;      // Picked-file size; 0 unless conversion succeeded
+    let convNewSize = 0;           // Generated blob size; 0 unless conversion succeeded
 
     const methodText = useWebSocket ? ' [WS]' : ' [HTTP]';
     const stageText = needsConversion ? 'Converting & uploading' : 'Uploading';
@@ -4798,7 +4820,8 @@ function uploadFile() {
       // Save file log to batch if in batch mode and this file was converted
       // Consider it successful only if conversion didn't fail
       if (useBatchLog && needsConversion) {
-        saveToFileBatchLog(file.name, !conversionFailed && conversionSucceeded);
+        const ok = !conversionFailed && conversionSucceeded;
+        saveToFileBatchLog(file.name, ok, ok ? convOriginalSize : 0, ok ? convNewSize : 0);
       }
 
       currentIndex++;
@@ -4809,7 +4832,7 @@ function uploadFile() {
       // Save failed file log to batch if in batch mode
       if (useBatchLog && needsConversion) {
         logError(`Upload failed: ${error}`);
-        saveToFileBatchLog(file.name, false);
+        saveToFileBatchLog(file.name, false, 0, 0);
       }
 
       failedFiles.push({ name: file.name, error: error, file: originalFile });
@@ -4854,6 +4877,10 @@ function uploadFile() {
           showLog();
         }
 
+        // Snapshot before the `file =` reassignment below, which swaps in the
+        // converted blob and makes file.size point at the optimised size.
+        const origFileSize = file.size;
+
         try {
           const convertedBlob = await convertEpubFile(file, (percent) => {
             // Pass current quality setting to converter
@@ -4864,6 +4891,8 @@ function uploadFile() {
           file = new File([convertedBlob], file.name, { type: 'application/epub+zip' });
           progressFill.style.backgroundColor = '#27ae60'; // Back to green for upload
           conversionSucceeded = true;
+          convOriginalSize = origFileSize;
+          convNewSize = convertedBlob.size;
         } catch (convError) {
           if (operationCancelled) { if (uploadGeneration === myGeneration) restoreAfterCancel(); return; }
           console.error('Conversion error:', convError);

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1537,7 +1537,7 @@
 
           <div class="convert-settings" id="convertSettings" style="display:block;">
             <span>⚫ True-Grayscale</span>
-          <span>📏 Max 480×800px</span>
+          <span id="convertSizeSummary">📏 Max 480×800px</span>
           <span>📦 85% JPEG</span>
           <span>🔧 Fix SVG</span>
         </div>
@@ -1572,6 +1572,19 @@
             </div>
           </div>
           -->
+          <!-- Target Device -->
+          <div class="advanced-setting-row" id="deviceSettingRow">
+            <div class="setting-title">📱 Target Device</div>
+            <div class="setting-controls">
+              <div class="rotation-buttons">
+                <button class="rotation-btn device-btn active" data-value="auto" onclick="setDeviceTarget('auto')">
+                  <span id="deviceAutoLabel">Auto</span>
+                </button>
+                <button class="rotation-btn device-btn" data-value="X4" onclick="setDeviceTarget('X4')">X4</button>
+                <button class="rotation-btn device-btn" data-value="X3" onclick="setDeviceTarget('X3')">X3</button>
+              </div>
+            </div>
+          </div>
           <!-- Rotation Direction -->
           <div class="advanced-setting-row" id="rotationSettingRow">
             <div class="setting-title">↻ Rotation Direction</div>
@@ -2990,14 +3003,24 @@ const WS_CHUNK_SIZE = 4096; // 4KB chunks - smaller for ESP32 stability
 // EPUB Image Conversion Functions (from Baseline JPEG Converter)
 // ============================================================================
 
+// Device profiles (short edge × long edge in portrait orientation)
+const DEVICE_PROFILES = {
+  X4: { width: 480, height: 800, label: 'X4' },
+  X3: { width: 528, height: 792, label: 'X3' },
+};
+
 // Default conversion settings
-const DEFAULT_MAX_WIDTH = 480;
-const DEFAULT_MAX_HEIGHT = 800;
+const DEFAULT_DEVICE = 'X4';
+const DEFAULT_MAX_WIDTH = DEVICE_PROFILES[DEFAULT_DEVICE].width;
+const DEFAULT_MAX_HEIGHT = DEVICE_PROFILES[DEFAULT_DEVICE].height;
 const DEFAULT_JPEG_QUALITY = 85;
 const DEFAULT_ENABLE_GRAYSCALE = true;
 // Note: Overlap is now always centered distribution (min 5%)
 
 // Dynamic conversion settings (updated by UI)
+let DEVICE_TARGET = 'auto';      // 'auto' | 'X4' | 'X3'
+let DETECTED_DEVICE = null;      // populated from /api/status
+let ACTIVE_DEVICE = DEFAULT_DEVICE;
 let MAX_WIDTH = DEFAULT_MAX_WIDTH;
 let MAX_HEIGHT = DEFAULT_MAX_HEIGHT;
 let JPEG_QUALITY = DEFAULT_JPEG_QUALITY;
@@ -3033,10 +3056,40 @@ async function fetchVersion() {
     if (response.ok) {
       const data = await response.json();
       crosspointVersion = data.version || 'Unknown';
+      if (data.device === 'X3' || data.device === 'X4') {
+        DETECTED_DEVICE = data.device;
+        applyDeviceTarget();
+      }
     }
   } catch (e) {
     console.error('Failed to fetch version:', e);
   }
+}
+
+// Resolve DEVICE_TARGET ('auto' | 'X4' | 'X3') to a concrete profile and update UI.
+function applyDeviceTarget() {
+  const resolved = DEVICE_TARGET === 'auto' ? (DETECTED_DEVICE || DEFAULT_DEVICE) : DEVICE_TARGET;
+  const profile = DEVICE_PROFILES[resolved] || DEVICE_PROFILES[DEFAULT_DEVICE];
+  ACTIVE_DEVICE = resolved;
+  MAX_WIDTH = profile.width;
+  MAX_HEIGHT = profile.height;
+
+  const summary = document.getElementById('convertSizeSummary');
+  if (summary) {
+    summary.textContent = `📏 Max ${profile.width}×${profile.height}px`;
+  }
+  document.querySelectorAll('.device-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.value === DEVICE_TARGET);
+  });
+  const autoLabel = document.getElementById('deviceAutoLabel');
+  if (autoLabel) {
+    autoLabel.textContent = DETECTED_DEVICE ? `Auto (${DETECTED_DEVICE})` : 'Auto';
+  }
+}
+
+function setDeviceTarget(value) {
+  DEVICE_TARGET = value;
+  applyDeviceTarget();
 }
 
 // Batch logging system for multiple files

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -2953,6 +2953,11 @@
       const convertEnabled = document.getElementById('convertBeforeUpload').checked;
       if (advancedContent.classList.contains('visible') && files.length === 1 && convertEnabled && files[0].name.toLowerCase().endsWith('.epub')) {
         showImagePicker(files[0]).catch(err => console.error('Image picker error:', err));
+      } else {
+        // New selection no longer matches single-EPUB-with-advanced-expanded —
+        // tear down any picker from a previous file so the grid and picker-mode
+        // layout don't linger. clearImagePicker is idempotent.
+        clearImagePicker();
       }
 
       // If multiple files with conversion, inform user about batch mode

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -2385,13 +2385,13 @@
       const isTiny = (dims.width < 200 && dims.height < 200);
       
       // Images that fit screen can only rotate, not split
-      const fitsScreen = (dims.width <= 480 && dims.height <= 800);
-      
+      const fitsScreen = (dims.width <= MAX_WIDTH && dims.height <= MAX_HEIGHT);
+
       // Split capability - no upscaling allowed
-      // H-Split scales width to 800, so needs width >= 800
-      // V-Split scales height to 800, so needs height >= 800
-      const canHSplit = dims.width >= 800;
-      const canVSplit = dims.height >= 800;
+      // H-Split scales width to MAX_HEIGHT (long edge), so needs width >= MAX_HEIGHT
+      // V-Split scales height to MAX_HEIGHT, so needs height >= MAX_HEIGHT
+      const canHSplit = dims.width >= MAX_HEIGHT;
+      const canVSplit = dims.height >= MAX_HEIGHT;
 
       images.push({
         path: path,
@@ -2629,16 +2629,16 @@
         if (showSplitLines) {
           let finalWidth;
           if (state === 1) {
-            // H-Split: scale width to 800, rotate, then check width
-            const scaledH = Math.round(img.height * (800 / img.width));
+            // H-Split: scale width to MAX_HEIGHT, rotate, then check width
+            const scaledH = Math.round(img.height * (MAX_HEIGHT / img.width));
             finalWidth = scaledH; // After rotation, height becomes width
           } else {
-            // V-Split: scale height to 800, then check width
-            finalWidth = Math.round(img.width * (800 / img.height));
+            // V-Split: scale height to MAX_HEIGHT, then check width
+            finalWidth = Math.round(img.width * (MAX_HEIGHT / img.height));
           }
-          if (finalWidth > 480) {
-            const minOverlapPx = Math.round(480 * (OVERLAP_PERCENT / 100));
-            const maxStep = 480 - minOverlapPx;
+          if (finalWidth > MAX_WIDTH) {
+            const minOverlapPx = Math.round(MAX_WIDTH * (OVERLAP_PERCENT / 100));
+            const maxStep = MAX_WIDTH - minOverlapPx;
             numParts = Math.ceil((finalWidth - minOverlapPx) / maxStep);
             if (numParts < 2) numParts = 2;
           }
@@ -3084,6 +3084,19 @@ function applyDeviceTarget() {
   const autoLabel = document.getElementById('deviceAutoLabel');
   if (autoLabel) {
     autoLabel.textContent = DETECTED_DEVICE ? `Auto (${DETECTED_DEVICE})` : 'Auto';
+  }
+
+  // Recompute picker classification with new dimensions, then refresh grid.
+  if (Array.isArray(epubImagesCache) && epubImagesCache.length > 0) {
+    for (const img of epubImagesCache) {
+      img.fitsScreen = (img.width <= MAX_WIDTH && img.height <= MAX_HEIGHT);
+      img.canHSplit = img.width >= MAX_HEIGHT;
+      img.canVSplit = img.height >= MAX_HEIGHT;
+    }
+    const pickerSection = document.getElementById('imagePickerSection');
+    if (pickerSection && pickerSection.style.display !== 'none' && typeof renderImageGrid === 'function') {
+      renderImageGrid();
+    }
   }
 }
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -2931,11 +2931,20 @@
     const convertOptions = document.getElementById('convertOptions');
     fileInput.classList.toggle('has-files', files.length > 0);
 
-    // Show/hide convert options based on file selection
-    if (files.length > 0) {
+    // Show convert options only when at least one selected file is an EPUB.
+    const hasEpub = Array.from(files).some(f => f.name.toLowerCase().endsWith('.epub'));
+    if (files.length > 0 && hasEpub) {
       convertOptions.style.display = 'block';
     } else {
-      clearImagePicker();
+      convertOptions.style.display = 'none';
+      // Clear stale checkbox state so the "Optimize & Upload" button doesn't linger
+      // when the user re-picks a non-EPUB after having ticked Optimize for an EPUB.
+      const cb = document.getElementById('convertBeforeUpload');
+      if (cb && cb.checked) {
+        cb.checked = false;
+        toggleConvertOptions();
+      }
+      if (files.length === 0) clearImagePicker();
     }
 
     if (files.length > 0) {
@@ -4178,8 +4187,6 @@ async function processImage(data, imageState = 0, imagePath = '') {
 async function convertEpubFile(file, progressCallback) {
   const startTime = Date.now();
   const originalSize = file.size;
-  let totalImageSize = 0;
-  let totalNewSize = 0;
 
   // Initialize logging
   clearLog();
@@ -4262,9 +4269,6 @@ async function convertEpubFile(file, progressCallback) {
       const imgName = path.split('/').pop();
       const origFormat = path.split('.').pop();
       logImage(imgName, meta.origW, meta.origH, origFormat, meta.origSize, meta.finalW, meta.finalH, meta.finalSize, meta.wasSplit, meta.splitCount || 0, parts, meta.imageState || 0);
-
-      totalImageSize += meta.origSize;
-      totalNewSize += meta.finalSize;
 
       if (parts.length === 1 && parts[0].suffix === '') {
         const newPath = renamed[path] || path.replace(/\.[^.]+$/, newExt);
@@ -4506,7 +4510,7 @@ async function convertEpubFile(file, progressCallback) {
 
   // Log completion
   log('Conversion complete!', 'success', 'DONE');
-  logSummary(totalImageSize > 0 ? totalImageSize : originalSize, totalNewSize > 0 ? totalNewSize : newSize, timeElapsed);
+  logSummary(originalSize, newSize, timeElapsed);
 
   // Auto-export only if NOT in batch mode (batch mode exports at the end)
   if (!isBatchMode && exportLogCheckbox && exportLogCheckbox.checked) {


### PR DESCRIPTION
## Summary

Four fixes in the web file-upload modal's EPUB optimiser (`src/network/html/FilesPage.html`):

- **"Optimize EPUB" was offered for any file type.** The convert-options panel was shown unconditionally on every file selection. It now appears only when at least one selected file ends in `.epub`. When the selection changes back to non-EPUB, the checkbox is force-unchecked via `toggleConvertOptions()` so the "Optimize & Upload" button label and image-picker state reset cleanly. Mixed selections still show the option — the existing batch loop already filters EPUBs.

- **Per-file conversion summary reported wrong sizes.** `logSummary()` was being fed `totalImageSize` / `totalNewSize` (sum of *image* bytes only), so whenever the EPUB contained any images, *Original size*, *Optimized size*, and *Saved (X%)* didn't match the actual file on disk. It now receives `originalSize = file.size` and `newSize = newBlob.size`. The now-unused accumulators are removed.

- **Batch summary had no aggregate size totals.** `batchStats.totalOriginalSize` / `totalNewSize` were declared but never incremented or rendered. They are now wired up: `saveToFileBatchLog` takes optional `(originalSize, newSize)`, snapshotted before the converted blob replaces the picked file, and the batch summary renders *Total original*, *Total optimised*, *Total saved (X%)* whenever at least one file successfully converted. Files that fell back to original upload (or never converted) contribute 0/0 and don't poison the totals.

- **Image picker stayed visible after switching to multi-file selection.** `validateFile()` opened the picker on a single-EPUB selection with Advanced Mode expanded, but had no else branch — re-picking multiple files left the previous file's thumbnails and `picker-mode` layout visible. Added an else that calls the existing idempotent `clearImagePicker()` so the grid, layout classes, and the *Start Conversion* button tear down whenever the selection no longer matches the open-picker condition.

Per-image before/after numbers logged by `logImage()` are unchanged. Reuses the existing `formatBytes()` helper and `.saved` / `.increased` CSS classes — no new styling.

## Commits

1. `b38e0561` fix: gate EPUB optimiser by extension and report real file sizes
2. `fef6b242` feat: aggregate Total original / optimised / saved rows in batch summary
3. `4ca511bc` fix: clear stale image picker when selection switches to multi-file

## Test plan

- [ ] `pio run` succeeds (regenerates `FilesPageHtml.generated.h`)
- [ ] Pick a single `.txt` → "Optimize EPUB" panel hidden
- [ ] Pick a single `.epub` → panel shown
- [ ] Pick `.epub`, tick Optimize, then re-pick `.txt` without closing modal → panel hides, button reverts from "Optimize & Upload" to "Upload"
- [ ] Multi-select one `.epub` + one `.txt` → panel shown; running it optimises the EPUB and uploads the TXT untouched
- [ ] Single-file optimise of a known-size EPUB → summary's *Original size* equals the picked file's size on disk (not the image-bytes total) and *Optimized size* equals the generated blob size
- [ ] Batch of multiple EPUBs → final batch summary shows *Total original*, *Total optimised*, *Total saved (X%)* summing the individual files
- [ ] Batch with Optimize off → totals rows absent
- [ ] Batch where one file fails conversion and uploads original as fallback → that file contributes 0 to the totals (others still counted)
- [ ] Pick single `.epub`, tick Optimize, expand Advanced Mode → picker appears. Re-pick multiple `.epub` files → picker disappears, no leftover thumbnails or *Start Conversion* button
- [ ] Same starting state, then re-pick a different single `.epub` → picker re-populates with the new file's thumbnails