### PR TITLE
fix: prune books missing form sd card in recent books list

### DIFF
--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -56,11 +56,11 @@ void RecentBooksStore::updateBook(const std::string& path, const std::string& ti
   }
 }
 
+bool RecentBooksStore::isMissing(const RecentBook& book) { return !Storage.exists(book.path.c_str()); }
+
 bool RecentBooksStore::pruneMissing() {
   const size_t before = recentBooks.size();
-  recentBooks.erase(std::remove_if(recentBooks.begin(), recentBooks.end(),
-                                   [](const RecentBook& b) { return !Storage.exists(b.path.c_str()); }),
-                    recentBooks.end());
+  recentBooks.erase(std::remove_if(recentBooks.begin(), recentBooks.end(), &isMissing), recentBooks.end());
   return recentBooks.size() != before;
 }
 

--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -22,6 +22,9 @@ RecentBooksStore RecentBooksStore::instance;
 
 void RecentBooksStore::addBook(const std::string& path, const std::string& title, const std::string& author,
                                const std::string& coverBmpPath) {
+  // Drop stale entries first so a new add can't evict a valid book in their stead.
+  pruneMissing();
+
   // Remove existing entry if present
   auto it =
       std::find_if(recentBooks.begin(), recentBooks.end(), [&](const RecentBook& book) { return book.path == path; });
@@ -51,6 +54,14 @@ void RecentBooksStore::updateBook(const std::string& path, const std::string& ti
     book.coverBmpPath = coverBmpPath;
     saveToFile();
   }
+}
+
+bool RecentBooksStore::pruneMissing() {
+  const size_t before = recentBooks.size();
+  recentBooks.erase(std::remove_if(recentBooks.begin(), recentBooks.end(),
+                                   [](const RecentBook& b) { return !Storage.exists(b.path.c_str()); }),
+                    recentBooks.end());
+  return recentBooks.size() != before;
 }
 
 bool RecentBooksStore::saveToFile() const {

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -37,6 +37,9 @@ class RecentBooksStore {
   void updateBook(const std::string& path, const std::string& title, const std::string& author,
                   const std::string& coverBmpPath);
 
+  // True if the book's backing file is no longer present on the SD card.
+  static bool isMissing(const RecentBook& book);
+
   // Remove entries whose backing file is no longer on the SD card.
   // Returns true if any entry was removed. Does not persist — caller decides.
   bool pruneMissing();

--- a/src/RecentBooksStore.h
+++ b/src/RecentBooksStore.h
@@ -37,6 +37,10 @@ class RecentBooksStore {
   void updateBook(const std::string& path, const std::string& title, const std::string& author,
                   const std::string& coverBmpPath);
 
+  // Remove entries whose backing file is no longer on the SD card.
+  // Returns true if any entry was removed. Does not persist — caller decides.
+  bool pruneMissing();
+
   // Get the list of recent books (most recent first)
   const std::vector<RecentBook>& getBooks() const { return recentBooks; }
 

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -43,7 +43,7 @@ void HomeActivity::loadRecentBooks(int maxBooks) {
     }
 
     // Skip if file no longer exists
-    if (!Storage.exists(book.path.c_str())) {
+    if (RecentBooksStore::isMissing(book)) {
       continue;
     }
 

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -15,10 +15,7 @@ namespace {
 constexpr unsigned long GO_HOME_MS = 1000;
 }  // namespace
 
-void RecentBooksActivity::loadRecentBooks() {
-  const auto& books = RECENT_BOOKS.getBooks();
-  recentBooks = books;
-}
+void RecentBooksActivity::loadRecentBooks() { recentBooks = RECENT_BOOKS.getBooks(); }
 
 void RecentBooksActivity::onEnter() {
   Activity::onEnter();

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -16,21 +16,18 @@ constexpr unsigned long GO_HOME_MS = 1000;
 }  // namespace
 
 void RecentBooksActivity::loadRecentBooks() {
-  recentBooks.clear();
   const auto& books = RECENT_BOOKS.getBooks();
-  recentBooks.reserve(books.size());
-
-  for (const auto& book : books) {
-    // Skip if file no longer exists
-    if (!Storage.exists(book.path.c_str())) {
-      continue;
-    }
-    recentBooks.push_back(book);
-  }
+  recentBooks = books;
 }
 
 void RecentBooksActivity::onEnter() {
   Activity::onEnter();
+
+  // Prune entries whose backing files are gone; this is one of two interaction
+  // points where the persistent store gets cleaned (the other is addBook).
+  if (RECENT_BOOKS.pruneMissing()) {
+    RECENT_BOOKS.saveToFile();
+  }
 
   // Load data
   loadRecentBooks();


### PR DESCRIPTION
## Summary

When entering the recent books list or opening a new book, prune any books no longer on the sd card from the recent books list. This frees slots so the queue/list of recent books gets updated cleanly. Prior to this change there were times the book list wouldn't fill to '10' and it was due to books being removed from sd card.

## Additional Context

If a user does delete a book by accident, they can restore it prior to opening another book or opening the recent list to keep the accidentally deleted book in place on the recent book list.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? **Yes, claude**
