### PR TITLE
fix: remove wake on short power button press

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -235,11 +235,7 @@ void HalGPIO::startDeepSleep() {
   esp_deep_sleep_start();
 }
 
-void HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPressAllowed) {
-  if (shortPressAllowed) {
-    // Fast path - no duration check needed
-    return;
-  }
+void HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs) {
   // TODO: Intermittent edge case remains: a single tap followed by another single tap
   // can still power on the device. Tighten wake debounce/state handling here.
 

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -77,7 +77,7 @@ class HalGPIO {
   // Verify power button was held long enough after wakeup.
   // If verification fails, enters deep sleep and does not return.
   // Should only be called when wakeup reason is PowerButton.
-  void verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPressAllowed);
+  void verifyPowerButtonWakeup(uint16_t requiredDurationMs);
 
   // Check if USB is connected
   bool isUsbConnected() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -308,8 +308,7 @@ void setup() {
   switch (wakeupReason) {
     case HalGPIO::WakeupReason::PowerButton:
       LOG_DBG("MAIN", "Verifying power button press duration");
-      gpio.verifyPowerButtonWakeup(SETTINGS.getPowerButtonDuration(),
-                                   SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::SLEEP);
+      gpio.verifyPowerButtonWakeup(SETTINGS.getPowerButtonDuration());
       break;
     case HalGPIO::WakeupReason::AfterUSBPower:
       // If USB power caused a cold boot, go back to sleep


### PR DESCRIPTION
## Summary

Fixes #1966

Remove the seemingly unintended check for a single short power button press to wake the device.

---

Did you use AI tools to help write this code? _**< NO >**_
