### PR TITLE
refactor: extract Typesetter from ChapterHtmlSlimParser

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -128,7 +128,7 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
       currentTextBlock->setBlockStyle(style.getCombinedBlockStyle(blockStyle, BlockStyle::CombineAxis::Vertical));
 
       if (!pendingAnchorId.empty()) {
-        anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
+        anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(typesetter.getCompletedPageCount())});
         pendingAnchorId.clear();
       }
       return;
@@ -138,11 +138,11 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
   }
   // Record deferred anchor after previous block is flushed
   if (!pendingAnchorId.empty()) {
-    anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
+    anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(typesetter.getCompletedPageCount())});
     pendingAnchorId.clear();
   }
   currentTextBlock.reset(new ParsedText(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle));
-  wordsExtractedInBlock = 0;
+  typesetter.resetWordsExtractedInBlock();
 }
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
@@ -155,10 +155,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
   }
 
   if (strcmp(name, "p") == 0) {
-    self->xpathParagraphIndex++;
+    self->typesetter.incrementXpathParagraphIndex();
   }
   if (strcmp(name, "li") == 0) {
-    self->xpathListItemIndex++;
+    self->typesetter.incrementXpathListItemIndex();
   }
 
   // Extract class, style, and id attributes
@@ -448,45 +448,12 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   }
                 }
 
-                // Create page for image - only break if image won't fit remaining space
-                if (self->currentPage && !self->currentPage->elements.empty() &&
-                    (self->currentPageNextY + imageMarginTop + displayHeight + imageMarginBottom >
-                     self->viewportHeight)) {
-                  self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex,
-                                       self->xpathListItemIndex);
-                  self->completedPageCount++;
-                  self->currentPage.reset(new Page());
-                  if (!self->currentPage) {
-                    LOG_ERR("EHP", "Failed to create new page");
-                    return;
-                  }
-                  self->currentPageNextY = 0;
-                } else if (!self->currentPage) {
-                  self->currentPage.reset(new Page());
-                  if (!self->currentPage) {
-                    LOG_ERR("EHP", "Failed to create initial page");
-                    return;
-                  }
-                  self->currentPageNextY = 0;
-                }
-
-                // Apply top margin from container block
-                self->currentPageNextY += imageMarginTop;
-
-                // Create ImageBlock and add to page
                 auto imageBlock = std::make_shared<ImageBlock>(cachedImagePath, displayWidth, displayHeight);
                 if (!imageBlock) {
                   LOG_ERR("EHP", "Failed to create ImageBlock");
                   return;
                 }
-                int xPos = (self->viewportWidth - displayWidth) / 2;
-                auto pageImage = std::make_shared<PageImage>(imageBlock, xPos, self->currentPageNextY);
-                if (!pageImage) {
-                  LOG_ERR("EHP", "Failed to create PageImage");
-                  return;
-                }
-                self->currentPage->elements.push_back(pageImage);
-                self->currentPageNextY += displayHeight + imageMarginBottom;
+                self->typesetter.submitImage(imageBlock, imageMarginTop, imageMarginBottom);
 
                 // The image consumed the empty block's accumulated vertical spacing.
                 // Reset the block so the Vertical merge in startNewTextBlock doesn't
@@ -885,13 +852,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
   // Spotted when reading Intermezzo, there are some really long text blocks in there.
   if (self->currentTextBlock->size() > 750) {
     LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
-    const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
-    const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
-                                        ? static_cast<uint16_t>(self->viewportWidth - horizontalInset)
-                                        : self->viewportWidth;
-    self->currentTextBlock->layoutAndExtractLines(
-        self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+    self->typesetter.partialFlush(*self->currentTextBlock);
   }
 }
 
@@ -964,9 +925,9 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       entry.number[sizeof(entry.number) - 1] = '\0';
       strncpy(entry.href, self->currentFootnote.href, sizeof(entry.href) - 1);
       entry.href[sizeof(entry.href) - 1] = '\0';
-      int wordIndex =
-          self->wordsExtractedInBlock + (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);
-      self->pendingFootnotes.push_back({wordIndex, entry});
+      int wordIndex = self->typesetter.getWordsExtractedInBlock() +
+                      (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);
+      self->typesetter.addPendingFootnote(wordIndex, entry);
     }
     self->insideFootnoteLink = false;
   }
@@ -1116,46 +1077,14 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   if (currentTextBlock) {
     makePages();
     if (!pendingAnchorId.empty()) {
-      anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
+      anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(typesetter.getCompletedPageCount())});
       pendingAnchorId.clear();
     }
-    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
-    completedPageCount++;
-    currentPage.reset();
+    typesetter.finish();
     currentTextBlock.reset();
   }
 
   return true;
-}
-
-void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
-  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
-
-  if (!currentPage) {
-    currentPage.reset(new Page());
-    currentPageNextY = 0;
-  }
-
-  if (currentPageNextY + lineHeight > viewportHeight) {
-    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
-    completedPageCount++;
-    currentPage.reset(new Page());
-    currentPageNextY = 0;
-  }
-
-  // Track cumulative words to assign footnotes to the page containing their anchor
-  wordsExtractedInBlock += line->wordCount();
-  auto footnoteIt = pendingFootnotes.begin();
-  while (footnoteIt != pendingFootnotes.end() && footnoteIt->first <= wordsExtractedInBlock) {
-    currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href);
-    ++footnoteIt;
-  }
-  pendingFootnotes.erase(pendingFootnotes.begin(), footnoteIt);
-
-  // Apply horizontal left inset (margin + padding) as x position offset
-  const int16_t xOffset = line->getBlockStyle().leftInset();
-  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
-  currentPageNextY += lineHeight;
 }
 
 void ChapterHtmlSlimParser::makePages() {
@@ -1164,51 +1093,5 @@ void ChapterHtmlSlimParser::makePages() {
     return;
   }
 
-  if (!currentPage) {
-    currentPage.reset(new Page());
-    currentPageNextY = 0;
-  }
-
-  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
-
-  // Apply top spacing before the paragraph (stored in pixels)
-  const BlockStyle& blockStyle = currentTextBlock->getBlockStyle();
-  if (blockStyle.marginTop > 0) {
-    currentPageNextY += blockStyle.marginTop;
-  }
-  if (blockStyle.paddingTop > 0) {
-    currentPageNextY += blockStyle.paddingTop;
-  }
-
-  // Calculate effective width accounting for horizontal margins/padding
-  const int horizontalInset = blockStyle.totalHorizontalInset();
-  const uint16_t effectiveWidth =
-      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
-
-  currentTextBlock->layoutAndExtractLines(
-      renderer, fontId, effectiveWidth,
-      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
-
-  // Fallback: transfer any remaining pending footnotes to current page.
-  // Normally addLineToPage handles this via word-index tracking, but this catches
-  // edge cases where a footnote's word index equals the exact block size.
-  if (!pendingFootnotes.empty() && currentPage) {
-    for (const auto& [idx, fn] : pendingFootnotes) {
-      currentPage->addFootnote(fn.number, fn.href);
-    }
-    pendingFootnotes.clear();
-  }
-
-  // Apply bottom spacing after the paragraph (stored in pixels)
-  if (blockStyle.marginBottom > 0) {
-    currentPageNextY += blockStyle.marginBottom;
-  }
-  if (blockStyle.paddingBottom > 0) {
-    currentPageNextY += blockStyle.paddingBottom;
-  }
-
-  // Extra paragraph spacing if enabled (default behavior)
-  if (extraParagraphSpacing) {
-    currentPageNextY += lineHeight / 2;
-  }
+  typesetter.submitParagraph(std::move(currentTextBlock));
 }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <Typesetter.h>
 #include <expat.h>
 
 #include <climits>
@@ -25,8 +26,8 @@ class ChapterHtmlSlimParser {
   std::shared_ptr<Epub> epub;
   const std::string& filepath;
   GfxRenderer& renderer;
-  std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn;
   std::function<void()> popupFn;  // Popup callback
+  Typesetter typesetter;
   int depth = 0;
   int skipUntilDepth = INT_MAX;
   int boldUntilDepth = INT_MAX;
@@ -38,8 +39,6 @@ class ChapterHtmlSlimParser {
   int partWordBufferIndex = 0;
   bool nextWordContinues = false;  // true when next flushed word attaches to previous (inline element boundary)
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
-  std::unique_ptr<Page> currentPage = nullptr;
-  int16_t currentPageNextY = 0;
   int fontId;
   float lineCompression;
   bool extraParagraphSpacing;
@@ -73,19 +72,14 @@ class ChapterHtmlSlimParser {
   int tableColIndex = 0;
 
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
-  int completedPageCount = 0;
   std::vector<std::pair<std::string, uint16_t>> anchorData;
   std::string pendingAnchorId;  // deferred until after previous text block is flushed
-  uint16_t xpathParagraphIndex = 0;
-  uint16_t xpathListItemIndex = 0;
 
   // Footnote link tracking
   bool insideFootnoteLink = false;
   int footnoteLinkDepth = -1;
   FootnoteEntry currentFootnote = {};
   int currentFootnoteLinkTextLen = 0;
-  std::vector<std::pair<int, FootnoteEntry>> pendingFootnotes;  // <wordIndex, entry>
-  int wordsExtractedInBlock = 0;
 
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
@@ -111,6 +105,9 @@ class ChapterHtmlSlimParser {
       : epub(epub),
         filepath(filepath),
         renderer(renderer),
+        popupFn(popupFn),
+        typesetter(renderer, fontId, lineCompression, extraParagraphSpacing, viewportWidth, viewportHeight,
+                   completePageFn),
         fontId(fontId),
         lineCompression(lineCompression),
         extraParagraphSpacing(extraParagraphSpacing),
@@ -119,8 +116,6 @@ class ChapterHtmlSlimParser {
         viewportHeight(viewportHeight),
         hyphenationEnabled(hyphenationEnabled),
         focusReadingEnabled(focusReadingEnabled),
-        completePageFn(completePageFn),
-        popupFn(popupFn),
         cssParser(cssParser),
         embeddedStyle(embeddedStyle),
         imageRendering(imageRendering),
@@ -129,6 +124,5 @@ class ChapterHtmlSlimParser {
 
   ~ChapterHtmlSlimParser() = default;
   bool parseAndBuildPages();
-  void addLineToPage(std::shared_ptr<TextBlock> line);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 };

--- a/lib/Typesetter/Typesetter.cpp
+++ b/lib/Typesetter/Typesetter.cpp
@@ -1,0 +1,135 @@
+#include "Typesetter.h"
+
+#include <GfxRenderer.h>
+#include <Logging.h>
+
+Typesetter::Typesetter(GfxRenderer& renderer, int fontId, float lineCompression, bool extraParagraphSpacing,
+                       uint16_t viewportWidth, uint16_t viewportHeight,
+                       std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn)
+    : renderer(renderer),
+      fontId(fontId),
+      lineCompression(lineCompression),
+      extraParagraphSpacing(extraParagraphSpacing),
+      viewportWidth(viewportWidth),
+      viewportHeight(viewportHeight),
+      completePageFn(std::move(completePageFn)) {}
+
+void Typesetter::addLineToPage(std::shared_ptr<TextBlock> line) {
+  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
+
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  if (currentPageNextY + lineHeight > viewportHeight) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  wordsExtractedInBlock += line->wordCount();
+  auto footnoteIt = pendingFootnotes.begin();
+  while (footnoteIt != pendingFootnotes.end() && footnoteIt->first <= wordsExtractedInBlock) {
+    currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href);
+    ++footnoteIt;
+  }
+  pendingFootnotes.erase(pendingFootnotes.begin(), footnoteIt);
+
+  const int16_t xOffset = line->getBlockStyle().leftInset();
+  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  currentPageNextY += lineHeight;
+}
+
+void Typesetter::submitParagraph(std::unique_ptr<ParsedText> paragraph) {
+  if (!paragraph) {
+    LOG_ERR("TYP", "!! No text block to make pages for !!");
+    return;
+  }
+
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
+
+  const BlockStyle& blockStyle = paragraph->getBlockStyle();
+  if (blockStyle.marginTop > 0) {
+    currentPageNextY += blockStyle.marginTop;
+  }
+  if (blockStyle.paddingTop > 0) {
+    currentPageNextY += blockStyle.paddingTop;
+  }
+
+  const int horizontalInset = blockStyle.totalHorizontalInset();
+  const uint16_t effectiveWidth =
+      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+
+  paragraph->layoutAndExtractLines(renderer, fontId, effectiveWidth,
+                                   [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
+
+  if (!pendingFootnotes.empty() && currentPage) {
+    for (const auto& [idx, fn] : pendingFootnotes) {
+      currentPage->addFootnote(fn.number, fn.href);
+    }
+    pendingFootnotes.clear();
+  }
+
+  if (blockStyle.marginBottom > 0) {
+    currentPageNextY += blockStyle.marginBottom;
+  }
+  if (blockStyle.paddingBottom > 0) {
+    currentPageNextY += blockStyle.paddingBottom;
+  }
+
+  if (extraParagraphSpacing) {
+    currentPageNextY += lineHeight / 2;
+  }
+}
+
+void Typesetter::submitImage(std::shared_ptr<ImageBlock> imageBlock, int16_t imageMarginTop,
+                             int16_t imageMarginBottom) {
+  if (!imageBlock) {
+    LOG_ERR("TYP", "Null ImageBlock submitted");
+    return;
+  }
+
+  const int16_t displayWidth = imageBlock->getWidth();
+  const int16_t displayHeight = imageBlock->getHeight();
+
+  if (currentPage && !currentPage->elements.empty() &&
+      (currentPageNextY + imageMarginTop + displayHeight + imageMarginBottom > viewportHeight)) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  } else if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  currentPageNextY += imageMarginTop;
+
+  int xPos = (viewportWidth - displayWidth) / 2;
+  auto pageImage = std::make_shared<PageImage>(imageBlock, xPos, currentPageNextY);
+  currentPage->elements.push_back(pageImage);
+  currentPageNextY += displayHeight + imageMarginBottom;
+}
+
+void Typesetter::partialFlush(ParsedText& block) {
+  const int horizontalInset = block.getBlockStyle().totalHorizontalInset();
+  const uint16_t effectiveWidth =
+      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+  block.layoutAndExtractLines(renderer, fontId, effectiveWidth,
+                              [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
+}
+
+void Typesetter::finish() {
+  if (currentPage) {
+    completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
+    completedPageCount++;
+    currentPage.reset();
+  }
+}

--- a/lib/Typesetter/Typesetter.cpp
+++ b/lib/Typesetter/Typesetter.cpp
@@ -122,8 +122,9 @@ void Typesetter::partialFlush(ParsedText& block) {
   const int horizontalInset = block.getBlockStyle().totalHorizontalInset();
   const uint16_t effectiveWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
-  block.layoutAndExtractLines(renderer, fontId, effectiveWidth,
-                              [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
+  block.layoutAndExtractLines(
+      renderer, fontId, effectiveWidth,
+      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
 }
 
 void Typesetter::finish() {

--- a/lib/Typesetter/Typesetter.h
+++ b/lib/Typesetter/Typesetter.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <Epub/FootnoteEntry.h>
+#include <Epub/Page.h>
+#include <Epub/ParsedText.h>
+#include <Epub/blocks/ImageBlock.h>
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+class GfxRenderer;
+
+class Typesetter {
+  GfxRenderer& renderer;
+  int fontId;
+  float lineCompression;
+  bool extraParagraphSpacing;
+  uint16_t viewportWidth;
+  uint16_t viewportHeight;
+
+  std::unique_ptr<Page> currentPage;
+  int16_t currentPageNextY = 0;
+  int completedPageCount = 0;
+
+  std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn;
+
+  std::vector<std::pair<int, FootnoteEntry>> pendingFootnotes;
+  int wordsExtractedInBlock = 0;
+  uint16_t xpathParagraphIndex = 0;
+  uint16_t xpathListItemIndex = 0;
+
+  void addLineToPage(std::shared_ptr<TextBlock> line);
+
+ public:
+  explicit Typesetter(GfxRenderer& renderer, int fontId, float lineCompression, bool extraParagraphSpacing,
+                      uint16_t viewportWidth, uint16_t viewportHeight,
+                      std::function<void(std::unique_ptr<Page>, uint16_t, uint16_t)> completePageFn);
+
+  ~Typesetter() = default;
+
+  void submitParagraph(std::unique_ptr<ParsedText> paragraph);
+  void partialFlush(ParsedText& block);
+  void submitImage(std::shared_ptr<ImageBlock> imageBlock, int16_t imageMarginTop, int16_t imageMarginBottom);
+  void finish();
+
+  void incrementXpathParagraphIndex() { ++xpathParagraphIndex; }
+  void incrementXpathListItemIndex() { ++xpathListItemIndex; }
+
+  void addPendingFootnote(int wordIndex, const FootnoteEntry& entry) { pendingFootnotes.push_back({wordIndex, entry}); }
+
+  int getWordsExtractedInBlock() const { return wordsExtractedInBlock; }
+  void resetWordsExtractedInBlock() { wordsExtractedInBlock = 0; }
+
+  int getCompletedPageCount() const { return completedPageCount; }
+};


### PR DESCRIPTION
## Summary

This is the first of several changes to isolate the formatted text rendering engine from Epub, to be reused by Txt and Markdown readers.

This change extracts page layout logic from `ChapterHtmlSlimParser` into a new `Typesetter` class (`lib/Typesetter/`). The parser retains HTML/XML parsing and style resolution, while `Typesetter` now owns all page construction state and exposes four operations:
- `submitParagraph` for laying out a complete text block
- `partialFlush` for early-flushing oversized blocks (the 750+ word path)
- `submitImage` for placing images with page-break handling
- `finish` for flushing the final in-progress page. 

There are no behavioral changes; this is a pure mechanical extraction.

At the moment, `Typesetter` depends on types in `lib/Epub/` (`Page`, `ParsedText`, `ImageBlock`, `FootnoteEntry`), which creates a bidirectional library reference. Those types are self-contained layout primitives with no back-dependency on the parser, so the cycle is structural rather than logical. Extracting them into `Typesetter` will come in future changes. Eventually `Typesetter` will sit _below_ `Epub`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
