### PR TITLE
fix: stream WebDAV downloads in chunks to prevent client disconnects

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -12,6 +12,7 @@
 
 #include "CrossPointSettings.h"
 #include "FontInstaller.h"
+#include "HttpFileStreamer.h"
 #include "OpdsServerStore.h"
 #include "SdCardFontSystem.h"
 #include "SettingsList.h"
@@ -553,27 +554,12 @@ void CrossPointWebServer::handleDownload() const {
   server->send(200, contentType.c_str(), "");
 
   NetworkClient client = server->client();
-  const size_t chunkSize = 4096;
-  uint8_t buffer[chunkSize];
-
-  bool downloadOk = true;
-  while (downloadOk && file.available()) {
-    int result = file.read(buffer, chunkSize);
-    if (result <= 0) break;
-    size_t bytesRead = static_cast<size_t>(result);
-    size_t totalWritten = 0;
-    while (totalWritten < bytesRead) {
-      esp_task_wdt_reset();
-      size_t wrote = client.write(buffer + totalWritten, bytesRead - totalWritten);
-      if (wrote == 0) {
-        downloadOk = false;
-        break;
-      }
-      totalWritten += wrote;
-    }
-  }
+  bool downloadOk = HttpFileStreamer::streamFileToClient(file, client);
   client.clear();
-  file.close();
+
+  if (!downloadOk) {
+    LOG_DBG("WEB", "Download interrupted while streaming: %s", itemPath.c_str());
+  }
 }
 
 // Diagnostic counters for upload performance analysis

--- a/src/network/HttpFileStreamer.cpp
+++ b/src/network/HttpFileStreamer.cpp
@@ -1,0 +1,45 @@
+#include "HttpFileStreamer.h"
+
+#include <Logging.h>
+#include <esp_task_wdt.h>
+
+namespace {
+constexpr size_t DOWNLOAD_CHUNK_SIZE = 4096;
+}
+
+namespace HttpFileStreamer {
+bool streamFileToClient(FsFile& file, NetworkClient& client) {
+  auto* buffer = static_cast<uint8_t*>(malloc(DOWNLOAD_CHUNK_SIZE));
+  if (!buffer) {
+    LOG_ERR("HTTP", "malloc failed: %zu bytes", DOWNLOAD_CHUNK_SIZE);
+    return false;
+  }
+
+  bool ok = true;
+  while (ok) {
+    esp_task_wdt_reset();
+    int result = file.read(buffer, DOWNLOAD_CHUNK_SIZE);
+    if (result < 0) {
+      ok = false;
+      break;
+    }
+    if (result == 0) break;
+
+    size_t bytesRead = static_cast<size_t>(result);
+    size_t totalWritten = 0;
+    while (totalWritten < bytesRead) {
+      esp_task_wdt_reset();
+      size_t wrote = client.write(buffer + totalWritten, bytesRead - totalWritten);
+      if (wrote == 0) {
+        ok = false;
+        break;
+      }
+      totalWritten += wrote;
+    }
+  }
+
+  free(buffer);
+  buffer = nullptr;
+  return ok;
+}
+}  // namespace HttpFileStreamer

--- a/src/network/HttpFileStreamer.h
+++ b/src/network/HttpFileStreamer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <HalStorage.h>
+#include <NetworkClient.h>
+
+namespace HttpFileStreamer {
+bool streamFileToClient(FsFile& file, NetworkClient& client);
+}

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -6,6 +6,8 @@
 #include <Logging.h>
 #include <esp_task_wdt.h>
 
+#include "HttpFileStreamer.h"
+
 namespace {
 constexpr const char* HIDDEN_ITEMS[] = {"System Volume Information", "XTCache"};
 
@@ -327,8 +329,12 @@ void WebDAVHandler::handleGet(WebServer& s) {
   s.send(200, contentType.c_str(), "");
 
   NetworkClient client = s.client();
-  client.write(file);
-  file.close();
+  bool downloadOk = HttpFileStreamer::streamFileToClient(file, client);
+  client.clear();
+
+  if (!downloadOk) {
+    LOG_DBG("DAV", "GET interrupted while streaming: %s", path.c_str());
+  }
 }
 
 // ── HEAD ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Some WebDAV clients immediately fail with "lost connection" when attempting to download any file. This fixes the issue by replacing the single-call `client.write(file)` in the WebDAV GET handler with the same chunked streaming loop already used by the browser download endpoint.

* **What changes are included?**
  - Extract the chunked file streaming logic from `CrossPointWebServer::handleDownload()` into a shared `HttpFileStreamer` utility
  - Replace `client.write(file)` in `WebDAVHandler::handleGet()` with the chunked streaming approach
  - No functional change to the browser download path — just extracted into the shared function

## Additional Context

* The browser download endpoint already used chunked streaming with watchdog resets — WebDAV's GET handler was the only path still using `NetworkClient::write(file)`.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_