### PR TITLE
fix: take orientation into account for border generation in ScreenshotUtil

### DIFF
--- a/src/util/ScreenshotUtil.cpp
+++ b/src/util/ScreenshotUtil.cpp
@@ -88,7 +88,12 @@ void ScreenshotUtil::takeScreenshot(GfxRenderer& renderer) {
 
   // Display a border around the screen to indicate a screenshot was taken
   if (renderer.storeBwBuffer()) {
-    renderer.drawRect(6, 6, renderer.getDisplayHeight() - 12, renderer.getDisplayWidth() - 12, 2, true);
+    int marginTop, marginRight, marginBottom, marginLeft;
+    renderer.getOrientedViewableTRBL(&marginTop, &marginRight, &marginBottom, &marginLeft);
+    int width = renderer.getScreenWidth() - marginLeft - marginRight - 1;
+    int height = renderer.getScreenHeight() - marginTop - marginBottom - 1;
+    // Add extra margin to the border to make it more visible
+    renderer.drawRect(marginLeft + 1, marginTop + 1, width - 2, height - 2, 2, true);
     renderer.displayBuffer();
     delay(1000);
     renderer.restoreBwBuffer();


### PR DESCRIPTION
## Summary

Previously `ScreenshotUtil` used physical display size to draw a border around the screen contents. Because of this, in landscape orientation the border was shown as a broken square. This PR changes border drawing to use logical screen size instead of a physical display size to take orientation into account.

## Additional Context

* Tested on X4 in all 4 reading orientations. Behavior is now correct, however it doesn't look perfect on my X4: the border is much closer to the physical top side of the display than to the other sides. This might be related to assembly variation during manufacturing, but it might as well be related to the way a eink controller is connected to the display (controller supports bigger display sizes, so an offset may be present).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
