### PR TITLE
feat: Add incremental EPUB section indexing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "open-x4-sdk"]
 	path = open-x4-sdk
-	url = https://github.com/crosspoint-reader/community-sdk.git
+	url = https://github.com/LSTAR1900/community-sdk.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "open-x4-sdk"]
 	path = open-x4-sdk
-	url = https://github.com/LSTAR1900/community-sdk.git
+	url = https://github.com/crosspoint-reader/community-sdk.git

--- a/docs/prs/01-incremental-indexing-redraws.md
+++ b/docs/prs/01-incremental-indexing-redraws.md
@@ -1,0 +1,35 @@
+# PR 1: fix: Incremental Indexing Redraw Cleanup
+
+## Goal
+- Keep normal EPUB first-page loads free of pre-page indexing popups and redraws.
+- Stop background and prewarm indexing state changes from repainting the current page.
+- Improve genuine cold-start metadata indexing for medium-size EPUBs.
+- Preserve responsive sleep/manual input behavior while indexing is active.
+
+## Scope
+- `EpubReaderActivity` redraw scheduling around background/prewarm indexing.
+- Reader-menu book cache deletion removes `progress.bin` instead of rewriting it.
+- Fresh EPUB entry shows the Indexing popup before missing `book.bin`/progress work, and fresh-entry section creation reuses that feedback without adding a duplicate redraw.
+- Medium-size EPUBs now use the fast OPF item index, TOC spine lookup index, and batch ZIP size lookup instead of waiting for very large spine counts.
+- `book.bin` construction logs sub-stage timings so cold-start gains can be measured on-device.
+- Manual sleep now drains the queued SleepActivity transition directly instead of running one more outgoing reader loop first, and foreground section pumps stop between batches when sleep is pending.
+- EPUB progress percent calculations now share the same displayed-page basis as the status bar, avoiding a one-page lag in the reader menu, percent selector, and screenshot metadata.
+- Incremental anchor cache reads now validate serialized anchor key length before allocating, so a corrupt `.anc` file cannot request an unbounded string allocation.
+- Static incremental contracts that protect the redraw and indexing-popup behavior.
+
+## Explicitly Not In This PR
+- Image-only section rendering and SVG-wrapped raster image parsing are covered by PR 2.
+- Configurable cover skipping and `text/start` fresh-entry behavior are covered by PR 3.
+
+## Verification
+- `python test/incremental_section/StaticIncrementalContracts.py`
+- `./bin/clang-format-fix`
+- Direct host tests:
+  - `IncrementalSectionTypesTest`
+  - `EpubIndexingPolicyTest`
+  - `ReaderProgressPolicyTest`
+  - `StatusPageInfoTest`
+- `git diff --check`
+- `test/run_incremental_section_tests.sh`
+- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`
+- `pio run --jobs 1`

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -355,8 +355,11 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
           // continue anyway - book will work without CSS and we'll still load any inline style CSS
         }
         parseCssFiles();
-        // Invalidate section caches so they are rebuilt with the new CSS
-        Storage.removeDir((cachePath + "/sections").c_str());
+        // Invalidate section caches so they are rebuilt with the new CSS.
+        const auto sectionsPath = cachePath + "/sections";
+        if (Storage.exists(sectionsPath.c_str())) {
+          FsHelpers::removeDirRecursive(sectionsPath.c_str());
+        }
       }
     }
     LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
@@ -458,7 +461,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   if (!skipLoadingCss) {
     // Parse CSS files after cache reload
     parseCssFiles();
-    Storage.removeDir((cachePath + "/sections").c_str());
+    const auto sectionsPath = cachePath + "/sections";
+    if (Storage.exists(sectionsPath.c_str())) {
+      FsHelpers::removeDirRecursive(sectionsPath.c_str());
+    }
   }
 
   LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
@@ -471,7 +477,7 @@ bool Epub::clearCache() const {
     return true;
   }
 
-  if (!Storage.removeDir(cachePath.c_str())) {
+  if (!FsHelpers::removeDirRecursive(cachePath.c_str())) {
     LOG_ERR("EPB", "Failed to clear cache");
     return false;
   }

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -358,7 +358,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
         // Invalidate section caches so they are rebuilt with the new CSS.
         const auto sectionsPath = cachePath + "/sections";
         if (Storage.exists(sectionsPath.c_str())) {
-          FsHelpers::removeDirRecursive(sectionsPath.c_str());
+          if (!FsHelpers::removeDirRecursive(sectionsPath.c_str())) {
+            LOG_ERR("EBP", "Failed to remove stale section cache after CSS rebuild: %s", sectionsPath.c_str());
+            return false;
+          }
         }
       }
     }
@@ -463,7 +466,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
     parseCssFiles();
     const auto sectionsPath = cachePath + "/sections";
     if (Storage.exists(sectionsPath.c_str())) {
-      FsHelpers::removeDirRecursive(sectionsPath.c_str());
+      if (!FsHelpers::removeDirRecursive(sectionsPath.c_str())) {
+        LOG_ERR("EBP", "Failed to remove stale section cache after CSS parse: %s", sectionsPath.c_str());
+        return false;
+      }
     }
   }
 

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -1,5 +1,6 @@
 #include "BookMetadataCache.h"
 
+#include <Arduino.h>
 #include <Logging.h>
 #include <Serialization.h>
 #include <ZipFile.h>
@@ -40,6 +41,7 @@ bool BookMetadataCache::endContentOpfPass() {
 
 bool BookMetadataCache::beginTocPass() {
   LOG_DBG("BMC", "Beginning toc pass");
+  const uint32_t indexStart = millis();
 
   if (!Storage.openFileForRead("BMC", cachePath + tmpSpineBinFile, spineFile)) {
     return false;
@@ -50,7 +52,7 @@ bool BookMetadataCache::beginTocPass() {
     return false;
   }
 
-  if (spineCount >= LARGE_SPINE_THRESHOLD) {
+  if (spineCount >= FAST_LOOKUP_SPINE_THRESHOLD) {
     spineHrefIndex.clear();
     spineHrefIndex.resize(spineCount);
     spineFile.seek(0);
@@ -68,7 +70,7 @@ bool BookMetadataCache::beginTocPass() {
               });
     spineFile.seek(0);
     useSpineHrefIndex = true;
-    LOG_DBG("BMC", "Using fast index for %d spine items", spineCount);
+    LOG_DBG("BMC", "Using fast TOC spine index for %d spine items (%lu ms)", spineCount, millis() - indexStart);
   } else {
     useSpineHrefIndex = false;
   }
@@ -100,6 +102,9 @@ bool BookMetadataCache::endWrite() {
 }
 
 bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMetadata& metadata) {
+  const uint32_t buildStart = millis();
+  uint32_t stageStart = buildStart;
+
   // Open all three files, writing to meta, reading from spine and toc
   if (!Storage.openFileForWrite("BMC", cachePath + bookBinFile, bookFile)) {
     return false;
@@ -153,6 +158,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     auto tocEntry = readTocEntry(tocFile);
     serialization::writePod(bookFile, pos + lutOffset + lutSize + static_cast<uint32_t>(spineFile.position()));
   }
+  const uint32_t headerAndLutMs = millis() - stageStart;
+  stageStart = millis();
 
   // LUTs complete
   // Loop through spines from spine file matching up TOC indexes, calculating cumulative size and writing to book.bin
@@ -168,6 +175,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
       }
     }
   }
+  const uint32_t tocMapMs = millis() - stageStart;
+  stageStart = millis();
 
   ZipFile zip(epubPath);
   // Pre-open zip file to speed up size calculations
@@ -179,6 +188,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     tocFile.close();
     return false;
   }
+  const uint32_t zipOpenMs = millis() - stageStart;
+  stageStart = millis();
   // NOTE: We intentionally skip calling loadAllFileStatSlims() here.
   // For large EPUBs (2000+ chapters), pre-loading all ZIP central directory entries
   // into memory causes OOM crashes on ESP32-C3's limited ~380KB RAM.
@@ -190,7 +201,7 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
   std::deque<uint32_t> spineSizes;
   bool useBatchSizes = false;
 
-  if (spineCount >= LARGE_SPINE_THRESHOLD) {
+  if (spineCount >= FAST_LOOKUP_SPINE_THRESHOLD) {
     LOG_DBG("BMC", "Using batch size lookup for %d spine items", spineCount);
 
     std::deque<ZipFile::SizeTarget> targets;
@@ -221,6 +232,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
 
     useBatchSizes = true;
   }
+  const uint32_t sizePrefetchMs = millis() - stageStart;
+  stageStart = millis();
 
   uint32_t cumSize = 0;
   spineFile.seek(0);
@@ -261,6 +274,8 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     // Write out spine data to book.bin
     writeSpineEntry(bookFile, spineEntry);
   }
+  const uint32_t spineWriteMs = millis() - stageStart;
+  stageStart = millis();
   // Close opened zip file
   zip.close();
 
@@ -270,12 +285,17 @@ bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMeta
     auto tocEntry = readTocEntry(tocFile);
     writeTocEntry(bookFile, tocEntry);
   }
+  const uint32_t tocWriteMs = millis() - stageStart;
 
   // Explicit close() required: member variables persist beyond function scope
   bookFile.close();
   spineFile.close();
   tocFile.close();
 
+  LOG_DBG("BMC",
+          "buildBookBin timings: header_lut=%lums toc_map=%lums zip_open=%lums size_prefetch=%lums spine_write=%lums "
+          "toc_write=%lums total=%lums",
+          headerAndLutMs, tocMapMs, zipOpenMs, sizePrefetchMs, spineWriteMs, tocWriteMs, millis() - buildStart);
   LOG_DBG("BMC", "Successfully built book.bin");
   return true;
 }

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -55,7 +55,7 @@ class BookMetadataCache {
   FsFile spineFile;
   FsFile tocFile;
 
-  // Index for fast href→spineIndex lookup (used only for large EPUBs)
+  // Index for fast href→spineIndex lookup (used for medium/large EPUBs)
   struct SpineHrefIndexEntry {
     uint64_t hrefHash;  // FNV-1a 64-bit hash
     uint16_t hrefLen;   // length for collision reduction
@@ -64,7 +64,8 @@ class BookMetadataCache {
   std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
 
-  static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
+  // Keeps tiny books on the lowest-memory path while moving 100-250 spine cold starts off repeated SD scans.
+  static constexpr uint16_t FAST_LOOKUP_SPINE_THRESHOLD = 64;
 
   // FNV-1a 64-bit hash function
   static uint64_t fnvHash64(const std::string& s) {

--- a/lib/Epub/Epub/EpubIndexingPolicy.h
+++ b/lib/Epub/Epub/EpubIndexingPolicy.h
@@ -6,11 +6,11 @@ class EpubIndexingPolicy {
  public:
   static constexpr uint16_t INDEX_BATCH_MIN_PAGES = 1;
   static constexpr uint16_t INDEX_BATCH_MAX_PAGES = 10;
-  static constexpr uint16_t CURRENT_INDEX_BATCH_PAGES = 10;
-  static constexpr uint16_t INITIAL_INDEX_BATCH_PAGES = 3;
-  static constexpr uint16_t INITIAL_INDEX_TARGET_PAGES = 3;
-  static constexpr uint16_t OUTRUN_INDEX_BATCH_PAGES = 5;
-  static constexpr uint16_t NEXT_PREWARM_BATCH_PAGES = 3;
+  static constexpr uint16_t CURRENT_INDEX_BATCH_PAGES = 1;
+  static constexpr uint16_t INITIAL_INDEX_BATCH_PAGES = 1;
+  static constexpr uint16_t INITIAL_INDEX_TARGET_PAGES = 1;
+  static constexpr uint16_t OUTRUN_INDEX_BATCH_PAGES = 1;
+  static constexpr uint16_t NEXT_PREWARM_BATCH_PAGES = 1;
   static constexpr uint16_t NEXT_PREWARM_INPUT_CHUNKS_PER_PAGE = 3;
   static constexpr uint32_t INDEX_BATCH_MS_PER_PAGE = 50;
   static constexpr uint32_t CURRENT_INDEX_MIN_INTERVAL_MS = 1000;

--- a/lib/Epub/Epub/EpubIndexingPolicy.h
+++ b/lib/Epub/Epub/EpubIndexingPolicy.h
@@ -48,7 +48,7 @@ class EpubIndexingPolicy {
   }
 
   static constexpr bool outrunIndexWindowNeedsPages(const uint32_t targetPage, const uint32_t knownPages,
-                                                   const bool complete) {
+                                                    const bool complete) {
     return !complete && knownPages < outrunTargetKnownPages(targetPage);
   }
 

--- a/lib/Epub/Epub/EpubIndexingPolicy.h
+++ b/lib/Epub/Epub/EpubIndexingPolicy.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+
+class EpubIndexingPolicy {
+ public:
+  static constexpr uint16_t INDEX_BATCH_MIN_PAGES = 1;
+  static constexpr uint16_t INDEX_BATCH_MAX_PAGES = 10;
+  static constexpr uint16_t CURRENT_INDEX_BATCH_PAGES = 10;
+  static constexpr uint16_t INITIAL_INDEX_BATCH_PAGES = 3;
+  static constexpr uint16_t INITIAL_INDEX_TARGET_PAGES = 3;
+  static constexpr uint16_t OUTRUN_INDEX_BATCH_PAGES = 5;
+  static constexpr uint16_t NEXT_PREWARM_BATCH_PAGES = 3;
+  static constexpr uint16_t NEXT_PREWARM_INPUT_CHUNKS_PER_PAGE = 3;
+  static constexpr uint32_t INDEX_BATCH_MS_PER_PAGE = 50;
+  static constexpr uint32_t CURRENT_INDEX_MIN_INTERVAL_MS = 1000;
+  static constexpr uint32_t NEXT_PREWARM_MIN_INTERVAL_MS = 1500;
+  static constexpr uint32_t FOREGROUND_INCREMENTAL_MIN_FREE_HEAP = 12 * 1024;
+  static constexpr uint32_t ACTIVE_INCREMENTAL_MIN_FREE_HEAP = 16 * 1024;
+  static constexpr uint32_t EMBEDDED_STYLE_MIN_FREE_HEAP = 48 * 1024;
+
+  static constexpr uint16_t clampIndexBatchPages(const uint16_t pages) {
+    if (pages < INDEX_BATCH_MIN_PAGES) {
+      return INDEX_BATCH_MIN_PAGES;
+    }
+    if (pages > INDEX_BATCH_MAX_PAGES) {
+      return INDEX_BATCH_MAX_PAGES;
+    }
+    return pages;
+  }
+
+  static constexpr uint16_t indexBatchInputChunks(const uint16_t pages) { return clampIndexBatchPages(pages); }
+
+  static constexpr uint16_t nextPrewarmInputChunks(const uint16_t pages) {
+    return static_cast<uint16_t>(clampIndexBatchPages(pages) * NEXT_PREWARM_INPUT_CHUNKS_PER_PAGE);
+  }
+
+  static constexpr uint32_t indexBatchMaxMillis(const uint16_t pages) {
+    return static_cast<uint32_t>(clampIndexBatchPages(pages)) * INDEX_BATCH_MS_PER_PAGE;
+  }
+
+  static constexpr bool initialIndexWindowNeedsPages(const uint32_t knownPages, const bool complete) {
+    return !complete && knownPages < INITIAL_INDEX_TARGET_PAGES;
+  }
+
+  static constexpr uint32_t outrunTargetKnownPages(const uint32_t targetPage) {
+    return targetPage + static_cast<uint32_t>(clampIndexBatchPages(OUTRUN_INDEX_BATCH_PAGES));
+  }
+
+  static constexpr bool outrunIndexWindowNeedsPages(const uint32_t targetPage, const uint32_t knownPages,
+                                                   const bool complete) {
+    return !complete && knownPages < outrunTargetKnownPages(targetPage);
+  }
+
+  static constexpr bool shouldPrewarmNextChapter(const uint32_t currentPage, const uint32_t finalPageCount,
+                                                 const bool complete) {
+    (void)currentPage;
+    return complete && finalPageCount > 0;
+  }
+
+  static constexpr bool prewarmMatchesSpine(const int prewarmSpineIndex, const int targetSpineIndex) {
+    return prewarmSpineIndex == targetSpineIndex;
+  }
+
+  static constexpr bool hasHeapForActiveIncrementalPump(const uint32_t freeHeap) {
+    return freeHeap >= ACTIVE_INCREMENTAL_MIN_FREE_HEAP;
+  }
+
+  static constexpr bool hasHeapForForegroundIncrementalPump(const uint32_t freeHeap) {
+    return freeHeap >= FOREGROUND_INCREMENTAL_MIN_FREE_HEAP;
+  }
+
+  static constexpr bool hasHeapForEmbeddedStyle(const uint32_t freeHeap) {
+    return freeHeap >= EMBEDDED_STYLE_MIN_FREE_HEAP;
+  }
+};

--- a/lib/Epub/Epub/IncrementalBuildBudget.h
+++ b/lib/Epub/Epub/IncrementalBuildBudget.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+
+#include "EpubIndexingPolicy.h"
+
+enum class IncrementalBuildBudgetProfile {
+  InitialIndex,
+  CurrentBackground,
+  NextPrewarm,
+  Outrun,
+};
+
+struct IncrementalBuildBudget {
+  uint16_t maxInputChunks = 0;
+  uint16_t maxCompletedPages = 1;
+  uint32_t maxMillis = 20;
+  uint32_t minFreeHeap = EpubIndexingPolicy::ACTIVE_INCREMENTAL_MIN_FREE_HEAP;
+};
+
+class IncrementalBuildBudgets {
+ public:
+  static constexpr IncrementalBuildBudget forProfile(const IncrementalBuildBudgetProfile profile) {
+    switch (profile) {
+      case IncrementalBuildBudgetProfile::InitialIndex:
+        return standard(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES,
+                        EpubIndexingPolicy::FOREGROUND_INCREMENTAL_MIN_FREE_HEAP);
+      case IncrementalBuildBudgetProfile::CurrentBackground:
+        return standard(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES,
+                        EpubIndexingPolicy::ACTIVE_INCREMENTAL_MIN_FREE_HEAP);
+      case IncrementalBuildBudgetProfile::NextPrewarm:
+        return {EpubIndexingPolicy::nextPrewarmInputChunks(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES),
+                EpubIndexingPolicy::clampIndexBatchPages(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES),
+                EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES),
+                EpubIndexingPolicy::ACTIVE_INCREMENTAL_MIN_FREE_HEAP};
+      case IncrementalBuildBudgetProfile::Outrun:
+        return standard(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES,
+                        EpubIndexingPolicy::FOREGROUND_INCREMENTAL_MIN_FREE_HEAP);
+    }
+    return standard(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES,
+                    EpubIndexingPolicy::ACTIVE_INCREMENTAL_MIN_FREE_HEAP);
+  }
+
+ private:
+  static constexpr IncrementalBuildBudget standard(const uint16_t pages, const uint32_t minFreeHeap) {
+    return {EpubIndexingPolicy::indexBatchInputChunks(pages), EpubIndexingPolicy::clampIndexBatchPages(pages),
+            EpubIndexingPolicy::indexBatchMaxMillis(pages), minFreeHeap};
+  }
+};

--- a/lib/Epub/Epub/IncrementalSectionBuilder.cpp
+++ b/lib/Epub/Epub/IncrementalSectionBuilder.cpp
@@ -1,0 +1,281 @@
+#include "IncrementalSectionBuilder.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+#include <Memory.h>
+#include <esp_system.h>
+
+#include <utility>
+
+#include "Epub.h"
+#include "Page.h"
+#include "css/CssParser.h"
+#include "hyphenation/Hyphenator.h"
+
+namespace {
+
+constexpr uint32_t LOW_HEAP_LOG_INTERVAL_MS = 1000;
+
+const char* parsePumpStatusName(const ParsePumpStatus status) {
+  switch (status) {
+    case ParsePumpStatus::NeedsMore:
+      return "NeedsMore";
+    case ParsePumpStatus::PageReady:
+      return "PageReady";
+    case ParsePumpStatus::Complete:
+      return "Complete";
+    case ParsePumpStatus::Cancelled:
+      return "Cancelled";
+    case ParsePumpStatus::Error:
+      return "Error";
+  }
+  return "Unknown";
+}
+
+}  // namespace
+
+IncrementalSectionBuilder::IncrementalSectionBuilder(std::shared_ptr<Epub> epub, const int spineIndex,
+                                                     GfxRenderer& renderer,
+                                                     IncrementalSection::LayoutCacheKey layoutKey,
+                                                     IncrementalBuildOptions options)
+    : epub_(std::move(epub)),
+      spineIndex_(spineIndex),
+      renderer_(renderer),
+      layoutKey_(layoutKey),
+      options_(std::move(options)),
+      cache_(epub_->getCachePath() + "/sections", static_cast<uint32_t>(spineIndex)) {}
+
+IncrementalSectionBuilder::~IncrementalSectionBuilder() { cancel(); }
+
+bool IncrementalSectionBuilder::extractTempHtml(uint32_t& fileSize) {
+  const auto localPath = epub_->getSpineItem(spineIndex_).href;
+  tmpHtmlPath_ = epub_->getCachePath() + "/.tmp_inc_" + std::to_string(spineIndex_) + ".html";
+
+  bool success = false;
+  fileSize = 0;
+  for (int attempt = 0; attempt < 3 && !success; attempt++) {
+    if (attempt > 0) {
+      LOG_DBG("ISB", "Retrying incremental stream (attempt %d)", attempt + 1);
+      delay(50);
+    }
+
+    if (Storage.exists(tmpHtmlPath_.c_str())) {
+      Storage.remove(tmpHtmlPath_.c_str());
+    }
+
+    FsFile tmpHtml;
+    if (!Storage.openFileForWrite("ISB", tmpHtmlPath_, tmpHtml)) {
+      continue;
+    }
+    success = epub_->readItemContentsToStream(localPath, tmpHtml, 1024);
+    fileSize = tmpHtml.size();
+    tmpHtml.close();
+
+    if (!success && Storage.exists(tmpHtmlPath_.c_str())) {
+      Storage.remove(tmpHtmlPath_.c_str());
+    }
+  }
+
+  if (!success) {
+    LOG_ERR("ISB", "Failed to extract temp HTML for spine %d", spineIndex_);
+  }
+  return success;
+}
+
+void IncrementalSectionBuilder::cleanupTempHtml() const {
+  if (!tmpHtmlPath_.empty() && Storage.exists(tmpHtmlPath_.c_str())) {
+    Storage.remove(tmpHtmlPath_.c_str());
+  }
+}
+
+bool IncrementalSectionBuilder::start() {
+  if (state_ != IncrementalBuildState::Idle) {
+    return state_ == IncrementalBuildState::Parsing || state_ == IncrementalBuildState::Complete;
+  }
+
+  state_ = IncrementalBuildState::Extracting;
+  cancelRequested_ = false;
+  appendFailed_ = false;
+  knownPageCount_ = 0;
+  generationId_ = millis();
+
+  uint32_t fileSize = 0;
+  if (!extractTempHtml(fileSize)) {
+    failAndCleanup();
+    return false;
+  }
+  sourceFileSize_ = fileSize;
+
+  if (!cache_.beginBuild(layoutKey_, fileSize, generationId_)) {
+    failAndCleanup();
+    return false;
+  }
+
+  const auto localPath = epub_->getSpineItem(spineIndex_).href;
+  const size_t lastSlash = localPath.find_last_of('/');
+  const std::string contentBase = (lastSlash != std::string::npos) ? localPath.substr(0, lastSlash + 1) : "";
+  const std::string imageBasePath = epub_->getCachePath() + "/img_" + std::to_string(spineIndex_) + "_";
+
+  const CssParser* cssParser = nullptr;
+  if (options_.embeddedStyle) {
+    const uint32_t freeHeapBeforeCss = esp_get_free_heap_size();
+    if (EpubIndexingPolicy::hasHeapForEmbeddedStyle(freeHeapBeforeCss)) {
+      cssParser_ = makeUniqueNoThrow<CssParser>(epub_->getCachePath());
+      if (!cssParser_) {
+        LOG_ERR("ISB", "OOM: CssParser");
+        failAndCleanup();
+        return false;
+      }
+      cssParser = cssParser_.get();
+      if (!cssParser_->loadFromCache()) {
+        LOG_ERR("ISB", "Failed to load CSS from cache");
+      }
+      if (!EpubIndexingPolicy::hasHeapForEmbeddedStyle(esp_get_free_heap_size())) {
+        cssParser_.reset();
+        cssParser = nullptr;
+      }
+    }
+  }
+
+  parser_ = makeUniqueNoThrow<ChapterHtmlSlimParser>(
+      epub_, tmpHtmlPath_, renderer_, options_.fontId, options_.lineCompression, options_.extraParagraphSpacing,
+      options_.paragraphAlignment, options_.viewportWidth, options_.viewportHeight, options_.hyphenationEnabled,
+      options_.focusReadingEnabled,
+      [this](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex) {
+        if (!page) {
+          appendFailed_ = true;
+          cancelRequested_ = true;
+          return;
+        }
+        const uint32_t pageNumber = knownPageCount_;
+        if (!cache_.appendPage(pageNumber, *page, paragraphIndex, listItemIndex)) {
+          appendFailed_ = true;
+          cancelRequested_ = true;
+          return;
+        }
+        knownPageCount_ = pageNumber + 1;
+      },
+      options_.embeddedStyle, contentBase, imageBasePath, options_.imageRendering, options_.popupFn, cssParser);
+  if (!parser_) {
+    LOG_ERR("ISB", "OOM: ChapterHtmlSlimParser");
+    failAndCleanup();
+    return false;
+  }
+
+  Hyphenator::setPreferredLanguage(epub_->getLanguage());
+  if (!parser_->begin(&cancelRequested_)) {
+    failAndCleanup();
+    return false;
+  }
+
+  state_ = IncrementalBuildState::Parsing;
+  LOG_DBG("ISB", "incremental-section start spine=%d bytes=%lu pages=%lu heap=%lu", spineIndex_,
+          static_cast<unsigned long>(sourceFileSize_), static_cast<unsigned long>(knownPageCount_),
+          static_cast<unsigned long>(esp_get_free_heap_size()));
+  return true;
+}
+
+IncrementalBuildState IncrementalSectionBuilder::pump(const IncrementalBuildBudget& budget) {
+  if (state_ == IncrementalBuildState::Idle && !start()) {
+    return state_;
+  }
+  if (state_ != IncrementalBuildState::Parsing || !parser_) {
+    return state_;
+  }
+
+  const uint32_t freeHeap = esp_get_free_heap_size();
+  if (freeHeap < budget.minFreeHeap) {
+    const uint32_t now = millis();
+    if (now - lastDeferredLogMs_ >= LOW_HEAP_LOG_INTERVAL_MS) {
+      LOG_DBG("ISB", "Deferring spine=%d heap=%lu need=%lu", spineIndex_, static_cast<unsigned long>(freeHeap),
+              static_cast<unsigned long>(budget.minFreeHeap));
+      lastDeferredLogMs_ = now;
+    }
+    return IncrementalBuildState::DeferredLowMemory;
+  }
+
+  ParsePumpBudget parseBudget;
+  parseBudget.maxInputChunks = budget.maxInputChunks;
+  parseBudget.maxCompletedPages = budget.maxCompletedPages;
+  parseBudget.maxMillis = budget.maxMillis;
+  const auto status = parser_->pump(parseBudget);
+  if (appendFailed_) {
+    failAndCleanup();
+    return state_;
+  }
+
+  if (status == ParsePumpStatus::Complete) {
+    if (!parser_->finish()) {
+      failAndCleanup();
+      return state_;
+    }
+    uint32_t anchorCount = 0;
+    for (const auto& [anchor, page] : parser_->getAnchors()) {
+      if (!cache_.appendAnchor(anchor, page)) {
+        failAndCleanup();
+        return state_;
+      }
+      anchorCount++;
+    }
+    if (!cache_.markComplete(knownPageCount_, anchorCount)) {
+      failAndCleanup();
+      return state_;
+    }
+    parser_.reset();
+    cssParser_.reset();
+    cleanupTempHtml();
+    state_ = IncrementalBuildState::Complete;
+    LOG_DBG("ISB", "incremental-section complete spine=%d pages=%lu", spineIndex_,
+            static_cast<unsigned long>(knownPageCount_));
+    return state_;
+  }
+
+  if (status == ParsePumpStatus::Cancelled || status == ParsePumpStatus::Error) {
+    LOG_ERR("ISB", "incremental-section failed spine=%d status=%s", spineIndex_, parsePumpStatusName(status));
+    failAndCleanup();
+    return state_;
+  }
+
+  return IncrementalBuildState::Parsing;
+}
+
+void IncrementalSectionBuilder::cancel() {
+  if (state_ == IncrementalBuildState::Complete || state_ == IncrementalBuildState::Cancelled ||
+      state_ == IncrementalBuildState::Failed) {
+    return;
+  }
+  cancelRequested_ = true;
+  if (parser_) {
+    parser_->close();
+    parser_.reset();
+  }
+  cssParser_.reset();
+  if (state_ == IncrementalBuildState::Parsing || state_ == IncrementalBuildState::Extracting) {
+    cache_.removeAllFiles();
+  }
+  cleanupTempHtml();
+  knownPageCount_ = 0;
+  state_ = IncrementalBuildState::Cancelled;
+}
+
+bool IncrementalSectionBuilder::hasPage(const uint32_t pageNumber) const { return pageNumber < knownPageCount_; }
+
+std::unique_ptr<Page> IncrementalSectionBuilder::loadPage(const uint32_t pageNumber) const {
+  return cache_.loadPage(pageNumber);
+}
+
+uint32_t IncrementalSectionBuilder::knownPageCount() const { return knownPageCount_; }
+
+bool IncrementalSectionBuilder::isComplete() const { return state_ == IncrementalBuildState::Complete; }
+
+void IncrementalSectionBuilder::failAndCleanup() {
+  if (parser_) {
+    parser_->close();
+    parser_.reset();
+  }
+  cssParser_.reset();
+  cache_.removeAllFiles();
+  cleanupTempHtml();
+  knownPageCount_ = 0;
+  state_ = IncrementalBuildState::Failed;
+}

--- a/lib/Epub/Epub/IncrementalSectionBuilder.h
+++ b/lib/Epub/Epub/IncrementalSectionBuilder.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "IncrementalBuildBudget.h"
+#include "IncrementalSectionCache.h"
+#include "parsers/ChapterHtmlSlimParser.h"
+
+class Epub;
+class GfxRenderer;
+class Page;
+
+enum class IncrementalBuildState {
+  Idle,
+  Extracting,
+  Parsing,
+  Complete,
+  Cancelled,
+  Failed,
+  DeferredLowMemory,
+};
+
+struct IncrementalBuildOptions {
+  int fontId = 0;
+  float lineCompression = 1.0F;
+  bool extraParagraphSpacing = false;
+  uint8_t paragraphAlignment = 0;
+  uint16_t viewportWidth = 0;
+  uint16_t viewportHeight = 0;
+  bool hyphenationEnabled = false;
+  bool embeddedStyle = false;
+  uint8_t imageRendering = 0;
+  bool focusReadingEnabled = false;
+  std::function<void()> popupFn = nullptr;
+};
+
+class IncrementalSectionBuilder {
+ public:
+  IncrementalSectionBuilder(std::shared_ptr<Epub> epub, int spineIndex, GfxRenderer& renderer,
+                            IncrementalSection::LayoutCacheKey layoutKey, IncrementalBuildOptions options);
+  ~IncrementalSectionBuilder();
+
+  bool start();
+  IncrementalBuildState pump(const IncrementalBuildBudget& budget);
+  void cancel();
+  bool hasPage(uint32_t pageNumber) const;
+  std::unique_ptr<Page> loadPage(uint32_t pageNumber) const;
+  uint32_t knownPageCount() const;
+  bool isComplete() const;
+  IncrementalBuildState state() const { return state_; }
+  int spineIndex() const { return spineIndex_; }
+
+ private:
+  std::shared_ptr<Epub> epub_;
+  int spineIndex_;
+  GfxRenderer& renderer_;
+  IncrementalSection::LayoutCacheKey layoutKey_;
+  IncrementalBuildOptions options_;
+  IncrementalSection::Cache cache_;
+  std::unique_ptr<ChapterHtmlSlimParser> parser_;
+  std::unique_ptr<CssParser> cssParser_;
+  std::string tmpHtmlPath_;
+  bool cancelRequested_ = false;
+  bool appendFailed_ = false;
+  uint32_t generationId_ = 0;
+  IncrementalBuildState state_ = IncrementalBuildState::Idle;
+  uint32_t sourceFileSize_ = 0;
+  uint32_t knownPageCount_ = 0;
+  uint32_t lastDeferredLogMs_ = 0;
+
+  bool extractTempHtml(uint32_t& fileSize);
+  void cleanupTempHtml() const;
+  void failAndCleanup();
+};

--- a/lib/Epub/Epub/IncrementalSectionCache.cpp
+++ b/lib/Epub/Epub/IncrementalSectionCache.cpp
@@ -1,0 +1,369 @@
+#include "IncrementalSectionCache.h"
+
+#include <HalStorage.h>
+#include <Logging.h>
+#include <Serialization.h>
+#include <common/FsApiConstants.h>
+
+#include <utility>
+
+#include "Page.h"
+
+namespace IncrementalSection {
+namespace {
+
+bool ensureDirectory(const std::string& path) {
+  if (Storage.exists(path.c_str())) {
+    return true;
+  }
+  return Storage.mkdir(path.c_str());
+}
+
+void writeLayoutKey(FsFile& file, const LayoutCacheKey& key) {
+  serialization::writePod(file, key.cacheVersion);
+  serialization::writePod(file, key.fontId);
+  serialization::writePod(file, key.lineCompression);
+  serialization::writePod(file, key.extraParagraphSpacing);
+  serialization::writePod(file, key.paragraphAlignment);
+  serialization::writePod(file, key.viewportWidth);
+  serialization::writePod(file, key.viewportHeight);
+  serialization::writePod(file, key.hyphenationEnabled);
+  serialization::writePod(file, key.embeddedStyle);
+  serialization::writePod(file, key.imageRendering);
+  serialization::writePod(file, key.focusReadingEnabled);
+}
+
+void readLayoutKey(FsFile& file, LayoutCacheKey& key) {
+  serialization::readPod(file, key.cacheVersion);
+  serialization::readPod(file, key.fontId);
+  serialization::readPod(file, key.lineCompression);
+  serialization::readPod(file, key.extraParagraphSpacing);
+  serialization::readPod(file, key.paragraphAlignment);
+  serialization::readPod(file, key.viewportWidth);
+  serialization::readPod(file, key.viewportHeight);
+  serialization::readPod(file, key.hyphenationEnabled);
+  serialization::readPod(file, key.embeddedStyle);
+  serialization::readPod(file, key.imageRendering);
+  serialization::readPod(file, key.focusReadingEnabled);
+}
+
+void writeIndexRecord(FsFile& file, const PageIndexRecord& record) {
+  serialization::writePod(file, record.pageOffset);
+  serialization::writePod(file, record.pageLength);
+  serialization::writePod(file, record.paragraphIndex);
+  serialization::writePod(file, record.listItemIndex);
+  serialization::writePod(file, record.sourceByteOffset);
+}
+
+void readIndexRecordFromFile(FsFile& file, PageIndexRecord& record) {
+  serialization::readPod(file, record.pageOffset);
+  serialization::readPod(file, record.pageLength);
+  serialization::readPod(file, record.paragraphIndex);
+  serialization::readPod(file, record.listItemIndex);
+  serialization::readPod(file, record.sourceByteOffset);
+}
+
+}  // namespace
+
+Cache::Cache(std::string sectionsDir, const uint32_t spineIndex)
+    : sectionsDir_(std::move(sectionsDir)), spineIndex_(spineIndex), paths_(pathsForSection(sectionsDir_, spineIndex)) {}
+
+bool Cache::loadMeta(Meta& out) const {
+  FsFile file;
+  if (!Storage.openFileForRead("ISC", paths_.meta, file)) {
+    return false;
+  }
+
+  uint32_t magic = 0;
+  uint8_t version = 0;
+  serialization::readPod(file, magic);
+  serialization::readPod(file, version);
+  if (magic != CACHE_MAGIC || version != CACHE_VERSION) {
+    file.close();
+    return false;
+  }
+
+  uint8_t state = 0;
+  serialization::readPod(file, state);
+  out.state = static_cast<CacheState>(state);
+  serialization::readPod(file, out.spineIndex);
+  readLayoutKey(file, out.layoutKey);
+  serialization::readPod(file, out.sourceUncompressedSize);
+  serialization::readPod(file, out.finalPageCount);
+  serialization::readPod(file, out.anchorCount);
+  serialization::readPod(file, out.generationId);
+  const bool matchesSpine = out.spineIndex == spineIndex_;
+  file.close();
+  return matchesSpine;
+}
+
+bool Cache::writeMeta(const Meta& meta) const {
+  FsFile file;
+  if (!Storage.openFileForWrite("ISC", paths_.meta, file)) {
+    return false;
+  }
+
+  serialization::writePod(file, CACHE_MAGIC);
+  serialization::writePod(file, CACHE_VERSION);
+  serialization::writePod(file, static_cast<uint8_t>(meta.state));
+  serialization::writePod(file, meta.spineIndex);
+  writeLayoutKey(file, meta.layoutKey);
+  serialization::writePod(file, meta.sourceUncompressedSize);
+  serialization::writePod(file, meta.finalPageCount);
+  serialization::writePod(file, meta.anchorCount);
+  serialization::writePod(file, meta.generationId);
+  file.close();
+  return true;
+}
+
+bool Cache::beginBuild(const LayoutCacheKey& key, const uint32_t sourceUncompressedSize, const uint32_t generationId) {
+  removeAllFiles();
+  if (!ensureDirectory(sectionsDir_)) {
+    LOG_ERR("ISC", "Failed to create section cache dir: %s", sectionsDir_.c_str());
+    return false;
+  }
+
+  FsFile pages;
+  if (!Storage.openFileForWrite("ISC", paths_.pages, pages)) {
+    removeAllFiles();
+    return false;
+  }
+  pages.close();
+
+  FsFile index;
+  if (!Storage.openFileForWrite("ISC", paths_.index, index)) {
+    removeAllFiles();
+    return false;
+  }
+  index.close();
+
+  FsFile anchors;
+  if (!Storage.openFileForWrite("ISC", paths_.anchors, anchors)) {
+    removeAllFiles();
+    return false;
+  }
+  anchors.close();
+
+  Meta meta;
+  meta.state = CacheState::Building;
+  meta.spineIndex = spineIndex_;
+  meta.layoutKey = key;
+  meta.sourceUncompressedSize = sourceUncompressedSize;
+  meta.generationId = generationId;
+  if (!writeMeta(meta)) {
+    removeAllFiles();
+    return false;
+  }
+  return true;
+}
+
+bool Cache::appendPage(const uint32_t pageNumber, const Page& page, const uint16_t paragraphIndex,
+                       const uint16_t listItemIndex, const uint32_t sourceByteOffset) {
+  if (pageNumber != knownPageCount()) {
+    LOG_ERR("ISC", "Unexpected page append order: got %lu expected %lu", static_cast<unsigned long>(pageNumber),
+            static_cast<unsigned long>(knownPageCount()));
+    return false;
+  }
+
+  FsFile pages = Storage.open(paths_.pages.c_str(), O_WRITE | O_CREAT | O_APPEND);
+  if (!pages) {
+    return false;
+  }
+  const uint32_t offset = pages.size();
+  pages.seek(offset);
+  if (!page.serialize(pages)) {
+    pages.close();
+    return false;
+  }
+  const uint32_t end = pages.position();
+  pages.close();
+
+  FsFile index = Storage.open(paths_.index.c_str(), O_WRITE | O_CREAT | O_APPEND);
+  if (!index) {
+    return false;
+  }
+  PageIndexRecord record;
+  record.pageOffset = offset;
+  record.pageLength = end - offset;
+  record.paragraphIndex = paragraphIndex;
+  record.listItemIndex = listItemIndex;
+  record.sourceByteOffset = sourceByteOffset;
+  writeIndexRecord(index, record);
+  index.close();
+  return true;
+}
+
+bool Cache::appendAnchor(const std::string& anchor, const uint16_t page) {
+  FsFile file = Storage.open(paths_.anchors.c_str(), O_WRITE | O_CREAT | O_APPEND);
+  if (!file) {
+    return false;
+  }
+  serialization::writeString(file, anchor);
+  serialization::writePod(file, page);
+  file.close();
+  return true;
+}
+
+bool Cache::markComplete(const uint32_t finalPageCount, const uint32_t anchorCount) {
+  Meta meta;
+  if (!loadMeta(meta)) {
+    return false;
+  }
+  if (knownPageCount() != finalPageCount) {
+    LOG_ERR("ISC", "Final page count mismatch: known=%lu final=%lu", static_cast<unsigned long>(knownPageCount()),
+            static_cast<unsigned long>(finalPageCount));
+    return false;
+  }
+  meta.state = CacheState::Complete;
+  meta.finalPageCount = finalPageCount;
+  meta.anchorCount = anchorCount;
+  return writeMeta(meta);
+}
+
+bool Cache::readIndexRecord(const uint32_t pageNumber, PageIndexRecord& out) const {
+  FsFile index;
+  if (!Storage.openFileForRead("ISC", paths_.index, index)) {
+    return false;
+  }
+  const size_t indexSize = index.size();
+  if ((pageNumber + 1) * PAGE_INDEX_RECORD_SIZE > indexSize) {
+    index.close();
+    return false;
+  }
+  if (!index.seek(pageNumber * PAGE_INDEX_RECORD_SIZE)) {
+    index.close();
+    return false;
+  }
+  readIndexRecordFromFile(index, out);
+  index.close();
+  return true;
+}
+
+std::unique_ptr<Page> Cache::loadPage(const uint32_t pageNumber) const {
+  PageIndexRecord record;
+  if (!readIndexRecord(pageNumber, record)) {
+    return nullptr;
+  }
+  FsFile pages;
+  if (!Storage.openFileForRead("ISC", paths_.pages, pages)) {
+    return nullptr;
+  }
+  if (!pages.seek(record.pageOffset)) {
+    pages.close();
+    return nullptr;
+  }
+  auto page = Page::deserialize(pages);
+  pages.close();
+  return page;
+}
+
+std::optional<uint16_t> Cache::getPageForAnchor(const std::string& anchor) const {
+  Meta meta;
+  if (!loadMeta(meta) || meta.anchorCount == 0) {
+    return std::nullopt;
+  }
+  FsFile file;
+  if (!Storage.openFileForRead("ISC", paths_.anchors, file)) {
+    return std::nullopt;
+  }
+  for (uint32_t i = 0; i < meta.anchorCount && file.available() > 0; i++) {
+    std::string key;
+    uint16_t page = 0;
+    serialization::readString(file, key);
+    serialization::readPod(file, page);
+    if (key == anchor) {
+      file.close();
+      return page;
+    }
+  }
+  file.close();
+  return std::nullopt;
+}
+
+std::optional<uint16_t> Cache::getParagraphIndexForPage(const uint32_t pageNumber) const {
+  PageIndexRecord record;
+  if (!readIndexRecord(pageNumber, record)) {
+    return std::nullopt;
+  }
+  return record.paragraphIndex;
+}
+
+std::optional<uint16_t> Cache::getPageForParagraphIndex(const uint16_t paragraphIndex) const {
+  const uint32_t count = knownPageCount();
+  if (count == 0) {
+    return std::nullopt;
+  }
+  uint16_t resultPage = static_cast<uint16_t>(count - 1);
+  for (uint32_t i = 0; i < count; i++) {
+    PageIndexRecord record;
+    if (!readIndexRecord(i, record)) {
+      return std::nullopt;
+    }
+    if (record.paragraphIndex >= paragraphIndex) {
+      resultPage = static_cast<uint16_t>(i);
+      break;
+    }
+  }
+  return resultPage;
+}
+
+std::optional<uint16_t> Cache::getPageForListItemIndex(const uint16_t listItemIndex) const {
+  const uint32_t count = knownPageCount();
+  if (count == 0) {
+    return std::nullopt;
+  }
+  uint16_t resultPage = static_cast<uint16_t>(count - 1);
+  for (uint32_t i = 0; i < count; i++) {
+    PageIndexRecord record;
+    if (!readIndexRecord(i, record)) {
+      return std::nullopt;
+    }
+    if (record.listItemIndex >= listItemIndex) {
+      resultPage = static_cast<uint16_t>(i);
+      break;
+    }
+  }
+  return resultPage;
+}
+
+uint32_t Cache::knownPageCount() const {
+  if (!Storage.exists(paths_.index.c_str())) {
+    return 0;
+  }
+  FsFile index;
+  if (!Storage.openFileForRead("ISC", paths_.index, index)) {
+    return 0;
+  }
+  const auto pageCount = knownPageCountFromIndexBytes(index.size());
+  index.close();
+  return pageCount;
+}
+
+bool Cache::isComplete() const {
+  Meta meta;
+  return loadMeta(meta) && meta.state == CacheState::Complete && meta.finalPageCount == knownPageCount();
+}
+
+bool Cache::isCompatibleWith(const LayoutCacheKey& key) const {
+  Meta meta;
+  return loadMeta(meta) && meta.layoutKey.matches(key);
+}
+
+bool Cache::hasPage(const uint32_t pageNumber) const { return pageNumber < knownPageCount(); }
+
+void Cache::removeAllFiles() const {
+  if (Storage.exists(paths_.meta.c_str())) {
+    Storage.remove(paths_.meta.c_str());
+  }
+  if (Storage.exists(paths_.pages.c_str())) {
+    Storage.remove(paths_.pages.c_str());
+  }
+  if (Storage.exists(paths_.index.c_str())) {
+    Storage.remove(paths_.index.c_str());
+  }
+  if (Storage.exists(paths_.anchors.c_str())) {
+    Storage.remove(paths_.anchors.c_str());
+  }
+}
+
+}  // namespace IncrementalSection

--- a/lib/Epub/Epub/IncrementalSectionCache.cpp
+++ b/lib/Epub/Epub/IncrementalSectionCache.cpp
@@ -13,6 +13,8 @@
 namespace IncrementalSection {
 namespace {
 
+constexpr uint32_t MAX_ANCHOR_KEY_LEN = 1024;
+
 bool ensureDirectory(const std::string& path) {
   if (Storage.exists(path.c_str())) {
     return true;
@@ -45,6 +47,34 @@ bool checkedWriteString(FsFile& file, const std::string& value, const char* labe
   const uint32_t length = static_cast<uint32_t>(value.size());
   return checkedWritePod(file, length, label) &&
          checkedWriteBytes(file, reinterpret_cast<const uint8_t*>(value.data()), length, label);
+}
+
+bool readAnchorEntry(FsFile& file, std::string& key, uint16_t& page) {
+  if (file.available() < static_cast<int>(sizeof(uint32_t) + sizeof(uint16_t))) {
+    LOG_ERR("ISC", "Truncated anchor entry");
+    return false;
+  }
+
+  uint32_t length = 0;
+  serialization::readPod(file, length);
+  const int remaining = file.available();
+  if (remaining < static_cast<int>(sizeof(uint16_t)) ||
+      length > static_cast<uint32_t>(remaining - static_cast<int>(sizeof(uint16_t))) || length > MAX_ANCHOR_KEY_LEN) {
+    LOG_ERR("ISC", "Invalid anchor key length: %lu", static_cast<unsigned long>(length));
+    return false;
+  }
+
+  key.resize(length);
+  if (length > 0) {
+    const size_t read = file.read(reinterpret_cast<uint8_t*>(&key[0]), length);
+    if (read != length) {
+      LOG_ERR("ISC", "Short read anchor key: %u/%lu bytes", static_cast<unsigned>(read),
+              static_cast<unsigned long>(length));
+      return false;
+    }
+  }
+  serialization::readPod(file, page);
+  return true;
 }
 
 bool checkedWriteLayoutKey(FsFile& file, const LayoutCacheKey& key) {
@@ -313,8 +343,10 @@ std::optional<uint16_t> Cache::getPageForAnchor(const std::string& anchor) const
   for (uint32_t i = 0; i < meta.anchorCount && file.available() > 0; i++) {
     std::string key;
     uint16_t page = 0;
-    serialization::readString(file, key);
-    serialization::readPod(file, page);
+    if (!readAnchorEntry(file, key, page)) {
+      file.close();
+      return std::nullopt;
+    }
     if (key == anchor) {
       file.close();
       return page;

--- a/lib/Epub/Epub/IncrementalSectionCache.cpp
+++ b/lib/Epub/Epub/IncrementalSectionCache.cpp
@@ -26,8 +26,7 @@ bool checkedWriteBytes(FsFile& file, const uint8_t* data, const size_t size, con
   }
   const size_t written = file.write(data, size);
   if (written != size) {
-    LOG_ERR("ISC", "Short write %s: %u/%u bytes", label, static_cast<unsigned>(written),
-            static_cast<unsigned>(size));
+    LOG_ERR("ISC", "Short write %s: %u/%u bytes", label, static_cast<unsigned>(written), static_cast<unsigned>(size));
     return false;
   }
   return true;
@@ -95,7 +94,9 @@ void readIndexRecordFromFile(FsFile& file, PageIndexRecord& record) {
 }  // namespace
 
 Cache::Cache(std::string sectionsDir, const uint32_t spineIndex)
-    : sectionsDir_(std::move(sectionsDir)), spineIndex_(spineIndex), paths_(pathsForSection(sectionsDir_, spineIndex)) {}
+    : sectionsDir_(std::move(sectionsDir)),
+      spineIndex_(spineIndex),
+      paths_(pathsForSection(sectionsDir_, spineIndex)) {}
 
 bool Cache::loadMeta(Meta& out) const {
   FsFile file;
@@ -133,15 +134,14 @@ bool Cache::writeMeta(const Meta& meta) const {
   }
 
   const uint8_t state = static_cast<uint8_t>(meta.state);
-  const bool success = checkedWritePod(file, CACHE_MAGIC, "meta.magic") &&
-                       checkedWritePod(file, CACHE_VERSION, "meta.version") &&
-                       checkedWritePod(file, state, "meta.state") &&
-                       checkedWritePod(file, meta.spineIndex, "meta.spineIndex") &&
-                       checkedWriteLayoutKey(file, meta.layoutKey) &&
-                       checkedWritePod(file, meta.sourceUncompressedSize, "meta.sourceUncompressedSize") &&
-                       checkedWritePod(file, meta.finalPageCount, "meta.finalPageCount") &&
-                       checkedWritePod(file, meta.anchorCount, "meta.anchorCount") &&
-                       checkedWritePod(file, meta.generationId, "meta.generationId");
+  const bool success =
+      checkedWritePod(file, CACHE_MAGIC, "meta.magic") && checkedWritePod(file, CACHE_VERSION, "meta.version") &&
+      checkedWritePod(file, state, "meta.state") && checkedWritePod(file, meta.spineIndex, "meta.spineIndex") &&
+      checkedWriteLayoutKey(file, meta.layoutKey) &&
+      checkedWritePod(file, meta.sourceUncompressedSize, "meta.sourceUncompressedSize") &&
+      checkedWritePod(file, meta.finalPageCount, "meta.finalPageCount") &&
+      checkedWritePod(file, meta.anchorCount, "meta.anchorCount") &&
+      checkedWritePod(file, meta.generationId, "meta.generationId");
   file.close();
   return success;
 }

--- a/lib/Epub/Epub/IncrementalSectionCache.cpp
+++ b/lib/Epub/Epub/IncrementalSectionCache.cpp
@@ -91,6 +91,14 @@ void readIndexRecordFromFile(FsFile& file, PageIndexRecord& record) {
   serialization::readPod(file, record.sourceByteOffset);
 }
 
+bool readNextIndexRecord(FsFile& file, PageIndexRecord& record) {
+  if (static_cast<size_t>(file.available()) < PAGE_INDEX_RECORD_SIZE) {
+    return false;
+  }
+  readIndexRecordFromFile(file, record);
+  return true;
+}
+
 }  // namespace
 
 Cache::Cache(std::string sectionsDir, const uint32_t spineIndex)
@@ -261,7 +269,8 @@ bool Cache::readIndexRecord(const uint32_t pageNumber, PageIndexRecord& out) con
     return false;
   }
   const size_t indexSize = index.size();
-  if ((pageNumber + 1) * PAGE_INDEX_RECORD_SIZE > indexSize) {
+  const size_t recordCount = indexSize / PAGE_INDEX_RECORD_SIZE;
+  if (pageNumber >= recordCount) {
     index.close();
     return false;
   }
@@ -329,9 +338,14 @@ std::optional<uint16_t> Cache::getPageForParagraphIndex(const uint16_t paragraph
     return std::nullopt;
   }
   uint16_t resultPage = static_cast<uint16_t>(count - 1);
+  FsFile index;
+  if (!Storage.openFileForRead("ISC", paths_.index, index)) {
+    return std::nullopt;
+  }
   for (uint32_t i = 0; i < count; i++) {
     PageIndexRecord record;
-    if (!readIndexRecord(i, record)) {
+    if (!readNextIndexRecord(index, record)) {
+      index.close();
       return std::nullopt;
     }
     if (record.paragraphIndex >= paragraphIndex) {
@@ -339,6 +353,7 @@ std::optional<uint16_t> Cache::getPageForParagraphIndex(const uint16_t paragraph
       break;
     }
   }
+  index.close();
   return resultPage;
 }
 
@@ -348,9 +363,14 @@ std::optional<uint16_t> Cache::getPageForListItemIndex(const uint16_t listItemIn
     return std::nullopt;
   }
   uint16_t resultPage = static_cast<uint16_t>(count - 1);
+  FsFile index;
+  if (!Storage.openFileForRead("ISC", paths_.index, index)) {
+    return std::nullopt;
+  }
   for (uint32_t i = 0; i < count; i++) {
     PageIndexRecord record;
-    if (!readIndexRecord(i, record)) {
+    if (!readNextIndexRecord(index, record)) {
+      index.close();
       return std::nullopt;
     }
     if (record.listItemIndex >= listItemIndex) {
@@ -358,6 +378,7 @@ std::optional<uint16_t> Cache::getPageForListItemIndex(const uint16_t listItemIn
       break;
     }
   }
+  index.close();
   return resultPage;
 }
 

--- a/lib/Epub/Epub/IncrementalSectionCache.cpp
+++ b/lib/Epub/Epub/IncrementalSectionCache.cpp
@@ -5,6 +5,7 @@
 #include <Serialization.h>
 #include <common/FsApiConstants.h>
 
+#include <limits>
 #include <utility>
 
 #include "Page.h"
@@ -19,18 +20,46 @@ bool ensureDirectory(const std::string& path) {
   return Storage.mkdir(path.c_str());
 }
 
-void writeLayoutKey(FsFile& file, const LayoutCacheKey& key) {
-  serialization::writePod(file, key.cacheVersion);
-  serialization::writePod(file, key.fontId);
-  serialization::writePod(file, key.lineCompression);
-  serialization::writePod(file, key.extraParagraphSpacing);
-  serialization::writePod(file, key.paragraphAlignment);
-  serialization::writePod(file, key.viewportWidth);
-  serialization::writePod(file, key.viewportHeight);
-  serialization::writePod(file, key.hyphenationEnabled);
-  serialization::writePod(file, key.embeddedStyle);
-  serialization::writePod(file, key.imageRendering);
-  serialization::writePod(file, key.focusReadingEnabled);
+bool checkedWriteBytes(FsFile& file, const uint8_t* data, const size_t size, const char* label) {
+  if (size == 0) {
+    return true;
+  }
+  const size_t written = file.write(data, size);
+  if (written != size) {
+    LOG_ERR("ISC", "Short write %s: %u/%u bytes", label, static_cast<unsigned>(written),
+            static_cast<unsigned>(size));
+    return false;
+  }
+  return true;
+}
+
+template <typename T>
+bool checkedWritePod(FsFile& file, const T& value, const char* label) {
+  return checkedWriteBytes(file, reinterpret_cast<const uint8_t*>(&value), sizeof(T), label);
+}
+
+bool checkedWriteString(FsFile& file, const std::string& value, const char* label) {
+  if (value.size() > std::numeric_limits<uint32_t>::max()) {
+    LOG_ERR("ISC", "String too large for %s: %u bytes", label, static_cast<unsigned>(value.size()));
+    return false;
+  }
+  const uint32_t length = static_cast<uint32_t>(value.size());
+  return checkedWritePod(file, length, label) &&
+         checkedWriteBytes(file, reinterpret_cast<const uint8_t*>(value.data()), length, label);
+}
+
+bool checkedWriteLayoutKey(FsFile& file, const LayoutCacheKey& key) {
+  return checkedWritePod(file, key.cacheVersion, "layout.cacheVersion") &&
+         checkedWritePod(file, key.fontId, "layout.fontId") &&
+         checkedWritePod(file, key.lineCompression, "layout.lineCompression") &&
+         checkedWritePod(file, key.extraParagraphSpacing, "layout.extraParagraphSpacing") &&
+         checkedWritePod(file, key.paragraphAlignment, "layout.paragraphAlignment") &&
+         checkedWritePod(file, key.viewportWidth, "layout.viewportWidth") &&
+         checkedWritePod(file, key.viewportHeight, "layout.viewportHeight") &&
+         checkedWritePod(file, key.hyphenationEnabled, "layout.hyphenationEnabled") &&
+         checkedWritePod(file, key.embeddedStyle, "layout.embeddedStyle") &&
+         checkedWritePod(file, key.imageRendering, "layout.imageRendering") &&
+         checkedWritePod(file, key.focusReadingEnabled, "layout.focusReadingEnabled");
 }
 
 void readLayoutKey(FsFile& file, LayoutCacheKey& key) {
@@ -47,12 +76,12 @@ void readLayoutKey(FsFile& file, LayoutCacheKey& key) {
   serialization::readPod(file, key.focusReadingEnabled);
 }
 
-void writeIndexRecord(FsFile& file, const PageIndexRecord& record) {
-  serialization::writePod(file, record.pageOffset);
-  serialization::writePod(file, record.pageLength);
-  serialization::writePod(file, record.paragraphIndex);
-  serialization::writePod(file, record.listItemIndex);
-  serialization::writePod(file, record.sourceByteOffset);
+bool checkedWriteIndexRecord(FsFile& file, const PageIndexRecord& record) {
+  return checkedWritePod(file, record.pageOffset, "index.pageOffset") &&
+         checkedWritePod(file, record.pageLength, "index.pageLength") &&
+         checkedWritePod(file, record.paragraphIndex, "index.paragraphIndex") &&
+         checkedWritePod(file, record.listItemIndex, "index.listItemIndex") &&
+         checkedWritePod(file, record.sourceByteOffset, "index.sourceByteOffset");
 }
 
 void readIndexRecordFromFile(FsFile& file, PageIndexRecord& record) {
@@ -103,17 +132,18 @@ bool Cache::writeMeta(const Meta& meta) const {
     return false;
   }
 
-  serialization::writePod(file, CACHE_MAGIC);
-  serialization::writePod(file, CACHE_VERSION);
-  serialization::writePod(file, static_cast<uint8_t>(meta.state));
-  serialization::writePod(file, meta.spineIndex);
-  writeLayoutKey(file, meta.layoutKey);
-  serialization::writePod(file, meta.sourceUncompressedSize);
-  serialization::writePod(file, meta.finalPageCount);
-  serialization::writePod(file, meta.anchorCount);
-  serialization::writePod(file, meta.generationId);
+  const uint8_t state = static_cast<uint8_t>(meta.state);
+  const bool success = checkedWritePod(file, CACHE_MAGIC, "meta.magic") &&
+                       checkedWritePod(file, CACHE_VERSION, "meta.version") &&
+                       checkedWritePod(file, state, "meta.state") &&
+                       checkedWritePod(file, meta.spineIndex, "meta.spineIndex") &&
+                       checkedWriteLayoutKey(file, meta.layoutKey) &&
+                       checkedWritePod(file, meta.sourceUncompressedSize, "meta.sourceUncompressedSize") &&
+                       checkedWritePod(file, meta.finalPageCount, "meta.finalPageCount") &&
+                       checkedWritePod(file, meta.anchorCount, "meta.anchorCount") &&
+                       checkedWritePod(file, meta.generationId, "meta.generationId");
   file.close();
-  return true;
+  return success;
 }
 
 bool Cache::beginBuild(const LayoutCacheKey& key, const uint32_t sourceUncompressedSize, const uint32_t generationId) {
@@ -188,7 +218,10 @@ bool Cache::appendPage(const uint32_t pageNumber, const Page& page, const uint16
   record.paragraphIndex = paragraphIndex;
   record.listItemIndex = listItemIndex;
   record.sourceByteOffset = sourceByteOffset;
-  writeIndexRecord(index, record);
+  if (!checkedWriteIndexRecord(index, record)) {
+    index.close();
+    return false;
+  }
   index.close();
   return true;
 }
@@ -198,8 +231,10 @@ bool Cache::appendAnchor(const std::string& anchor, const uint16_t page) {
   if (!file) {
     return false;
   }
-  serialization::writeString(file, anchor);
-  serialization::writePod(file, page);
+  if (!checkedWriteString(file, anchor, "anchor.key") || !checkedWritePod(file, page, "anchor.page")) {
+    file.close();
+    return false;
+  }
   file.close();
   return true;
 }

--- a/lib/Epub/Epub/IncrementalSectionCache.h
+++ b/lib/Epub/Epub/IncrementalSectionCache.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "IncrementalSectionTypes.h"
+
+class Page;
+
+namespace IncrementalSection {
+
+struct PageIndexRecord {
+  uint32_t pageOffset = 0;
+  uint32_t pageLength = 0;
+  uint16_t paragraphIndex = 0;
+  uint16_t listItemIndex = 0;
+  uint32_t sourceByteOffset = 0;
+};
+
+static_assert(sizeof(PageIndexRecord) == PAGE_INDEX_RECORD_SIZE, "Incremental page index record must stay 16 bytes");
+
+struct Meta {
+  CacheState state = CacheState::Building;
+  uint32_t spineIndex = 0;
+  LayoutCacheKey layoutKey{};
+  uint32_t sourceUncompressedSize = 0;
+  uint32_t finalPageCount = 0;
+  uint32_t anchorCount = 0;
+  uint32_t generationId = 0;
+};
+
+class Cache {
+ public:
+  explicit Cache(std::string sectionsDir, uint32_t spineIndex);
+
+  bool loadMeta(Meta& out) const;
+  bool beginBuild(const LayoutCacheKey& key, uint32_t sourceUncompressedSize, uint32_t generationId);
+  bool appendPage(uint32_t pageNumber, const Page& page, uint16_t paragraphIndex, uint16_t listItemIndex,
+                  uint32_t sourceByteOffset = 0);
+  bool appendAnchor(const std::string& anchor, uint16_t page);
+  bool markComplete(uint32_t finalPageCount, uint32_t anchorCount);
+  std::unique_ptr<Page> loadPage(uint32_t pageNumber) const;
+  std::optional<uint16_t> getPageForAnchor(const std::string& anchor) const;
+  std::optional<uint16_t> getPageForParagraphIndex(uint16_t paragraphIndex) const;
+  std::optional<uint16_t> getPageForListItemIndex(uint16_t listItemIndex) const;
+  std::optional<uint16_t> getParagraphIndexForPage(uint32_t pageNumber) const;
+  uint32_t knownPageCount() const;
+  bool isComplete() const;
+  bool isCompatibleWith(const LayoutCacheKey& key) const;
+  bool hasPage(uint32_t pageNumber) const;
+  void removeAllFiles() const;
+
+ private:
+  std::string sectionsDir_;
+  uint32_t spineIndex_;
+  Paths paths_;
+
+  bool writeMeta(const Meta& meta) const;
+  bool readIndexRecord(uint32_t pageNumber, PageIndexRecord& out) const;
+};
+
+}  // namespace IncrementalSection

--- a/lib/Epub/Epub/IncrementalSectionTypes.h
+++ b/lib/Epub/Epub/IncrementalSectionTypes.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace IncrementalSection {
+
+static constexpr uint32_t CACHE_MAGIC = 0x43504953U;  // CPIS
+static constexpr uint8_t CACHE_VERSION = 1;
+static constexpr size_t PAGE_INDEX_RECORD_SIZE = 16;
+
+enum class CacheState : uint8_t {
+  Building = 1,
+  Complete = 2,
+  Failed = 3,
+};
+
+struct LayoutCacheKey {
+  uint8_t cacheVersion = CACHE_VERSION;
+  int32_t fontId = 0;
+  float lineCompression = 1.0F;
+  bool extraParagraphSpacing = false;
+  uint8_t paragraphAlignment = 0;
+  uint16_t viewportWidth = 0;
+  uint16_t viewportHeight = 0;
+  bool hyphenationEnabled = false;
+  bool embeddedStyle = false;
+  uint8_t imageRendering = 0;
+  bool focusReadingEnabled = false;
+
+  bool matches(const LayoutCacheKey& other) const {
+    return cacheVersion == other.cacheVersion && fontId == other.fontId &&
+           lineCompression == other.lineCompression && extraParagraphSpacing == other.extraParagraphSpacing &&
+           paragraphAlignment == other.paragraphAlignment && viewportWidth == other.viewportWidth &&
+           viewportHeight == other.viewportHeight && hyphenationEnabled == other.hyphenationEnabled &&
+           embeddedStyle == other.embeddedStyle && imageRendering == other.imageRendering &&
+           focusReadingEnabled == other.focusReadingEnabled;
+  }
+};
+
+struct Paths {
+  std::string meta;
+  std::string pages;
+  std::string index;
+  std::string anchors;
+};
+
+inline uint32_t knownPageCountFromIndexBytes(const size_t indexBytes) {
+  if (indexBytes == 0 || indexBytes % PAGE_INDEX_RECORD_SIZE != 0) {
+    return 0;
+  }
+  return static_cast<uint32_t>(indexBytes / PAGE_INDEX_RECORD_SIZE);
+}
+
+inline Paths pathsForSection(const std::string& sectionsDir, const uint32_t spineIndex) {
+  const auto base = sectionsDir + "/" + std::to_string(spineIndex);
+  return {base + ".met", base + ".pag", base + ".idx", base + ".anc"};
+}
+
+}  // namespace IncrementalSection

--- a/lib/Epub/Epub/IncrementalSectionTypes.h
+++ b/lib/Epub/Epub/IncrementalSectionTypes.h
@@ -30,12 +30,11 @@ struct LayoutCacheKey {
   bool focusReadingEnabled = false;
 
   bool matches(const LayoutCacheKey& other) const {
-    return cacheVersion == other.cacheVersion && fontId == other.fontId &&
-           lineCompression == other.lineCompression && extraParagraphSpacing == other.extraParagraphSpacing &&
-           paragraphAlignment == other.paragraphAlignment && viewportWidth == other.viewportWidth &&
-           viewportHeight == other.viewportHeight && hyphenationEnabled == other.hyphenationEnabled &&
-           embeddedStyle == other.embeddedStyle && imageRendering == other.imageRendering &&
-           focusReadingEnabled == other.focusReadingEnabled;
+    return cacheVersion == other.cacheVersion && fontId == other.fontId && lineCompression == other.lineCompression &&
+           extraParagraphSpacing == other.extraParagraphSpacing && paragraphAlignment == other.paragraphAlignment &&
+           viewportWidth == other.viewportWidth && viewportHeight == other.viewportHeight &&
+           hyphenationEnabled == other.hyphenationEnabled && embeddedStyle == other.embeddedStyle &&
+           imageRendering == other.imageRendering && focusReadingEnabled == other.focusReadingEnabled;
   }
 };
 

--- a/lib/Epub/Epub/SectionHandle.cpp
+++ b/lib/Epub/Epub/SectionHandle.cpp
@@ -1,0 +1,201 @@
+#include "SectionHandle.h"
+
+#include <Logging.h>
+#include <Memory.h>
+
+#include <utility>
+
+#include "Epub.h"
+#include "Page.h"
+
+std::unique_ptr<SectionHandle> SectionHandle::openOrCreate(const std::shared_ptr<Epub>& epub, const int spineIndex,
+                                                           GfxRenderer& renderer,
+                                                           const IncrementalSection::LayoutCacheKey& layoutKey,
+                                                           const IncrementalBuildOptions& options) {
+  auto handle = makeUniqueNoThrow<SectionHandle>(spineIndex);
+  if (!handle) {
+    LOG_ERR("SH", "OOM: SectionHandle");
+    return nullptr;
+  }
+
+  handle->epub_ = epub;
+  handle->renderer_ = &renderer;
+  handle->layoutKey_ = layoutKey;
+  handle->options_ = options;
+
+  const auto sectionsDir = epub->getCachePath() + "/sections";
+  handle->incrementalCache_ = makeUniqueNoThrow<IncrementalSection::Cache>(sectionsDir, static_cast<uint32_t>(spineIndex));
+  if (!handle->incrementalCache_) {
+    LOG_ERR("SH", "OOM: IncrementalSection::Cache");
+    return handle;
+  }
+
+  IncrementalSection::Meta meta;
+  if (handle->incrementalCache_->loadMeta(meta) && meta.layoutKey.matches(layoutKey)) {
+    if (meta.state == IncrementalSection::CacheState::Complete && handle->incrementalCache_->isComplete()) {
+      handle->knownPageCount_ = meta.finalPageCount;
+      handle->mode_ = SectionHandleMode::IncrementalComplete;
+      return handle;
+    }
+    handle->incrementalCache_->removeAllFiles();
+  }
+
+  handle->startBuilder();
+  return handle;
+}
+
+bool SectionHandle::startBuilder() {
+  if (builder_) {
+    return true;
+  }
+  if (!epub_ || !renderer_) {
+    mode_ = SectionHandleMode::MissingOrFailed;
+    return false;
+  }
+
+  builder_ = makeUniqueNoThrow<IncrementalSectionBuilder>(epub_, spineIndex_, *renderer_, layoutKey_, options_);
+  if (!builder_) {
+    LOG_ERR("SH", "OOM: IncrementalSectionBuilder");
+    mode_ = SectionHandleMode::MissingOrFailed;
+    return false;
+  }
+  if (!builder_->start()) {
+    builder_.reset();
+    knownPageCount_ = 0;
+    mode_ = SectionHandleMode::MissingOrFailed;
+    return false;
+  }
+  knownPageCount_ = builder_->knownPageCount();
+  mode_ = SectionHandleMode::IncrementalBuilding;
+  return true;
+}
+
+bool SectionHandle::hasPage(const uint32_t pageNumber) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed) {
+    return false;
+  }
+  return pageNumber < knownPageCount_;
+}
+
+bool SectionHandle::ensurePageAvailable(const uint32_t pageNumber, const IncrementalBuildBudget& budget) {
+  while (!hasPage(pageNumber) && mode_ == SectionHandleMode::IncrementalBuilding) {
+    const auto result = pump(budget);
+    if (result.status == SectionPumpStatus::DeferredLowMemory || result.status == SectionPumpStatus::Failed ||
+        result.status == SectionPumpStatus::NoWork) {
+      return false;
+    }
+  }
+  return hasPage(pageNumber);
+}
+
+std::unique_ptr<Page> SectionHandle::loadPage(const uint32_t pageNumber) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed) {
+    return nullptr;
+  }
+  if (builder_) {
+    return builder_->loadPage(pageNumber);
+  }
+  return incrementalCache_ ? incrementalCache_->loadPage(pageNumber) : nullptr;
+}
+
+bool SectionHandle::isComplete() const {
+  return mode_ == SectionHandleMode::IncrementalComplete;
+}
+
+uint32_t SectionHandle::knownPageCount() const {
+  if (mode_ == SectionHandleMode::MissingOrFailed) {
+    return 0;
+  }
+  return knownPageCount_;
+}
+
+uint32_t SectionHandle::finalPageCount() const { return isComplete() ? knownPageCount() : 0; }
+
+SectionPumpResult SectionHandle::pump(const IncrementalBuildBudget& budget) {
+  if (mode_ != SectionHandleMode::IncrementalBuilding) {
+    return {SectionPumpStatus::NoWork, knownPageCount(), knownPageCount()};
+  }
+  if (!builder_ && !startBuilder()) {
+    return {SectionPumpStatus::Failed, 0, 0};
+  }
+
+  const uint32_t pagesBefore = knownPageCount_;
+  const auto state = builder_->pump(budget);
+  const uint32_t pagesAfter = builder_ ? builder_->knownPageCount() : knownPageCount_;
+  return applyPumpState(state, pagesBefore, pagesAfter);
+}
+
+SectionPumpResult SectionHandle::applyPumpState(const IncrementalBuildState state, const uint32_t pagesBefore,
+                                                const uint32_t pagesAfter) {
+  if (state == IncrementalBuildState::DeferredLowMemory) {
+    knownPageCount_ = pagesAfter;
+    return {SectionPumpStatus::DeferredLowMemory, pagesBefore, pagesAfter};
+  }
+  if (state == IncrementalBuildState::Complete) {
+    knownPageCount_ = pagesAfter;
+    mode_ = SectionHandleMode::IncrementalComplete;
+    builder_.reset();
+    return {SectionPumpStatus::Complete, pagesBefore, pagesAfter};
+  }
+  if (state == IncrementalBuildState::Failed || state == IncrementalBuildState::Cancelled) {
+    knownPageCount_ = 0;
+    mode_ = SectionHandleMode::MissingOrFailed;
+    builder_.reset();
+    return {SectionPumpStatus::Failed, pagesBefore, pagesAfter};
+  }
+  knownPageCount_ = pagesAfter;
+  if (pagesAfter > pagesBefore) {
+    return {SectionPumpStatus::Pumped, pagesBefore, pagesAfter};
+  }
+  return {SectionPumpStatus::NoWork, pagesBefore, pagesAfter};
+}
+
+bool SectionHandle::hasActiveBuilder() const { return builder_ && mode_ == SectionHandleMode::IncrementalBuilding; }
+
+void SectionHandle::cancel() {
+  if (builder_) {
+    builder_->cancel();
+    builder_.reset();
+  }
+  if (mode_ == SectionHandleMode::IncrementalBuilding) {
+    knownPageCount_ = 0;
+    mode_ = SectionHandleMode::MissingOrFailed;
+  }
+}
+
+void SectionHandle::clearCache() {
+  cancel();
+  if (incrementalCache_) {
+    incrementalCache_->removeAllFiles();
+  }
+  knownPageCount_ = 0;
+  mode_ = SectionHandleMode::MissingOrFailed;
+}
+
+std::optional<uint16_t> SectionHandle::getPageForAnchor(const std::string& anchor) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed || !incrementalCache_) {
+    return std::nullopt;
+  }
+  return incrementalCache_->getPageForAnchor(anchor);
+}
+
+std::optional<uint16_t> SectionHandle::getPageForParagraphIndex(const uint16_t paragraphIndex) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed || !incrementalCache_) {
+    return std::nullopt;
+  }
+  return incrementalCache_->getPageForParagraphIndex(paragraphIndex);
+}
+
+std::optional<uint16_t> SectionHandle::getPageForListItemIndex(const uint16_t listItemIndex) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed || !incrementalCache_) {
+    return std::nullopt;
+  }
+  return incrementalCache_->getPageForListItemIndex(listItemIndex);
+}
+
+std::optional<uint16_t> SectionHandle::getParagraphIndexForPage(const uint16_t page) const {
+  if (mode_ == SectionHandleMode::MissingOrFailed || !incrementalCache_) {
+    return std::nullopt;
+  }
+  return incrementalCache_->getParagraphIndexForPage(page);
+}

--- a/lib/Epub/Epub/SectionHandle.cpp
+++ b/lib/Epub/Epub/SectionHandle.cpp
@@ -143,6 +143,9 @@ SectionPumpResult SectionHandle::applyPumpState(const IncrementalBuildState stat
     return {SectionPumpStatus::Failed, pagesBefore, pagesAfter};
   }
   knownPageCount_ = pagesAfter;
+  if (state == IncrementalBuildState::Parsing) {
+    return {SectionPumpStatus::Pumped, pagesBefore, pagesAfter};
+  }
   if (pagesAfter > pagesBefore) {
     return {SectionPumpStatus::Pumped, pagesBefore, pagesAfter};
   }

--- a/lib/Epub/Epub/SectionHandle.cpp
+++ b/lib/Epub/Epub/SectionHandle.cpp
@@ -24,7 +24,8 @@ std::unique_ptr<SectionHandle> SectionHandle::openOrCreate(const std::shared_ptr
   handle->options_ = options;
 
   const auto sectionsDir = epub->getCachePath() + "/sections";
-  handle->incrementalCache_ = makeUniqueNoThrow<IncrementalSection::Cache>(sectionsDir, static_cast<uint32_t>(spineIndex));
+  handle->incrementalCache_ =
+      makeUniqueNoThrow<IncrementalSection::Cache>(sectionsDir, static_cast<uint32_t>(spineIndex));
   if (!handle->incrementalCache_) {
     LOG_ERR("SH", "OOM: IncrementalSection::Cache");
     return handle;
@@ -98,9 +99,7 @@ std::unique_ptr<Page> SectionHandle::loadPage(const uint32_t pageNumber) const {
   return incrementalCache_ ? incrementalCache_->loadPage(pageNumber) : nullptr;
 }
 
-bool SectionHandle::isComplete() const {
-  return mode_ == SectionHandleMode::IncrementalComplete;
-}
+bool SectionHandle::isComplete() const { return mode_ == SectionHandleMode::IncrementalComplete; }
 
 uint32_t SectionHandle::knownPageCount() const {
   if (mode_ == SectionHandleMode::MissingOrFailed) {

--- a/lib/Epub/Epub/SectionHandle.h
+++ b/lib/Epub/Epub/SectionHandle.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "IncrementalSectionBuilder.h"
+
+class Epub;
+class GfxRenderer;
+class Page;
+
+enum class SectionHandleMode {
+  IncrementalComplete,
+  IncrementalBuilding,
+  MissingOrFailed,
+};
+
+enum class SectionPumpStatus {
+  NoWork,
+  Pumped,
+  DeferredLowMemory,
+  Complete,
+  Failed,
+};
+
+struct SectionPumpResult {
+  SectionPumpStatus status = SectionPumpStatus::NoWork;
+  uint32_t pagesBefore = 0;
+  uint32_t pagesAfter = 0;
+};
+
+class SectionHandle {
+ public:
+  explicit SectionHandle(int spineIndex) : spineIndex_(spineIndex) {}
+
+  static std::unique_ptr<SectionHandle> openOrCreate(const std::shared_ptr<Epub>& epub, int spineIndex,
+                                                     GfxRenderer& renderer,
+                                                     const IncrementalSection::LayoutCacheKey& layoutKey,
+                                                     const IncrementalBuildOptions& options);
+
+  int currentPage = 0;
+
+  bool hasPage(uint32_t pageNumber) const;
+  bool ensurePageAvailable(uint32_t pageNumber, const IncrementalBuildBudget& budget);
+  std::unique_ptr<Page> loadPage(uint32_t pageNumber) const;
+  bool isComplete() const;
+  uint32_t knownPageCount() const;
+  uint32_t finalPageCount() const;
+  SectionPumpResult pump(const IncrementalBuildBudget& budget);
+  bool hasActiveBuilder() const;
+  void cancel();
+  void clearCache();
+  SectionHandleMode mode() const { return mode_; }
+  int spineIndex() const { return spineIndex_; }
+
+  std::optional<uint16_t> getPageForAnchor(const std::string& anchor) const;
+  std::optional<uint16_t> getPageForParagraphIndex(uint16_t paragraphIndex) const;
+  std::optional<uint16_t> getPageForListItemIndex(uint16_t listItemIndex) const;
+  std::optional<uint16_t> getParagraphIndexForPage(uint16_t page) const;
+
+ private:
+  bool startBuilder();
+  SectionPumpResult applyPumpState(IncrementalBuildState state, uint32_t pagesBefore, uint32_t pagesAfter);
+
+  int spineIndex_;
+  SectionHandleMode mode_ = SectionHandleMode::MissingOrFailed;
+  std::unique_ptr<IncrementalSection::Cache> incrementalCache_;
+  std::unique_ptr<IncrementalSectionBuilder> builder_;
+  std::shared_ptr<Epub> epub_;
+  GfxRenderer* renderer_ = nullptr;
+  IncrementalSection::LayoutCacheKey layoutKey_{};
+  IncrementalBuildOptions options_{};
+  uint32_t knownPageCount_ = 0;
+};

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -125,6 +125,7 @@ void ChapterHtmlSlimParser::compactCurrentTextBlockIfNeeded() {
   const int horizontalInset = currentTextBlock->getBlockStyle().totalHorizontalInset();
   const uint16_t effectiveWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+  applyCurrentTextBlockTopInset();
   currentTextBlock->layoutAndExtractLines(
       renderer, fontId, effectiveWidth,
       [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
@@ -159,6 +160,7 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
     pendingAnchorId.clear();
   }
   currentTextBlock.reset(new ParsedText(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle));
+  currentTextBlockTopInsetApplied = false;
   wordsExtractedInBlock = 0;
 }
 
@@ -1234,6 +1236,26 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
   currentPageNextY += lineHeight;
 }
 
+void ChapterHtmlSlimParser::applyCurrentTextBlockTopInset() {
+  if (!currentTextBlock || currentTextBlockTopInsetApplied) {
+    return;
+  }
+
+  if (!currentPage) {
+    currentPage.reset(new Page());
+    currentPageNextY = 0;
+  }
+
+  const BlockStyle& blockStyle = currentTextBlock->getBlockStyle();
+  if (blockStyle.marginTop > 0) {
+    currentPageNextY += blockStyle.marginTop;
+  }
+  if (blockStyle.paddingTop > 0) {
+    currentPageNextY += blockStyle.paddingTop;
+  }
+  currentTextBlockTopInsetApplied = true;
+}
+
 void ChapterHtmlSlimParser::makePages() {
   if (!currentTextBlock) {
     LOG_ERR("EHP", "!! No text block to make pages for !!");
@@ -1247,16 +1269,10 @@ void ChapterHtmlSlimParser::makePages() {
 
   const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
 
-  // Apply top spacing before the paragraph (stored in pixels)
-  const BlockStyle& blockStyle = currentTextBlock->getBlockStyle();
-  if (blockStyle.marginTop > 0) {
-    currentPageNextY += blockStyle.marginTop;
-  }
-  if (blockStyle.paddingTop > 0) {
-    currentPageNextY += blockStyle.paddingTop;
-  }
+  applyCurrentTextBlockTopInset();
 
   // Calculate effective width accounting for horizontal margins/padding
+  const BlockStyle& blockStyle = currentTextBlock->getBlockStyle();
   const int horizontalInset = blockStyle.totalHorizontalInset();
   const uint16_t effectiveWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -18,7 +18,8 @@
 
 // Minimum file size (in bytes) to show indexing popup - smaller chapters don't benefit from it
 constexpr size_t MIN_SIZE_FOR_POPUP = 10 * 1024;  // 10KB
-constexpr size_t PARSE_BUFFER_SIZE = 1024;
+constexpr size_t PARSE_BUFFER_SIZE = 256;
+constexpr size_t MAX_BUFFERED_WORDS_BEFORE_LAYOUT = 96;
 
 constexpr const char* HEADER_TAGS[] = {"h1", "h2", "h3", "h4", "h5", "h6"};
 constexpr const char* BLOCK_TAGS[] = {"p", "li", "div", "br", "blockquote"};
@@ -64,6 +65,8 @@ bool isHeaderOrBlock(const char* name) {
 bool isTableStructuralTag(const char* name) {
   return strcmp(name, "table") == 0 || strcmp(name, "tr") == 0 || strcmp(name, "td") == 0 || strcmp(name, "th") == 0;
 }
+
+ChapterHtmlSlimParser::~ChapterHtmlSlimParser() { close(); }
 
 // Update effective bold/italic/underline based on block style and inline style stack
 void ChapterHtmlSlimParser::updateEffectiveInlineStyle() {
@@ -111,6 +114,20 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
   currentTextBlock->addWord(partWordBuffer, fontStyle, false, nextWordContinues);
   partWordBufferIndex = 0;
   nextWordContinues = false;
+  compactCurrentTextBlockIfNeeded();
+}
+
+void ChapterHtmlSlimParser::compactCurrentTextBlockIfNeeded() {
+  if (!currentTextBlock || currentTextBlock->size() <= MAX_BUFFERED_WORDS_BEFORE_LAYOUT) {
+    return;
+  }
+
+  const int horizontalInset = currentTextBlock->getBlockStyle().totalHorizontalInset();
+  const uint16_t effectiveWidth =
+      (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
+  currentTextBlock->layoutAndExtractLines(
+      renderer, fontId, effectiveWidth,
+      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); }, false);
 }
 
 // start a new text block if needed
@@ -879,20 +896,7 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
 
-  // If we have > 750 words buffered up, perform the layout and consume out all but the last line
-  // There should be enough here to build out 1-2 full pages and doing this will free up a lot of
-  // memory.
-  // Spotted when reading Intermezzo, there are some really long text blocks in there.
-  if (self->currentTextBlock->size() > 750) {
-    LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
-    const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
-    const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
-                                        ? static_cast<uint16_t>(self->viewportWidth - horizontalInset)
-                                        : self->viewportWidth;
-    self->currentTextBlock->layoutAndExtractLines(
-        self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
-  }
+  self->compactCurrentTextBlockIfNeeded();
 }
 
 void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const XML_Char* s, const int len) {
@@ -1032,7 +1036,12 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 }
 
-bool ChapterHtmlSlimParser::parseAndBuildPages() {
+bool ChapterHtmlSlimParser::begin(bool* cancel) {
+  cancelFlag = cancel;
+  parseDone = false;
+  parseStarted = false;
+  finalPageEmitted = false;
+
   // Initialize block style stack with a root entry representing "no ancestor block elements".
   // The user's paragraph alignment is set as the default so child elements without explicit
   // text-align inherit it correctly through getCombinedBlockStyle.
@@ -1050,9 +1059,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   paragraphAlignmentBlockStyle.alignment = align;
   startNewTextBlock(paragraphAlignmentBlockStyle);
 
-  XML_Parser parser = XML_ParserCreate(nullptr);
-  int done;
-
+  parser = XML_ParserCreate(nullptr);
   if (!parser) {
     LOG_ERR("EHP", "Couldn't allocate memory for parser");
     return false;
@@ -1062,14 +1069,13 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   // Using DefaultHandlerExpand preserves normal entity expansion from DOCTYPE
   XML_SetDefaultHandlerExpand(parser, defaultHandlerExpand);
 
-  FsFile file;
-  if (!Storage.openFileForRead("EHP", filepath, file)) {
-    destroyXmlParser(parser);
+  if (!Storage.openFileForRead("EHP", filepath, parseFile)) {
+    close();
     return false;
   }
 
   // Get file size to decide whether to show indexing popup.
-  if (popupFn && file.size() >= MIN_SIZE_FOR_POPUP) {
+  if (popupFn && parseFile.size() >= MIN_SIZE_FOR_POPUP) {
     popupFn();
   }
 
@@ -1078,40 +1084,79 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   XML_SetCharacterDataHandler(parser, characterData);
 
   // Compute the time taken to parse and build pages
-  const uint32_t chapterStartTime = millis();
-  do {
+  chapterStartTime = millis();
+  parseStarted = true;
+  return true;
+}
+
+ParsePumpStatus ChapterHtmlSlimParser::pump(const ParsePumpBudget& budget) {
+  if (cancelFlag && *cancelFlag) {
+    close();
+    return ParsePumpStatus::Cancelled;
+  }
+  if (!parseStarted || !parser || !parseFile) {
+    return ParsePumpStatus::Error;
+  }
+  if (parseDone) {
+    return ParsePumpStatus::Complete;
+  }
+
+  const uint32_t pumpStart = millis();
+  const int pagesAtStart = completedPageCount;
+  uint16_t chunksProcessed = 0;
+
+  while (!parseDone) {
+    if (cancelFlag && *cancelFlag) {
+      close();
+      return ParsePumpStatus::Cancelled;
+    }
+
     void* const buf = XML_GetBuffer(parser, PARSE_BUFFER_SIZE);
     if (!buf) {
       LOG_ERR("EHP", "Couldn't allocate memory for buffer");
-      destroyXmlParser(parser);
-      file.close();
-      return false;
+      close();
+      return ParsePumpStatus::Error;
     }
 
-    const size_t len = file.read(buf, PARSE_BUFFER_SIZE);
+    const size_t len = parseFile.read(buf, PARSE_BUFFER_SIZE);
 
-    if (len == 0 && file.available() > 0) {
+    if (len == 0 && parseFile.available() > 0) {
       LOG_ERR("EHP", "File read error");
-      destroyXmlParser(parser);
-      file.close();
-      return false;
+      close();
+      return ParsePumpStatus::Error;
     }
 
-    done = file.available() == 0;
+    const int done = parseFile.available() == 0;
 
     if (XML_ParseBuffer(parser, static_cast<int>(len), done) == XML_STATUS_ERROR) {
       LOG_ERR("EHP", "Parse error at line %lu:\n%s", XML_GetCurrentLineNumber(parser),
               XML_ErrorString(XML_GetErrorCode(parser)));
-      destroyXmlParser(parser);
-      file.close();
-      return false;
+      close();
+      return ParsePumpStatus::Error;
     }
-  } while (!done);
+
+    chunksProcessed++;
+    parseDone = done;
+
+    if (budget.maxCompletedPages > 0 && completedPageCount - pagesAtStart >= budget.maxCompletedPages) {
+      return ParsePumpStatus::PageReady;
+    }
+    if (budget.maxInputChunks > 0 && chunksProcessed >= budget.maxInputChunks) {
+      return ParsePumpStatus::NeedsMore;
+    }
+    if (budget.maxMillis > 0 && millis() - pumpStart >= budget.maxMillis) {
+      return ParsePumpStatus::NeedsMore;
+    }
+  }
+
   LOG_DBG("EHP", "Time to parse and build pages: %lu ms", millis() - chapterStartTime);
+  return ParsePumpStatus::Complete;
+}
 
-  destroyXmlParser(parser);
-  file.close();
-
+bool ChapterHtmlSlimParser::finish() {
+  if (finalPageEmitted) {
+    return true;
+  }
   // Process last page if there is still text
   if (currentTextBlock) {
     makePages();
@@ -1125,7 +1170,38 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
     currentTextBlock.reset();
   }
 
+  finalPageEmitted = true;
+  close();
   return true;
+}
+
+void ChapterHtmlSlimParser::close() {
+  if (parser) {
+    destroyXmlParser(parser);
+    parser = nullptr;
+  }
+  if (parseFile) {
+    parseFile.close();
+  }
+}
+
+bool ChapterHtmlSlimParser::parseAndBuildPages() {
+  bool cancel = false;
+  if (!begin(&cancel)) {
+    return false;
+  }
+
+  ParsePumpBudget budget;
+  while (true) {
+    const auto status = pump(budget);
+    if (status == ParsePumpStatus::Complete) {
+      return finish();
+    }
+    if (status == ParsePumpStatus::Cancelled || status == ParsePumpStatus::Error) {
+      close();
+      return false;
+    }
+  }
 }
 
 void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <expat.h>
 #include <HalStorage.h>
+#include <expat.h>
 
 #include <climits>
 #include <functional>

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <expat.h>
+#include <HalStorage.h>
 
 #include <climits>
 #include <functional>
@@ -9,17 +10,31 @@
 #include <vector>
 
 #include "Epub/FootnoteEntry.h"
+#include "Epub/Page.h"
 #include "Epub/ParsedText.h"
 #include "Epub/blocks/ImageBlock.h"
 #include "Epub/blocks/TextBlock.h"
 #include "Epub/css/CssParser.h"
 #include "Epub/css/CssStyle.h"
 
-class Page;
 class GfxRenderer;
 class Epub;
 
 #define MAX_WORD_SIZE 200
+
+enum class ParsePumpStatus {
+  NeedsMore,
+  PageReady,
+  Complete,
+  Cancelled,
+  Error,
+};
+
+struct ParsePumpBudget {
+  uint16_t maxInputChunks = 0;
+  uint16_t maxCompletedPages = 0;
+  uint32_t maxMillis = 0;
+};
 
 class ChapterHtmlSlimParser {
   std::shared_ptr<Epub> epub;
@@ -86,10 +101,18 @@ class ChapterHtmlSlimParser {
   int currentFootnoteLinkTextLen = 0;
   std::vector<std::pair<int, FootnoteEntry>> pendingFootnotes;  // <wordIndex, entry>
   int wordsExtractedInBlock = 0;
+  XML_Parser parser = nullptr;
+  FsFile parseFile;
+  bool* cancelFlag = nullptr;
+  bool parseStarted = false;
+  bool parseDone = false;
+  bool finalPageEmitted = false;
+  uint32_t chapterStartTime = 0;
 
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPartWordBuffer();
+  void compactCurrentTextBlockIfNeeded();
   void makePages();
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);
@@ -127,7 +150,11 @@ class ChapterHtmlSlimParser {
         contentBase(contentBase),
         imageBasePath(imageBasePath) {}
 
-  ~ChapterHtmlSlimParser() = default;
+  ~ChapterHtmlSlimParser();
+  bool begin(bool* cancel = nullptr);
+  ParsePumpStatus pump(const ParsePumpBudget& budget);
+  bool finish();
+  void close();
   bool parseAndBuildPages();
   void addLineToPage(std::shared_ptr<TextBlock> line);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -55,6 +55,7 @@ class ChapterHtmlSlimParser {
   std::unique_ptr<ParsedText> currentTextBlock = nullptr;
   std::unique_ptr<Page> currentPage = nullptr;
   int16_t currentPageNextY = 0;
+  bool currentTextBlockTopInsetApplied = false;
   int fontId;
   float lineCompression;
   bool extraParagraphSpacing;
@@ -113,6 +114,7 @@ class ChapterHtmlSlimParser {
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPartWordBuffer();
   void compactCurrentTextBlockIfNeeded();
+  void applyCurrentTextBlockTopInset();
   void makePages();
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -119,12 +119,12 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     }
 
     // Sort item index for binary search if we have enough items
-    if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
+    if (self->itemIndex.size() >= FAST_LOOKUP_SPINE_THRESHOLD) {
       std::sort(self->itemIndex.begin(), self->itemIndex.end(), [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
         return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
       });
       self->useItemIndex = true;
-      LOG_DBG("COF", "Using fast index for %zu manifest items", self->itemIndex.size());
+      LOG_DBG("COF", "Using fast spine item index for %zu manifest items", self->itemIndex.size());
     }
     return;
   }

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -32,7 +32,7 @@ class ContentOpfParser final : public Print {
   FsFile tempItemStore;
   std::string coverItemId;
 
-  // Index for fast idref→href lookup (used only for large EPUBs)
+  // Index for fast idref→href lookup (used for medium/large EPUBs)
   struct ItemIndexEntry {
     uint32_t idHash;      // FNV-1a hash of itemId
     uint16_t idLen;       // length for collision reduction
@@ -41,7 +41,8 @@ class ContentOpfParser final : public Print {
   std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;
 
-  static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
+  // Keeps tiny books on the lowest-memory path while moving 100-250 spine cold starts off repeated SD scans.
+  static constexpr uint16_t FAST_LOOKUP_SPINE_THRESHOLD = 64;
 
   // FNV-1a hash function
   static uint32_t fnvHash(const std::string& s) {

--- a/lib/FsHelpers/FsHelpers.cpp
+++ b/lib/FsHelpers/FsHelpers.cpp
@@ -1,11 +1,41 @@
 #include "FsHelpers.h"
 
+#include <Arduino.h>
+#include <HalStorage.h>
+#include <Logging.h>
+
 #include <algorithm>
 #include <cctype>
 #include <cstring>
 #include <vector>
 
 namespace FsHelpers {
+namespace {
+
+constexpr uint8_t REMOVE_RETRY_COUNT = 3;
+constexpr uint16_t REMOVE_RETRY_DELAY_MS = 10;
+
+bool removeFileWithRetry(const std::string& path) {
+  for (uint8_t attempt = 0; attempt < REMOVE_RETRY_COUNT; attempt++) {
+    if (Storage.remove(path.c_str()) || !Storage.exists(path.c_str())) {
+      return true;
+    }
+    delay(REMOVE_RETRY_DELAY_MS);
+  }
+  return false;
+}
+
+bool removeDirectoryWithRetry(const char* path) {
+  for (uint8_t attempt = 0; attempt < REMOVE_RETRY_COUNT; attempt++) {
+    if (Storage.rmdir(path) || !Storage.exists(path)) {
+      return true;
+    }
+    delay(REMOVE_RETRY_DELAY_MS);
+  }
+  return false;
+}
+
+}  // namespace
 
 std::string normalisePath(const std::string& path) {
   std::vector<std::string> components;
@@ -137,6 +167,71 @@ std::string extractFolderPath(const std::string& filePath) {
     return "/";
   }
   return filePath.substr(0, lastSlash);
+}
+
+bool removeDirRecursive(const char* path) {
+  if (path == nullptr || path[0] == '\0') {
+    return false;
+  }
+
+  FsFile dir = Storage.open(path);
+  if (!dir || !dir.isDirectory()) {
+    if (dir) {
+      dir.close();
+    }
+    if (!Storage.exists(path)) {
+      return true;
+    }
+    LOG_ERR("FSH", "removeDirRecursive open failed: %s", path);
+    return false;
+  }
+
+  bool success = true;
+  char name[128];
+  while (true) {
+    FsFile entry = dir.openNextFile();
+    if (!entry) {
+      break;
+    }
+
+    const size_t nameLen = entry.getName(name, sizeof(name));
+    const bool isDirectory = entry.isDirectory();
+    entry.close();
+
+    if (nameLen == 0 || nameLen >= sizeof(name) || std::strcmp(name, ".") == 0 || std::strcmp(name, "..") == 0) {
+      LOG_ERR("FSH", "removeDirRecursive invalid child under %s len=%u", path, static_cast<unsigned>(nameLen));
+      success = false;
+      break;
+    }
+
+    std::string childPath = path;
+    if (!childPath.empty() && childPath.back() != '/') {
+      childPath += "/";
+    }
+    childPath += name;
+
+    if (isDirectory) {
+      if (!removeDirRecursive(childPath.c_str())) {
+        LOG_ERR("FSH", "removeDirRecursive child dir failed: %s", childPath.c_str());
+        success = false;
+        break;
+      }
+    } else if (!removeFileWithRetry(childPath)) {
+      LOG_ERR("FSH", "removeDirRecursive file failed: %s", childPath.c_str());
+      success = false;
+      break;
+    }
+  }
+
+  dir.close();
+  if (!success) {
+    return false;
+  }
+  if (!removeDirectoryWithRetry(path)) {
+    LOG_ERR("FSH", "removeDirRecursive rmdir failed: %s", path);
+    return false;
+  }
+  return true;
 }
 
 void sanitizePathComponentForFat32(const char* input, char* output, size_t maxLen) {

--- a/lib/FsHelpers/FsHelpers.h
+++ b/lib/FsHelpers/FsHelpers.h
@@ -62,14 +62,16 @@ std::string extractFolderPath(const std::string& filePath);
 
 /**
  * Recursively remove a directory while closing each enumerated child before
- * deleting it. Some filesystem wrappers fail removal while an open child
+ * deleting it. Some filesystem
+ * wrappers fail removal while an open child
  * handle still points at the target.
  */
 bool removeDirRecursive(const char* path);
 
 /**
  * Sanitize a filename/path component for FAT32 in a caller-provided buffer.
- * Replaces invalid path characters, spaces, and control characters with '-'.
+ * Replaces invalid path characters,
+ * spaces, and control characters with '-'.
  */
 void sanitizePathComponentForFat32(const char* input, char* output, size_t maxLen);
 

--- a/lib/FsHelpers/FsHelpers.h
+++ b/lib/FsHelpers/FsHelpers.h
@@ -61,6 +61,13 @@ bool hasMarkdownExtension(std::string_view fileName);
 std::string extractFolderPath(const std::string& filePath);
 
 /**
+ * Recursively remove a directory while closing each enumerated child before
+ * deleting it. Some filesystem wrappers fail removal while an open child
+ * handle still points at the target.
+ */
+bool removeDirRecursive(const char* path);
+
+/**
  * Sanitize a filename/path component for FAT32 in a caller-provided buffer.
  * Replaces invalid path characters, spaces, and control characters with '-'.
  */

--- a/platformio.ini
+++ b/platformio.ini
@@ -81,7 +81,7 @@ build_flags =
   ${base.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
   -DENABLE_SERIAL_LOG
-  -DLOG_LEVEL=1 ; Set log level to info for release builds
+  -DLOG_LEVEL=0 ; Set log level to errors only for production builds
 
 [env:gh_release_rc]
 extends = base

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -61,6 +61,10 @@ void ActivityManager::loop() {
     currentActivity->loop();
   }
 
+  processPendingActions();
+}
+
+void ActivityManager::processPendingActions() {
   while (pendingAction != PendingAction::None) {
     if (pendingAction == PendingAction::Pop) {
       RenderLock lock;
@@ -197,8 +201,12 @@ void ActivityManager::goToReader(std::string path) {
 }
 
 void ActivityManager::goToSleep() {
+  sleepTransitionPending.store(true, std::memory_order_relaxed);
   replaceActivity(std::make_unique<SleepActivity>(renderer, mappedInput));
-  loop();  // Important: sleep screen must be rendered immediately, the caller will go to sleep right after this returns
+  // Important: sleep screen must be rendered immediately, the caller will go to sleep right after this returns.
+  // Do not run the outgoing activity loop here; the reader may still have background indexing work to pump.
+  processPendingActions();
+  sleepTransitionPending.store(false, std::memory_order_relaxed);
 }
 
 void ActivityManager::goToBoot() { replaceActivity(std::make_unique<BootActivity>(renderer, mappedInput)); }

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -4,6 +4,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#include <atomic>
 #include <cassert>
 #include <memory>
 #include <string>
@@ -45,6 +46,8 @@ class ActivityManager {
   std::unique_ptr<Activity> pendingActivity;
   enum class PendingAction { None, Push, Pop, Replace };
   PendingAction pendingAction = PendingAction::None;
+  void processPendingActions();
+  std::atomic<bool> sleepTransitionPending{false};
 
   // Task to render and display the activity
   TaskHandle_t renderTaskHandle = nullptr;
@@ -98,6 +101,7 @@ class ActivityManager {
   void popActivity();
 
   bool preventAutoSleep() const;
+  bool isSleepTransitionPending() const { return sleepTransitionPending.load(std::memory_order_relaxed); }
   bool isReaderActivity() const;
   bool skipLoopDelay() const;
   ScreenshotInfo getScreenshotInfo() const;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -28,6 +28,7 @@
 #include "ProgressMapper.h"
 #include "QrDisplayActivity.h"
 #include "ReaderUtils.h"
+#include "ReaderProgressPolicy.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "components/themes/StatusPageInfo.h"
@@ -86,11 +87,26 @@ IncrementalBuildBudget indexBudget(const IncrementalBuildBudgetProfile profile) 
   return IncrementalBuildBudgets::forProfile(profile);
 }
 
+IncrementalBuildBudget responsiveBackgroundBudget(const IncrementalBuildBudgetProfile profile) {
+  auto budget = indexBudget(profile);
+  budget.maxInputChunks = (profile == IncrementalBuildBudgetProfile::NextPrewarm)
+                              ? EpubIndexingPolicy::nextPrewarmInputChunks(1)
+                              : EpubIndexingPolicy::indexBatchInputChunks(1);
+  budget.maxCompletedPages = 1;
+  budget.maxMillis = EpubIndexingPolicy::indexBatchMaxMillis(1);
+  return budget;
+}
+
 uint32_t displayPageCount(const SectionHandle* section) {
   if (!section) {
     return 0;
   }
   return section->isComplete() ? section->finalPageCount() : section->knownPageCount();
+}
+
+uint16_t persistablePageCountForSection(const SectionHandle* section) {
+  return ReaderProgressPolicy::persistablePageCount(section && section->isComplete(),
+                                                   section ? section->finalPageCount() : 0);
 }
 
 bool sectionPumpDidRun(const SectionPumpResult& result) {
@@ -234,13 +250,89 @@ void EpubReaderActivity::onExit() {
   APP_STATE.saveToFile();
   section.reset();
   nextSectionPrewarm.reset();
+  backgroundIndexingWorkActive = false;
   epub.reset();
+}
+
+bool EpubReaderActivity::hasCurrentIndexingWork() const {
+  return section && section->hasActiveBuilder() && !section->isComplete();
+}
+
+bool EpubReaderActivity::hasPrewarmIndexingWork() const {
+  return nextSectionPrewarm && nextSectionPrewarm->hasActiveBuilder() && !nextSectionPrewarm->isComplete();
+}
+
+bool EpubReaderActivity::hasBackgroundIndexingWork() const {
+  if (RenderLock::peek()) {
+    return true;
+  }
+  return backgroundIndexingWorkActive;
+}
+
+bool EpubReaderActivity::skipLoopDelay() { return hasBackgroundIndexingWork(); }
+
+bool EpubReaderActivity::preventAutoSleep() { return hasBackgroundIndexingWork(); }
+
+bool EpubReaderActivity::pumpBackgroundIndexing() {
+  if (!epub || !section) {
+    return false;
+  }
+
+  const bool currentWasActive = hasCurrentIndexingWork();
+  const bool prewarmWasActive = hasPrewarmIndexingWork();
+  bool didWork = false;
+
+  if (currentWasActive) {
+    const auto result = section->pump(responsiveBackgroundBudget(IncrementalBuildBudgetProfile::CurrentBackground));
+    didWork = sectionPumpDidRun(result);
+  }
+
+  int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
+  renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
+                                   &orientedMarginLeft);
+  orientedMarginTop += SETTINGS.screenMargin;
+  orientedMarginLeft += SETTINGS.screenMargin;
+  orientedMarginRight += SETTINGS.screenMargin;
+
+  const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
+  if (automaticPageTurnActive &&
+      (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight())) {
+    orientedMarginBottom +=
+        std::max(SETTINGS.screenMargin,
+                 static_cast<uint8_t>(statusBarHeight + UITheme::getInstance().getMetrics().statusBarVerticalMargin));
+  } else {
+    orientedMarginBottom += std::max(SETTINGS.screenMargin, statusBarHeight);
+  }
+
+  const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
+  const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
+  didWork = maintainPrewarmWindow(viewportWidth, viewportHeight) || didWork;
+
+  const bool currentNowActive = hasCurrentIndexingWork();
+  const bool prewarmNowActive = hasPrewarmIndexingWork();
+  backgroundIndexingWorkActive = currentNowActive || prewarmNowActive;
+  if (currentWasActive != currentNowActive || prewarmWasActive != prewarmNowActive) {
+    requestUpdate();
+  }
+
+  return didWork || currentWasActive || prewarmWasActive;
 }
 
 void EpubReaderActivity::loop() {
   if (!epub) {
     // Should never happen
     finish();
+    return;
+  }
+
+  if (pendingPageTurnDirection != 0 && !RenderLock::peek()) {
+    const bool queuedForwardTurn = pendingPageTurnDirection > 0;
+    pendingPageTurnDirection = 0;
+    if (!section) {
+      requestUpdate();
+      return;
+    }
+    pageTurn(queuedForwardTurn);
     return;
   }
 
@@ -314,11 +406,16 @@ void EpubReaderActivity::loop() {
 
   const auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
   if (!prevTriggered && !nextTriggered) {
+    // Loop-side background indexing waits for render ownership to clear.
+    if (!RenderLock::peek()) {
+      pumpBackgroundIndexing();
+    }
     return;
   }
 
   if (RenderLock::peek()) {
-    LOG_DBG("ERS", "Ignoring page turn while render/indexing is active");
+    pendingPageTurnDirection = nextTriggered ? 1 : -1;
+    LOG_DBG("ERS", "Queued page turn while render/indexing is active");
     lastPageTurnTime = millis();
     return;
   }
@@ -523,7 +620,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         if (epub && section) {
           uint16_t backupSpine = currentSpineIndex;
           uint16_t backupPage = section->currentPage;
-          uint16_t backupPageCount = static_cast<uint16_t>(std::min<uint32_t>(displayPageCount(section.get()), UINT16_MAX));
+          uint16_t backupPageCount = persistablePageCountForSection(section.get());
           section.reset();
           nextSectionPrewarm.reset();
           epub->clearCache();
@@ -548,6 +645,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       if (KOREADER_STORE.hasCredentials()) {
         const int currentPage = section ? section->currentPage : nextPageNumber;
         const int totalPages = section ? static_cast<int>(displayPageCount(section.get())) : cachedChapterTotalPageCount;
+        const int persistableTotalPages =
+            section ? static_cast<int>(persistablePageCountForSection(section.get())) : cachedChapterTotalPageCount;
         std::optional<uint16_t> paragraphIndex;
         if (section && currentPage >= 0 && section->hasPage(static_cast<uint32_t>(currentPage))) {
           const uint16_t paragraphPage =
@@ -570,7 +669,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
         // Persist current position so the reader resumes at the right page on return.
         // goToReader() depends on this file, so abort the sync if the write fails.
-        if (!saveProgress(currentSpineIndex, currentPage, totalPages)) {
+        if (!saveProgress(currentSpineIndex, currentPage, persistableTotalPages)) {
           LOG_ERR("KOSync", "Aborting sync because current progress could not be saved");
           pendingSyncSaveError = true;
           requestUpdate();
@@ -610,7 +709,7 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
     RenderLock lock(*this);
     if (section) {
       cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = static_cast<int>(displayPageCount(section.get()));
+      cachedChapterTotalPageCount = static_cast<int>(persistablePageCountForSection(section.get()));
       nextPageNumber = section->currentPage;
     }
     nextSectionPrewarm.reset();
@@ -645,7 +744,7 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
     RenderLock lock(*this);
     if (section) {
       cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = static_cast<int>(displayPageCount(section.get()));
+      cachedChapterTotalPageCount = static_cast<int>(persistablePageCountForSection(section.get()));
       nextPageNumber = section->currentPage;
     }
     nextSectionPrewarm.reset();
@@ -854,15 +953,30 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     // handles changes in reader settings and reset to approximate position based on cached progress
     if (cachedChapterTotalPageCount > 0) {
-      // only goes to relative position if spine index matches cached value
-      const uint32_t knownPages = displayPageCount(section.get());
-      if (currentSpineIndex == cachedSpineIndex && knownPages > 0 &&
-          knownPages != static_cast<uint32_t>(cachedChapterTotalPageCount)) {
-        float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
-        int newPage = static_cast<int>(progress * knownPages);
-        section->currentPage = newPage;
+      auto remapDecision =
+          ReaderProgressPolicy::decideResumeRemap(currentSpineIndex, cachedSpineIndex, section->currentPage,
+                                                  static_cast<uint32_t>(cachedChapterTotalPageCount),
+                                                  section->isComplete(), section->finalPageCount());
+      if (remapDecision.deferUntilComplete) {
+        const auto remapResult =
+            pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                             IncrementalBuildBudgetProfile::Outrun);
+        if (remapResult.status == SectionPumpStatus::DeferredLowMemory || !section->isComplete()) {
+          requestUpdate();
+          showPendingSyncSaveError();
+          return;
+        }
+        remapDecision =
+            ReaderProgressPolicy::decideResumeRemap(currentSpineIndex, cachedSpineIndex, section->currentPage,
+                                                    static_cast<uint32_t>(cachedChapterTotalPageCount),
+                                                    section->isComplete(), section->finalPageCount());
       }
-      cachedChapterTotalPageCount = 0;  // resets to 0 to prevent reading cached progress again
+      if (remapDecision.applyPage) {
+        section->currentPage = remapDecision.pageNumber;
+      }
+      if (!remapDecision.deferUntilComplete) {
+        cachedChapterTotalPageCount = 0;  // resets to 0 to prevent reading cached progress again
+      }
     }
 
     if (pendingPercentJump) {
@@ -945,11 +1059,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
   }
-  if (section->hasActiveBuilder() && !section->isComplete()) {
-    section->pump(indexBudget(IncrementalBuildBudgetProfile::CurrentBackground));
-  }
-  maintainPrewarmWindow(viewportWidth, viewportHeight);
-  saveProgress(currentSpineIndex, section->currentPage, static_cast<int>(displayPageCount(section.get())));
+  saveProgress(currentSpineIndex, section->currentPage, static_cast<int>(persistablePageCountForSection(section.get())));
 
   showPendingSyncSaveError();
 
@@ -959,23 +1069,25 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
 }
 
-void EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, const uint16_t viewportHeight) {
+bool EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, const uint16_t viewportHeight) {
   if (!epub || !section || !section->isComplete()) {
-    return;
+    return false;
   }
 
   if (!EpubIndexingPolicy::shouldPrewarmNextChapter(static_cast<uint32_t>(std::max(section->currentPage, 0)),
                                                     section->finalPageCount(), section->isComplete())) {
-    return;
+    return false;
   }
 
   const int nextSpineIndex = currentSpineIndex + 1;
   if (nextSpineIndex < 0 || nextSpineIndex >= epub->getSpineItemsCount()) {
-    return;
+    return false;
   }
 
+  bool changed = false;
   if (nextSectionPrewarm && nextSectionPrewarm->spineIndex() != nextSpineIndex) {
     nextSectionPrewarm.reset();
+    changed = true;
   }
 
   if (!nextSectionPrewarm) {
@@ -985,18 +1097,23 @@ void EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, con
     if (!nextSectionPrewarm || nextSectionPrewarm->mode() == SectionHandleMode::MissingOrFailed) {
       LOG_DBG("ERS", "Next section prewarm open failed: %d", nextSpineIndex);
       nextSectionPrewarm.reset();
-      return;
+      return changed;
     }
     LOG_DBG("ERS", "Next section prewarm opened: %d", nextSpineIndex);
+    changed = true;
   }
 
   if (nextSectionPrewarm->hasActiveBuilder()) {
-    const auto result = nextSectionPrewarm->pump(indexBudget(IncrementalBuildBudgetProfile::NextPrewarm));
+    const auto result = nextSectionPrewarm->pump(responsiveBackgroundBudget(IncrementalBuildBudgetProfile::NextPrewarm));
+    changed = sectionPumpDidRun(result) || changed;
     if (result.status == SectionPumpStatus::Failed) {
       LOG_DBG("ERS", "Next section prewarm failed: %d", nextSpineIndex);
       nextSectionPrewarm.reset();
+      changed = true;
     }
   }
+
+  return changed;
 }
 
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1,5 +1,6 @@
 #include "EpubReaderActivity.h"
 
+#include <Epub/IncrementalSectionCache.h>
 #include <Epub/Page.h>
 #include <Epub/blocks/TextBlock.h>
 #include <FontCacheManager.h>
@@ -12,7 +13,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <functional>
 #include <iterator>
 #include <limits>
 
@@ -66,8 +66,7 @@ IncrementalSection::LayoutCacheKey makeLayoutCacheKey(const uint16_t viewportWid
   return key;
 }
 
-IncrementalBuildOptions makeBuildOptions(const uint16_t viewportWidth, const uint16_t viewportHeight,
-                                         const std::function<void()>& popupFn = nullptr) {
+IncrementalBuildOptions makeBuildOptions(const uint16_t viewportWidth, const uint16_t viewportHeight) {
   IncrementalBuildOptions options;
   options.fontId = SETTINGS.getReaderFontId();
   options.lineCompression = SETTINGS.getReaderLineCompression();
@@ -79,7 +78,6 @@ IncrementalBuildOptions makeBuildOptions(const uint16_t viewportWidth, const uin
   options.embeddedStyle = SETTINGS.embeddedStyle;
   options.imageRendering = SETTINGS.imageRendering;
   options.focusReadingEnabled = SETTINGS.focusReadingEnabled;
-  options.popupFn = popupFn;
   return options;
 }
 
@@ -104,6 +102,16 @@ uint32_t displayPageCount(const SectionHandle* section) {
   return section->isComplete() ? section->finalPageCount() : section->knownPageCount();
 }
 
+float displayedSectionProgress(const SectionHandle* section) {
+  const uint32_t pageCount = displayPageCount(section);
+  if (!section || pageCount == 0) {
+    return 0.0f;
+  }
+  const uint32_t displayedPage = section->currentPage >= 0 ? static_cast<uint32_t>(section->currentPage) + 1U : 0U;
+  const uint32_t clampedPage = std::min(displayedPage, pageCount);
+  return static_cast<float>(clampedPage) / static_cast<float>(pageCount);
+}
+
 uint16_t persistablePageCountForSection(const SectionHandle* section) {
   return ReaderProgressPolicy::persistablePageCount(section && section->isComplete(),
                                                     section ? section->finalPageCount() : 0);
@@ -112,6 +120,34 @@ uint16_t persistablePageCountForSection(const SectionHandle* section) {
 bool sectionPumpDidRun(const SectionPumpResult& result) {
   return result.status == SectionPumpStatus::Pumped || result.status == SectionPumpStatus::Complete ||
          result.status == SectionPumpStatus::Failed;
+}
+
+const char* sectionPumpStatusName(const SectionPumpStatus status) {
+  switch (status) {
+    case SectionPumpStatus::NoWork:
+      return "NoWork";
+    case SectionPumpStatus::Pumped:
+      return "Pumped";
+    case SectionPumpStatus::DeferredLowMemory:
+      return "DeferredLowMemory";
+    case SectionPumpStatus::Complete:
+      return "Complete";
+    case SectionPumpStatus::Failed:
+      return "Failed";
+  }
+  return "Unknown";
+}
+
+const char* sectionHandleModeName(const SectionHandleMode mode) {
+  switch (mode) {
+    case SectionHandleMode::IncrementalComplete:
+      return "IncrementalComplete";
+    case SectionHandleMode::IncrementalBuilding:
+      return "IncrementalBuilding";
+    case SectionHandleMode::MissingOrFailed:
+      return "MissingOrFailed";
+  }
+  return "Unknown";
 }
 
 enum class SectionPumpGoal {
@@ -135,6 +171,32 @@ struct SectionPumpLoopResult {
   bool pumped = false;
   bool goalMet = false;
 };
+
+void logSectionPumpTiming(const char* label, const unsigned long start, const SectionPumpLoopResult& result) {
+  LOG_DBG("ERS", "%s: status=%s pages=%lu->%lu goal=%s elapsed=%lums", label, sectionPumpStatusName(result.status),
+          static_cast<unsigned long>(result.pagesBefore), static_cast<unsigned long>(result.pagesAfter),
+          result.goalMet ? "met" : "pending", millis() - start);
+}
+
+void showIndexingPopupOnce(const GfxRenderer& renderer, bool& shown) {
+  if (shown) {
+    return;
+  }
+  GUI.drawPopup(renderer, tr(STR_INDEXING));
+  shown = true;
+}
+
+bool hasCompatibleCompleteIncrementalCache(const std::shared_ptr<Epub>& epub, const int spineIndex,
+                                           const IncrementalSection::LayoutCacheKey& layoutKey) {
+  if (!epub || spineIndex < 0 || spineIndex >= epub->getSpineItemsCount()) {
+    return false;
+  }
+
+  IncrementalSection::Cache cache(epub->getCachePath() + "/sections", static_cast<uint32_t>(spineIndex));
+  IncrementalSection::Meta meta;
+  return cache.loadMeta(meta) && meta.layoutKey.matches(layoutKey) &&
+         meta.state == IncrementalSection::CacheState::Complete && cache.isComplete();
+}
 
 bool sectionPumpGoalMet(const SectionHandle& section, const SectionPumpGoalSpec& spec) {
   switch (spec.goal) {
@@ -160,6 +222,10 @@ SectionPumpLoopResult pumpSectionUntil(SectionHandle& section, const SectionPump
   loopResult.goalMet = sectionPumpGoalMet(section, goal);
 
   while (!loopResult.goalMet && section.mode() == SectionHandleMode::IncrementalBuilding) {
+    if (activityManager.isSleepTransitionPending()) {
+      LOG_DBG("ERS", "Stopping section pump for pending sleep");
+      break;
+    }
     const auto pumpResult = section.pump(indexBudget(budgetProfile));
     loopResult.status = pumpResult.status;
     loopResult.pagesAfter = pumpResult.pagesAfter;
@@ -199,12 +265,14 @@ void EpubReaderActivity::onEnter() {
   epub->setupCacheDir();
 
   FsFile f;
+  bool loadedSavedProgress = false;
   if (Storage.openFileForRead("ERS", epub->getCachePath() + "/progress.bin", f)) {
     uint8_t data[6];
     int dataSize = f.read(data, 6);
     if (dataSize == 4 || dataSize == 6) {
       currentSpineIndex = data[0] + (data[1] << 8);
       nextPageNumber = data[2] + (data[3] << 8);
+      loadedSavedProgress = true;
       if (nextPageNumber == UINT16_MAX) {
         // UINT16_MAX is an in-memory navigation sentinel for "open previous
         // chapter on its last page". It should never be treated as persisted
@@ -220,6 +288,7 @@ void EpubReaderActivity::onEnter() {
     }
     f.close();
   }
+  freshBookEntry = !loadedSavedProgress;
   // We may want a better condition to detect if we are opening for the first time.
   // This will trigger if the book is re-opened at Chapter 0.
   if (currentSpineIndex == 0) {
@@ -310,9 +379,6 @@ bool EpubReaderActivity::pumpBackgroundIndexing() {
   const bool currentNowActive = hasCurrentIndexingWork();
   const bool prewarmNowActive = hasPrewarmIndexingWork();
   backgroundIndexingWorkActive = currentNowActive || prewarmNowActive;
-  if (currentWasActive != currentNowActive || prewarmWasActive != prewarmNowActive) {
-    requestUpdate();
-  }
 
   return didWork || currentWasActive || prewarmWasActive;
 }
@@ -368,8 +434,7 @@ void EpubReaderActivity::loop() {
     float bookProgress = 0.0f;
     const uint32_t pageCount = displayPageCount(section.get());
     if (epub->getBookSize() > 0 && section && pageCount > 0) {
-      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
-      bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+      bookProgress = epub->calculateProgress(currentSpineIndex, displayedSectionProgress(section.get())) * 100.0f;
     }
     const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
     startActivityForResult(std::make_unique<EpubReaderMenuActivity>(
@@ -568,8 +633,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       float bookProgress = 0.0f;
       const uint32_t pageCount = displayPageCount(section.get());
       if (epub && epub->getBookSize() > 0 && section && pageCount > 0) {
-        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
-        bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+        bookProgress = epub->calculateProgress(currentSpineIndex, displayedSectionProgress(section.get())) * 100.0f;
       }
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
       startActivityForResult(
@@ -616,17 +680,12 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     case EpubReaderMenuActivity::MenuAction::DELETE_CACHE: {
       {
         RenderLock lock(*this);
-        if (epub && section) {
-          uint16_t backupSpine = currentSpineIndex;
-          uint16_t backupPage = section->currentPage;
-          uint16_t backupPageCount = persistablePageCountForSection(section.get());
+        if (epub) {
+          bookCacheDeleted = true;
           section.reset();
           nextSectionPrewarm.reset();
           epub->clearCache();
-          epub->setupCacheDir();
-          if (!saveProgress(backupSpine, backupPage, backupPageCount)) {
-            LOG_ERR("ERS", "Failed to save progress before cache clear");
-          }
+          LOG_DBG("ERS", "Book cache deleted; progress cache removed");
         }
       }
       onGoHome();
@@ -793,6 +852,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   if (!epub) {
     return;
   }
+  if (bookCacheDeleted) {
+    return;
+  }
 
   const auto showPendingSyncSaveError = [this]() {
     if (!pendingSyncSaveError) return;
@@ -841,6 +903,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
   const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
+  const auto layoutKey = makeLayoutCacheKey(viewportWidth, viewportHeight);
+  bool loadedSectionThisRender = false;
+  unsigned long sectionLoadStart = 0;
 
   if (!section && nextSectionPrewarm && nextSectionPrewarm->spineIndex() == currentSpineIndex) {
     LOG_DBG("ERS", "Adopting prewarmed section: %d", currentSpineIndex);
@@ -853,10 +918,34 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
-    const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
-    section = SectionHandle::openOrCreate(epub, currentSpineIndex, renderer,
-                                          makeLayoutCacheKey(viewportWidth, viewportHeight),
-                                          makeBuildOptions(viewportWidth, viewportHeight, popupFn));
+    loadedSectionThisRender = true;
+    sectionLoadStart = millis();
+    bool indexingPopupShown = false;
+
+    const bool positionLoadMayNeedIndexing =
+        !pendingAnchor.empty() || pendingPercentJump ||
+        (pendingPageJump.has_value() && *pendingPageJump == std::numeric_limits<uint16_t>::max());
+    const bool needsSectionIndexing = !hasCompatibleCompleteIncrementalCache(epub, currentSpineIndex, layoutKey);
+    if (freshBookEntry && needsSectionIndexing) {
+      if (initialBookEntryIndexingPopupShown) {
+        indexingPopupShown = true;
+      } else {
+        showIndexingPopupOnce(renderer, indexingPopupShown);
+        initialBookEntryIndexingPopupShown = true;
+      }
+    }
+    if (positionLoadMayNeedIndexing && needsSectionIndexing) {
+      showIndexingPopupOnce(renderer, indexingPopupShown);
+    }
+
+    const auto sectionOpenStart = millis();
+    section = SectionHandle::openOrCreate(epub, currentSpineIndex, renderer, layoutKey,
+                                          makeBuildOptions(viewportWidth, viewportHeight));
+    const auto sectionOpenElapsed = millis() - sectionOpenStart;
+    LOG_DBG("ERS", "Section open/create: spine=%d mode=%s complete=%d known=%lu elapsed=%lums heap=%lu",
+            currentSpineIndex, section ? sectionHandleModeName(section->mode()) : "null",
+            section && section->isComplete(), section ? static_cast<unsigned long>(section->knownPageCount()) : 0UL,
+            sectionOpenElapsed, static_cast<unsigned long>(ESP.getFreeHeap()));
     if (!section || section->mode() == SectionHandleMode::MissingOrFailed) {
       LOG_ERR("ERS", "Failed to open or build section data");
       section.reset();
@@ -868,9 +957,13 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (!section->hasPage(0) && !section->isComplete()) {
-      GUI.drawPopup(renderer, tr(STR_INDEXING));
+      const auto firstPagePumpStart = millis();
       const auto firstPageResult = pumpSectionUntil(*section, {SectionPumpGoal::PageAvailable, 0, nullptr},
                                                     IncrementalBuildBudgetProfile::InitialIndex);
+      logSectionPumpTiming("First-page pump", firstPagePumpStart, firstPageResult);
+      if (activityManager.isSleepTransitionPending()) {
+        return;
+      }
       if (!firstPageResult.goalMet) {
         if (section->mode() == SectionHandleMode::MissingOrFailed) {
           LOG_ERR("ERS", "Failed to build first page");
@@ -887,8 +980,13 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (EpubIndexingPolicy::initialIndexWindowNeedsPages(section->knownPageCount(), section->isComplete())) {
+      const auto initialWindowPumpStart = millis();
       const auto initialWindowResult = pumpSectionUntil(*section, {SectionPumpGoal::InitialWindowFilled, 0, nullptr},
                                                         IncrementalBuildBudgetProfile::InitialIndex);
+      logSectionPumpTiming("Initial-window pump", initialWindowPumpStart, initialWindowResult);
+      if (activityManager.isSleepTransitionPending()) {
+        return;
+      }
       if (initialWindowResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
       }
@@ -904,8 +1002,16 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     if (pendingPageJump.has_value()) {
       if (*pendingPageJump == std::numeric_limits<uint16_t>::max()) {
+        if (!section->isComplete()) {
+          showIndexingPopupOnce(renderer, indexingPopupShown);
+        }
+        const auto lastPagePumpStart = millis();
         const auto lastPageResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
                                                      IncrementalBuildBudgetProfile::Outrun);
+        logSectionPumpTiming("Position-resolution pump (last-page)", lastPagePumpStart, lastPageResult);
+        if (activityManager.isSleepTransitionPending()) {
+          return;
+        }
         if (lastPageResult.status == SectionPumpStatus::DeferredLowMemory) {
           requestUpdate();
           showPendingSyncSaveError();
@@ -932,8 +1038,17 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (!pendingAnchor.empty()) {
+      if (!section->isComplete() &&
+          !sectionPumpGoalMet(*section, {SectionPumpGoal::AnchorResolved, 0, &pendingAnchor})) {
+        showIndexingPopupOnce(renderer, indexingPopupShown);
+      }
+      const auto anchorPumpStart = millis();
       const auto anchorResult = pumpSectionUntil(*section, {SectionPumpGoal::AnchorResolved, 0, &pendingAnchor},
                                                  IncrementalBuildBudgetProfile::Outrun);
+      logSectionPumpTiming("Position-resolution pump (anchor)", anchorPumpStart, anchorResult);
+      if (activityManager.isSleepTransitionPending()) {
+        return;
+      }
       if (anchorResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
         showPendingSyncSaveError();
@@ -954,8 +1069,16 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           currentSpineIndex, cachedSpineIndex, section->currentPage, static_cast<uint32_t>(cachedChapterTotalPageCount),
           section->isComplete(), section->finalPageCount());
       if (remapDecision.deferUntilComplete) {
+        if (!section->isComplete()) {
+          showIndexingPopupOnce(renderer, indexingPopupShown);
+        }
+        const auto remapPumpStart = millis();
         const auto remapResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
                                                   IncrementalBuildBudgetProfile::Outrun);
+        logSectionPumpTiming("Position-resolution pump (resume-remap)", remapPumpStart, remapResult);
+        if (activityManager.isSleepTransitionPending()) {
+          return;
+        }
         if (remapResult.status == SectionPumpStatus::DeferredLowMemory || !section->isComplete()) {
           requestUpdate();
           showPendingSyncSaveError();
@@ -974,8 +1097,16 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (pendingPercentJump) {
+      if (!section->isComplete()) {
+        showIndexingPopupOnce(renderer, indexingPopupShown);
+      }
+      const auto percentJumpPumpStart = millis();
       const auto percentJumpResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
                                                       IncrementalBuildBudgetProfile::Outrun);
+      logSectionPumpTiming("Position-resolution pump (percent)", percentJumpPumpStart, percentJumpResult);
+      if (activityManager.isSleepTransitionPending()) {
+        return;
+      }
       if (percentJumpResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
         showPendingSyncSaveError();
@@ -989,6 +1120,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       section->currentPage = newPage;
       pendingPercentJump = false;
     }
+  }
+
+  if (activityManager.isSleepTransitionPending()) {
+    return;
   }
 
   renderer.clearScreen();
@@ -1033,7 +1168,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
 
   {
+    const auto pageLoadStart = millis();
     auto p = section->loadPage(static_cast<uint32_t>(section->currentPage));
+    LOG_DBG("ERS", "Page load: spine=%d page=%d elapsed=%lums", currentSpineIndex, section->currentPage,
+            millis() - pageLoadStart);
     if (!p) {
       LOG_ERR("ERS", "Failed to load page from SD - clearing section cache");
       section->clearCache();
@@ -1048,9 +1186,15 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // Collect footnotes from the loaded page
     currentPageFootnotes = std::move(p->footnotes);
 
-    const auto start = millis();
+    const auto pageRenderStart = millis();
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
-    LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
+    LOG_DBG("ERS", "Page render/display: spine=%d page=%d elapsed=%lums", currentSpineIndex, section->currentPage,
+            millis() - pageRenderStart);
+  }
+  if (loadedSectionThisRender) {
+    LOG_DBG("ERS", "Initial section load total: spine=%d page=%d elapsed=%lums", currentSpineIndex,
+            section->currentPage, millis() - sectionLoadStart);
+    freshBookEntry = false;
   }
   saveProgress(currentSpineIndex, section->currentPage,
                static_cast<int>(persistablePageCountForSection(section.get())));
@@ -1217,9 +1361,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
 void EpubReaderActivity::renderStatusBar() const {
   // Calculate progress in book
   const uint32_t pageCount = displayPageCount(section.get());
-  const float sectionChapterProg =
-      (pageCount > 0) ? (static_cast<float>(section->currentPage + 1) / static_cast<float>(pageCount)) : 0.0f;
-  const float bookProgress = epub->calculateProgress(currentSpineIndex, sectionChapterProg) * 100;
+  const float bookProgress = epub->calculateProgress(currentSpineIndex, displayedSectionProgress(section.get())) * 100;
   StatusPageInfo pageInfo;
   pageInfo.currentPage = section->currentPage >= 0 ? static_cast<uint32_t>(section->currentPage) : 0;
   pageInfo.totalPages = pageCount;
@@ -1329,8 +1471,8 @@ ScreenshotInfo EpubReaderActivity::getScreenshotInfo() const {
     const uint32_t pageCount = displayPageCount(section.get());
     info.totalPages = static_cast<int>(pageCount);
     if (epub && epub->getBookSize() > 0 && pageCount > 0) {
-      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
-      int pct = static_cast<int>(epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f + 0.5f);
+      int pct = static_cast<int>(
+          epub->calculateProgress(currentSpineIndex, displayedSectionProgress(section.get())) * 100.0f + 0.5f);
       if (pct < 0) pct = 0;
       if (pct > 100) pct = 100;
       info.progressPercent = pct;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -27,8 +27,8 @@
 #include "MappedInputManager.h"
 #include "ProgressMapper.h"
 #include "QrDisplayActivity.h"
-#include "ReaderUtils.h"
 #include "ReaderProgressPolicy.h"
+#include "ReaderUtils.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "components/themes/StatusPageInfo.h"
@@ -106,7 +106,7 @@ uint32_t displayPageCount(const SectionHandle* section) {
 
 uint16_t persistablePageCountForSection(const SectionHandle* section) {
   return ReaderProgressPolicy::persistablePageCount(section && section->isComplete(),
-                                                   section ? section->finalPageCount() : 0);
+                                                    section ? section->finalPageCount() : 0);
 }
 
 bool sectionPumpDidRun(const SectionPumpResult& result) {
@@ -143,9 +143,8 @@ bool sectionPumpGoalMet(const SectionHandle& section, const SectionPumpGoalSpec&
     case SectionPumpGoal::InitialWindowFilled:
       return !EpubIndexingPolicy::initialIndexWindowNeedsPages(section.knownPageCount(), section.isComplete());
     case SectionPumpGoal::OutrunWindowFilled:
-      return section.hasPage(spec.pageNumber) &&
-             !EpubIndexingPolicy::outrunIndexWindowNeedsPages(spec.pageNumber, section.knownPageCount(),
-                                                              section.isComplete());
+      return section.hasPage(spec.pageNumber) && !EpubIndexingPolicy::outrunIndexWindowNeedsPages(
+                                                     spec.pageNumber, section.knownPageCount(), section.isComplete());
     case SectionPumpGoal::SectionComplete:
       return section.isComplete();
     case SectionPumpGoal::AnchorResolved:
@@ -644,7 +643,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     case EpubReaderMenuActivity::MenuAction::SYNC: {
       if (KOREADER_STORE.hasCredentials()) {
         const int currentPage = section ? section->currentPage : nextPageNumber;
-        const int totalPages = section ? static_cast<int>(displayPageCount(section.get())) : cachedChapterTotalPageCount;
+        const int totalPages =
+            section ? static_cast<int>(displayPageCount(section.get())) : cachedChapterTotalPageCount;
         const int persistableTotalPages =
             section ? static_cast<int>(persistablePageCountForSection(section.get())) : cachedChapterTotalPageCount;
         std::optional<uint16_t> paragraphIndex;
@@ -755,7 +755,8 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   if (isForwardTurn) {
     const uint32_t targetPage = static_cast<uint32_t>(section->currentPage + 1);
-    const bool targetAvailable = section->hasPage(targetPage) || (!section->isComplete() && ensureOutrunWindowAvailable(*section, targetPage));
+    const bool targetAvailable =
+        section->hasPage(targetPage) || (!section->isComplete() && ensureOutrunWindowAvailable(*section, targetPage));
     if (targetAvailable) {
       section->currentPage++;
     } else if (section->isComplete()) {
@@ -868,9 +869,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     if (!section->hasPage(0) && !section->isComplete()) {
       GUI.drawPopup(renderer, tr(STR_INDEXING));
-      const auto firstPageResult =
-          pumpSectionUntil(*section, {SectionPumpGoal::PageAvailable, 0, nullptr},
-                           IncrementalBuildBudgetProfile::InitialIndex);
+      const auto firstPageResult = pumpSectionUntil(*section, {SectionPumpGoal::PageAvailable, 0, nullptr},
+                                                    IncrementalBuildBudgetProfile::InitialIndex);
       if (!firstPageResult.goalMet) {
         if (section->mode() == SectionHandleMode::MissingOrFailed) {
           LOG_ERR("ERS", "Failed to build first page");
@@ -887,9 +887,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (EpubIndexingPolicy::initialIndexWindowNeedsPages(section->knownPageCount(), section->isComplete())) {
-      const auto initialWindowResult =
-          pumpSectionUntil(*section, {SectionPumpGoal::InitialWindowFilled, 0, nullptr},
-                           IncrementalBuildBudgetProfile::InitialIndex);
+      const auto initialWindowResult = pumpSectionUntil(*section, {SectionPumpGoal::InitialWindowFilled, 0, nullptr},
+                                                        IncrementalBuildBudgetProfile::InitialIndex);
       if (initialWindowResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
       }
@@ -905,9 +904,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     if (pendingPageJump.has_value()) {
       if (*pendingPageJump == std::numeric_limits<uint16_t>::max()) {
-        const auto lastPageResult =
-            pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
-                             IncrementalBuildBudgetProfile::Outrun);
+        const auto lastPageResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                                                     IncrementalBuildBudgetProfile::Outrun);
         if (lastPageResult.status == SectionPumpStatus::DeferredLowMemory) {
           requestUpdate();
           showPendingSyncSaveError();
@@ -934,9 +932,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (!pendingAnchor.empty()) {
-      const auto anchorResult =
-          pumpSectionUntil(*section, {SectionPumpGoal::AnchorResolved, 0, &pendingAnchor},
-                           IncrementalBuildBudgetProfile::Outrun);
+      const auto anchorResult = pumpSectionUntil(*section, {SectionPumpGoal::AnchorResolved, 0, &pendingAnchor},
+                                                 IncrementalBuildBudgetProfile::Outrun);
       if (anchorResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
         showPendingSyncSaveError();
@@ -953,23 +950,20 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
     // handles changes in reader settings and reset to approximate position based on cached progress
     if (cachedChapterTotalPageCount > 0) {
-      auto remapDecision =
-          ReaderProgressPolicy::decideResumeRemap(currentSpineIndex, cachedSpineIndex, section->currentPage,
-                                                  static_cast<uint32_t>(cachedChapterTotalPageCount),
-                                                  section->isComplete(), section->finalPageCount());
+      auto remapDecision = ReaderProgressPolicy::decideResumeRemap(
+          currentSpineIndex, cachedSpineIndex, section->currentPage, static_cast<uint32_t>(cachedChapterTotalPageCount),
+          section->isComplete(), section->finalPageCount());
       if (remapDecision.deferUntilComplete) {
-        const auto remapResult =
-            pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
-                             IncrementalBuildBudgetProfile::Outrun);
+        const auto remapResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                                                  IncrementalBuildBudgetProfile::Outrun);
         if (remapResult.status == SectionPumpStatus::DeferredLowMemory || !section->isComplete()) {
           requestUpdate();
           showPendingSyncSaveError();
           return;
         }
-        remapDecision =
-            ReaderProgressPolicy::decideResumeRemap(currentSpineIndex, cachedSpineIndex, section->currentPage,
-                                                    static_cast<uint32_t>(cachedChapterTotalPageCount),
-                                                    section->isComplete(), section->finalPageCount());
+        remapDecision = ReaderProgressPolicy::decideResumeRemap(
+            currentSpineIndex, cachedSpineIndex, section->currentPage,
+            static_cast<uint32_t>(cachedChapterTotalPageCount), section->isComplete(), section->finalPageCount());
       }
       if (remapDecision.applyPage) {
         section->currentPage = remapDecision.pageNumber;
@@ -980,9 +974,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     }
 
     if (pendingPercentJump) {
-      const auto percentJumpResult =
-          pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
-                           IncrementalBuildBudgetProfile::Outrun);
+      const auto percentJumpResult = pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                                                      IncrementalBuildBudgetProfile::Outrun);
       if (percentJumpResult.status == SectionPumpStatus::DeferredLowMemory) {
         requestUpdate();
         showPendingSyncSaveError();
@@ -1059,7 +1052,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
   }
-  saveProgress(currentSpineIndex, section->currentPage, static_cast<int>(persistablePageCountForSection(section.get())));
+  saveProgress(currentSpineIndex, section->currentPage,
+               static_cast<int>(persistablePageCountForSection(section.get())));
 
   showPendingSyncSaveError();
 
@@ -1091,9 +1085,9 @@ bool EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, con
   }
 
   if (!nextSectionPrewarm) {
-    nextSectionPrewarm = SectionHandle::openOrCreate(epub, nextSpineIndex, renderer,
-                                                     makeLayoutCacheKey(viewportWidth, viewportHeight),
-                                                     makeBuildOptions(viewportWidth, viewportHeight));
+    nextSectionPrewarm =
+        SectionHandle::openOrCreate(epub, nextSpineIndex, renderer, makeLayoutCacheKey(viewportWidth, viewportHeight),
+                                    makeBuildOptions(viewportWidth, viewportHeight));
     if (!nextSectionPrewarm || nextSectionPrewarm->mode() == SectionHandleMode::MissingOrFailed) {
       LOG_DBG("ERS", "Next section prewarm open failed: %d", nextSpineIndex);
       nextSectionPrewarm.reset();
@@ -1104,7 +1098,8 @@ bool EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, con
   }
 
   if (nextSectionPrewarm->hasActiveBuilder()) {
-    const auto result = nextSectionPrewarm->pump(responsiveBackgroundBudget(IncrementalBuildBudgetProfile::NextPrewarm));
+    const auto result =
+        nextSectionPrewarm->pump(responsiveBackgroundBudget(IncrementalBuildBudgetProfile::NextPrewarm));
     changed = sectionPumpDidRun(result) || changed;
     if (result.status == SectionPumpStatus::Failed) {
       LOG_DBG("ERS", "Next section prewarm failed: %d", nextSpineIndex);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -10,6 +10,9 @@
 #include <Logging.h>
 #include <esp_system.h>
 
+#include <algorithm>
+#include <cstdint>
+#include <functional>
 #include <iterator>
 #include <limits>
 
@@ -27,6 +30,7 @@
 #include "ReaderUtils.h"
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
+#include "components/themes/StatusPageInfo.h"
 #include "fontIds.h"
 #include "util/ScreenshotUtil.h"
 
@@ -43,6 +47,125 @@ int clampPercent(int percent) {
     return 100;
   }
   return percent;
+}
+
+IncrementalSection::LayoutCacheKey makeLayoutCacheKey(const uint16_t viewportWidth, const uint16_t viewportHeight) {
+  IncrementalSection::LayoutCacheKey key;
+  key.cacheVersion = IncrementalSection::CACHE_VERSION;
+  key.fontId = SETTINGS.getReaderFontId();
+  key.lineCompression = SETTINGS.getReaderLineCompression();
+  key.extraParagraphSpacing = SETTINGS.extraParagraphSpacing;
+  key.paragraphAlignment = SETTINGS.paragraphAlignment;
+  key.viewportWidth = viewportWidth;
+  key.viewportHeight = viewportHeight;
+  key.hyphenationEnabled = SETTINGS.hyphenationEnabled;
+  key.embeddedStyle = SETTINGS.embeddedStyle;
+  key.imageRendering = SETTINGS.imageRendering;
+  key.focusReadingEnabled = SETTINGS.focusReadingEnabled;
+  return key;
+}
+
+IncrementalBuildOptions makeBuildOptions(const uint16_t viewportWidth, const uint16_t viewportHeight,
+                                         const std::function<void()>& popupFn = nullptr) {
+  IncrementalBuildOptions options;
+  options.fontId = SETTINGS.getReaderFontId();
+  options.lineCompression = SETTINGS.getReaderLineCompression();
+  options.extraParagraphSpacing = SETTINGS.extraParagraphSpacing;
+  options.paragraphAlignment = SETTINGS.paragraphAlignment;
+  options.viewportWidth = viewportWidth;
+  options.viewportHeight = viewportHeight;
+  options.hyphenationEnabled = SETTINGS.hyphenationEnabled;
+  options.embeddedStyle = SETTINGS.embeddedStyle;
+  options.imageRendering = SETTINGS.imageRendering;
+  options.focusReadingEnabled = SETTINGS.focusReadingEnabled;
+  options.popupFn = popupFn;
+  return options;
+}
+
+IncrementalBuildBudget indexBudget(const IncrementalBuildBudgetProfile profile) {
+  return IncrementalBuildBudgets::forProfile(profile);
+}
+
+uint32_t displayPageCount(const SectionHandle* section) {
+  if (!section) {
+    return 0;
+  }
+  return section->isComplete() ? section->finalPageCount() : section->knownPageCount();
+}
+
+bool sectionPumpDidRun(const SectionPumpResult& result) {
+  return result.status == SectionPumpStatus::Pumped || result.status == SectionPumpStatus::Complete ||
+         result.status == SectionPumpStatus::Failed;
+}
+
+enum class SectionPumpGoal {
+  PageAvailable,
+  InitialWindowFilled,
+  OutrunWindowFilled,
+  SectionComplete,
+  AnchorResolved,
+};
+
+struct SectionPumpGoalSpec {
+  SectionPumpGoal goal = SectionPumpGoal::SectionComplete;
+  uint32_t pageNumber = 0;
+  const std::string* anchor = nullptr;
+};
+
+struct SectionPumpLoopResult {
+  SectionPumpStatus status = SectionPumpStatus::NoWork;
+  uint32_t pagesBefore = 0;
+  uint32_t pagesAfter = 0;
+  bool pumped = false;
+  bool goalMet = false;
+};
+
+bool sectionPumpGoalMet(const SectionHandle& section, const SectionPumpGoalSpec& spec) {
+  switch (spec.goal) {
+    case SectionPumpGoal::PageAvailable:
+      return section.hasPage(spec.pageNumber);
+    case SectionPumpGoal::InitialWindowFilled:
+      return !EpubIndexingPolicy::initialIndexWindowNeedsPages(section.knownPageCount(), section.isComplete());
+    case SectionPumpGoal::OutrunWindowFilled:
+      return section.hasPage(spec.pageNumber) &&
+             !EpubIndexingPolicy::outrunIndexWindowNeedsPages(spec.pageNumber, section.knownPageCount(),
+                                                              section.isComplete());
+    case SectionPumpGoal::SectionComplete:
+      return section.isComplete();
+    case SectionPumpGoal::AnchorResolved:
+      return spec.anchor && section.getPageForAnchor(*spec.anchor).has_value();
+  }
+  return false;
+}
+
+SectionPumpLoopResult pumpSectionUntil(SectionHandle& section, const SectionPumpGoalSpec& goal,
+                                       const IncrementalBuildBudgetProfile budgetProfile) {
+  SectionPumpLoopResult loopResult;
+  loopResult.pagesBefore = section.knownPageCount();
+  loopResult.goalMet = sectionPumpGoalMet(section, goal);
+
+  while (!loopResult.goalMet && section.mode() == SectionHandleMode::IncrementalBuilding) {
+    const auto pumpResult = section.pump(indexBudget(budgetProfile));
+    loopResult.status = pumpResult.status;
+    loopResult.pagesAfter = pumpResult.pagesAfter;
+    loopResult.pumped = loopResult.pumped || sectionPumpDidRun(pumpResult);
+    loopResult.goalMet = sectionPumpGoalMet(section, goal);
+
+    if (pumpResult.status == SectionPumpStatus::DeferredLowMemory || pumpResult.status == SectionPumpStatus::Failed ||
+        pumpResult.status == SectionPumpStatus::Complete || pumpResult.status == SectionPumpStatus::NoWork) {
+      break;
+    }
+  }
+
+  loopResult.goalMet = sectionPumpGoalMet(section, goal);
+  loopResult.pagesAfter = section.knownPageCount();
+  return loopResult;
+}
+
+bool ensureOutrunWindowAvailable(SectionHandle& section, const uint32_t pageNumber) {
+  const auto result = pumpSectionUntil(section, {SectionPumpGoal::OutrunWindowFilled, pageNumber, nullptr},
+                                       IncrementalBuildBudgetProfile::Outrun);
+  return result.goalMet || section.hasPage(pageNumber);
 }
 
 }  // namespace
@@ -80,6 +203,7 @@ void EpubReaderActivity::onEnter() {
     if (dataSize == 6) {
       cachedChapterTotalPageCount = data[4] + (data[5] << 8);
     }
+    f.close();
   }
   // We may want a better condition to detect if we are opening for the first time.
   // This will trigger if the book is re-opened at Chapter 0.
@@ -109,6 +233,7 @@ void EpubReaderActivity::onExit() {
   APP_STATE.readerActivityLoadCount = 0;
   APP_STATE.saveToFile();
   section.reset();
+  nextSectionPrewarm.reset();
   epub.reset();
 }
 
@@ -148,10 +273,11 @@ void EpubReaderActivity::loop() {
   // Enter reader menu activity.
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const int currentPage = section ? section->currentPage + 1 : 0;
-    const int totalPages = section ? section->pageCount : 0;
+    const int totalPages = section ? static_cast<int>(displayPageCount(section.get())) : 0;
     float bookProgress = 0.0f;
-    if (epub->getBookSize() > 0 && section && section->pageCount > 0) {
-      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+    const uint32_t pageCount = displayPageCount(section.get());
+    if (epub->getBookSize() > 0 && section && pageCount > 0) {
+      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
       bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
     }
     const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
@@ -188,6 +314,12 @@ void EpubReaderActivity::loop() {
 
   const auto [prevTriggered, nextTriggered, fromTilt] = ReaderUtils::detectPageTurn(mappedInput);
   if (!prevTriggered && !nextTriggered) {
+    return;
+  }
+
+  if (RenderLock::peek()) {
+    LOG_DBG("ERS", "Ignoring page turn while render/indexing is active");
+    lastPageTurnTime = millis();
     return;
   }
 
@@ -338,8 +470,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     }
     case EpubReaderMenuActivity::MenuAction::GO_TO_PERCENT: {
       float bookProgress = 0.0f;
-      if (epub && epub->getBookSize() > 0 && section && section->pageCount > 0) {
-        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+      const uint32_t pageCount = displayPageCount(section.get());
+      if (epub && epub->getBookSize() > 0 && section && pageCount > 0) {
+        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
         bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
       }
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
@@ -353,8 +486,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::DISPLAY_QR: {
-      if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
-        auto p = section->loadPageFromSectionFile();
+      if (section && section->currentPage >= 0 && section->hasPage(static_cast<uint32_t>(section->currentPage))) {
+        auto p = section->loadPage(static_cast<uint32_t>(section->currentPage));
         if (p) {
           std::string fullText;
           for (const auto& el : p->elements) {
@@ -390,8 +523,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         if (epub && section) {
           uint16_t backupSpine = currentSpineIndex;
           uint16_t backupPage = section->currentPage;
-          uint16_t backupPageCount = section->pageCount;
+          uint16_t backupPageCount = static_cast<uint16_t>(std::min<uint32_t>(displayPageCount(section.get()), UINT16_MAX));
           section.reset();
+          nextSectionPrewarm.reset();
           epub->clearCache();
           epub->setupCacheDir();
           if (!saveProgress(backupSpine, backupPage, backupPageCount)) {
@@ -413,9 +547,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
     case EpubReaderMenuActivity::MenuAction::SYNC: {
       if (KOREADER_STORE.hasCredentials()) {
         const int currentPage = section ? section->currentPage : nextPageNumber;
-        const int totalPages = section ? section->pageCount : cachedChapterTotalPageCount;
+        const int totalPages = section ? static_cast<int>(displayPageCount(section.get())) : cachedChapterTotalPageCount;
         std::optional<uint16_t> paragraphIndex;
-        if (section && currentPage >= 0 && currentPage < section->pageCount) {
+        if (section && currentPage >= 0 && section->hasPage(static_cast<uint32_t>(currentPage))) {
           const uint16_t paragraphPage =
               currentPage > 0 ? static_cast<uint16_t>(currentPage - 1) : static_cast<uint16_t>(currentPage);
           if (const auto pIdx = section->getParagraphIndexForPage(paragraphPage)) {
@@ -451,6 +585,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
             nextPageNumber = section->currentPage;
           }
           section.reset();
+          nextSectionPrewarm.reset();
           epub.reset();
         }
         LOG_DBG("KOSync", "Epub released (heap after: %u)", (unsigned)ESP.getFreeHeap());
@@ -475,9 +610,10 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
     RenderLock lock(*this);
     if (section) {
       cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = section->pageCount;
+      cachedChapterTotalPageCount = static_cast<int>(displayPageCount(section.get()));
       nextPageNumber = section->currentPage;
     }
+    nextSectionPrewarm.reset();
 
     // Persist the selection so the reader keeps the new orientation on next launch.
     SETTINGS.orientation = orientation;
@@ -509,18 +645,21 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
     RenderLock lock(*this);
     if (section) {
       cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = section->pageCount;
+      cachedChapterTotalPageCount = static_cast<int>(displayPageCount(section.get()));
       nextPageNumber = section->currentPage;
     }
+    nextSectionPrewarm.reset();
     section.reset();
   }
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
   if (isForwardTurn) {
-    if (section->currentPage < section->pageCount - 1) {
+    const uint32_t targetPage = static_cast<uint32_t>(section->currentPage + 1);
+    const bool targetAvailable = section->hasPage(targetPage) || (!section->isComplete() && ensureOutrunWindowAvailable(*section, targetPage));
+    if (targetAvailable) {
       section->currentPage++;
-    } else {
+    } else if (section->isComplete()) {
       // We don't want to delete the section mid-render, so grab the semaphore
       {
         RenderLock lock(*this);
@@ -528,6 +667,8 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
         currentSpineIndex++;
         section.reset();
       }
+    } else if (section->mode() == SectionHandleMode::MissingOrFailed) {
+      section.reset();
     }
   } else {
     if (section->currentPage > 0) {
@@ -601,37 +742,82 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   const uint16_t viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
   const uint16_t viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
 
+  if (!section && nextSectionPrewarm && nextSectionPrewarm->spineIndex() == currentSpineIndex) {
+    LOG_DBG("ERS", "Adopting prewarmed section: %d", currentSpineIndex);
+    section = std::move(nextSectionPrewarm);
+  } else if (nextSectionPrewarm &&
+             !EpubIndexingPolicy::prewarmMatchesSpine(nextSectionPrewarm->spineIndex(), currentSpineIndex + 1)) {
+    nextSectionPrewarm.reset();
+  }
+
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
-    section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+    const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
+    section = SectionHandle::openOrCreate(epub, currentSpineIndex, renderer,
+                                          makeLayoutCacheKey(viewportWidth, viewportHeight),
+                                          makeBuildOptions(viewportWidth, viewportHeight, popupFn));
+    if (!section || section->mode() == SectionHandleMode::MissingOrFailed) {
+      LOG_ERR("ERS", "Failed to open or build section data");
+      section.reset();
+      renderer.clearScreen();
+      renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+      renderer.displayBuffer();
+      showPendingSyncSaveError();
+      return;
+    }
 
-    if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
-                                  SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
-                                  viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                  SETTINGS.imageRendering, SETTINGS.focusReadingEnabled)) {
-      LOG_DBG("ERS", "Cache not found, building...");
-
+    if (!section->hasPage(0) && !section->isComplete()) {
       GUI.drawPopup(renderer, tr(STR_INDEXING));
-
-      const auto popupFn = [this]() { GUI.drawPopup(renderer, tr(STR_INDEXING)); };
-
-      if (!section->createSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
-                                      SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
-                                      viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                      SETTINGS.imageRendering, SETTINGS.focusReadingEnabled, popupFn)) {
-        LOG_ERR("ERS", "Failed to persist page data to SD");
-        section.reset();
+      const auto firstPageResult =
+          pumpSectionUntil(*section, {SectionPumpGoal::PageAvailable, 0, nullptr},
+                           IncrementalBuildBudgetProfile::InitialIndex);
+      if (!firstPageResult.goalMet) {
+        if (section->mode() == SectionHandleMode::MissingOrFailed) {
+          LOG_ERR("ERS", "Failed to build first page");
+          section.reset();
+          renderer.clearScreen();
+          renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+          renderer.displayBuffer();
+        } else {
+          requestUpdate();
+        }
         showPendingSyncSaveError();
         return;
       }
-    } else {
-      LOG_DBG("ERS", "Cache found, skipping build...");
+    }
+
+    if (EpubIndexingPolicy::initialIndexWindowNeedsPages(section->knownPageCount(), section->isComplete())) {
+      const auto initialWindowResult =
+          pumpSectionUntil(*section, {SectionPumpGoal::InitialWindowFilled, 0, nullptr},
+                           IncrementalBuildBudgetProfile::InitialIndex);
+      if (initialWindowResult.status == SectionPumpStatus::DeferredLowMemory) {
+        requestUpdate();
+      }
+      if (section->mode() == SectionHandleMode::MissingOrFailed) {
+        section.reset();
+        renderer.clearScreen();
+        renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+        renderer.displayBuffer();
+        showPendingSyncSaveError();
+        return;
+      }
     }
 
     if (pendingPageJump.has_value()) {
-      if (*pendingPageJump >= section->pageCount && section->pageCount > 0) {
-        section->currentPage = section->pageCount - 1;
+      if (*pendingPageJump == std::numeric_limits<uint16_t>::max()) {
+        const auto lastPageResult =
+            pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                             IncrementalBuildBudgetProfile::Outrun);
+        if (lastPageResult.status == SectionPumpStatus::DeferredLowMemory) {
+          requestUpdate();
+          showPendingSyncSaveError();
+          return;
+        }
+        section->currentPage = section->finalPageCount() > 0 ? static_cast<int>(section->finalPageCount() - 1) : 0;
+      } else if (section->isComplete() && *pendingPageJump >= section->finalPageCount() &&
+                 section->finalPageCount() > 0) {
+        section->currentPage = static_cast<int>(section->finalPageCount() - 1);
       } else {
         section->currentPage = *pendingPageJump;
       }
@@ -640,13 +826,23 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       section->currentPage = nextPageNumber;
       if (section->currentPage < 0) {
         section->currentPage = 0;
-      } else if (section->currentPage >= section->pageCount && section->pageCount > 0) {
-        LOG_DBG("ERS", "Clamping cached page %d to %d", section->currentPage, section->pageCount - 1);
-        section->currentPage = section->pageCount - 1;
+      } else if (section->isComplete() && section->currentPage >= static_cast<int>(section->finalPageCount()) &&
+                 section->finalPageCount() > 0) {
+        LOG_DBG("ERS", "Clamping cached page %d to %lu", section->currentPage,
+                static_cast<unsigned long>(section->finalPageCount() - 1));
+        section->currentPage = static_cast<int>(section->finalPageCount() - 1);
       }
     }
 
     if (!pendingAnchor.empty()) {
+      const auto anchorResult =
+          pumpSectionUntil(*section, {SectionPumpGoal::AnchorResolved, 0, &pendingAnchor},
+                           IncrementalBuildBudgetProfile::Outrun);
+      if (anchorResult.status == SectionPumpStatus::DeferredLowMemory) {
+        requestUpdate();
+        showPendingSyncSaveError();
+        return;
+      }
       if (const auto page = section->getPageForAnchor(pendingAnchor)) {
         section->currentPage = *page;
         LOG_DBG("ERS", "Resolved anchor '%s' to page %d", pendingAnchor.c_str(), *page);
@@ -659,19 +855,29 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // handles changes in reader settings and reset to approximate position based on cached progress
     if (cachedChapterTotalPageCount > 0) {
       // only goes to relative position if spine index matches cached value
-      if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
+      const uint32_t knownPages = displayPageCount(section.get());
+      if (currentSpineIndex == cachedSpineIndex && knownPages > 0 &&
+          knownPages != static_cast<uint32_t>(cachedChapterTotalPageCount)) {
         float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
-        int newPage = static_cast<int>(progress * section->pageCount);
+        int newPage = static_cast<int>(progress * knownPages);
         section->currentPage = newPage;
       }
       cachedChapterTotalPageCount = 0;  // resets to 0 to prevent reading cached progress again
     }
 
-    if (pendingPercentJump && section->pageCount > 0) {
+    if (pendingPercentJump) {
+      const auto percentJumpResult =
+          pumpSectionUntil(*section, {SectionPumpGoal::SectionComplete, 0, nullptr},
+                           IncrementalBuildBudgetProfile::Outrun);
+      if (percentJumpResult.status == SectionPumpStatus::DeferredLowMemory) {
+        requestUpdate();
+        showPendingSyncSaveError();
+        return;
+      }
       // Apply the pending percent jump now that we know the new section's page count.
-      int newPage = static_cast<int>(pendingSpineProgress * static_cast<float>(section->pageCount));
-      if (newPage >= section->pageCount) {
-        newPage = section->pageCount - 1;
+      int newPage = static_cast<int>(pendingSpineProgress * static_cast<float>(section->finalPageCount()));
+      if (newPage >= static_cast<int>(section->finalPageCount())) {
+        newPage = section->finalPageCount() > 0 ? static_cast<int>(section->finalPageCount() - 1) : 0;
       }
       section->currentPage = newPage;
       pendingPercentJump = false;
@@ -680,7 +886,7 @@ void EpubReaderActivity::render(RenderLock&& lock) {
 
   renderer.clearScreen();
 
-  if (section->pageCount == 0) {
+  if (section->knownPageCount() == 0 && section->isComplete()) {
     LOG_DBG("ERS", "No pages to render");
     renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_EMPTY_CHAPTER), true, EpdFontFamily::BOLD);
     renderStatusBar();
@@ -690,8 +896,8 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     return;
   }
 
-  if (section->currentPage < 0 || section->currentPage >= section->pageCount) {
-    LOG_DBG("ERS", "Page out of bounds: %d (max %d)", section->currentPage, section->pageCount);
+  if (section->currentPage < 0) {
+    LOG_DBG("ERS", "Page out of bounds: %d", section->currentPage);
     renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_OUT_OF_BOUNDS), true, EpdFontFamily::BOLD);
     renderStatusBar();
     renderer.displayBuffer();
@@ -700,8 +906,27 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     return;
   }
 
+  if (!section->hasPage(static_cast<uint32_t>(section->currentPage))) {
+    if (!ensureOutrunWindowAvailable(*section, static_cast<uint32_t>(section->currentPage))) {
+      if (section->mode() != SectionHandleMode::MissingOrFailed && !section->isComplete()) {
+        requestUpdate();
+        automaticPageTurnActive = false;
+        showPendingSyncSaveError();
+        return;
+      }
+      LOG_DBG("ERS", "Page unavailable: %d (known %lu)", section->currentPage,
+              static_cast<unsigned long>(section->knownPageCount()));
+      renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_OUT_OF_BOUNDS), true, EpdFontFamily::BOLD);
+      renderStatusBar();
+      renderer.displayBuffer();
+      automaticPageTurnActive = false;
+      showPendingSyncSaveError();
+      return;
+    }
+  }
+
   {
-    auto p = section->loadPageFromSectionFile();
+    auto p = section->loadPage(static_cast<uint32_t>(section->currentPage));
     if (!p) {
       LOG_ERR("ERS", "Failed to load page from SD - clearing section cache");
       section->clearCache();
@@ -720,8 +945,11 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
   }
-  silentIndexNextChapterIfNeeded(viewportWidth, viewportHeight);
-  saveProgress(currentSpineIndex, section->currentPage, section->pageCount);
+  if (section->hasActiveBuilder() && !section->isComplete()) {
+    section->pump(indexBudget(IncrementalBuildBudgetProfile::CurrentBackground));
+  }
+  maintainPrewarmWindow(viewportWidth, viewportHeight);
+  saveProgress(currentSpineIndex, section->currentPage, static_cast<int>(displayPageCount(section.get())));
 
   showPendingSyncSaveError();
 
@@ -731,13 +959,13 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
 }
 
-void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportWidth, const uint16_t viewportHeight) {
-  if (!epub || !section || section->pageCount < 2) {
+void EpubReaderActivity::maintainPrewarmWindow(const uint16_t viewportWidth, const uint16_t viewportHeight) {
+  if (!epub || !section || !section->isComplete()) {
     return;
   }
 
-  // Build the next chapter cache while the penultimate page is on screen.
-  if (section->currentPage != section->pageCount - 2) {
+  if (!EpubIndexingPolicy::shouldPrewarmNextChapter(static_cast<uint32_t>(std::max(section->currentPage, 0)),
+                                                    section->finalPageCount(), section->isComplete())) {
     return;
   }
 
@@ -746,20 +974,28 @@ void EpubReaderActivity::silentIndexNextChapterIfNeeded(const uint16_t viewportW
     return;
   }
 
-  Section nextSection(epub, nextSpineIndex, renderer);
-  if (nextSection.loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
-                                  SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
-                                  viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                  SETTINGS.imageRendering, SETTINGS.focusReadingEnabled)) {
-    return;
+  if (nextSectionPrewarm && nextSectionPrewarm->spineIndex() != nextSpineIndex) {
+    nextSectionPrewarm.reset();
   }
 
-  LOG_DBG("ERS", "Silently indexing next chapter: %d", nextSpineIndex);
-  if (!nextSection.createSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
-                                     SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,
-                                     viewportHeight, SETTINGS.hyphenationEnabled, SETTINGS.embeddedStyle,
-                                     SETTINGS.imageRendering, SETTINGS.focusReadingEnabled)) {
-    LOG_ERR("ERS", "Failed silent indexing for chapter: %d", nextSpineIndex);
+  if (!nextSectionPrewarm) {
+    nextSectionPrewarm = SectionHandle::openOrCreate(epub, nextSpineIndex, renderer,
+                                                     makeLayoutCacheKey(viewportWidth, viewportHeight),
+                                                     makeBuildOptions(viewportWidth, viewportHeight));
+    if (!nextSectionPrewarm || nextSectionPrewarm->mode() == SectionHandleMode::MissingOrFailed) {
+      LOG_DBG("ERS", "Next section prewarm open failed: %d", nextSpineIndex);
+      nextSectionPrewarm.reset();
+      return;
+    }
+    LOG_DBG("ERS", "Next section prewarm opened: %d", nextSpineIndex);
+  }
+
+  if (nextSectionPrewarm->hasActiveBuilder()) {
+    const auto result = nextSectionPrewarm->pump(indexBudget(IncrementalBuildBudgetProfile::NextPrewarm));
+    if (result.status == SectionPumpStatus::Failed) {
+      LOG_DBG("ERS", "Next section prewarm failed: %d", nextSpineIndex);
+      nextSectionPrewarm.reset();
+    }
   }
 }
 
@@ -810,8 +1046,18 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   const auto tDisplay = millis();
 
   // Save bw buffer to reset buffer state after grayscale data sync
-  renderer.storeBwBuffer();
+  const bool bwStored = renderer.storeBwBuffer();
   const auto tBwStore = millis();
+
+  if (SETTINGS.textAntiAliasing && !bwStored) {
+    LOG_ERR("ERS", "Skipping EPUB text grayscale AA: failed to store BW buffer");
+    const auto tEnd = millis();
+    LOG_DBG("ERS",
+            "Page render: prewarm=%lums bw_render=%lums display=%lums bw_store=%lums "
+            "aa=skipped total=%lums",
+            tPrewarm - t0, tBwRender - tPrewarm, tDisplay - tBwRender, tBwStore - tDisplay, tEnd - t0);
+    return;
+  }
 
   // grayscale rendering
   // TODO: Only do this if font supports it
@@ -858,10 +1104,17 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
 
 void EpubReaderActivity::renderStatusBar() const {
   // Calculate progress in book
-  const int currentPage = section->currentPage + 1;
-  const float pageCount = section->pageCount;
-  const float sectionChapterProg = (pageCount > 0) ? (static_cast<float>(currentPage) / pageCount) : 0;
+  const uint32_t pageCount = displayPageCount(section.get());
+  const float sectionChapterProg =
+      (pageCount > 0) ? (static_cast<float>(section->currentPage + 1) / static_cast<float>(pageCount)) : 0.0f;
   const float bookProgress = epub->calculateProgress(currentSpineIndex, sectionChapterProg) * 100;
+  StatusPageInfo pageInfo;
+  pageInfo.currentPage = section->currentPage >= 0 ? static_cast<uint32_t>(section->currentPage) : 0;
+  pageInfo.totalPages = pageCount;
+  pageInfo.totalKnown = section->isComplete();
+  pageInfo.hasMorePages = !section->isComplete() && section->knownPageCount() > 0;
+  pageInfo.futureIndexingActive =
+      nextSectionPrewarm && nextSectionPrewarm->hasActiveBuilder() && !nextSectionPrewarm->isComplete();
 
   std::string title;
 
@@ -890,7 +1143,7 @@ void EpubReaderActivity::renderStatusBar() const {
     title = epub->getTitle();
   }
 
-  GUI.drawStatusBar(renderer, bookProgress, currentPage, pageCount, title, 0, textYOffset);
+  GUI.drawStatusBar(renderer, bookProgress, pageInfo, title, 0, textYOffset);
 }
 
 void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool savePosition) {
@@ -961,9 +1214,10 @@ ScreenshotInfo EpubReaderActivity::getScreenshotInfo() const {
   }
   if (section) {
     info.currentPage = section->currentPage + 1;
-    info.totalPages = section->pageCount;
-    if (epub && epub->getBookSize() > 0 && section->pageCount > 0) {
-      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+    const uint32_t pageCount = displayPageCount(section.get());
+    info.totalPages = static_cast<int>(pageCount);
+    if (epub && epub->getBookSize() > 0 && pageCount > 0) {
+      const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(pageCount);
       int pct = static_cast<int>(epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f + 0.5f);
       if (pct < 0) pct = 0;
       if (pct > 100) pct = 100;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -32,6 +32,8 @@ class EpubReaderActivity final : public Activity {
   bool pendingSyncSaveError = false;
   bool skipNextButtonCheck = false;  // Skip button processing for one frame after subactivity exit
   bool automaticPageTurnActive = false;
+  bool backgroundIndexingWorkActive = false;
+  int pendingPageTurnDirection = 0;
 
   // Footnote support
   std::vector<FootnoteEntry> currentPageFootnotes;
@@ -46,7 +48,11 @@ class EpubReaderActivity final : public Activity {
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
                       int orientedMarginBottom, int orientedMarginLeft);
   void renderStatusBar() const;
-  void maintainPrewarmWindow(uint16_t viewportWidth, uint16_t viewportHeight);
+  bool maintainPrewarmWindow(uint16_t viewportWidth, uint16_t viewportHeight);
+  bool hasCurrentIndexingWork() const;
+  bool hasPrewarmIndexingWork() const;
+  bool hasBackgroundIndexingWork() const;
+  bool pumpBackgroundIndexing();
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);
@@ -66,6 +72,8 @@ class EpubReaderActivity final : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&& lock) override;
+  bool skipLoopDelay() override;
+  bool preventAutoSleep() override;
   bool isReaderActivity() const override { return true; }
   ScreenshotInfo getScreenshotInfo() const override;
 };

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -33,6 +33,9 @@ class EpubReaderActivity final : public Activity {
   bool skipNextButtonCheck = false;  // Skip button processing for one frame after subactivity exit
   bool automaticPageTurnActive = false;
   bool backgroundIndexingWorkActive = false;
+  bool bookCacheDeleted = false;
+  bool freshBookEntry = false;
+  bool initialBookEntryIndexingPopupShown = false;
   int pendingPageTurnDirection = 0;
 
   // Footnote support
@@ -66,8 +69,11 @@ class EpubReaderActivity final : public Activity {
   void restoreSavedPosition();
 
  public:
-  explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub)
-      : Activity("EpubReader", renderer, mappedInput), epub(std::move(epub)) {}
+  explicit EpubReaderActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::unique_ptr<Epub> epub,
+                              const bool initialIndexingPopupShown = false)
+      : Activity("EpubReader", renderer, mappedInput),
+        epub(std::move(epub)),
+        initialBookEntryIndexingPopupShown(initialIndexingPopupShown) {}
   void onEnter() override;
   void onExit() override;
   void loop() override;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
-#include <Epub/Section.h>
+#include <Epub/SectionHandle.h>
 
 #include <optional>
 
@@ -10,7 +10,8 @@
 
 class EpubReaderActivity final : public Activity {
   std::shared_ptr<Epub> epub;
-  std::unique_ptr<Section> section = nullptr;
+  std::unique_ptr<SectionHandle> section = nullptr;
+  std::unique_ptr<SectionHandle> nextSectionPrewarm = nullptr;
   int currentSpineIndex = 0;
   int nextPageNumber = 0;
   std::optional<uint16_t> pendingPageJump;
@@ -45,7 +46,7 @@ class EpubReaderActivity final : public Activity {
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,
                       int orientedMarginBottom, int orientedMarginLeft);
   void renderStatusBar() const;
-  void silentIndexNextChapterIfNeeded(uint16_t viewportWidth, uint16_t viewportHeight);
+  void maintainPrewarmWindow(uint16_t viewportWidth, uint16_t viewportHeight);
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);

--- a/src/activities/reader/EpubReaderUtils.h
+++ b/src/activities/reader/EpubReaderUtils.h
@@ -28,8 +28,10 @@ inline bool saveProgress(Epub& epub, int spineIndex, int pageNumber, int pageCou
   const size_t written = f.write(data, sizeof(data));
   if (written != sizeof(data)) {
     LOG_ERR("ERS", "Short write saving progress: %u/%u bytes", (unsigned)written, (unsigned)sizeof(data));
+    f.close();
     return false;
   }
+  f.close();
   LOG_DBG("ERS", "Progress saved: spine=%d page=%d", spineIndex, pageNumber);
   return true;
 }

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -10,7 +10,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <optional>
 
+#include "Epub/IncrementalSectionCache.h"
 #include "Epub/Section.h"
 #include "EpubReaderUtils.h"
 #include "KOReaderCredentialStore.h"
@@ -179,10 +181,13 @@ void KOReaderSyncActivity::performSync() {
 
   // Refine page using section cache LUTs: li index, anchor, or paragraph index.
   if (remotePosition.hasLiIndex || remotePosition.xpathAnchorId[0] != '\0' || remotePosition.hasParagraphIndex) {
-    Section tempSection(epub, remotePosition.spineIndex, renderer);
+    IncrementalSection::Cache incrementalCache(epub->getCachePath() + "/sections",
+                                               static_cast<uint32_t>(remotePosition.spineIndex));
+    const bool useIncrementalCache = incrementalCache.isComplete();
     bool refined = false;
     if (remotePosition.hasLiIndex) {
-      const auto liPage = tempSection.getPageForListItemIndex(remotePosition.liIndex);
+      const auto liPage = useIncrementalCache ? incrementalCache.getPageForListItemIndex(remotePosition.liIndex)
+                                              : std::optional<uint16_t>{};
       if (liPage.has_value()) {
         LOG_DBG("KOSync", "Li index %u -> page %d (was %d)", remotePosition.liIndex, *liPage,
                 remotePosition.pageNumber);
@@ -193,7 +198,8 @@ void KOReaderSyncActivity::performSync() {
       }
     }
     if (!refined && remotePosition.xpathAnchorId[0] != '\0') {
-      const auto anchorPage = tempSection.getPageForAnchor(std::string(remotePosition.xpathAnchorId));
+      const auto anchorPage = useIncrementalCache ? incrementalCache.getPageForAnchor(std::string(remotePosition.xpathAnchorId))
+                                                  : std::optional<uint16_t>{};
       if (anchorPage.has_value()) {
         LOG_DBG("KOSync", "Anchor '%s' -> page %d (was %d)", remotePosition.xpathAnchorId, *anchorPage,
                 remotePosition.pageNumber);
@@ -204,8 +210,12 @@ void KOReaderSyncActivity::performSync() {
       }
     }
     if (!refined && remotePosition.hasParagraphIndex) {
-      const auto paragraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex);
-      const auto nextParagraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex + 1);
+      const auto paragraphPage = useIncrementalCache
+                                     ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex)
+                                     : std::optional<uint16_t>{};
+      const auto nextParagraphPage =
+          useIncrementalCache ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex + 1)
+                              : std::optional<uint16_t>{};
       if (paragraphPage.has_value()) {
         int refinedPage = std::max(remotePosition.pageNumber, static_cast<int>(*paragraphPage));
         if (nextParagraphPage.has_value()) {
@@ -227,6 +237,44 @@ void KOReaderSyncActivity::performSync() {
         remotePosition.pageNumber = refinedPage;
       } else {
         LOG_DBG("KOSync", "Paragraph %u not found in section LUT", remotePosition.paragraphIndex);
+      }
+    }
+
+    if (!useIncrementalCache && !refined) {
+      Section tempSection(epub, remotePosition.spineIndex, renderer);
+      if (remotePosition.hasLiIndex) {
+        const auto liPage = tempSection.getPageForListItemIndex(remotePosition.liIndex);
+        if (liPage.has_value()) {
+          LOG_DBG("KOSync", "Legacy li index %u -> page %d (was %d)", remotePosition.liIndex, *liPage,
+                  remotePosition.pageNumber);
+          remotePosition.pageNumber = *liPage;
+          refined = true;
+        }
+      }
+      if (!refined && remotePosition.xpathAnchorId[0] != '\0') {
+        const auto anchorPage = tempSection.getPageForAnchor(std::string(remotePosition.xpathAnchorId));
+        if (anchorPage.has_value()) {
+          LOG_DBG("KOSync", "Legacy anchor '%s' -> page %d (was %d)", remotePosition.xpathAnchorId, *anchorPage,
+                  remotePosition.pageNumber);
+          remotePosition.pageNumber = *anchorPage;
+          refined = true;
+        }
+      }
+      if (!refined && remotePosition.hasParagraphIndex) {
+        const auto paragraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex);
+        const auto nextParagraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex + 1);
+        if (paragraphPage.has_value()) {
+          int refinedPage = std::max(remotePosition.pageNumber, static_cast<int>(*paragraphPage));
+          if (nextParagraphPage.has_value()) {
+            const int lutSpan = static_cast<int>(*nextParagraphPage) - static_cast<int>(*paragraphPage);
+            if (lutSpan > 1 && refinedPage >= static_cast<int>(*nextParagraphPage)) {
+              refinedPage = static_cast<int>(*nextParagraphPage) - 1;
+            }
+          }
+          LOG_DBG("KOSync", "Legacy paragraph %u -> page %d (was %d)", remotePosition.paragraphIndex, refinedPage,
+                  remotePosition.pageNumber);
+          remotePosition.pageNumber = refinedPage;
+        }
       }
     }
   }

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -198,8 +198,9 @@ void KOReaderSyncActivity::performSync() {
       }
     }
     if (!refined && remotePosition.xpathAnchorId[0] != '\0') {
-      const auto anchorPage = useIncrementalCache ? incrementalCache.getPageForAnchor(std::string(remotePosition.xpathAnchorId))
-                                                  : std::optional<uint16_t>{};
+      const auto anchorPage = useIncrementalCache
+                                  ? incrementalCache.getPageForAnchor(std::string(remotePosition.xpathAnchorId))
+                                  : std::optional<uint16_t>{};
       if (anchorPage.has_value()) {
         LOG_DBG("KOSync", "Anchor '%s' -> page %d (was %d)", remotePosition.xpathAnchorId, *anchorPage,
                 remotePosition.pageNumber);
@@ -213,9 +214,9 @@ void KOReaderSyncActivity::performSync() {
       const auto paragraphPage = useIncrementalCache
                                      ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex)
                                      : std::optional<uint16_t>{};
-      const auto nextParagraphPage =
-          useIncrementalCache ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex + 1)
-                              : std::optional<uint16_t>{};
+      const auto nextParagraphPage = useIncrementalCache
+                                         ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex + 1)
+                                         : std::optional<uint16_t>{};
       if (paragraphPage.has_value()) {
         int refinedPage = std::max(remotePosition.pageNumber, static_cast<int>(*paragraphPage));
         if (nextParagraphPage.has_value()) {

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -10,10 +10,15 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
+#include <cstdio>
 #include <optional>
 
+#include "CrossPointSettings.h"
+#include "Epub/IncrementalBuildBudget.h"
 #include "Epub/IncrementalSectionCache.h"
 #include "Epub/Section.h"
+#include "Epub/SectionHandle.h"
 #include "EpubReaderUtils.h"
 #include "KOReaderCredentialStore.h"
 #include "KOReaderDocumentId.h"
@@ -26,6 +31,11 @@
 #include "fontIds.h"
 
 namespace {
+struct ReaderViewport {
+  uint16_t width = 0;
+  uint16_t height = 0;
+};
+
 void syncTimeWithNTP() {
   // Stop SNTP if already running (can't reconfigure while running)
   if (esp_sntp_enabled()) {
@@ -51,6 +61,116 @@ void syncTimeWithNTP() {
     LOG_DBG("KOSync", "NTP sync timeout, using fallback");
   }
 }
+
+IncrementalSection::LayoutCacheKey makeLayoutCacheKey(const uint16_t viewportWidth, const uint16_t viewportHeight) {
+  IncrementalSection::LayoutCacheKey key;
+  key.cacheVersion = IncrementalSection::CACHE_VERSION;
+  key.fontId = SETTINGS.getReaderFontId();
+  key.lineCompression = SETTINGS.getReaderLineCompression();
+  key.extraParagraphSpacing = SETTINGS.extraParagraphSpacing;
+  key.paragraphAlignment = SETTINGS.paragraphAlignment;
+  key.viewportWidth = viewportWidth;
+  key.viewportHeight = viewportHeight;
+  key.hyphenationEnabled = SETTINGS.hyphenationEnabled;
+  key.embeddedStyle = SETTINGS.embeddedStyle;
+  key.imageRendering = SETTINGS.imageRendering;
+  key.focusReadingEnabled = SETTINGS.focusReadingEnabled;
+  return key;
+}
+
+IncrementalBuildOptions makeBuildOptions(const uint16_t viewportWidth, const uint16_t viewportHeight) {
+  IncrementalBuildOptions options;
+  options.fontId = SETTINGS.getReaderFontId();
+  options.lineCompression = SETTINGS.getReaderLineCompression();
+  options.extraParagraphSpacing = SETTINGS.extraParagraphSpacing;
+  options.paragraphAlignment = SETTINGS.paragraphAlignment;
+  options.viewportWidth = viewportWidth;
+  options.viewportHeight = viewportHeight;
+  options.hyphenationEnabled = SETTINGS.hyphenationEnabled;
+  options.embeddedStyle = SETTINGS.embeddedStyle;
+  options.imageRendering = SETTINGS.imageRendering;
+  options.focusReadingEnabled = SETTINGS.focusReadingEnabled;
+  return options;
+}
+
+IncrementalBuildBudget indexBudget(const IncrementalBuildBudgetProfile profile) {
+  return IncrementalBuildBudgets::forProfile(profile);
+}
+
+ReaderViewport syncReaderViewport(GfxRenderer& renderer) {
+  int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
+  renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
+                                   &orientedMarginLeft);
+  orientedMarginTop += SETTINGS.screenMargin;
+  orientedMarginLeft += SETTINGS.screenMargin;
+  orientedMarginRight += SETTINGS.screenMargin;
+  const uint8_t statusBarHeight = UITheme::getInstance().getStatusBarHeight();
+  orientedMarginBottom += std::max(SETTINGS.screenMargin, statusBarHeight);
+
+  const int viewportWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
+  const int viewportHeight = renderer.getScreenHeight() - orientedMarginTop - orientedMarginBottom;
+  return {static_cast<uint16_t>(std::max(0, viewportWidth)), static_cast<uint16_t>(std::max(0, viewportHeight))};
+}
+
+bool hasPreciseRemoteLocation(const CrossPointPosition& position) {
+  return position.hasLiIndex || position.xpathAnchorId[0] != '\0' || position.hasParagraphIndex;
+}
+
+template <typename Lookup>
+bool refineRemotePositionFromLookup(const Lookup& lookup, CrossPointPosition& position, const char* source) {
+  if (position.hasLiIndex) {
+    const auto liPage = lookup.getPageForListItemIndex(position.liIndex);
+    if (liPage.has_value()) {
+      LOG_DBG("KOSync", "%s li index %u -> page %d (was %d)", source, position.liIndex, *liPage, position.pageNumber);
+      position.pageNumber = *liPage;
+      return true;
+    }
+    LOG_DBG("KOSync", "%s li index %u not found in section LUT", source, position.liIndex);
+  }
+
+  if (position.xpathAnchorId[0] != '\0') {
+    const auto anchorPage = lookup.getPageForAnchor(std::string(position.xpathAnchorId));
+    if (anchorPage.has_value()) {
+      LOG_DBG("KOSync", "%s anchor '%s' -> page %d (was %d)", source, position.xpathAnchorId, *anchorPage,
+              position.pageNumber);
+      position.pageNumber = *anchorPage;
+      return true;
+    }
+    LOG_DBG("KOSync", "%s anchor '%s' not found in section LUT", source, position.xpathAnchorId);
+  }
+
+  if (position.hasParagraphIndex) {
+    const auto paragraphPage = lookup.getPageForParagraphIndex(position.paragraphIndex);
+    const auto nextParagraphPage = (position.paragraphIndex < UINT16_MAX)
+                                       ? lookup.getPageForParagraphIndex(position.paragraphIndex + 1)
+                                       : std::optional<uint16_t>{};
+    if (paragraphPage.has_value()) {
+      int refinedPage = std::max(position.pageNumber, static_cast<int>(*paragraphPage));
+      if (nextParagraphPage.has_value()) {
+        const int lutSpan = static_cast<int>(*nextParagraphPage) - static_cast<int>(*paragraphPage);
+        // Only cap when the LUT span is >1. A span of 1 means the LUT granularity is too
+        // coarse to trust over the intra-spine position.
+        if (lutSpan > 1 && refinedPage >= static_cast<int>(*nextParagraphPage)) {
+          refinedPage = static_cast<int>(*nextParagraphPage) - 1;
+        }
+      }
+
+      char nextParaBuf[8];
+      if (nextParagraphPage.has_value()) {
+        snprintf(nextParaBuf, sizeof(nextParaBuf), "%d", *nextParagraphPage);
+      } else {
+        snprintf(nextParaBuf, sizeof(nextParaBuf), "none");
+      }
+      LOG_DBG("KOSync", "%s paragraph %u -> LUT page %d, nextPara page %s, intra page %d, using %d", source,
+              position.paragraphIndex, *paragraphPage, nextParaBuf, position.pageNumber, refinedPage);
+      position.pageNumber = refinedPage;
+      return true;
+    }
+    LOG_DBG("KOSync", "%s paragraph %u not found in section LUT", source, position.paragraphIndex);
+  }
+
+  return false;
+}
 }  // namespace
 
 void KOReaderSyncActivity::ensureEpubLoaded() {
@@ -66,6 +186,50 @@ void KOReaderSyncActivity::ensureEpubLoaded() {
     }
     LOG_DBG("KOSync", "Epub loaded (heap: %u)", (unsigned)ESP.getFreeHeap());
   }
+}
+
+bool KOReaderSyncActivity::refineRemoteProgressWithIncrementalIndexing(CrossPointPosition& position) {
+  if (!epub || !hasPreciseRemoteLocation(position)) {
+    return false;
+  }
+  if (position.spineIndex < 0 || position.spineIndex >= epub->getSpineItemsCount()) {
+    LOG_DBG("KOSync", "Skipping indexed refinement for out-of-range spine %d", position.spineIndex);
+    return false;
+  }
+
+  const auto viewport = syncReaderViewport(renderer);
+  if (viewport.width == 0 || viewport.height == 0) {
+    LOG_ERR("KOSync", "Skipping indexed refinement with invalid viewport %ux%u", viewport.width, viewport.height);
+    return false;
+  }
+
+  auto sectionHandle = SectionHandle::openOrCreate(epub, position.spineIndex, renderer,
+                                                   makeLayoutCacheKey(viewport.width, viewport.height),
+                                                   makeBuildOptions(viewport.width, viewport.height));
+  if (!sectionHandle || sectionHandle->mode() == SectionHandleMode::MissingOrFailed) {
+    LOG_DBG("KOSync", "Could not open incremental section %d for remote progress refinement", position.spineIndex);
+    return false;
+  }
+
+  bool refined = refineRemotePositionFromLookup(*sectionHandle, position, "Indexed");
+  while (!refined && sectionHandle->hasActiveBuilder()) {
+    const auto pumpResult = sectionHandle->pump(indexBudget(IncrementalBuildBudgetProfile::Outrun));
+    refined = refineRemotePositionFromLookup(*sectionHandle, position, "Indexed");
+
+    if (refined || pumpResult.status == SectionPumpStatus::DeferredLowMemory ||
+        pumpResult.status == SectionPumpStatus::Failed || pumpResult.status == SectionPumpStatus::Complete) {
+      if (!refined && pumpResult.status == SectionPumpStatus::DeferredLowMemory) {
+        LOG_DBG("KOSync", "Deferred indexed refinement for low memory at %lu known pages",
+                static_cast<unsigned long>(sectionHandle->knownPageCount()));
+      }
+      break;
+    }
+    if (pumpResult.status == SectionPumpStatus::NoWork && !sectionHandle->hasActiveBuilder()) {
+      break;
+    }
+  }
+
+  return refined;
 }
 
 void KOReaderSyncActivity::saveProgressAndReturn(int spineIndex, int page) {
@@ -179,103 +343,27 @@ void KOReaderSyncActivity::performSync() {
   KOReaderPosition koPos = {remoteProgress.progress, remoteProgress.percentage};
   remotePosition = ProgressMapper::toCrossPoint(epub, koPos, currentSpineIndex, totalPagesInSpine);
 
-  // Refine page using section cache LUTs: li index, anchor, or paragraph index.
-  if (remotePosition.hasLiIndex || remotePosition.xpathAnchorId[0] != '\0' || remotePosition.hasParagraphIndex) {
+  // Refine page using section LUTs: li index, anchor, or paragraph index.
+  if (hasPreciseRemoteLocation(remotePosition)) {
     IncrementalSection::Cache incrementalCache(epub->getCachePath() + "/sections",
                                                static_cast<uint32_t>(remotePosition.spineIndex));
     const bool useIncrementalCache = incrementalCache.isComplete();
-    bool refined = false;
-    if (remotePosition.hasLiIndex) {
-      const auto liPage = useIncrementalCache ? incrementalCache.getPageForListItemIndex(remotePosition.liIndex)
-                                              : std::optional<uint16_t>{};
-      if (liPage.has_value()) {
-        LOG_DBG("KOSync", "Li index %u -> page %d (was %d)", remotePosition.liIndex, *liPage,
-                remotePosition.pageNumber);
-        remotePosition.pageNumber = *liPage;
-        refined = true;
-      } else {
-        LOG_DBG("KOSync", "Li index %u not found in section LUT", remotePosition.liIndex);
+    bool refined = useIncrementalCache && refineRemotePositionFromLookup(incrementalCache, remotePosition, "Cached");
+
+    if (!useIncrementalCache && !refined) {
+      {
+        RenderLock lock(*this);
+        statusMessage = tr(STR_INDEXING);
       }
-    }
-    if (!refined && remotePosition.xpathAnchorId[0] != '\0') {
-      const auto anchorPage = useIncrementalCache
-                                  ? incrementalCache.getPageForAnchor(std::string(remotePosition.xpathAnchorId))
-                                  : std::optional<uint16_t>{};
-      if (anchorPage.has_value()) {
-        LOG_DBG("KOSync", "Anchor '%s' -> page %d (was %d)", remotePosition.xpathAnchorId, *anchorPage,
-                remotePosition.pageNumber);
-        remotePosition.pageNumber = *anchorPage;
-        refined = true;
-      } else {
-        LOG_DBG("KOSync", "Anchor '%s' not found in section cache", remotePosition.xpathAnchorId);
-      }
-    }
-    if (!refined && remotePosition.hasParagraphIndex) {
-      const auto paragraphPage = useIncrementalCache
-                                     ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex)
-                                     : std::optional<uint16_t>{};
-      const auto nextParagraphPage = useIncrementalCache
-                                         ? incrementalCache.getPageForParagraphIndex(remotePosition.paragraphIndex + 1)
-                                         : std::optional<uint16_t>{};
-      if (paragraphPage.has_value()) {
-        int refinedPage = std::max(remotePosition.pageNumber, static_cast<int>(*paragraphPage));
-        if (nextParagraphPage.has_value()) {
-          const int lutSpan = static_cast<int>(*nextParagraphPage) - static_cast<int>(*paragraphPage);
-          // Only cap when the LUT span is >1. A span of 1 means the LUT granularity is too
-          // coarse to trust over the intra-spine position (e.g. a stale cache where the paragraph
-          // occupies different pages than at build time).
-          if (lutSpan > 1 && refinedPage >= static_cast<int>(*nextParagraphPage)) {
-            refinedPage = static_cast<int>(*nextParagraphPage) - 1;
-          }
-        }
-        char nextParaBuf[8];
-        if (nextParagraphPage.has_value())
-          snprintf(nextParaBuf, sizeof(nextParaBuf), "%d", *nextParagraphPage);
-        else
-          snprintf(nextParaBuf, sizeof(nextParaBuf), "none");
-        LOG_DBG("KOSync", "Paragraph %u -> LUT page %d, nextPara page %s, intra page %d, using %d",
-                remotePosition.paragraphIndex, *paragraphPage, nextParaBuf, remotePosition.pageNumber, refinedPage);
-        remotePosition.pageNumber = refinedPage;
-      } else {
-        LOG_DBG("KOSync", "Paragraph %u not found in section LUT", remotePosition.paragraphIndex);
-      }
+      requestUpdateAndWait();
+      refined = refineRemoteProgressWithIncrementalIndexing(remotePosition);
     }
 
     if (!useIncrementalCache && !refined) {
       Section tempSection(epub, remotePosition.spineIndex, renderer);
-      if (remotePosition.hasLiIndex) {
-        const auto liPage = tempSection.getPageForListItemIndex(remotePosition.liIndex);
-        if (liPage.has_value()) {
-          LOG_DBG("KOSync", "Legacy li index %u -> page %d (was %d)", remotePosition.liIndex, *liPage,
-                  remotePosition.pageNumber);
-          remotePosition.pageNumber = *liPage;
-          refined = true;
-        }
-      }
-      if (!refined && remotePosition.xpathAnchorId[0] != '\0') {
-        const auto anchorPage = tempSection.getPageForAnchor(std::string(remotePosition.xpathAnchorId));
-        if (anchorPage.has_value()) {
-          LOG_DBG("KOSync", "Legacy anchor '%s' -> page %d (was %d)", remotePosition.xpathAnchorId, *anchorPage,
-                  remotePosition.pageNumber);
-          remotePosition.pageNumber = *anchorPage;
-          refined = true;
-        }
-      }
-      if (!refined && remotePosition.hasParagraphIndex) {
-        const auto paragraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex);
-        const auto nextParagraphPage = tempSection.getPageForParagraphIndex(remotePosition.paragraphIndex + 1);
-        if (paragraphPage.has_value()) {
-          int refinedPage = std::max(remotePosition.pageNumber, static_cast<int>(*paragraphPage));
-          if (nextParagraphPage.has_value()) {
-            const int lutSpan = static_cast<int>(*nextParagraphPage) - static_cast<int>(*paragraphPage);
-            if (lutSpan > 1 && refinedPage >= static_cast<int>(*nextParagraphPage)) {
-              refinedPage = static_cast<int>(*nextParagraphPage) - 1;
-            }
-          }
-          LOG_DBG("KOSync", "Legacy paragraph %u -> page %d (was %d)", remotePosition.paragraphIndex, refinedPage,
-                  remotePosition.pageNumber);
-          remotePosition.pageNumber = refinedPage;
-        }
+      if (!refineRemotePositionFromLookup(tempSection, remotePosition, "Legacy")) {
+        LOG_DBG("KOSync", "Remote progress location was not resolved; keeping approximate page %d",
+                remotePosition.pageNumber);
       }
     }
   }

--- a/src/activities/reader/KOReaderSyncActivity.h
+++ b/src/activities/reader/KOReaderSyncActivity.h
@@ -88,6 +88,7 @@ class KOReaderSyncActivity final : public Activity {
   void performSync();
   void performUpload();
   void ensureEpubLoaded();
+  bool refineRemoteProgressWithIncrementalIndexing(CrossPointPosition& position);
   void saveProgressAndReturn(int spineIndex, int page);
   void returnToReader();
 };

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -2,6 +2,8 @@
 
 #include <FsHelpers.h>
 #include <HalStorage.h>
+#include <I18n.h>
+#include <Memory.h>
 
 #include "CrossPointSettings.h"
 #include "Epub.h"
@@ -13,6 +15,7 @@
 #include "XtcReaderActivity.h"
 #include "activities/util/BmpViewerActivity.h"
 #include "activities/util/FullScreenMessageActivity.h"
+#include "components/UITheme.h"
 
 bool ReaderActivity::isXtcFile(const std::string& path) { return FsHelpers::hasXtcExtension(path); }
 
@@ -23,13 +26,26 @@ bool ReaderActivity::isTxtFile(const std::string& path) {
 
 bool ReaderActivity::isBmpFile(const std::string& path) { return FsHelpers::hasBmpExtension(path); }
 
-std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
+std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path, const GfxRenderer& renderer,
+                                               bool& indexingPopupShown) {
   if (!Storage.exists(path.c_str())) {
     LOG_ERR("READER", "File does not exist: %s", path.c_str());
     return nullptr;
   }
 
-  auto epub = std::unique_ptr<Epub>(new Epub(path, "/.crosspoint"));
+  auto epub = makeUniqueNoThrow<Epub>(path, "/.crosspoint");
+  if (!epub) {
+    LOG_ERR("READER", "Failed to allocate epub");
+    return nullptr;
+  }
+
+  const auto bookBinPath = epub->getCachePath() + "/book.bin";
+  const auto progressPath = epub->getCachePath() + "/progress.bin";
+  if (!Storage.exists(bookBinPath.c_str()) || !Storage.exists(progressPath.c_str())) {
+    GUI.drawPopup(renderer, tr(STR_INDEXING));
+    indexingPopupShown = true;
+  }
+
   if (epub->load(true, SETTINGS.embeddedStyle == 0)) {
     return epub;
   }
@@ -74,10 +90,11 @@ void ReaderActivity::goToLibrary(const std::string& fromBookPath) {
   activityManager.goToFileBrowser(std::move(initialPath));
 }
 
-void ReaderActivity::onGoToEpubReader(std::unique_ptr<Epub> epub) {
+void ReaderActivity::onGoToEpubReader(std::unique_ptr<Epub> epub, const bool initialIndexingPopupShown) {
   const auto epubPath = epub->getPath();
   currentBookPath = epubPath;
-  activityManager.replaceActivity(std::make_unique<EpubReaderActivity>(renderer, mappedInput, std::move(epub)));
+  activityManager.replaceActivity(
+      std::make_unique<EpubReaderActivity>(renderer, mappedInput, std::move(epub), initialIndexingPopupShown));
 }
 
 void ReaderActivity::onGoToBmpViewer(const std::string& path) {
@@ -124,12 +141,13 @@ void ReaderActivity::onEnter() {
     }
     onGoToTxtReader(std::move(txt));
   } else {
-    auto epub = loadEpub(initialBookPath);
+    bool initialIndexingPopupShown = false;
+    auto epub = loadEpub(initialBookPath, renderer, initialIndexingPopupShown);
     if (!epub) {
       onGoBack();
       return;
     }
-    onGoToEpubReader(std::move(epub));
+    onGoToEpubReader(std::move(epub), initialIndexingPopupShown);
   }
 }
 

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -11,7 +11,7 @@ class Txt;
 class ReaderActivity final : public Activity {
   std::string initialBookPath;
   std::string currentBookPath;  // Track current book path for navigation
-  static std::unique_ptr<Epub> loadEpub(const std::string& path);
+  static std::unique_ptr<Epub> loadEpub(const std::string& path, const GfxRenderer& renderer, bool& indexingPopupShown);
   static std::unique_ptr<Xtc> loadXtc(const std::string& path);
   static std::unique_ptr<Txt> loadTxt(const std::string& path);
   static bool isXtcFile(const std::string& path);
@@ -19,7 +19,7 @@ class ReaderActivity final : public Activity {
   static bool isBmpFile(const std::string& path);
 
   void goToLibrary(const std::string& fromBookPath = "");
-  void onGoToEpubReader(std::unique_ptr<Epub> epub);
+  void onGoToEpubReader(std::unique_ptr<Epub> epub, bool initialIndexingPopupShown);
   void onGoToXtcReader(std::unique_ptr<Xtc> xtc);
   void onGoToTxtReader(std::unique_ptr<Txt> txt);
   void onGoToBmpViewer(const std::string& path);

--- a/src/activities/reader/ReaderProgressPolicy.h
+++ b/src/activities/reader/ReaderProgressPolicy.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 
@@ -40,12 +41,27 @@ inline ResumeRemapDecision decideResumeRemap(const int currentSpineIndex, const 
     return decision;
   }
 
-  const float progress = static_cast<float>(currentPage) / static_cast<float>(cachedPageCount);
-  int remappedPage = static_cast<int>(progress * static_cast<float>(finalPageCount));
+  if (cachedPageCount == 1) {
+    decision.applyPage = true;
+    decision.pageNumber = 0;
+    return decision;
+  }
+
+  const int cachedLastPage = static_cast<int>(cachedPageCount - 1);
+  const int finalLastPage = static_cast<int>(finalPageCount - 1);
+  int cachedPage = currentPage;
+  if (cachedPage < 0) {
+    cachedPage = 0;
+  } else if (cachedPage > cachedLastPage) {
+    cachedPage = cachedLastPage;
+  }
+
+  const float progress = static_cast<float>(cachedPage) / static_cast<float>(cachedLastPage);
+  int remappedPage = static_cast<int>(std::lround(progress * static_cast<float>(finalLastPage)));
   if (remappedPage < 0) {
     remappedPage = 0;
-  } else if (remappedPage >= static_cast<int>(finalPageCount)) {
-    remappedPage = static_cast<int>(finalPageCount - 1);
+  } else if (remappedPage > finalLastPage) {
+    remappedPage = finalLastPage;
   }
 
   decision.applyPage = true;

--- a/src/activities/reader/ReaderProgressPolicy.h
+++ b/src/activities/reader/ReaderProgressPolicy.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace ReaderProgressPolicy {
+
+struct ResumeRemapDecision {
+  bool deferUntilComplete = false;
+  bool applyPage = false;
+  int pageNumber = 0;
+};
+
+inline constexpr uint16_t persistablePageCount(const bool sectionComplete, const uint32_t finalPageCount) {
+  if (!sectionComplete || finalPageCount == 0) {
+    return 0;
+  }
+  if (finalPageCount > std::numeric_limits<uint16_t>::max()) {
+    return std::numeric_limits<uint16_t>::max();
+  }
+  return static_cast<uint16_t>(finalPageCount);
+}
+
+inline ResumeRemapDecision decideResumeRemap(const int currentSpineIndex, const int cachedSpineIndex,
+                                             const int currentPage, const uint32_t cachedPageCount,
+                                             const bool sectionComplete, const uint32_t finalPageCount) {
+  ResumeRemapDecision decision;
+  decision.pageNumber = currentPage;
+
+  if (cachedPageCount == 0 || currentSpineIndex != cachedSpineIndex) {
+    return decision;
+  }
+
+  if (!sectionComplete) {
+    decision.deferUntilComplete = true;
+    return decision;
+  }
+
+  if (finalPageCount == 0 || finalPageCount == cachedPageCount) {
+    return decision;
+  }
+
+  const float progress = static_cast<float>(currentPage) / static_cast<float>(cachedPageCount);
+  int remappedPage = static_cast<int>(progress * static_cast<float>(finalPageCount));
+  if (remappedPage < 0) {
+    remappedPage = 0;
+  } else if (remappedPage >= static_cast<int>(finalPageCount)) {
+    remappedPage = static_cast<int>(finalPageCount - 1);
+  }
+
+  decision.applyPage = true;
+  decision.pageNumber = remappedPage;
+  return decision;
+}
+
+}  // namespace ReaderProgressPolicy

--- a/src/activities/settings/ClearCacheActivity.cpp
+++ b/src/activities/settings/ClearCacheActivity.cpp
@@ -1,7 +1,7 @@
 #include "ClearCacheActivity.h"
 
-#include <GfxRenderer.h>
 #include <FsHelpers.h>
+#include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>

--- a/src/activities/settings/ClearCacheActivity.cpp
+++ b/src/activities/settings/ClearCacheActivity.cpp
@@ -1,9 +1,13 @@
 #include "ClearCacheActivity.h"
 
 #include <GfxRenderer.h>
+#include <FsHelpers.h>
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Logging.h>
+
+#include <string>
+#include <vector>
 
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
@@ -88,30 +92,41 @@ void ClearCacheActivity::clearCache() {
   clearedCount = 0;
   failedCount = 0;
   char name[128];
+  std::vector<std::string> cachePaths;
 
   // Iterate through all entries in the directory
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
-    file.getName(name, sizeof(name));
-    String itemName(name);
+    const size_t nameLen = file.getName(name, sizeof(name));
+    const bool isDirectory = file.isDirectory();
+    file.close();
 
-    // Only delete directories starting with epub_ or xtc_
-    if (file.isDirectory() && (itemName.startsWith("epub_") || itemName.startsWith("xtc_"))) {
-      String fullPath = "/.crosspoint/" + itemName;
-      LOG_DBG("CLEAR_CACHE", "Removing cache: %s", fullPath.c_str());
+    if (nameLen == 0 || nameLen >= sizeof(name)) {
+      LOG_ERR("CLEAR_CACHE", "Skipping cache entry with invalid name length: %u", static_cast<unsigned>(nameLen));
+      continue;
+    }
 
-      file.close();  // Close before attempting to delete
+    const std::string itemName(name);
+    const bool isCacheDir = itemName.rfind("epub_", 0) == 0 || itemName.rfind("xtc_", 0) == 0;
 
-      if (Storage.removeDir(fullPath.c_str())) {
-        clearedCount++;
-      } else {
-        LOG_ERR("CLEAR_CACHE", "Failed to remove: %s", fullPath.c_str());
-        failedCount++;
-      }
-    } else {
-      file.close();
+    // Only delete directories starting with epub_ or xtc_.
+    if (isDirectory && isCacheDir) {
+      cachePaths.emplace_back("/.crosspoint/" + itemName);
     }
   }
   root.close();
+
+  // Delete after closing the parent directory iterator. Some embedded FS
+  // wrappers reject rmdir while the parent directory is still being enumerated.
+  for (const auto& fullPath : cachePaths) {
+    LOG_DBG("CLEAR_CACHE", "Removing cache: %s", fullPath.c_str());
+
+    if (FsHelpers::removeDirRecursive(fullPath.c_str())) {
+      clearedCount++;
+    } else {
+      LOG_ERR("CLEAR_CACHE", "Failed to remove: %s", fullPath.c_str());
+      failedCount++;
+    }
+  }
 
   LOG_DBG("CLEAR_CACHE", "Cache cleared: %d removed, %d failed", clearedCount, failedCount);
 

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -754,9 +754,8 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
       const int pagePercentGapWidth = renderer.getTextWidth(SMALL_FONT_ID, "  ");
       pageTextWidth = renderer.getTextWidth(SMALL_FONT_ID, pageStr);
       plusTextWidth = renderer.getTextWidth(SMALL_FONT_ID, "+");
-      progressTextWidth =
-          statusPageAndPercentTextWidth(pageTextWidth, percentTextWidth, pagePercentGapWidth, plusTextWidth,
-                                        drawFutureIndicator);
+      progressTextWidth = statusPageAndPercentTextWidth(pageTextWidth, percentTextWidth, pagePercentGapWidth,
+                                                        plusTextWidth, drawFutureIndicator);
       progressTextX =
           renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth;
       pageTextX = progressTextX;
@@ -805,8 +804,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     renderer.fillRect(orientedMarginLeft, progressBarY, barWidth, progressBarHeight, true);
   }
 
-  const bool drawCurrentIndicator =
-      !SETTINGS.statusBarChapterPageCount && shouldDrawCurrentIndexingIndicator(pageInfo);
+  const bool drawCurrentIndicator = !SETTINGS.statusBarChapterPageCount && shouldDrawCurrentIndexingIndicator(pageInfo);
   if (drawCurrentIndicator) {
     constexpr const char* indicator = "+";
     const int indicatorWidth = renderer.getTextWidth(SMALL_FONT_ID, indicator);

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -784,12 +784,12 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
   }
 
   // Draw Progress Bar
-  const bool drawProgressBar =
+  const bool shouldDrawProgressBar =
       SETTINGS.statusBarProgressBar != CrossPointSettings::STATUS_BAR_PROGRESS_BAR::HIDE_PROGRESS &&
       (SETTINGS.statusBarProgressBar != CrossPointSettings::STATUS_BAR_PROGRESS_BAR::CHAPTER_PROGRESS ||
        shouldDrawChapterProgressBar(pageInfo));
   const int progressBarHeight = (SETTINGS.statusBarProgressBarThickness + 1) * 2;
-  if (drawProgressBar) {
+  if (shouldDrawProgressBar) {
     const int progressBarMaxWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
     const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom - progressBarHeight - paddingBottom;
     size_t progress;
@@ -812,7 +812,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
       renderer.drawText(SMALL_FONT_ID, progressTextX - INDEXING_INDICATOR_AFTER_PAGE_COUNT_GAP - indicatorWidth, textY,
                         indicator);
     } else {
-      const int reservedBottomHeight = drawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
+      const int reservedBottomHeight = shouldDrawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
       const auto position = currentIndexingStandalonePlusBottomRight(
           renderer.getScreenWidth(), screenHeight, orientedMarginRight, orientedMarginBottom, paddingBottom,
           reservedBottomHeight, metrics.statusBarVerticalMargin, renderer.getTextHeight(SMALL_FONT_ID));
@@ -828,7 +828,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
                                                             textY, renderer.getTextHeight(SMALL_FONT_ID));
       drawFutureIndexingDot(renderer, position.x, position.y);
     } else {
-      const int reservedBottomHeight = drawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
+      const int reservedBottomHeight = shouldDrawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
       const auto position = futureIndexingDotBottomRight(
           renderer.getScreenWidth(), screenHeight, orientedMarginRight, orientedMarginBottom, paddingBottom,
           reservedBottomHeight, metrics.statusBarVerticalMargin, renderer.getTextHeight(SMALL_FONT_ID));

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -767,8 +767,10 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     } else if (SETTINGS.statusBarBookProgressPercentage) {
       snprintf(progressStr, sizeof(progressStr), "%s", percentStr);
       progressTextWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);
-      progressTextX =
-          renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth;
+      const int futureIndicatorReservation =
+          drawFutureIndicator ? futureIndexingPageCountRightReservation(FUTURE_INDEXING_DOT_SIZE) : 0;
+      progressTextX = renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight -
+                      progressTextWidth - futureIndicatorReservation;
       renderer.drawText(SMALL_FONT_ID, progressTextX, textY, progressStr);
     } else {
       snprintf(progressStr, sizeof(progressStr), "%s", pageStr);

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string>
+#include <utility>
 
 #include "I18n.h"
 #include "RecentBooksStore.h"
@@ -19,6 +20,18 @@ namespace {
 constexpr int homeMenuMargin = 20;
 constexpr int homeMarginTop = 30;
 constexpr int subtitleY = 738;
+
+void drawCurrentIndexingStandalonePlus(const GfxRenderer& renderer, const int x, const int y) {
+  constexpr int strokeOffset = (CURRENT_INDEXING_STANDALONE_PLUS_SIZE - CURRENT_INDEXING_STANDALONE_PLUS_STROKE) / 2;
+  renderer.fillRect(x, y + strokeOffset, CURRENT_INDEXING_STANDALONE_PLUS_SIZE,
+                    CURRENT_INDEXING_STANDALONE_PLUS_STROKE);
+  renderer.fillRect(x + strokeOffset, y, CURRENT_INDEXING_STANDALONE_PLUS_STROKE,
+                    CURRENT_INDEXING_STANDALONE_PLUS_SIZE);
+}
+
+void drawFutureIndexingDot(const GfxRenderer& renderer, const int x, const int y) {
+  renderer.fillRect(x, y, FUTURE_INDEXING_DOT_SIZE, FUTURE_INDEXING_DOT_SIZE);
+}
 
 }  // namespace
 
@@ -702,6 +715,16 @@ void BaseTheme::fillPopupProgress(const GfxRenderer& renderer, const Rect& layou
 void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                               const int pageCount, std::string title, const int paddingBottom,
                               const int textYOffset) const {
+  StatusPageInfo pageInfo;
+  pageInfo.currentPage = currentPage > 0 ? static_cast<uint32_t>(currentPage - 1) : 0;
+  pageInfo.totalPages = pageCount > 0 ? static_cast<uint32_t>(pageCount) : 0;
+  pageInfo.totalKnown = true;
+  pageInfo.hasMorePages = false;
+  drawStatusBar(renderer, bookProgress, pageInfo, std::move(title), paddingBottom, textYOffset);
+}
+
+void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, const StatusPageInfo pageInfo,
+                              std::string title, const int paddingBottom, const int textYOffset) const {
   auto metrics = UITheme::getInstance().getMetrics();
   int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
   renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
@@ -711,41 +734,108 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
   const auto screenHeight = renderer.getScreenHeight();
   auto textY = screenHeight - UITheme::getInstance().getStatusBarHeight() - orientedMarginBottom - paddingBottom - 4;
   int progressTextWidth = 0;
+  int progressTextX = 0;
+  int pageTextWidth = 0;
+  int pageTextX = 0;
+  int plusTextWidth = 0;
+
+  const bool drawFutureIndicator = shouldDrawFutureIndexingIndicator(pageInfo);
 
   if (SETTINGS.statusBarBookProgressPercentage || SETTINGS.statusBarChapterPageCount) {
     // Right aligned text for progress counter
     char progressStr[32];
+    char pageStr[16];
+    char percentStr[16];
+    formatStatusPageText(pageStr, sizeof(pageStr), pageInfo);
+    snprintf(percentStr, sizeof(percentStr), "%.0f%%", bookProgress);
 
     if (SETTINGS.statusBarBookProgressPercentage && SETTINGS.statusBarChapterPageCount) {
-      snprintf(progressStr, sizeof(progressStr), "%d/%d  %.0f%%", currentPage, pageCount, bookProgress);
+      const int percentTextWidth = renderer.getTextWidth(SMALL_FONT_ID, percentStr);
+      const int pagePercentGapWidth = renderer.getTextWidth(SMALL_FONT_ID, "  ");
+      pageTextWidth = renderer.getTextWidth(SMALL_FONT_ID, pageStr);
+      plusTextWidth = renderer.getTextWidth(SMALL_FONT_ID, "+");
+      progressTextWidth =
+          statusPageAndPercentTextWidth(pageTextWidth, percentTextWidth, pagePercentGapWidth, plusTextWidth,
+                                        drawFutureIndicator);
+      progressTextX =
+          renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth;
+      pageTextX = progressTextX;
+      renderer.drawText(SMALL_FONT_ID, pageTextX, textY, pageStr);
+      const int percentTextX = progressTextX + pageTextWidth +
+                               (drawFutureIndicator ? futureIndexingPageCountRightReservation(plusTextWidth) : 0) +
+                               pagePercentGapWidth;
+      renderer.drawText(SMALL_FONT_ID, percentTextX, textY, percentStr);
     } else if (SETTINGS.statusBarBookProgressPercentage) {
-      snprintf(progressStr, sizeof(progressStr), "%.0f%%", bookProgress);
+      snprintf(progressStr, sizeof(progressStr), "%s", percentStr);
+      progressTextWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);
+      progressTextX =
+          renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth;
+      renderer.drawText(SMALL_FONT_ID, progressTextX, textY, progressStr);
     } else {
-      snprintf(progressStr, sizeof(progressStr), "%d/%d", currentPage, pageCount);
+      snprintf(progressStr, sizeof(progressStr), "%s", pageStr);
+      pageTextWidth = renderer.getTextWidth(SMALL_FONT_ID, pageStr);
+      plusTextWidth = renderer.getTextWidth(SMALL_FONT_ID, "+");
+      progressTextWidth =
+          pageTextWidth + (drawFutureIndicator ? futureIndexingPageCountRightReservation(plusTextWidth) : 0);
+      progressTextX =
+          renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth;
+      pageTextX = progressTextX;
+      renderer.drawText(SMALL_FONT_ID, pageTextX, textY, progressStr);
     }
-
-    progressTextWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);
-    renderer.drawText(
-        SMALL_FONT_ID,
-        renderer.getScreenWidth() - metrics.statusBarHorizontalMargin - orientedMarginRight - progressTextWidth, textY,
-        progressStr);
   }
 
   // Draw Progress Bar
-  if (SETTINGS.statusBarProgressBar != CrossPointSettings::STATUS_BAR_PROGRESS_BAR::HIDE_PROGRESS) {
+  const bool drawProgressBar =
+      SETTINGS.statusBarProgressBar != CrossPointSettings::STATUS_BAR_PROGRESS_BAR::HIDE_PROGRESS &&
+      (SETTINGS.statusBarProgressBar != CrossPointSettings::STATUS_BAR_PROGRESS_BAR::CHAPTER_PROGRESS ||
+       shouldDrawChapterProgressBar(pageInfo));
+  const int progressBarHeight = (SETTINGS.statusBarProgressBarThickness + 1) * 2;
+  if (drawProgressBar) {
     const int progressBarMaxWidth = renderer.getScreenWidth() - orientedMarginLeft - orientedMarginRight;
-    const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom -
-                             ((SETTINGS.statusBarProgressBarThickness + 1) * 2) - paddingBottom;
+    const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom - progressBarHeight - paddingBottom;
     size_t progress;
     if (SETTINGS.statusBarProgressBar == CrossPointSettings::STATUS_BAR_PROGRESS_BAR::BOOK_PROGRESS) {
       progress = static_cast<size_t>(bookProgress);
     } else {
       // Chapter progress
-      progress = (pageCount > 0) ? (static_cast<float>(currentPage) / pageCount) * 100 : 0;
+      const uint32_t currentPage = pageInfo.currentPage + 1;
+      progress = (pageInfo.totalPages > 0) ? (static_cast<float>(currentPage) / pageInfo.totalPages) * 100 : 0;
     }
     const int barWidth = progressBarMaxWidth * progress / 100;
-    renderer.fillRect(orientedMarginLeft, progressBarY, barWidth, ((SETTINGS.statusBarProgressBarThickness + 1) * 2),
-                      true);
+    renderer.fillRect(orientedMarginLeft, progressBarY, barWidth, progressBarHeight, true);
+  }
+
+  const bool drawCurrentIndicator =
+      !SETTINGS.statusBarChapterPageCount && shouldDrawCurrentIndexingIndicator(pageInfo);
+  if (drawCurrentIndicator) {
+    constexpr const char* indicator = "+";
+    const int indicatorWidth = renderer.getTextWidth(SMALL_FONT_ID, indicator);
+    if (progressTextWidth > 0) {
+      renderer.drawText(SMALL_FONT_ID, progressTextX - INDEXING_INDICATOR_AFTER_PAGE_COUNT_GAP - indicatorWidth, textY,
+                        indicator);
+    } else {
+      const int reservedBottomHeight = drawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
+      const auto position = currentIndexingStandalonePlusBottomRight(
+          renderer.getScreenWidth(), screenHeight, orientedMarginRight, orientedMarginBottom, paddingBottom,
+          reservedBottomHeight, metrics.statusBarVerticalMargin, renderer.getTextHeight(SMALL_FONT_ID));
+      drawCurrentIndexingStandalonePlus(renderer, position.x, position.y);
+    }
+  } else if (drawFutureIndicator) {
+    if (SETTINGS.statusBarChapterPageCount && pageTextWidth > 0) {
+      const auto position = futureIndexingDotAfterPageCount(pageTextX, pageTextWidth, plusTextWidth, textY,
+                                                            renderer.getTextHeight(SMALL_FONT_ID));
+      drawFutureIndexingDot(renderer, position.x, position.y);
+    } else if (progressTextWidth > 0) {
+      const auto position = futureIndexingDotAfterPageCount(progressTextX, progressTextWidth, FUTURE_INDEXING_DOT_SIZE,
+                                                            textY, renderer.getTextHeight(SMALL_FONT_ID));
+      drawFutureIndexingDot(renderer, position.x, position.y);
+    } else {
+      const int reservedBottomHeight = drawProgressBar ? progressBarHeight + INDEXING_INDICATOR_GAP : 0;
+      const auto position = futureIndexingDotBottomRight(
+          renderer.getScreenWidth(), screenHeight, orientedMarginRight, orientedMarginBottom, paddingBottom,
+          reservedBottomHeight, metrics.statusBarVerticalMargin, renderer.getTextHeight(SMALL_FONT_ID));
+      drawFutureIndexingDot(renderer, position.x, position.y);
+    }
   }
 
   // Draw Battery

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "components/themes/StatusPageInfo.h"
+
 class GfxRenderer;
 struct RecentBook;
 
@@ -156,6 +158,8 @@ class BaseTheme {
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
   void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage, const int pageCount,
                      std::string title, const int paddingBottom = 0, const int textYOffset = 0) const;
+  void drawStatusBar(GfxRenderer& renderer, float bookProgress, StatusPageInfo pageInfo, std::string title,
+                     int paddingBottom = 0, int textYOffset = 0) const;
   void drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label) const;
   virtual void drawTextField(const GfxRenderer& renderer, Rect rect, const int textWidth, bool cursorMode = false,
                              int contentStartX = 0, int contentWidth = 0) const;

--- a/src/components/themes/StatusPageInfo.h
+++ b/src/components/themes/StatusPageInfo.h
@@ -91,13 +91,18 @@ inline void formatStatusPageText(char* buffer, const size_t bufferSize, const St
     return;
   }
 
+  if (pageInfo.totalPages == 0) {
+    std::snprintf(buffer, bufferSize, "0/0");
+    return;
+  }
+
   const auto displayPage = static_cast<unsigned long>(pageInfo.currentPage + 1);
   if (pageInfo.totalKnown) {
     std::snprintf(buffer, bufferSize, "%lu/%lu", displayPage, static_cast<unsigned long>(pageInfo.totalPages));
     return;
   }
 
-  if (pageInfo.hasMorePages && pageInfo.totalPages > 0) {
+  if (pageInfo.hasMorePages) {
     std::snprintf(buffer, bufferSize, "%lu/%lu+", displayPage, static_cast<unsigned long>(pageInfo.totalPages));
     return;
   }

--- a/src/components/themes/StatusPageInfo.h
+++ b/src/components/themes/StatusPageInfo.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+struct StatusPageInfo {
+  uint32_t currentPage = 0;
+  uint32_t totalPages = 0;
+  bool totalKnown = true;
+  bool hasMorePages = false;
+  bool futureIndexingActive = false;
+};
+
+struct IndexingIndicatorPosition {
+  int x = 0;
+  int y = 0;
+};
+
+using FutureIndexingDotPosition = IndexingIndicatorPosition;
+
+inline constexpr int INDEXING_INDICATOR_GAP = 4;
+inline constexpr int INDEXING_INDICATOR_AFTER_PAGE_COUNT_GAP = 5;
+inline constexpr int INDEXING_INDICATOR_STANDALONE_RIGHT_INSET = 10;
+inline constexpr int INDEXING_INDICATOR_STANDALONE_TEXT_BOTTOM_GAP = 4;
+inline constexpr int CURRENT_INDEXING_STANDALONE_PLUS_SIZE = 9;
+inline constexpr int CURRENT_INDEXING_STANDALONE_PLUS_STROKE = 2;
+inline constexpr int FUTURE_INDEXING_DOT_SIZE = 3;
+inline constexpr int FUTURE_INDEXING_DOT_TEXT_Y_NUDGE = 2;
+
+inline constexpr bool shouldDrawChapterProgressBar(const StatusPageInfo& pageInfo) {
+  return pageInfo.totalKnown && pageInfo.totalPages > 0;
+}
+
+inline constexpr bool shouldDrawCurrentIndexingIndicator(const StatusPageInfo& pageInfo) {
+  return !pageInfo.totalKnown && pageInfo.hasMorePages && pageInfo.totalPages > 0;
+}
+
+inline constexpr bool shouldDrawFutureIndexingIndicator(const StatusPageInfo& pageInfo) {
+  return pageInfo.futureIndexingActive;
+}
+
+inline constexpr int indexingIndicatorCenteredOffset(const int outerSize, const int innerSize) {
+  return outerSize > innerSize ? (outerSize - innerSize) / 2 : 0;
+}
+
+inline constexpr IndexingIndicatorPosition currentIndexingStandalonePlusBottomRight(
+    const int screenWidth, const int screenHeight, const int orientedMarginRight, const int orientedMarginBottom,
+    const int paddingBottom, const int reservedBottomHeight, const int statusBarVerticalMargin, const int textHeight) {
+  return IndexingIndicatorPosition{
+      screenWidth - orientedMarginRight - INDEXING_INDICATOR_STANDALONE_RIGHT_INSET -
+          CURRENT_INDEXING_STANDALONE_PLUS_SIZE,
+      screenHeight - orientedMarginBottom - paddingBottom - reservedBottomHeight - statusBarVerticalMargin -
+          INDEXING_INDICATOR_STANDALONE_TEXT_BOTTOM_GAP +
+          indexingIndicatorCenteredOffset(textHeight, CURRENT_INDEXING_STANDALONE_PLUS_SIZE)};
+}
+
+inline constexpr int futureIndexingPageCountRightReservation(const int plusTextWidth) {
+  return INDEXING_INDICATOR_AFTER_PAGE_COUNT_GAP +
+         (plusTextWidth > FUTURE_INDEXING_DOT_SIZE ? plusTextWidth : FUTURE_INDEXING_DOT_SIZE);
+}
+
+inline constexpr int statusPageAndPercentTextWidth(const int pageTextWidth, const int percentTextWidth,
+                                                   const int pagePercentGapWidth, const int plusTextWidth,
+                                                   const bool futureIndexingActive) {
+  return pageTextWidth + (futureIndexingActive ? futureIndexingPageCountRightReservation(plusTextWidth) : 0) +
+         pagePercentGapWidth + percentTextWidth;
+}
+
+inline constexpr FutureIndexingDotPosition futureIndexingDotAfterPageCount(const int pageTextX, const int pageTextWidth,
+                                                                           const int plusTextWidth, const int textY,
+                                                                           const int textHeight) {
+  (void)plusTextWidth;
+  return FutureIndexingDotPosition{
+      pageTextX + pageTextWidth + INDEXING_INDICATOR_AFTER_PAGE_COUNT_GAP,
+      textY + indexingIndicatorCenteredOffset(textHeight, FUTURE_INDEXING_DOT_SIZE) + FUTURE_INDEXING_DOT_TEXT_Y_NUDGE};
+}
+
+inline constexpr FutureIndexingDotPosition futureIndexingDotBottomRight(
+    const int screenWidth, const int screenHeight, const int orientedMarginRight, const int orientedMarginBottom,
+    const int paddingBottom, const int reservedBottomHeight, const int statusBarVerticalMargin, const int textHeight) {
+  return FutureIndexingDotPosition{
+      screenWidth - orientedMarginRight - INDEXING_INDICATOR_STANDALONE_RIGHT_INSET - FUTURE_INDEXING_DOT_SIZE,
+      screenHeight - orientedMarginBottom - paddingBottom - reservedBottomHeight - statusBarVerticalMargin -
+          INDEXING_INDICATOR_STANDALONE_TEXT_BOTTOM_GAP +
+          indexingIndicatorCenteredOffset(textHeight, FUTURE_INDEXING_DOT_SIZE) + FUTURE_INDEXING_DOT_TEXT_Y_NUDGE};
+}
+
+inline void formatStatusPageText(char* buffer, const size_t bufferSize, const StatusPageInfo& pageInfo) {
+  if (buffer == nullptr || bufferSize == 0) {
+    return;
+  }
+
+  const auto displayPage = static_cast<unsigned long>(pageInfo.currentPage + 1);
+  if (pageInfo.totalKnown) {
+    std::snprintf(buffer, bufferSize, "%lu/%lu", displayPage, static_cast<unsigned long>(pageInfo.totalPages));
+    return;
+  }
+
+  if (pageInfo.hasMorePages && pageInfo.totalPages > 0) {
+    std::snprintf(buffer, bufferSize, "%lu/%lu+", displayPage, static_cast<unsigned long>(pageInfo.totalPages));
+    return;
+  }
+
+  std::snprintf(buffer, bufferSize, "%lu/?", displayPage);
+}

--- a/test/incremental_section/CleanScopeContractTest.sh
+++ b/test/incremental_section/CleanScopeContractTest.sh
@@ -6,9 +6,34 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 forbidden_changed_paths='^(lib/WorkInterrupt/|lib/GfxRenderer/|src/LoopPowerSavingPolicy\.h|src/MappedInputManager\.h|src/main\.cpp|src/activities/reader/TxtReaderActivity\.|lib/hal/HalGPIO\.)'
 allowed_sdk_path='libs/display/EInkDisplay/src/EInkDisplay.cpp'
 
-changed_paths="$(git -C "$ROOT_DIR" diff --name-only -- . \
+resolve_base_ref() {
+  if [[ -n "${INCREMENTAL_SECTION_BASE_REF:-}" ]]; then
+    printf '%s\n' "$INCREMENTAL_SECTION_BASE_REF"
+    return
+  fi
+  if git -C "$ROOT_DIR" rev-parse --verify --quiet origin/master >/dev/null; then
+    printf '%s\n' "origin/master"
+    return
+  fi
+  if git -C "$ROOT_DIR" rev-parse --verify --quiet master >/dev/null; then
+    printf '%s\n' "master"
+    return
+  fi
+  echo "Could not resolve base ref; set INCREMENTAL_SECTION_BASE_REF" >&2
+  exit 1
+}
+
+BASE_REF="$(resolve_base_ref)"
+BASE_COMMIT="$(git -C "$ROOT_DIR" merge-base "$BASE_REF" HEAD)"
+
+committed_changed_paths="$(git -C "$ROOT_DIR" diff --name-only "$BASE_COMMIT"..HEAD -- . \
   ':!test/incremental_section/CleanScopeContractTest.sh' \
   ':!open-x4-sdk')"
+working_changed_paths="$(git -C "$ROOT_DIR" diff --name-only -- . \
+  ':!test/incremental_section/CleanScopeContractTest.sh' \
+  ':!open-x4-sdk')"
+
+changed_paths="$(printf '%s\n%s\n' "$committed_changed_paths" "$working_changed_paths" | sed '/^$/d' | sort -u)"
 
 if printf '%s\n' "$changed_paths" | rg -q "$forbidden_changed_paths"; then
   echo "Incremental EPUB reimplementation touched forbidden debugging, power, input, TXT, graphics, HAL GPIO, or SDK scope" >&2
@@ -16,16 +41,55 @@ if printf '%s\n' "$changed_paths" | rg -q "$forbidden_changed_paths"; then
   exit 1
 fi
 
-if git -C "$ROOT_DIR" diff --name-only -- open-x4-sdk | rg -q '^open-x4-sdk$'; then
-  sdk_changed_paths="$(git -c safe.directory="$ROOT_DIR/open-x4-sdk" -C "$ROOT_DIR/open-x4-sdk" diff --name-only)"
+submodule_commit_at() {
+  git -C "$ROOT_DIR" ls-tree "$1" open-x4-sdk | awk '{print $3}'
+}
+
+ensure_sdk_commit_available() {
+  local commit="$1"
+  if [[ -z "$commit" ]] || ! git -C "$ROOT_DIR/open-x4-sdk" cat-file -e "$commit^{commit}" 2>/dev/null; then
+    echo "Cannot inspect open-x4-sdk diff for commit: ${commit:-missing}" >&2
+    exit 1
+  fi
+}
+
+inspect_sdk_range() {
+  local old_commit="$1"
+  local new_commit="$2"
+  if [[ "$old_commit" == "$new_commit" ]]; then
+    return
+  fi
+  ensure_sdk_commit_available "$old_commit"
+  ensure_sdk_commit_available "$new_commit"
+
+  local sdk_changed_paths
+  sdk_changed_paths="$(git -C "$ROOT_DIR/open-x4-sdk" diff --name-only "$old_commit" "$new_commit")"
   if [[ -n "$sdk_changed_paths" ]] && printf '%s\n' "$sdk_changed_paths" | rg -vq "^$allowed_sdk_path$"; then
     echo "Only the EInkDisplay AA cleanup is allowed under open-x4-sdk for this feature" >&2
     printf '%s\n' "$sdk_changed_paths" >&2
     exit 1
   fi
+}
+
+base_sdk_commit="$(submodule_commit_at "$BASE_COMMIT")"
+head_sdk_commit="$(submodule_commit_at HEAD)"
+inspect_sdk_range "$base_sdk_commit" "$head_sdk_commit"
+
+if git -C "$ROOT_DIR" diff --name-only -- open-x4-sdk | rg -q '^open-x4-sdk$'; then
+  worktree_sdk_commit="$(git -C "$ROOT_DIR/open-x4-sdk" rev-parse HEAD)"
+  inspect_sdk_range "$head_sdk_commit" "$worktree_sdk_commit"
 fi
 
-if git -C "$ROOT_DIR" diff -- . ':!test/incremental_section/CleanScopeContractTest.sh' | rg -q 'WorkInterrupt|pollAndQueueEvents|LoopPowerSavingPolicy|ReaderWorkActivity|PageTurnDeferral|InputManagerQueuedEvents'; then
+sdk_dirty_paths="$(git -C "$ROOT_DIR/open-x4-sdk" diff --name-only)"
+if [[ -n "$sdk_dirty_paths" ]] && printf '%s\n' "$sdk_dirty_paths" | rg -vq "^$allowed_sdk_path$"; then
+  echo "Only the EInkDisplay AA cleanup is allowed under open-x4-sdk for this feature" >&2
+  printf '%s\n' "$sdk_dirty_paths" >&2
+  exit 1
+fi
+
+combined_diff="$(git -C "$ROOT_DIR" diff "$BASE_COMMIT"..HEAD -- . ':!test/incremental_section/CleanScopeContractTest.sh' ':!open-x4-sdk'
+git -C "$ROOT_DIR" diff -- . ':!test/incremental_section/CleanScopeContractTest.sh' ':!open-x4-sdk')"
+if printf '%s\n' "$combined_diff" | rg -q 'WorkInterrupt|pollAndQueueEvents|LoopPowerSavingPolicy|ReaderWorkActivity|PageTurnDeferral|InputManagerQueuedEvents'; then
   echo "Incremental EPUB reimplementation reintroduced previous input/power/debug scaffolding" >&2
   exit 1
 fi

--- a/test/incremental_section/CleanScopeContractTest.sh
+++ b/test/incremental_section/CleanScopeContractTest.sh
@@ -94,7 +94,12 @@ if printf '%s\n' "$combined_diff" | rg -q 'WorkInterrupt|pollAndQueueEvents|Loop
   exit 1
 fi
 
-if ! rg -q 'LOG_LEVEL=0' "$ROOT_DIR/platformio.ini"; then
+gh_release_block="$(awk '
+  /^\[env:gh_release\]$/ { in_block = 1; next }
+  /^\[env:/ { if (in_block) exit }
+  in_block { print }
+' "$ROOT_DIR/platformio.ini")"
+if ! printf '%s\n' "$gh_release_block" | rg -q 'LOG_LEVEL=0'; then
   echo "gh_release must build with LOG_LEVEL=0 for performance verification" >&2
   exit 1
 fi

--- a/test/incremental_section/CleanScopeContractTest.sh
+++ b/test/incremental_section/CleanScopeContractTest.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+forbidden_changed_paths='^(lib/WorkInterrupt/|lib/GfxRenderer/|src/LoopPowerSavingPolicy\.h|src/MappedInputManager\.h|src/main\.cpp|src/activities/reader/TxtReaderActivity\.|lib/hal/HalGPIO\.)'
+allowed_sdk_path='libs/display/EInkDisplay/src/EInkDisplay.cpp'
+
+changed_paths="$(git -C "$ROOT_DIR" diff --name-only -- . \
+  ':!test/incremental_section/CleanScopeContractTest.sh' \
+  ':!open-x4-sdk')"
+
+if printf '%s\n' "$changed_paths" | rg -q "$forbidden_changed_paths"; then
+  echo "Incremental EPUB reimplementation touched forbidden debugging, power, input, TXT, graphics, HAL GPIO, or SDK scope" >&2
+  printf '%s\n' "$changed_paths" | rg "$forbidden_changed_paths" >&2
+  exit 1
+fi
+
+if git -C "$ROOT_DIR" diff --name-only -- open-x4-sdk | rg -q '^open-x4-sdk$'; then
+  sdk_changed_paths="$(git -c safe.directory="$ROOT_DIR/open-x4-sdk" -C "$ROOT_DIR/open-x4-sdk" diff --name-only)"
+  if [[ -n "$sdk_changed_paths" ]] && printf '%s\n' "$sdk_changed_paths" | rg -vq "^$allowed_sdk_path$"; then
+    echo "Only the EInkDisplay AA cleanup is allowed under open-x4-sdk for this feature" >&2
+    printf '%s\n' "$sdk_changed_paths" >&2
+    exit 1
+  fi
+fi
+
+if git -C "$ROOT_DIR" diff -- . ':!test/incremental_section/CleanScopeContractTest.sh' | rg -q 'WorkInterrupt|pollAndQueueEvents|LoopPowerSavingPolicy|ReaderWorkActivity|PageTurnDeferral|InputManagerQueuedEvents'; then
+  echo "Incremental EPUB reimplementation reintroduced previous input/power/debug scaffolding" >&2
+  exit 1
+fi
+
+if ! rg -q 'LOG_LEVEL=0' "$ROOT_DIR/platformio.ini"; then
+  echo "gh_release must build with LOG_LEVEL=0 for performance verification" >&2
+  exit 1
+fi

--- a/test/incremental_section/EpubIndexingPolicyTest.cpp
+++ b/test/incremental_section/EpubIndexingPolicyTest.cpp
@@ -1,7 +1,7 @@
+#include <cassert>
+
 #include "../../lib/Epub/Epub/EpubIndexingPolicy.h"
 #include "../../lib/Epub/Epub/IncrementalBuildBudget.h"
-
-#include <cassert>
 
 static_assert(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES == 1);
 static_assert(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES == 1);

--- a/test/incremental_section/EpubIndexingPolicyTest.cpp
+++ b/test/incremental_section/EpubIndexingPolicyTest.cpp
@@ -3,11 +3,11 @@
 
 #include <cassert>
 
-static_assert(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES == 10);
-static_assert(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES == 3);
-static_assert(EpubIndexingPolicy::INITIAL_INDEX_TARGET_PAGES == 3);
-static_assert(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES == 5);
-static_assert(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES == 3);
+static_assert(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES == 1);
+static_assert(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES == 1);
+static_assert(EpubIndexingPolicy::INITIAL_INDEX_TARGET_PAGES == 1);
+static_assert(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES == 1);
+static_assert(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES == 1);
 static_assert(EpubIndexingPolicy::INDEX_BATCH_MIN_PAGES == 1);
 static_assert(EpubIndexingPolicy::INDEX_BATCH_MAX_PAGES == 10);
 static_assert(EpubIndexingPolicy::CURRENT_INDEX_MIN_INTERVAL_MS == 1000);
@@ -17,22 +17,21 @@ static_assert(EpubIndexingPolicy::clampIndexBatchPages(0) == 1);
 static_assert(EpubIndexingPolicy::clampIndexBatchPages(6) == 6);
 static_assert(EpubIndexingPolicy::clampIndexBatchPages(11) == 10);
 
-static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 10);
-static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 3);
-static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 5);
-static_assert(EpubIndexingPolicy::nextPrewarmInputChunks(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES) == 9);
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 1);
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 1);
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 1);
+static_assert(EpubIndexingPolicy::nextPrewarmInputChunks(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES) == 3);
 
-static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 500);
-static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 150);
-static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 250);
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 50);
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 50);
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 50);
 
 static_assert(EpubIndexingPolicy::initialIndexWindowNeedsPages(0, false));
-static_assert(EpubIndexingPolicy::initialIndexWindowNeedsPages(2, false));
-static_assert(!EpubIndexingPolicy::initialIndexWindowNeedsPages(3, false));
+static_assert(!EpubIndexingPolicy::initialIndexWindowNeedsPages(1, false));
 static_assert(!EpubIndexingPolicy::initialIndexWindowNeedsPages(0, true));
-static_assert(EpubIndexingPolicy::outrunTargetKnownPages(22) == 27);
-static_assert(EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 26, false));
-static_assert(!EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 27, false));
+static_assert(EpubIndexingPolicy::outrunTargetKnownPages(22) == 23);
+static_assert(EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 22, false));
+static_assert(!EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 23, false));
 static_assert(!EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 23, true));
 
 static_assert(EpubIndexingPolicy::shouldPrewarmNextChapter(0, 10, true));
@@ -47,16 +46,18 @@ constexpr auto currentBudget = IncrementalBuildBudgets::forProfile(IncrementalBu
 constexpr auto prewarmBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::NextPrewarm);
 constexpr auto outrunBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::Outrun);
 
-static_assert(initialBudget.maxInputChunks == 3);
-static_assert(initialBudget.maxCompletedPages == 3);
-static_assert(initialBudget.maxMillis == 150);
-static_assert(currentBudget.maxInputChunks == 10);
-static_assert(currentBudget.maxCompletedPages == 10);
-static_assert(currentBudget.maxMillis == 500);
-static_assert(prewarmBudget.maxInputChunks == 9);
-static_assert(prewarmBudget.maxCompletedPages == 3);
-static_assert(outrunBudget.maxInputChunks == 5);
-static_assert(outrunBudget.maxCompletedPages == 5);
+static_assert(initialBudget.maxInputChunks == 1);
+static_assert(initialBudget.maxCompletedPages == 1);
+static_assert(initialBudget.maxMillis == 50);
+static_assert(currentBudget.maxInputChunks == 1);
+static_assert(currentBudget.maxCompletedPages == 1);
+static_assert(currentBudget.maxMillis == 50);
+static_assert(prewarmBudget.maxInputChunks == 3);
+static_assert(prewarmBudget.maxCompletedPages == 1);
+static_assert(prewarmBudget.maxMillis == 50);
+static_assert(outrunBudget.maxInputChunks == 1);
+static_assert(outrunBudget.maxCompletedPages == 1);
+static_assert(outrunBudget.maxMillis == 50);
 
 int main() {
   assert(EpubIndexingPolicy::hasHeapForForegroundIncrementalPump(

--- a/test/incremental_section/EpubIndexingPolicyTest.cpp
+++ b/test/incremental_section/EpubIndexingPolicyTest.cpp
@@ -1,0 +1,69 @@
+#include "../../lib/Epub/Epub/EpubIndexingPolicy.h"
+#include "../../lib/Epub/Epub/IncrementalBuildBudget.h"
+
+#include <cassert>
+
+static_assert(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES == 10);
+static_assert(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES == 3);
+static_assert(EpubIndexingPolicy::INITIAL_INDEX_TARGET_PAGES == 3);
+static_assert(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES == 5);
+static_assert(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES == 3);
+static_assert(EpubIndexingPolicy::INDEX_BATCH_MIN_PAGES == 1);
+static_assert(EpubIndexingPolicy::INDEX_BATCH_MAX_PAGES == 10);
+static_assert(EpubIndexingPolicy::CURRENT_INDEX_MIN_INTERVAL_MS == 1000);
+static_assert(EpubIndexingPolicy::NEXT_PREWARM_MIN_INTERVAL_MS == 1500);
+
+static_assert(EpubIndexingPolicy::clampIndexBatchPages(0) == 1);
+static_assert(EpubIndexingPolicy::clampIndexBatchPages(6) == 6);
+static_assert(EpubIndexingPolicy::clampIndexBatchPages(11) == 10);
+
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 10);
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 3);
+static_assert(EpubIndexingPolicy::indexBatchInputChunks(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 5);
+static_assert(EpubIndexingPolicy::nextPrewarmInputChunks(EpubIndexingPolicy::NEXT_PREWARM_BATCH_PAGES) == 9);
+
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::CURRENT_INDEX_BATCH_PAGES) == 500);
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::INITIAL_INDEX_BATCH_PAGES) == 150);
+static_assert(EpubIndexingPolicy::indexBatchMaxMillis(EpubIndexingPolicy::OUTRUN_INDEX_BATCH_PAGES) == 250);
+
+static_assert(EpubIndexingPolicy::initialIndexWindowNeedsPages(0, false));
+static_assert(EpubIndexingPolicy::initialIndexWindowNeedsPages(2, false));
+static_assert(!EpubIndexingPolicy::initialIndexWindowNeedsPages(3, false));
+static_assert(!EpubIndexingPolicy::initialIndexWindowNeedsPages(0, true));
+static_assert(EpubIndexingPolicy::outrunTargetKnownPages(22) == 27);
+static_assert(EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 26, false));
+static_assert(!EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 27, false));
+static_assert(!EpubIndexingPolicy::outrunIndexWindowNeedsPages(22, 23, true));
+
+static_assert(EpubIndexingPolicy::shouldPrewarmNextChapter(0, 10, true));
+static_assert(EpubIndexingPolicy::shouldPrewarmNextChapter(8, 10, true));
+static_assert(!EpubIndexingPolicy::shouldPrewarmNextChapter(8, 10, false));
+static_assert(!EpubIndexingPolicy::shouldPrewarmNextChapter(0, 0, true));
+static_assert(EpubIndexingPolicy::prewarmMatchesSpine(2, 2));
+static_assert(!EpubIndexingPolicy::prewarmMatchesSpine(1, 2));
+
+constexpr auto initialBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::InitialIndex);
+constexpr auto currentBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::CurrentBackground);
+constexpr auto prewarmBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::NextPrewarm);
+constexpr auto outrunBudget = IncrementalBuildBudgets::forProfile(IncrementalBuildBudgetProfile::Outrun);
+
+static_assert(initialBudget.maxInputChunks == 3);
+static_assert(initialBudget.maxCompletedPages == 3);
+static_assert(initialBudget.maxMillis == 150);
+static_assert(currentBudget.maxInputChunks == 10);
+static_assert(currentBudget.maxCompletedPages == 10);
+static_assert(currentBudget.maxMillis == 500);
+static_assert(prewarmBudget.maxInputChunks == 9);
+static_assert(prewarmBudget.maxCompletedPages == 3);
+static_assert(outrunBudget.maxInputChunks == 5);
+static_assert(outrunBudget.maxCompletedPages == 5);
+
+int main() {
+  assert(EpubIndexingPolicy::hasHeapForForegroundIncrementalPump(
+      EpubIndexingPolicy::FOREGROUND_INCREMENTAL_MIN_FREE_HEAP));
+  assert(!EpubIndexingPolicy::hasHeapForForegroundIncrementalPump(
+      EpubIndexingPolicy::FOREGROUND_INCREMENTAL_MIN_FREE_HEAP - 1));
+  assert(EpubIndexingPolicy::hasHeapForActiveIncrementalPump(EpubIndexingPolicy::ACTIVE_INCREMENTAL_MIN_FREE_HEAP));
+  assert(!EpubIndexingPolicy::hasHeapForEmbeddedStyle(EpubIndexingPolicy::EMBEDDED_STYLE_MIN_FREE_HEAP - 1));
+  assert(EpubIndexingPolicy::hasHeapForEmbeddedStyle(EpubIndexingPolicy::EMBEDDED_STYLE_MIN_FREE_HEAP));
+}

--- a/test/incremental_section/IncrementalSectionTypesTest.cpp
+++ b/test/incremental_section/IncrementalSectionTypesTest.cpp
@@ -1,7 +1,7 @@
-#include "../../lib/Epub/Epub/IncrementalSectionTypes.h"
-#include "../../lib/Epub/Epub/IncrementalSectionCache.h"
-
 #include <cassert>
+
+#include "../../lib/Epub/Epub/IncrementalSectionCache.h"
+#include "../../lib/Epub/Epub/IncrementalSectionTypes.h"
 
 int main() {
   assert(IncrementalSection::CACHE_MAGIC == 0x43504953U);

--- a/test/incremental_section/IncrementalSectionTypesTest.cpp
+++ b/test/incremental_section/IncrementalSectionTypesTest.cpp
@@ -1,0 +1,66 @@
+#include "../../lib/Epub/Epub/IncrementalSectionTypes.h"
+#include "../../lib/Epub/Epub/IncrementalSectionCache.h"
+
+#include <cassert>
+
+int main() {
+  assert(IncrementalSection::CACHE_MAGIC == 0x43504953U);
+  assert(IncrementalSection::CACHE_VERSION > 0);
+  assert(IncrementalSection::PAGE_INDEX_RECORD_SIZE == 16);
+  assert(sizeof(IncrementalSection::PageIndexRecord) == IncrementalSection::PAGE_INDEX_RECORD_SIZE);
+
+  assert(IncrementalSection::knownPageCountFromIndexBytes(0) == 0);
+  assert(IncrementalSection::knownPageCountFromIndexBytes(16) == 1);
+  assert(IncrementalSection::knownPageCountFromIndexBytes(31) == 0);
+  assert(IncrementalSection::knownPageCountFromIndexBytes(32) == 2);
+
+  const auto paths = IncrementalSection::pathsForSection("/.crosspoint/epub_1/sections", 16);
+  assert(paths.meta == "/.crosspoint/epub_1/sections/16.met");
+  assert(paths.pages == "/.crosspoint/epub_1/sections/16.pag");
+  assert(paths.index == "/.crosspoint/epub_1/sections/16.idx");
+  assert(paths.anchors == "/.crosspoint/epub_1/sections/16.anc");
+
+  IncrementalSection::LayoutCacheKey base{};
+  base.cacheVersion = IncrementalSection::CACHE_VERSION;
+  base.fontId = 1;
+  base.lineCompression = 1.0F;
+  base.extraParagraphSpacing = false;
+  base.paragraphAlignment = 2;
+  base.viewportWidth = 240;
+  base.viewportHeight = 320;
+  base.hyphenationEnabled = true;
+  base.embeddedStyle = true;
+  base.imageRendering = 1;
+  base.focusReadingEnabled = true;
+
+  auto same = base;
+  assert(base.matches(same));
+
+  auto changedFont = base;
+  changedFont.fontId = 2;
+  assert(!base.matches(changedFont));
+
+  auto changedViewport = base;
+  changedViewport.viewportHeight = 300;
+  assert(!base.matches(changedViewport));
+
+  auto changedHyphenation = base;
+  changedHyphenation.hyphenationEnabled = false;
+  assert(!base.matches(changedHyphenation));
+
+  auto changedFocusReading = base;
+  changedFocusReading.focusReadingEnabled = false;
+  assert(!base.matches(changedFocusReading));
+
+  IncrementalSection::PageIndexRecord record{};
+  record.pageOffset = 10;
+  record.pageLength = 20;
+  record.paragraphIndex = 3;
+  record.listItemIndex = 4;
+  record.sourceByteOffset = 30;
+  assert(record.pageOffset == 10);
+  assert(record.pageLength == 20);
+  assert(record.paragraphIndex == 3);
+  assert(record.listItemIndex == 4);
+  assert(record.sourceByteOffset == 30);
+}

--- a/test/incremental_section/ReaderProgressPolicyTest.cpp
+++ b/test/incremental_section/ReaderProgressPolicyTest.cpp
@@ -35,6 +35,14 @@ int main() {
   assert(remapped.applyPage);
   assert(remapped.pageNumber == 10);
 
+  const auto penultimate = ReaderProgressPolicy::decideResumeRemap(2, 2, 18, 20, true, 40);
+  assert(penultimate.applyPage);
+  assert(penultimate.pageNumber == 37);
+
+  const auto singleCachedPage = ReaderProgressPolicy::decideResumeRemap(2, 2, 0, 1, true, 40);
+  assert(singleCachedPage.applyPage);
+  assert(singleCachedPage.pageNumber == 0);
+
   const auto clamped = ReaderProgressPolicy::decideResumeRemap(2, 2, 20, 20, true, 40);
   assert(clamped.applyPage);
   assert(clamped.pageNumber == 39);

--- a/test/incremental_section/ReaderProgressPolicyTest.cpp
+++ b/test/incremental_section/ReaderProgressPolicyTest.cpp
@@ -1,0 +1,47 @@
+#include "../../src/activities/reader/ReaderProgressPolicy.h"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+  assert(ReaderProgressPolicy::persistablePageCount(false, 12) == 0);
+  assert(ReaderProgressPolicy::persistablePageCount(true, 0) == 0);
+  assert(ReaderProgressPolicy::persistablePageCount(true, 12) == 12);
+  assert(ReaderProgressPolicy::persistablePageCount(true, 70000) == std::numeric_limits<uint16_t>::max());
+
+  const auto unknownCount =
+      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 0, false, 0);
+  assert(!unknownCount.deferUntilComplete);
+  assert(!unknownCount.applyPage);
+  assert(unknownCount.pageNumber == 5);
+
+  const auto otherSpine =
+      ReaderProgressPolicy::decideResumeRemap(3, 2, 5, 20, false, 0);
+  assert(!otherSpine.deferUntilComplete);
+  assert(!otherSpine.applyPage);
+  assert(otherSpine.pageNumber == 5);
+
+  const auto incomplete =
+      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, false, 0);
+  assert(incomplete.deferUntilComplete);
+  assert(!incomplete.applyPage);
+  assert(incomplete.pageNumber == 5);
+
+  const auto samePageCount =
+      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 20);
+  assert(!samePageCount.deferUntilComplete);
+  assert(!samePageCount.applyPage);
+  assert(samePageCount.pageNumber == 5);
+
+  const auto remapped =
+      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 40);
+  assert(!remapped.deferUntilComplete);
+  assert(remapped.applyPage);
+  assert(remapped.pageNumber == 10);
+
+  const auto clamped =
+      ReaderProgressPolicy::decideResumeRemap(2, 2, 20, 20, true, 40);
+  assert(clamped.applyPage);
+  assert(clamped.pageNumber == 39);
+}

--- a/test/incremental_section/ReaderProgressPolicyTest.cpp
+++ b/test/incremental_section/ReaderProgressPolicyTest.cpp
@@ -1,8 +1,8 @@
-#include "../../src/activities/reader/ReaderProgressPolicy.h"
-
 #include <cassert>
 #include <cstdint>
 #include <limits>
+
+#include "../../src/activities/reader/ReaderProgressPolicy.h"
 
 int main() {
   assert(ReaderProgressPolicy::persistablePageCount(false, 12) == 0);
@@ -10,38 +10,32 @@ int main() {
   assert(ReaderProgressPolicy::persistablePageCount(true, 12) == 12);
   assert(ReaderProgressPolicy::persistablePageCount(true, 70000) == std::numeric_limits<uint16_t>::max());
 
-  const auto unknownCount =
-      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 0, false, 0);
+  const auto unknownCount = ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 0, false, 0);
   assert(!unknownCount.deferUntilComplete);
   assert(!unknownCount.applyPage);
   assert(unknownCount.pageNumber == 5);
 
-  const auto otherSpine =
-      ReaderProgressPolicy::decideResumeRemap(3, 2, 5, 20, false, 0);
+  const auto otherSpine = ReaderProgressPolicy::decideResumeRemap(3, 2, 5, 20, false, 0);
   assert(!otherSpine.deferUntilComplete);
   assert(!otherSpine.applyPage);
   assert(otherSpine.pageNumber == 5);
 
-  const auto incomplete =
-      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, false, 0);
+  const auto incomplete = ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, false, 0);
   assert(incomplete.deferUntilComplete);
   assert(!incomplete.applyPage);
   assert(incomplete.pageNumber == 5);
 
-  const auto samePageCount =
-      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 20);
+  const auto samePageCount = ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 20);
   assert(!samePageCount.deferUntilComplete);
   assert(!samePageCount.applyPage);
   assert(samePageCount.pageNumber == 5);
 
-  const auto remapped =
-      ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 40);
+  const auto remapped = ReaderProgressPolicy::decideResumeRemap(2, 2, 5, 20, true, 40);
   assert(!remapped.deferUntilComplete);
   assert(remapped.applyPage);
   assert(remapped.pageNumber == 10);
 
-  const auto clamped =
-      ReaderProgressPolicy::decideResumeRemap(2, 2, 20, 20, true, 40);
+  const auto clamped = ReaderProgressPolicy::decideResumeRemap(2, 2, 20, 20, true, 40);
   assert(clamped.applyPage);
   assert(clamped.pageNumber == 39);
 }

--- a/test/incremental_section/StaticIncrementalContracts.py
+++ b/test/incremental_section/StaticIncrementalContracts.py
@@ -71,6 +71,8 @@ def main() -> None:
     assert "return pageNumber < knownPageCount_;" in section_handle_cpp
     assert "incrementalCache_->hasPage" not in section_handle_cpp
     assert "return knownPageCount_;" in section_handle_cpp
+    assert "if (state == IncrementalBuildState::Parsing)" in section_handle_cpp
+    assert "return {SectionPumpStatus::Pumped, pagesBefore, pagesAfter};" in section_handle_cpp
 
     builder_cpp = read("lib/Epub/Epub/IncrementalSectionBuilder.cpp")
     assert "const uint32_t pageNumber = knownPageCount_;" in builder_cpp
@@ -182,9 +184,15 @@ def main() -> None:
         "src/activities/reader/KOReaderSyncActivity.cpp",
         "IncrementalSection::Cache incrementalCache",
         "incrementalCache.isComplete()",
-        "incrementalCache.getPageForListItemIndex",
-        "incrementalCache.getPageForAnchor",
-        "incrementalCache.getPageForParagraphIndex",
+        'refineRemotePositionFromLookup(incrementalCache, remotePosition, "Cached")',
+        "getPageForListItemIndex",
+        "getPageForAnchor",
+        "getPageForParagraphIndex",
+        "refineRemoteProgressWithIncrementalIndexing",
+        "SectionHandle::openOrCreate",
+        "while (!refined && sectionHandle->hasActiveBuilder())",
+        "sectionHandle->pump(indexBudget(IncrementalBuildBudgetProfile::Outrun))",
+        'refineRemotePositionFromLookup(*sectionHandle, position, "Indexed")',
         "Section tempSection",
     )
 
@@ -211,6 +219,15 @@ def main() -> None:
         "working_changed_paths",
         "inspect_sdk_range",
         "git -C \"$ROOT_DIR/open-x4-sdk\" diff --name-only",
+        "gh_release_block",
+        "^\\[env:gh_release\\]$",
+    )
+
+    assert_contains(
+        "test/run_incremental_section_tests.sh",
+        "command -v python",
+        "command -v python3",
+        "StaticIncrementalContracts.py",
     )
 
     assert_contains(
@@ -219,6 +236,8 @@ def main() -> None:
         "checkedWriteString",
         "checkedWriteLayoutKey",
         "checkedWriteIndexRecord",
+        "readNextIndexRecord",
+        "indexSize / PAGE_INDEX_RECORD_SIZE",
         "Short write",
     )
     cache_cpp = read("lib/Epub/Epub/IncrementalSectionCache.cpp")

--- a/test/incremental_section/StaticIncrementalContracts.py
+++ b/test/incremental_section/StaticIncrementalContracts.py
@@ -23,6 +23,12 @@ def assert_not_contains(rel: str, *needles: str) -> None:
         assert needle not in text, f"{rel} must not contain {needle!r}"
 
 
+def slice_between(text: str, start: str, end: str) -> str:
+    start_idx = text.index(start)
+    end_idx = text.index(end, start_idx)
+    return text[start_idx:end_idx]
+
+
 def main() -> None:
     assert_contains(
         "lib/Epub/Epub/IncrementalSectionTypes.h",
@@ -85,6 +91,14 @@ def main() -> None:
     assert "pages.close();" in cache_cpp
     assert "const auto pageCount = knownPageCountFromIndexBytes(index.size());" in cache_cpp
     assert "index.close();" in cache_cpp
+    anchor_lookup_body = slice_between(
+        cache_cpp,
+        "std::optional<uint16_t> Cache::getPageForAnchor",
+        "std::optional<uint16_t> Cache::getParagraphIndexForPage",
+    )
+    assert "readAnchorEntry(file, key, page)" in anchor_lookup_body
+    assert "serialization::readString(file, key)" not in anchor_lookup_body
+    assert "MAX_ANCHOR_KEY_LEN" in cache_cpp
 
     assert_contains(
         "src/activities/reader/EpubReaderUtils.h",
@@ -116,6 +130,9 @@ def main() -> None:
         "std::unique_ptr<SectionHandle> section",
         "std::unique_ptr<SectionHandle> nextSectionPrewarm",
         "bool backgroundIndexingWorkActive = false",
+        "bool bookCacheDeleted = false",
+        "bool freshBookEntry = false",
+        "bool initialBookEntryIndexingPopupShown = false",
         "int pendingPageTurnDirection = 0",
         "bool hasCurrentIndexingWork() const",
         "bool hasPrewarmIndexingWork() const",
@@ -162,6 +179,61 @@ def main() -> None:
         "persistablePageCountForSection",
         "ReaderProgressPolicy::decideResumeRemap",
     )
+    epub_reader_cpp = read("src/activities/reader/EpubReaderActivity.cpp")
+    pump_background_body = slice_between(
+        epub_reader_cpp,
+        "bool EpubReaderActivity::pumpBackgroundIndexing()",
+        "void EpubReaderActivity::loop()",
+    )
+    assert "backgroundIndexingWorkActive = currentNowActive || prewarmNowActive;" in pump_background_body
+    assert (
+        "requestUpdate();" not in pump_background_body
+    ), "Background/prewarm indexing state changes must not redraw the current page"
+    assert (
+        "currentWasActive != currentNowActive || prewarmWasActive != prewarmNowActive" not in pump_background_body
+    ), "Background/prewarm active-state transitions should not schedule UI-only repaints"
+    assert "displayedSectionProgress" in epub_reader_cpp
+    assert "static_cast<float>(section->currentPage) / static_cast<float>(pageCount)" not in epub_reader_cpp
+    assert "calculateProgress(currentSpineIndex, displayedSectionProgress(section.get()))" in epub_reader_cpp
+
+    activity_manager_cpp = read("src/activities/ActivityManager.cpp")
+    sleep_body = slice_between(
+        activity_manager_cpp,
+        "void ActivityManager::goToSleep()",
+        "void ActivityManager::goToBoot()",
+    )
+    assert "sleepTransitionPending.store(true" in sleep_body
+    assert "processPendingActions();" in sleep_body
+    assert "loop();" not in sleep_body, "Sleep must not run the outgoing activity loop before drawing the sleep screen"
+    assert "sleepTransitionPending.store(false" in sleep_body
+    assert "void ActivityManager::processPendingActions()" in activity_manager_cpp
+    assert "bool isSleepTransitionPending() const" in read("src/activities/ActivityManager.h")
+    activity_loop_body = slice_between(
+        activity_manager_cpp,
+        "void ActivityManager::loop()",
+        "void ActivityManager::processPendingActions()",
+    )
+    assert "currentActivity->loop();" in activity_loop_body
+    assert "processPendingActions();" in activity_loop_body
+
+    assert "popupFn" not in epub_reader_cpp, "Normal EPUB reader section loads must not wire parser popup redraws"
+    assert (
+        epub_reader_cpp.count("GUI.drawPopup(renderer, tr(STR_INDEXING));") == 1
+    ), "Indexing popup should be centralized behind a once-only helper, not drawn by first-page load"
+    assert "showIndexingPopupOnce" in epub_reader_cpp
+    assert "hasCompatibleCompleteIncrementalCache" in epub_reader_cpp
+    assert "Section open/create:" in epub_reader_cpp
+    assert "First-page pump" in epub_reader_cpp
+    assert "Initial-window pump" in epub_reader_cpp
+    assert "Position-resolution pump" in epub_reader_cpp
+    assert "Page load:" in epub_reader_cpp
+    assert "Page render/display:" in epub_reader_cpp
+    pump_until_body = slice_between(
+        epub_reader_cpp,
+        "SectionPumpLoopResult pumpSectionUntil(",
+        "bool ensureOutrunWindowAvailable(",
+    )
+    assert "activityManager.isSleepTransitionPending()" in pump_until_body
 
     assert_not_contains(
         "src/activities/reader/EpubReaderActivity.cpp",
@@ -195,6 +267,13 @@ def main() -> None:
         'refineRemotePositionFromLookup(*sectionHandle, position, "Indexed")',
         "Section tempSection",
     )
+    koreader_sync_cpp = read("src/activities/reader/KOReaderSyncActivity.cpp")
+    indexing_status = koreader_sync_cpp.index("statusMessage = tr(STR_INDEXING);")
+    indexing_wait = koreader_sync_cpp.index("requestUpdateAndWait();", indexing_status)
+    refine_after_wait = koreader_sync_cpp.index(
+        "refined = refineRemoteProgressWithIncrementalIndexing(remotePosition);", indexing_wait
+    )
+    assert indexing_status < indexing_wait < refine_after_wait
 
     assert_contains(
         "lib/FsHelpers/FsHelpers.h",
@@ -300,6 +379,88 @@ def main() -> None:
         "lib/Epub/Epub.cpp",
         "FsHelpers::removeDirRecursive(cachePath.c_str())",
     )
+
+    assert_contains(
+        "lib/Epub/Epub/BookMetadataCache.h",
+        "FAST_LOOKUP_SPINE_THRESHOLD = 64",
+    )
+    assert_contains(
+        "lib/Epub/Epub/BookMetadataCache.cpp",
+        "spineCount >= FAST_LOOKUP_SPINE_THRESHOLD",
+        "Using fast TOC spine index",
+        "Using batch size lookup for %d spine items",
+        "buildBookBin timings:",
+    )
+    assert_not_contains(
+        "lib/Epub/Epub/BookMetadataCache.cpp",
+        "spineCount >= LARGE_SPINE_THRESHOLD",
+    )
+    assert_contains(
+        "lib/Epub/Epub/parsers/ContentOpfParser.h",
+        "FAST_LOOKUP_SPINE_THRESHOLD = 64",
+    )
+    assert_contains(
+        "lib/Epub/Epub/parsers/ContentOpfParser.cpp",
+        "itemIndex.size() >= FAST_LOOKUP_SPINE_THRESHOLD",
+        "Using fast spine item index",
+    )
+    assert_not_contains(
+        "lib/Epub/Epub/parsers/ContentOpfParser.cpp",
+        "itemIndex.size() >= LARGE_SPINE_THRESHOLD",
+    )
+    on_enter_body = slice_between(
+        epub_reader_cpp,
+        "void EpubReaderActivity::onEnter()",
+        "void EpubReaderActivity::onExit()",
+    )
+    assert "bool loadedSavedProgress = false;" in on_enter_body
+    assert "loadedSavedProgress = true;" in on_enter_body
+    assert "freshBookEntry = !loadedSavedProgress;" in on_enter_body
+    render_load_section_body = slice_between(
+        epub_reader_cpp,
+        "if (!section) {",
+        "    const auto sectionOpenStart = millis();",
+    )
+    assert "freshBookEntry &&" in render_load_section_body
+    assert "!hasCompatibleCompleteIncrementalCache(epub, currentSpineIndex, layoutKey)" in render_load_section_body
+    assert "initialBookEntryIndexingPopupShown" in render_load_section_body
+    assert "showIndexingPopupOnce(renderer, indexingPopupShown);" in render_load_section_body
+    assert "freshBookEntry = false;" in epub_reader_cpp
+
+    reader_activity_cpp = read("src/activities/reader/ReaderActivity.cpp")
+    assert_contains(
+        "src/activities/reader/ReaderActivity.h",
+        "loadEpub(const std::string& path, const GfxRenderer& renderer,",
+        "onGoToEpubReader(std::unique_ptr<Epub> epub, bool initialIndexingPopupShown)",
+    )
+    load_epub_body = slice_between(
+        reader_activity_cpp,
+        "std::unique_ptr<Epub> ReaderActivity::loadEpub",
+        "std::unique_ptr<Xtc> ReaderActivity::loadXtc",
+    )
+    assert "makeUniqueNoThrow<Epub>" in load_epub_body
+    assert '"/book.bin"' in load_epub_body
+    assert '"/progress.bin"' in load_epub_body
+    assert "GUI.drawPopup(renderer, tr(STR_INDEXING));" in load_epub_body
+    assert "indexingPopupShown = true;" in load_epub_body
+    assert "epub->load(true, SETTINGS.embeddedStyle == 0)" in load_epub_body
+    assert "onGoToEpubReader(std::move(epub), initialIndexingPopupShown);" in reader_activity_cpp
+    delete_cache_body = slice_between(
+        epub_reader_cpp,
+        "case EpubReaderMenuActivity::MenuAction::DELETE_CACHE:",
+        "case EpubReaderMenuActivity::MenuAction::SCREENSHOT:",
+    )
+    assert "epub->clearCache();" in delete_cache_body
+    assert "bookCacheDeleted = true;" in delete_cache_body
+    assert "saveProgress" not in delete_cache_body
+    assert "setupCacheDir" not in delete_cache_body
+    assert "Book cache deleted; progress cache removed" in delete_cache_body
+    render_body = slice_between(
+        epub_reader_cpp,
+        "void EpubReaderActivity::render(RenderLock&& lock)",
+        "void EpubReaderActivity::renderContents(",
+    )
+    assert "if (bookCacheDeleted) {\n    return;\n  }" in render_body
 
 
 if __name__ == "__main__":

--- a/test/incremental_section/StaticIncrementalContracts.py
+++ b/test/incremental_section/StaticIncrementalContracts.py
@@ -102,9 +102,25 @@ def main() -> None:
     )
 
     assert_contains(
+        "src/activities/reader/ReaderProgressPolicy.h",
+        "namespace ReaderProgressPolicy",
+        "persistablePageCount",
+        "decideResumeRemap",
+        "deferUntilComplete",
+    )
+
+    assert_contains(
         "src/activities/reader/EpubReaderActivity.h",
         "std::unique_ptr<SectionHandle> section",
         "std::unique_ptr<SectionHandle> nextSectionPrewarm",
+        "bool backgroundIndexingWorkActive = false",
+        "int pendingPageTurnDirection = 0",
+        "bool hasCurrentIndexingWork() const",
+        "bool hasPrewarmIndexingWork() const",
+        "bool hasBackgroundIndexingWork() const",
+        "bool pumpBackgroundIndexing()",
+        "bool skipLoopDelay() override",
+        "bool preventAutoSleep() override",
     )
 
     assert_contains(
@@ -112,14 +128,45 @@ def main() -> None:
         "SectionHandle::openOrCreate",
         "pumpSectionUntil",
         "maintainPrewarmWindow",
+        "responsiveBackgroundBudget",
+        "maxCompletedPages = 1",
+        "indexBatchMaxMillis(1)",
+        "bool EpubReaderActivity::hasCurrentIndexingWork() const",
+        "bool EpubReaderActivity::hasPrewarmIndexingWork() const",
+        "bool EpubReaderActivity::hasBackgroundIndexingWork() const",
+        "bool EpubReaderActivity::hasBackgroundIndexingWork() const {\n  if (RenderLock::peek()) {",
+        "return backgroundIndexingWorkActive;",
+        "bool EpubReaderActivity::skipLoopDelay()",
+        "bool EpubReaderActivity::preventAutoSleep()",
+        "bool EpubReaderActivity::pumpBackgroundIndexing()",
+        "if (pendingPageTurnDirection != 0 && !RenderLock::peek())",
+        "const bool queuedForwardTurn = pendingPageTurnDirection > 0;",
+        "pendingPageTurnDirection = 0;",
+        "Loop-side background indexing waits for render ownership to clear",
+        "if (!prevTriggered && !nextTriggered) {\n    // Loop-side background indexing waits for render ownership to clear.\n    if (!RenderLock::peek()) {\n      pumpBackgroundIndexing();\n    }\n    return;\n  }",
+        "backgroundIndexingWorkActive = false;",
+        "backgroundIndexingWorkActive = currentNowActive || prewarmNowActive;",
+        "const bool currentWasActive",
+        "const bool prewarmWasActive",
+        "requestUpdate();",
         "knownPageCount()",
         "finalPageCount()",
         "loadPage(",
-        "Ignoring page turn while render/indexing is active",
+        "Queued page turn while render/indexing is active",
         "renderer.copyGrayscaleLsbBuffers();",
         "renderer.copyGrayscaleMsbBuffers();",
         "renderer.displayGrayBuffer();",
         "Skipping EPUB text grayscale AA: failed to store BW buffer",
+        "persistablePageCountForSection",
+        "ReaderProgressPolicy::decideResumeRemap",
+    )
+
+    assert_not_contains(
+        "src/activities/reader/EpubReaderActivity.cpp",
+        "Background render/indexing owns section state; keep loop-side pumps out until it releases the lock.",
+        "  pumpBackgroundIndexing();\n  saveProgress",
+        "Ignoring page turn while render/indexing is active",
+        "saveProgress(currentSpineIndex, section->currentPage, static_cast<int>(displayPageCount(section.get())))",
     )
 
     assert_contains(
@@ -154,6 +201,30 @@ def main() -> None:
         "removeDirectoryWithRetry(path)",
         "Storage.rmdir(path)",
     )
+
+    assert_contains(
+        "test/incremental_section/CleanScopeContractTest.sh",
+        "INCREMENTAL_SECTION_BASE_REF",
+        "origin/master",
+        "merge-base",
+        "committed_changed_paths",
+        "working_changed_paths",
+        "inspect_sdk_range",
+        "git -C \"$ROOT_DIR/open-x4-sdk\" diff --name-only",
+    )
+
+    assert_contains(
+        "lib/Epub/Epub/IncrementalSectionCache.cpp",
+        "checkedWritePod",
+        "checkedWriteString",
+        "checkedWriteLayoutKey",
+        "checkedWriteIndexRecord",
+        "Short write",
+    )
+    cache_cpp = read("lib/Epub/Epub/IncrementalSectionCache.cpp")
+    cache_write_section = cache_cpp[: cache_cpp.index("void readLayoutKey")]
+    assert "serialization::writePod" not in cache_write_section
+    assert "serialization::writeString" not in cache_write_section
 
     assert_not_contains(
         "src/activities/reader/EpubReaderActivity.cpp",

--- a/test/incremental_section/StaticIncrementalContracts.py
+++ b/test/incremental_section/StaticIncrementalContracts.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(rel: str) -> str:
+    path = ROOT / rel
+    assert path.exists(), f"Missing expected file: {rel}"
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(rel: str, *needles: str) -> None:
+    text = read(rel)
+    for needle in needles:
+        assert needle in text, f"{rel} is missing {needle!r}"
+
+
+def assert_not_contains(rel: str, *needles: str) -> None:
+    text = read(rel)
+    for needle in needles:
+        assert needle not in text, f"{rel} must not contain {needle!r}"
+
+
+def main() -> None:
+    assert_contains(
+        "lib/Epub/Epub/IncrementalSectionTypes.h",
+        "CACHE_MAGIC = 0x43504953U",
+        "PAGE_INDEX_RECORD_SIZE = 16",
+        "focusReadingEnabled",
+        "pathsForSection",
+        '".met"',
+        '".pag"',
+        '".idx"',
+        '".anc"',
+    )
+
+    assert_contains(
+        "lib/Epub/Epub/IncrementalSectionCache.h",
+        "struct PageIndexRecord",
+        "uint32_t pageOffset",
+        "uint32_t pageLength",
+        "uint16_t paragraphIndex",
+        "uint16_t listItemIndex",
+        "uint32_t sourceByteOffset",
+        "static_assert(sizeof(PageIndexRecord) == PAGE_INDEX_RECORD_SIZE",
+        "getPageForListItemIndex",
+    )
+
+    assert_contains(
+        "lib/Epub/Epub/IncrementalSectionBuilder.h",
+        "IncrementalBuildState",
+        "DeferredLowMemory",
+        "IncrementalBuildOptions",
+        "focusReadingEnabled",
+        "pump(const IncrementalBuildBudget& budget)",
+    )
+
+    assert_contains(
+        "lib/Epub/Epub/SectionHandle.h",
+        "SectionHandleMode",
+        "openOrCreate",
+        "knownPageCount",
+        "finalPageCount",
+        "getPageForListItemIndex",
+        "knownPageCount_",
+    )
+
+    section_handle_cpp = read("lib/Epub/Epub/SectionHandle.cpp")
+    assert "return pageNumber < knownPageCount_;" in section_handle_cpp
+    assert "incrementalCache_->hasPage" not in section_handle_cpp
+    assert "return knownPageCount_;" in section_handle_cpp
+
+    builder_cpp = read("lib/Epub/Epub/IncrementalSectionBuilder.cpp")
+    assert "const uint32_t pageNumber = knownPageCount_;" in builder_cpp
+    assert "knownPageCount_ = pageNumber + 1;" in builder_cpp
+    assert "return pageNumber < knownPageCount_;" in builder_cpp
+    assert "uint32_t IncrementalSectionBuilder::knownPageCount() const { return knownPageCount_; }" in builder_cpp
+
+    cache_cpp = read("lib/Epub/Epub/IncrementalSectionCache.cpp")
+    assert "auto page = Page::deserialize(pages);" in cache_cpp
+    assert "pages.close();" in cache_cpp
+    assert "const auto pageCount = knownPageCountFromIndexBytes(index.size());" in cache_cpp
+    assert "index.close();" in cache_cpp
+
+    assert_contains(
+        "src/activities/reader/EpubReaderUtils.h",
+        "f.close();",
+    )
+
+    assert_contains(
+        "lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h",
+        "enum class ParsePumpStatus",
+        "struct ParsePumpBudget",
+        "bool begin(",
+        "ParsePumpStatus pump(",
+        "bool finish()",
+        "void close()",
+        "bool parseAndBuildPages()",
+        "focusReadingEnabled",
+    )
+
+    assert_contains(
+        "src/activities/reader/EpubReaderActivity.h",
+        "std::unique_ptr<SectionHandle> section",
+        "std::unique_ptr<SectionHandle> nextSectionPrewarm",
+    )
+
+    assert_contains(
+        "src/activities/reader/EpubReaderActivity.cpp",
+        "SectionHandle::openOrCreate",
+        "pumpSectionUntil",
+        "maintainPrewarmWindow",
+        "knownPageCount()",
+        "finalPageCount()",
+        "loadPage(",
+        "Ignoring page turn while render/indexing is active",
+        "renderer.copyGrayscaleLsbBuffers();",
+        "renderer.copyGrayscaleMsbBuffers();",
+        "renderer.displayGrayBuffer();",
+        "Skipping EPUB text grayscale AA: failed to store BW buffer",
+    )
+
+    assert_contains(
+        "src/components/themes/StatusPageInfo.h",
+        "struct StatusPageInfo",
+        "formatStatusPageText",
+        "shouldDrawChapterProgressBar",
+        "shouldDrawCurrentIndexingIndicator",
+        "shouldDrawFutureIndexingIndicator",
+    )
+
+    assert_contains(
+        "src/activities/reader/KOReaderSyncActivity.cpp",
+        "IncrementalSection::Cache incrementalCache",
+        "incrementalCache.isComplete()",
+        "incrementalCache.getPageForListItemIndex",
+        "incrementalCache.getPageForAnchor",
+        "incrementalCache.getPageForParagraphIndex",
+        "Section tempSection",
+    )
+
+    assert_contains(
+        "lib/FsHelpers/FsHelpers.h",
+        "removeDirRecursive",
+    )
+
+    assert_contains(
+        "lib/FsHelpers/FsHelpers.cpp",
+        "bool removeDirRecursive",
+        "entry.close();",
+        "removeFileWithRetry(childPath)",
+        "removeDirectoryWithRetry(path)",
+        "Storage.rmdir(path)",
+    )
+
+    assert_not_contains(
+        "src/activities/reader/EpubReaderActivity.cpp",
+        "storeGrayMaskBuffer",
+        "displayFactoryGrayBufferFromStoredBwAndGrayMasks",
+        "displayFactoryGrayBuffer",
+        'aa=%s',
+    )
+
+    assert_contains(
+        "src/activities/reader/ReaderUtils.h",
+        "renderer.copyGrayscaleLsbBuffers();",
+        "renderer.copyGrayscaleMsbBuffers();",
+        "renderer.displayGrayBuffer();",
+    )
+
+    assert_not_contains(
+        "src/activities/reader/ReaderUtils.h",
+        "storeGrayMaskBuffer",
+        "displayFactoryGrayBufferFromStoredBwAndGrayMasks",
+        "displayFactoryGrayBuffer",
+    )
+
+    assert_not_contains(
+        "lib/GfxRenderer/GfxRenderer.h",
+        "storeGrayMaskBuffer",
+        "displayFactoryGrayBufferFromStoredBwAndGrayMasks",
+        "grayMaskBufferChunks",
+    )
+
+    assert_not_contains(
+        "lib/hal/HalDisplay.h",
+        "displayFactoryGrayBuffer",
+    )
+
+    display_cpp = read("open-x4-sdk/libs/display/EInkDisplay/src/EInkDisplay.cpp")
+    cleanup_start = display_cpp.index("void EInkDisplay::cleanupGrayscaleBuffers")
+    cleanup_end = display_cpp.index("void EInkDisplay::displayBuffer", cleanup_start)
+    cleanup_body = display_cpp[cleanup_start:cleanup_end]
+    assert (
+        "inGrayscaleMode = false;" in cleanup_body
+    ), "cleanupGrayscaleBuffers must clear grayscale mode after syncing controller RAM"
+    assert (
+        cleanup_body.rfind("inGrayscaleMode = false;")
+        > cleanup_body.rfind("writeRamBuffer(CMD_WRITE_RAM_RED, bwBuffer, bufferSize);")
+    ), "cleanupGrayscaleBuffers should clear grayscale mode after the non-X3 RED RAM sync"
+
+    assert_contains(
+        "src/activities/settings/ClearCacheActivity.cpp",
+        "FsHelpers::removeDirRecursive",
+    )
+
+    assert_contains(
+        "lib/Epub/Epub.cpp",
+        "FsHelpers::removeDirRecursive(cachePath.c_str())",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/incremental_section/StatusPageInfoTest.cpp
+++ b/test/incremental_section/StatusPageInfoTest.cpp
@@ -19,7 +19,10 @@ int main() {
   assert(std::strcmp(buffer, "4/8+") == 0);
 
   formatStatusPageText(buffer, sizeof(buffer), StatusPageInfo{0, 0, false, false, false});
-  assert(std::strcmp(buffer, "1/?") == 0);
+  assert(std::strcmp(buffer, "0/0") == 0);
+
+  formatStatusPageText(buffer, sizeof(buffer), StatusPageInfo{3, 0, true, false, false});
+  assert(std::strcmp(buffer, "0/0") == 0);
 
   char tiny[2] = {};
   formatStatusPageText(tiny, sizeof(tiny), StatusPageInfo{99, 100, true, false, false});

--- a/test/incremental_section/StatusPageInfoTest.cpp
+++ b/test/incremental_section/StatusPageInfoTest.cpp
@@ -1,7 +1,7 @@
-#include "../../src/components/themes/StatusPageInfo.h"
-
 #include <cassert>
 #include <cstring>
+
+#include "../../src/components/themes/StatusPageInfo.h"
 
 static_assert(shouldDrawChapterProgressBar(StatusPageInfo{0, 10, true, false, false}));
 static_assert(!shouldDrawChapterProgressBar(StatusPageInfo{0, 10, false, true, false}));

--- a/test/incremental_section/StatusPageInfoTest.cpp
+++ b/test/incremental_section/StatusPageInfoTest.cpp
@@ -1,0 +1,27 @@
+#include "../../src/components/themes/StatusPageInfo.h"
+
+#include <cassert>
+#include <cstring>
+
+static_assert(shouldDrawChapterProgressBar(StatusPageInfo{0, 10, true, false, false}));
+static_assert(!shouldDrawChapterProgressBar(StatusPageInfo{0, 10, false, true, false}));
+static_assert(shouldDrawCurrentIndexingIndicator(StatusPageInfo{0, 10, false, true, false}));
+static_assert(!shouldDrawCurrentIndexingIndicator(StatusPageInfo{0, 0, false, false, false}));
+static_assert(shouldDrawFutureIndexingIndicator(StatusPageInfo{0, 10, true, false, true}));
+
+int main() {
+  char buffer[16] = {};
+
+  formatStatusPageText(buffer, sizeof(buffer), StatusPageInfo{3, 12, true, false, false});
+  assert(std::strcmp(buffer, "4/12") == 0);
+
+  formatStatusPageText(buffer, sizeof(buffer), StatusPageInfo{3, 8, false, true, false});
+  assert(std::strcmp(buffer, "4/8+") == 0);
+
+  formatStatusPageText(buffer, sizeof(buffer), StatusPageInfo{0, 0, false, false, false});
+  assert(std::strcmp(buffer, "1/?") == 0);
+
+  char tiny[2] = {};
+  formatStatusPageText(tiny, sizeof(tiny), StatusPageInfo{99, 100, true, false, false});
+  assert(tiny[sizeof(tiny) - 1] == '\0');
+}

--- a/test/run_incremental_section_tests.sh
+++ b/test/run_incremental_section_tests.sh
@@ -47,4 +47,5 @@ build_and_run() {
 
 build_and_run IncrementalSectionTypesTest.cpp IncrementalSectionTypesTest
 build_and_run EpubIndexingPolicyTest.cpp EpubIndexingPolicyTest
+build_and_run ReaderProgressPolicyTest.cpp ReaderProgressPolicyTest
 build_and_run StatusPageInfoTest.cpp StatusPageInfoTest

--- a/test/run_incremental_section_tests.sh
+++ b/test/run_incremental_section_tests.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="build/incremental_section"
+
+cd "$ROOT_DIR"
+mkdir -p "$BUILD_DIR"
+
+bash "$ROOT_DIR/test/incremental_section/CleanScopeContractTest.sh"
+python "$ROOT_DIR/test/incremental_section/StaticIncrementalContracts.py"
+
+if command -v c++ >/dev/null 2>&1; then
+  CXX=c++
+elif command -v g++ >/dev/null 2>&1; then
+  CXX=g++
+elif command -v clang++ >/dev/null 2>&1; then
+  CXX=clang++
+elif [ -x /c/msys64/ucrt64/bin/c++.exe ]; then
+  CXX=/c/msys64/ucrt64/bin/c++.exe
+  PATH="/c/msys64/ucrt64/bin:$PATH"
+else
+  echo "No host C++ compiler found; static incremental contracts passed, skipping compile-only host tests."
+  exit 0
+fi
+
+CXXFLAGS=(
+  -std=c++20
+  -O2
+  -Wall
+  -Wextra
+  -pedantic
+  -I"$ROOT_DIR"
+  -I"$ROOT_DIR/lib"
+  -I"$ROOT_DIR/src"
+  -I"$ROOT_DIR/test/incremental_section"
+)
+
+build_and_run() {
+  local source_file="$1"
+  local binary_name="$2"
+  local binary="$BUILD_DIR/$binary_name"
+
+  "$CXX" "${CXXFLAGS[@]}" "$ROOT_DIR/test/incremental_section/$source_file" -o "$binary"
+  "$binary"
+}
+
+build_and_run IncrementalSectionTypesTest.cpp IncrementalSectionTypesTest
+build_and_run EpubIndexingPolicyTest.cpp EpubIndexingPolicyTest
+build_and_run StatusPageInfoTest.cpp StatusPageInfoTest

--- a/test/run_incremental_section_tests.sh
+++ b/test/run_incremental_section_tests.sh
@@ -8,7 +8,15 @@ cd "$ROOT_DIR"
 mkdir -p "$BUILD_DIR"
 
 bash "$ROOT_DIR/test/incremental_section/CleanScopeContractTest.sh"
-python "$ROOT_DIR/test/incremental_section/StaticIncrementalContracts.py"
+if command -v python >/dev/null 2>&1; then
+  PYTHON=python
+elif command -v python3 >/dev/null 2>&1; then
+  PYTHON=python3
+else
+  echo "No Python interpreter found; cannot run static incremental contracts."
+  exit 1
+fi
+"$PYTHON" "$ROOT_DIR/test/incremental_section/StaticIncrementalContracts.py"
 
 if command -v c++ >/dev/null 2>&1; then
   CXX=c++


### PR DESCRIPTION
## Summary
This adds incremental EPUB section indexing so reader pages can be built and cached page-by-page instead of requiring whole-section indexing before the reader becomes usable. The branch also hardens resume behavior, cache writes, and static scope contracts around the new incremental path.

## Why
Large EPUB sections can make first render and navigation feel blocked while pagination completes. Incremental section indexing lets the reader render the first available page, continue indexing in bounded slices, prewarm the next section, and reuse complete section caches across opens.

## Demo

https://www.dropbox.com/scl/fi/xj245tz94kvon3z930ysj/Incremental-Indexing.mov?rlkey=1a63ym4djyak2a6ggu99eq9gf&st=nax78ybl&dl=0

Note:
- An unindexed chapter opens after a few seconds once the first page is available, with an in-progress page count such as `1/1+`.
- As the user navigates, the page count reflects the pages indexed so far, such as `3/22+`.
- ~~When the current chapter finishes indexing, the status bar redraws with the final page count, such as `3/25`.~~
- After the current chapter is fully indexed, the reader opportunistically indexes one additional chapter at lower priority. This is indicated by `•`, such as `3/25•`.
- ~~When the next chapter finishes indexing, the status bar redraws and removes the `•`.~~
- If page count is hidden, the `+` or `•` indicator is drawn at the bottom-right of the screen.
- (I've decided to disable the post-indexing, post-prewarming status bar redraws as they're somewhat expensive and were ignoring user input during the redraws. The current status is displayed until the user navigates, but I think the cost in UI transparency (alerting users to potential responsiveness issues) is made up for by better responsiveness.)

## What Changed
- Added `IncrementalSectionBuilder`, `IncrementalSectionCache`, `SectionHandle`, layout keys, build budgets, and related EPUB indexing policy helpers.
- Updated `EpubReaderActivity` to render from incremental section handles, pump foreground/background indexing work, prewarm the next section, and queue page turns while render/indexing owns section state.
- Added resume-safe page count persistence via `ReaderProgressPolicy`: incomplete sections persist page count `0` as unknown, while UI/status display can still use partial known page counts.
- Hardened incremental cache writes so metadata, page index records, and anchor records only succeed after checked SD writes.
- Added cache clearing support for incremental section files.
- Added static and C++ contract tests for indexing policy, section types, status page info, resume policy, scope boundaries, and cache write validation.
- Bumped `open-x4-sdk` from `76a1b2f` to `a49aae3` for the grayscale cleanup fix needed by the EPUB AA rendering path.


## Notable Decisions
- Incremental indexing is implemented inside the EPUB reader stack through `SectionHandle`, `IncrementalSectionBuilder`, and `IncrementalSectionCache`, rather than adding new app-wide input, power, or scheduling scaffolding.
- The reader can render as soon as the requested page is available, then continue indexing in small bounded slices. This keeps the UI responsive while still allowing complete section caches to be reused later.
- Section cache reuse is intentionally conservative: complete caches are reused when their layout key matches, while stale or incomplete caches are removed and rebuilt.
- Resume metadata remains backward-compatible. The progress file format is unchanged, and page count `0` continues to mean "unknown total pages" when a section has not completed indexing.
- Next-section prewarming is opportunistic and scoped to the adjacent spine item, so it improves forward navigation without trying to paginate the entire book in the background.
- The SDK bump is intentionally narrow and tied to reader anti-aliasing behavior: `open-x4-sdk` moves from `76a1b2f` to `a49aae3`, whose diff only touches `libs/display/EInkDisplay/src/EInkDisplay.cpp`.
- The contract tests are intentionally static and scope-oriented. They guard against reopening the earlier broad input/power/debug changes, ensure branch diffs are reviewed against a base ref, and enforce checked writes in the new incremental cache path.

## Known Follow-Up
There is a separate low-memory crash risk in embedded CSS cache loading where `CssParser::loadFromCache()` can throw `std::bad_alloc` while rebuilding/prewarming a section. That is intentionally left for another PR.


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_