### PR TITLE
feat: add the Domitian font family

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -113,6 +113,17 @@ families:
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 500}}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/bitter/Bitter-Italic%5Bwght%5D.ttf", variable: {wght: 700}}
 
+  - name: Domitian
+    description: "A humanist serif for literary reading (Latin, Greek, Cyrillic)"
+    intervals: latin-ext,greek,cyrillic
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Roman.otf"}
+      bold:       {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Bold.otf"}
+      italic:     {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Italic.otf"}
+      bolditalic: {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-BoldItalic.otf"}
+    
+
   # ── Sans-serif ─────────────────────────────────────────────────────────
 
   - name: NotoSansExtended


### PR DESCRIPTION
## Summary

This PR adds the [Domitian](https://ctan.org/tex-archive/fonts/domitian) font family to the fonts available for download in Crosspoint.

## Why

Domitian is an opensource drop-in replacement for Palatino. Palatino is a popular font, shipped by default on the most popular ereaders and used by many, both digitally and on print. Domitian is freely licensed and would allow Crosspoint to ship it without incurring in any legal issue. Quoting the font page, "Domitian is licensed under your choice of the GNU Affero GPL 3 (with a font exception), the LaTeX Project Public License 1.3c or the SIL Open Font License 1.1".

## Screenshots

![image](https://github.com/user-attachments/files/27882681/C54AA632-8BC0-47DF-AA76-86420A32A76D.bmp)
![image](https://github.com/user-attachments/files/27882717/3A979B80-079D-4222-B3E4-49CD89BE6BA6.bmp)

---

### AI Usage

Did you use AI tools to help write this code? _**NO**_
