### PR TITLE
fix: EPUB image rendering

### DIFF
--- a/docs/prs/02-image-rendering.md
+++ b/docs/prs/02-image-rendering.md
@@ -1,0 +1,43 @@
+# PR 2: "fix: Image Rendering"
+
+## Goal
+- Render image-only EPUB sections, including SVG wrapper pages that reference raster images.
+- Avoid decoding/rendering images during non-visible text measurement and grayscale passes.
+
+## What Was Broken
+- Some EPUB cover pages are not plain `<img src="...">` documents. They are small XHTML/SVG wrapper pages whose visible raster cover is referenced from an SVG `<image>` element.
+- The slim chapter parser only treated HTML `<img src>` as image content, so an SVG wrapper such as `<image href="cover.jpg">` or `<image xlink:href="cover.jpg">` could build a valid section without producing any `PageImage` content. The reader then drew a blank or text-only page even though the EPUB contained a cover image.
+- Once image pages did render, the normal page pipeline could also touch images during font prewarm/measurement and text anti-aliasing grayscale passes. Those passes are not user-visible image draws, so decoding images there wasted time and could duplicate cache work.
+
+## What Changed
+- The parser now recognizes both HTML and SVG image elements:
+  - `<img src="...">`
+  - `<image href="...">`
+  - `<image xlink:href="...">`
+- SVG-wrapped raster images reuse the same EPUB-relative path resolution as existing image handling, so paths relative to the current XHTML/SVG wrapper resolve consistently.
+- Image content is serialized as page image content and rendered only by the visible page pass.
+- Text scan/prewarm and grayscale text anti-aliasing passes use text-only rendering, so image decode/cache work is not repeated for invisible passes.
+- Existing image-rendering settings are preserved:
+  - display images
+  - placeholders
+  - suppress images
+
+## Scope
+- EPUB chapter image parsing for `img`, SVG `image href`, and SVG `image xlink:href`.
+- Page render helpers that let visible rendering include images while measurement/text-only passes skip them.
+- Image diagnostics for parsed, resolved, skipped, rejected, cache, and decode paths.
+
+## Verification
+- `python test/image_rendering_static_contracts.py`
+- `./bin/clang-format-fix`
+- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`
+- `pio run -e default`
+
+---
+
+### AI Usage
+
+While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
+helps set the right context for reviewers.
+
+Did you use AI tools to help write this code? _**YES**_

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -54,6 +54,14 @@ void Page::render(GfxRenderer& renderer, const int fontId, const int xOffset, co
   }
 }
 
+void Page::renderTextOnly(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) const {
+  for (auto& element : elements) {
+    if (element->getTag() == TAG_PageLine) {
+      element->render(renderer, fontId, xOffset, yOffset);
+    }
+  }
+}
+
 bool Page::serialize(FsFile& file) const {
   const uint16_t count = elements.size();
   serialization::writePod(file, count);

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -73,6 +73,7 @@ class Page {
   }
 
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
+  void renderTextOnly(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;
   bool serialize(FsFile& file) const;
   static std::unique_ptr<Page> deserialize(FsFile& file);
 

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -99,7 +99,7 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
 
   // Bounds check render position using logical screen dimensions
   if (x < 0 || y < 0 || x + width > screenWidth || y + height > screenHeight) {
-    LOG_ERR("IMG", "Invalid render position: (%d,%d) size (%dx%d) screen (%dx%d)", x, y, width, height, screenWidth,
+    LOG_ERR("IMG", "Render bounds rejected: (%d,%d) size (%dx%d) screen (%dx%d)", x, y, width, height, screenWidth,
             screenHeight);
     return;
   }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -25,7 +25,7 @@ constexpr const char* BLOCK_TAGS[] = {"p", "li", "div", "br", "blockquote"};
 constexpr const char* BOLD_TAGS[] = {"b", "strong"};
 constexpr const char* ITALIC_TAGS[] = {"i", "em"};
 constexpr const char* UNDERLINE_TAGS[] = {"u", "ins"};
-constexpr const char* IMAGE_TAGS[] = {"img"};
+constexpr const char* IMAGE_TAGS[] = {"img", "image"};
 constexpr const char* SKIP_TAGS[] = {"head"};
 
 bool isWhitespace(const char c) { return c == ' ' || c == '\r' || c == '\n' || c == '\t'; }
@@ -269,13 +269,23 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       for (int i = 0; atts[i]; i += 2) {
         if (strcmp(atts[i], "src") == 0) {
           src = atts[i + 1];
+        } else if (src.empty() && strcmp(atts[i], "href") == 0) {
+          src = atts[i + 1];
+        } else if (src.empty() && strcmp(atts[i], "xlink:href") == 0) {
+          src = atts[i + 1];
         } else if (strcmp(atts[i], "alt") == 0) {
           alt = atts[i + 1];
         }
       }
+      const size_t hashPos = src.find('#');
+      if (hashPos != std::string::npos) {
+        src = src.substr(0, hashPos);
+      }
+      LOG_DBG("EHP", "Parsed image element: tag=%s src=%s alt=%s", name, src.c_str(), alt.c_str());
 
       // imageRendering: 0=display, 1=placeholder (alt text only), 2=suppress entirely
       if (self->imageRendering == 2) {
+        LOG_DBG("EHP", "Image suppressed by reader setting: %s", src.c_str());
         self->skipUntilDepth = self->depth;
         self->depth += 1;
         return;
@@ -283,23 +293,27 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
       // Skip image if CSS display:none
       if (self->cssParser) {
-        CssStyle imgDisplayStyle = self->cssParser->resolveStyle("img", classAttr);
+        CssStyle imgDisplayStyle = self->cssParser->resolveStyle(name, classAttr);
         if (!styleAttr.empty()) {
           imgDisplayStyle.applyOver(CssParser::parseInlineStyle(styleAttr));
         }
         if (imgDisplayStyle.hasDisplay() && imgDisplayStyle.display == CssDisplay::None) {
+          LOG_DBG("EHP", "Image skipped by CSS display:none: %s", src.c_str());
           self->skipUntilDepth = self->depth;
           self->depth += 1;
           return;
         }
       }
 
-      if (!src.empty() && self->imageRendering != 1) {
-        LOG_DBG("EHP", "Found image: src=%s", src.c_str());
+      if (self->imageRendering == 1) {
+        LOG_DBG("EHP", "Image placeholder by reader setting: %s", src.c_str());
+      }
 
+      if (!src.empty() && self->imageRendering != 1) {
         {
           // Resolve the image path relative to the HTML file
           std::string resolvedPath = FsHelpers::normalisePath(self->contentBase + src);
+          LOG_DBG("EHP", "Resolved image: src=%s resolved=%s", src.c_str(), resolvedPath.c_str());
 
           if (ImageDecoderFactory::isFormatSupported(resolvedPath)) {
             // Create a unique filename for the cached image
@@ -508,7 +522,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
             } else {
               LOG_ERR("EHP", "Failed to extract image");
             }
-          }  // isFormatSupported
+          } else {
+            LOG_DBG("EHP", "Unsupported image format: %s", resolvedPath.c_str());
+          }
         }
       }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -774,7 +774,7 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   // Font prewarm: scan pass accumulates text, then prewarm, then real render
   auto* fcm = renderer.getFontCacheManager();
   auto scope = fcm->createPrewarmScope();
-  page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);  // scan pass
+  page->renderTextOnly(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);  // scan pass
   scope.endScanAndPrewarm();
   const auto tPrewarm = millis();
 
@@ -818,14 +818,14 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
   if (SETTINGS.textAntiAliasing) {
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+    page->renderTextOnly(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
     renderer.copyGrayscaleLsbBuffers();
     const auto tGrayLsb = millis();
 
     // Render and copy to MSB buffer
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
+    page->renderTextOnly(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);
     renderer.copyGrayscaleMsbBuffers();
     const auto tGrayMsb = millis();
 

--- a/test/image_rendering_static_contracts.py
+++ b/test/image_rendering_static_contracts.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(rel: str) -> str:
+    path = ROOT / rel
+    assert path.exists(), f"Missing expected file: {rel}"
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(rel: str, *needles: str) -> None:
+    text = read(rel)
+    for needle in needles:
+        assert needle in text, f"{rel} is missing {needle!r}"
+
+
+def slice_between(text: str, start: str, end: str) -> str:
+    start_idx = text.index(start)
+    end_idx = text.index(end, start_idx)
+    return text[start_idx:end_idx]
+
+
+def main() -> None:
+    assert_contains(
+        "lib/Epub/Epub/Page.h",
+        "void renderTextOnly(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) const;",
+    )
+
+    page_cpp = read("lib/Epub/Epub/Page.cpp")
+    render_text_only = slice_between(page_cpp, "void Page::renderTextOnly", "bool Page::serialize")
+    assert "TAG_PageLine" in render_text_only
+    assert "element->render(renderer, fontId, xOffset, yOffset);" in render_text_only
+
+    epub_reader_cpp = read("src/activities/reader/EpubReaderActivity.cpp")
+    render_contents = slice_between(
+        epub_reader_cpp,
+        "void EpubReaderActivity::renderContents(",
+        "void EpubReaderActivity::renderStatusBar()",
+    )
+    assert (
+        "page->renderTextOnly(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);"
+        in render_contents
+    ), "Font prewarm scan pass must avoid image rendering"
+    assert (
+        render_contents.count(
+            "page->renderTextOnly(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);"
+        )
+        >= 3
+    ), "Text AA passes must not decode/render images"
+    assert "page->render(renderer, SETTINGS.getReaderFontId(), orientedMarginLeft, orientedMarginTop);" in render_contents
+
+    chapter_parser_cpp = read("lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp")
+    image_branch = slice_between(
+        chapter_parser_cpp,
+        "if (matches(name, IMAGE_TAGS, std::size(IMAGE_TAGS)))",
+        "  if (matches(name, SKIP_TAGS",
+    )
+    for needle in (
+        'constexpr const char* IMAGE_TAGS[] = {"img", "image"};',
+        '"src"',
+        '"href"',
+        '"xlink:href"',
+        "src.substr(0, hashPos)",
+        "FsHelpers::normalisePath(self->contentBase + src)",
+        "std::make_shared<PageImage>",
+        "Parsed image element:",
+        "Resolved image:",
+        "Image placeholder by reader setting",
+        "Image suppressed by reader setting",
+        "Image skipped by CSS display:none",
+        "Unsupported image format",
+    ):
+        assert needle in chapter_parser_cpp if needle.startswith("constexpr") else needle in image_branch, needle
+
+    assert_contains(
+        "lib/Epub/Epub/blocks/ImageBlock.cpp",
+        "Decode successful",
+        "Loading from cache:",
+        "Render bounds rejected:",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

Fixes EPUB image-only section rendering by teaching the slim chapter parser to treat SVG `<image>` elements as raster image content alongside existing HTML `<img>` elements. The parser now recognizes `src`, `href`, and `xlink:href`, strips fragment anchors, preserves EPUB-relative path resolution, and logs parsed/resolved/skipped image paths.

The reader page pipeline now has `Page::renderTextOnly(...)` so font prewarm and text anti-aliasing grayscale passes skip image blocks. Real image decode/render work stays in the visible page pass, preserving the existing display/placeholder/suppress image setting behavior without repeating image decode work in invisible passes.

<img width="1600" height="1244" alt="image" src="https://github.com/user-attachments/assets/7edcc126-6d87-41eb-8695-2f3195815133" />
Left: Patched, Right: 1.3

## Why

Some EPUB covers/front-matter pages are XHTML/SVG wrappers around raster images. Before this change, those sections could parse without producing `PageImage` content, so the reader drew a blank page even though the EPUB contained a cover image. Once image rendering worked, the previous render pipeline could still touch images during non-visible text passes, adding expensive duplicate work.

## How to verify

- `python test/incremental_section/StaticIncrementalContracts.py`
- `git diff --check`
- `PATH=/c/msys64/ucrt64/bin:$PATH test/run_incremental_section_tests.sh`

`pio run -e default --jobs 1` was attempted from the fresh PR2 worktree but timed out after 10 minutes before producing useful output.

## Notable decisions

- This PR just uses normal image rendering and does not try to make reader-mode cover image quality match the sleep-screen cover renderer.
- Image blocks are intentionally excluded from text measurement and text AA grayscale passes to avoid repeated image decode/cache work.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_