### PR TITLE
fix: silent-restart on exit from KOReader auth and OTA update

### DIFF
--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -7,6 +7,7 @@
 #include "KOReaderCredentialStore.h"
 #include "KOReaderSyncClient.h"
 #include "MappedInputManager.h"
+#include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -65,11 +66,11 @@ void KOReaderAuthActivity::onEnter() {
 void KOReaderAuthActivity::onExit() {
   Activity::onExit();
 
-  // Turn off wifi
-  WiFi.disconnect(false);
-  delay(100);
-  WiFi.mode(WIFI_OFF);
-  delay(100);
+  if (WiFi.getMode() != WIFI_MODE_NULL) {
+    WiFi.disconnect(false);
+    delay(30);
+    silentRestart();
+  }
 }
 
 void KOReaderAuthActivity::render(RenderLock&&) {

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -5,6 +5,7 @@
 #include <WiFi.h>
 
 #include "MappedInputManager.h"
+#include "SilentRestart.h"
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -66,11 +67,15 @@ void OtaUpdateActivity::onEnter() {
 void OtaUpdateActivity::onExit() {
   Activity::onExit();
 
-  // Turn off wifi
-  WiFi.disconnect(false);  // false = don't erase credentials, send disconnect frame
-  delay(100);              // Allow disconnect frame to be sent
-  WiFi.mode(WIFI_OFF);
-  delay(100);  // Allow WiFi hardware to fully power down
+  // Success path reboots via the SHUTTING_DOWN state's plain ESP.restart()
+  // (loop() above) so the new firmware boots normally. Back-out paths land
+  // here with wifi still active; silent-restart to free the LWIP/mbedTLS
+  // fragmentation, same as the other wifi activities.
+  if (WiFi.getMode() != WIFI_MODE_NULL) {
+    WiFi.disconnect(false);
+    delay(30);
+    silentRestart();
+  }
 }
 
 void OtaUpdateActivity::render(RenderLock&&) {


### PR DESCRIPTION
PR #1908 silent-restarts on exit from any wifi-using activity to defuse LWIP/mbedTLS heap fragmentation, but two of the wifi-using paths slipped through that audit:

  KOReaderAuthActivity (Settings -> KOReader sync -> Authenticate)
  OtaUpdateActivity    (Settings -> Check for update, back-out paths)

Both used WiFi.disconnect + WiFi.mode(WIFI_OFF) on exit and returned control to Settings, leaving ~50KB of contiguous heap stranded for the rest of the session.

Mirror the FontDownloadActivity pattern: if WiFi was activated, disconnect and silentRestart. OTA's success path is unchanged: SHUTTING_DOWN already calls plain ESP.restart() so the new firmware boots normally; only the cancel/fail/no-update back-out paths now go through silentRestart().


Did you use AI tools to help write this code? partial
