### PR TITLE
feat: serial test harness for on-device validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ build
 lib/EpdFont/scripts/downloaded_fonts/
 lib/EpdFont/scripts/instanced_fonts/
 lib/EpdFont/scripts/output/
+# Local serial harness log capture; written by scripts/devharness when debugging.
+harness.log

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -207,10 +207,68 @@ void HalGPIO::update() {
   const bool connected = isUsbConnected();
   usbStateChanged = (connected != lastUsbConnected);
   lastUsbConnected = connected;
+
+#ifdef ENABLE_SERIAL_LOG
+  const uint32_t now = millis();
+  for (uint8_t i = 0; i < 7; i++) {
+    // Consume any scheduled auto-release whose deadline has passed.
+    if (_simulatedReleaseAt[i] != 0 && now >= _simulatedReleaseAt[i]) {
+      _simulatedDown[i] = false;
+      _simulatedReleaseAt[i] = 0;
+    }
+    _effectivePrev[i] = _effectiveCurr[i];
+    _effectiveCurr[i] = inputMgr.isPressed(i) || _simulatedDown[i];
+  }
+#endif
 }
 
 bool HalGPIO::wasUsbStateChanged() const { return usbStateChanged; }
 
+#ifdef ENABLE_SERIAL_LOG
+bool HalGPIO::isPressed(uint8_t buttonIndex) const {
+  if (buttonIndex >= 7) return false;
+  return _effectiveCurr[buttonIndex];
+}
+
+bool HalGPIO::wasPressed(uint8_t buttonIndex) const {
+  if (buttonIndex >= 7) return false;
+  return _effectiveCurr[buttonIndex] && !_effectivePrev[buttonIndex];
+}
+
+bool HalGPIO::wasAnyPressed() const {
+  for (uint8_t i = 0; i < 7; i++) {
+    if (_effectiveCurr[i] && !_effectivePrev[i]) return true;
+  }
+  return false;
+}
+
+bool HalGPIO::wasReleased(uint8_t buttonIndex) const {
+  if (buttonIndex >= 7) return false;
+  return !_effectiveCurr[buttonIndex] && _effectivePrev[buttonIndex];
+}
+
+bool HalGPIO::wasAnyReleased() const {
+  for (uint8_t i = 0; i < 7; i++) {
+    if (!_effectiveCurr[i] && _effectivePrev[i]) return true;
+  }
+  return false;
+}
+
+void HalGPIO::simulateButton(uint8_t buttonIndex, bool down) {
+  if (buttonIndex >= 7) return;
+  _simulatedDown[buttonIndex] = down;
+  _simulatedReleaseAt[buttonIndex] = 0;
+}
+
+void HalGPIO::simulateButtonTap(uint8_t buttonIndex, uint32_t holdMs) {
+  if (buttonIndex >= 7) return;
+  _simulatedDown[buttonIndex] = true;
+  // 0 is the "no scheduled release" sentinel; coerce up to 1 ms in the rare
+  // case where millis() rolled to exactly UINT32_MAX-holdMs+1 == 0.
+  const uint32_t deadline = millis() + holdMs;
+  _simulatedReleaseAt[buttonIndex] = deadline == 0 ? 1 : deadline;
+}
+#else
 bool HalGPIO::isPressed(uint8_t buttonIndex) const { return inputMgr.isPressed(buttonIndex); }
 
 bool HalGPIO::wasPressed(uint8_t buttonIndex) const { return inputMgr.wasPressed(buttonIndex); }
@@ -220,6 +278,7 @@ bool HalGPIO::wasAnyPressed() const { return inputMgr.wasAnyPressed(); }
 bool HalGPIO::wasReleased(uint8_t buttonIndex) const { return inputMgr.wasReleased(buttonIndex); }
 
 bool HalGPIO::wasAnyReleased() const { return inputMgr.wasAnyReleased(); }
+#endif
 
 unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -46,6 +46,18 @@ class HalGPIO {
   bool lastUsbConnected = false;
   bool usbStateChanged = false;
 
+#ifdef ENABLE_SERIAL_LOG
+  // Effective button state under injection. Updated each update() as
+  // (physical OR simulated); edges are derived from the prev/curr snapshot
+  // here rather than from inputMgr so injected events fire wasPressed/
+  // wasReleased the same as real ones. _simulatedReleaseAt[i] is non-zero
+  // when a TAP/HOLD has scheduled an auto-release; update() consumes it.
+  bool _simulatedDown[7] = {false};
+  bool _effectiveCurr[7] = {false};
+  bool _effectivePrev[7] = {false};
+  uint32_t _simulatedReleaseAt[7] = {0};
+#endif
+
  public:
   enum class DeviceType : uint8_t { X4, X3 };
 
@@ -69,6 +81,20 @@ class HalGPIO {
   bool wasAnyPressed() const;
   bool wasReleased(uint8_t buttonIndex) const;
   bool wasAnyReleased() const;
+
+#ifdef ENABLE_SERIAL_LOG
+  // Inject a virtual press or release for the test harness. The injected state
+  // OR's into the physical InputManager state, so wasPressed/wasReleased edges
+  // fire normally for every activity. ENABLE_SERIAL_LOG keeps this out of
+  // release/slim builds; the production code path is unchanged.
+  void simulateButton(uint8_t buttonIndex, bool down);
+
+  // Press a button and schedule an auto-release after holdMs. Lets the host
+  // send a single CMD for a tap or a long-press without paying RTT for the
+  // release. The release fires inside the next update() that lands past the
+  // deadline, so timing is sub-loop-tick (~5-20ms granularity in practice).
+  void simulateButtonTap(uint8_t buttonIndex, uint32_t holdMs);
+#endif
   unsigned long getHeldTime() const;
   unsigned long getPowerButtonHeldTime() const;
 

--- a/scripts/devharness/__init__.py
+++ b/scripts/devharness/__init__.py
@@ -1,0 +1,3 @@
+from .device import Device, PHYSICAL_BUTTONS
+
+__all__ = ["Device", "PHYSICAL_BUTTONS"]

--- a/scripts/devharness/device.py
+++ b/scripts/devharness/device.py
@@ -1,0 +1,275 @@
+"""Serial control + observation harness for a connected X3/X4.
+
+Opens the device's USB CDC port once, runs a reader thread that captures every
+log line, exposes a small API for sending CMD: messages and waiting on
+[STATE] / log signals. Built to drive ENABLE_SERIAL_LOG firmware; release/slim
+builds will silently ignore button-inject commands.
+
+Caveat for macOS: opening /dev/cu.usbmodem* with default DTR pulses the C3 USB
+peripheral and triggers a chip reset. We force DTR/RTS off before any traffic.
+"""
+from __future__ import annotations
+
+import glob
+import platform
+import re
+import threading
+import time
+from collections import deque
+
+import serial
+
+
+PHYSICAL_BUTTONS = {"BACK", "CONFIRM", "LEFT", "RIGHT", "UP", "DOWN", "POWER"}
+
+
+def _autodetect_port() -> str:
+    system = platform.system()
+    pattern = "/dev/tty.usbmodem*" if system == "Darwin" else "/dev/ttyACM*"
+    candidates = sorted(glob.glob(pattern.replace("tty", "cu")))
+    if not candidates:
+        candidates = sorted(glob.glob(pattern))
+    if not candidates:
+        raise RuntimeError("no /dev/cu.usbmodem* found; pass port=... explicitly")
+    return candidates[0]
+
+
+class Device:
+    """One persistent serial connection that both observes logs and injects CMDs.
+
+    Use as a context manager so the reader thread is torn down cleanly:
+
+        with Device() as d:
+            d.wait_for_activity("Home")
+            d.tap("DOWN")
+    """
+
+    def __init__(self, port: str | None = None, baud: int = 115200) -> None:
+        self.port = port or _autodetect_port()
+        self.baud = baud
+        self._ser: serial.Serial | None = None
+        self._reader: threading.Thread | None = None
+        self._stop = threading.Event()
+        self._lines: deque[tuple[float, str]] = deque(maxlen=4096)
+        self._lock = threading.Lock()
+        self._cond = threading.Condition(self._lock)
+        # Snapshot of len(_lines) taken just before the most recent CMD send.
+        # wait_for() defaults to this so common patterns like
+        # `hold(); wait_for(predicate)` aren't racy against the firmware
+        # processing the CMD faster than we can re-enter the Condition.
+        self._send_cursor: int = 0
+
+    def __enter__(self) -> "Device":
+        # Construct without a port so DTR/RTS are configured BEFORE open()
+        # instead of pulsing high and then being lowered after. macOS's USB
+        # CDC driver still appears to perturb the C3 on first enumeration
+        # regardless, so this doesn't fully prevent the chip reset, but it
+        # eliminates the pyserial-side contribution. The wait_for_activity
+        # in go_home() and the resync logic in conftest's session fixture
+        # both tolerate the reset; tests run through it cleanly.
+        self._ser = serial.Serial()
+        self._ser.port = self.port
+        self._ser.baudrate = self.baud
+        self._ser.timeout = 0.1
+        self._ser.dtr = False
+        self._ser.rts = False
+        self._ser.open()
+        self._reader = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self._stop.set()
+        if self._reader is not None:
+            self._reader.join(timeout=1.0)
+        if self._ser is not None:
+            self._ser.close()
+
+    # ----- reader -----
+
+    def _read_loop(self) -> None:
+        assert self._ser is not None
+        buf = b""
+        while not self._stop.is_set():
+            try:
+                chunk = self._ser.read(256)
+            except (OSError, serial.SerialException):
+                time.sleep(0.1)
+                continue
+            if not chunk:
+                continue
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                text = line.decode("utf-8", errors="replace").rstrip("\r")
+                if not text:
+                    continue
+                with self._cond:
+                    self._lines.append((time.time(), text))
+                    self._cond.notify_all()
+
+    # ----- inputs -----
+
+    def _write(self, payload: str) -> None:
+        """Send a CMD line. Snapshots the current line count first so the next
+        wait_for() can scan lines emitted in response to this send, even if
+        the firmware emits them before the host re-enters the Condition."""
+        assert self._ser is not None
+        with self._lock:
+            self._send_cursor = len(self._lines)
+        self._ser.write(payload.encode("utf-8"))
+        self._ser.flush()
+
+    def press(self, button: str) -> None:
+        button = button.upper()
+        if button not in PHYSICAL_BUTTONS:
+            raise ValueError(f"unknown physical button: {button}")
+        self._write(f"CMD:BTN PRESS {button}\n")
+
+    def release(self, button: str) -> None:
+        button = button.upper()
+        if button not in PHYSICAL_BUTTONS:
+            raise ValueError(f"unknown physical button: {button}")
+        self._write(f"CMD:BTN RELEASE {button}\n")
+
+    def tap(self, button: str, hold_ms: int = 80) -> None:
+        """Server-side tap: firmware schedules its own auto-release after
+        hold_ms. Avoids round-trip latency on the release; the activity layer's
+        wasReleased() edge still fires normally."""
+        button = button.upper()
+        if button not in PHYSICAL_BUTTONS:
+            raise ValueError(f"unknown physical button: {button}")
+        self._write(f"CMD:BTN TAP {button}\n" if hold_ms == 80
+                    else f"CMD:BTN HOLD {button} {hold_ms}\n")
+
+    def hold(self, button: str, ms: int) -> None:
+        """Press and hold for `ms`, then auto-release. Same primitive as tap,
+        named for readability when hold time is the point (e.g. power button
+        long-press, settle windows)."""
+        button = button.upper()
+        if button not in PHYSICAL_BUTTONS:
+            raise ValueError(f"unknown physical button: {button}")
+        self._write(f"CMD:BTN HOLD {button} {ms}\n")
+
+    def request_state(self) -> None:
+        """Ask the firmware to re-emit the current [STATE] line. Useful after
+        opening the connection to learn what activity we're on without waiting
+        for the next transition."""
+        self._write("CMD:STATE\n")
+
+    def go_home(self, timeout: float = 10.0) -> None:
+        """Test-harness escape: jump straight to Home regardless of current
+        state. The firmware calls activityManager.goHome() so this works from
+        any activity (Reader, FileBrowser, deep settings, etc.) without
+        navigation guessing. Use at the start of each test for a clean
+        baseline."""
+        if self.current_activity() == "Home":
+            return
+        self._write("CMD:HOME\n")
+        # _write snapshots _send_cursor; wait_for defaults to scanning from
+        # that point so the [STATE] line emitted while we re-enter the
+        # Condition is still seen.
+        self.wait_for_activity("Home", timeout=timeout)
+
+    def home_menu(self, timeout: float = 3.0) -> tuple[list[str], int]:
+        """Return (items, selector) from the [HOME] menu= line emitted by the
+        current Home session. Symbols are stable (FileBrowser, Recents,
+        OpdsBrowser if configured, FileTransfer, Settings, plus RecentBook<i>
+        entries for each recent book).
+
+        Bounded to lines from after the most recent CMD (_send_cursor) so we
+        don't pick up a stale selector value from a previous Home entry; the
+        wait timeout covers the ~100ms gap between [STATE] activity=Home and
+        Home's first render."""
+        # Backward scan from latest line down to _send_cursor.
+        with self._lock:
+            window = list(self._lines)[self._send_cursor:]
+        for _ts, text in reversed(window):
+            m = self._HOME_MENU_RE.search(text)
+            if m:
+                return m.group(1).split(","), int(m.group(2))
+        # No [HOME] line emitted since the last CMD; wait for the next one.
+        line = self.wait_for(
+            lambda text: bool(self._HOME_MENU_RE.search(text)),
+            timeout=timeout,
+        )
+        m = self._HOME_MENU_RE.search(line)
+        assert m is not None
+        return m.group(1).split(","), int(m.group(2))
+
+    def navigate_home_to(self, target: str) -> None:
+        """Tap Down/Up to reach the named menu item on Home, then Confirm.
+        Reads the current menu from the [HOME] log so it adapts to the
+        actual device config (OPDS configured, recent books present, etc.).
+        Each step is bounded by wait_for_refresh's 3s timeout, so the worst
+        case (full 7-item walk + Confirm) is under ~25s.
+
+        Raises ValueError if target isn't a valid menu item on this device.
+        """
+        items, selector = self.home_menu()
+        if target not in items:
+            raise ValueError(
+                f"{target!r} not in Home menu {items!r} on this device"
+            )
+        target_idx = items.index(target)
+        delta = target_idx - selector
+        button = "DOWN" if delta > 0 else "UP"
+        for _ in range(abs(delta)):
+            self.tap(button)
+            self.wait_for_refresh(timeout=3.0)
+        self.tap("CONFIRM")
+
+    # ----- observation -----
+
+    def lines_count(self) -> int:
+        """Snapshot the current number of captured lines. Pair with wait_for's
+        `since=` to wait for events produced after a specific moment (e.g.
+        after sending a CMD)."""
+        with self._lock:
+            return len(self._lines)
+
+    def wait_for(self, predicate, timeout: float = 5.0, since: int | None = None) -> str:
+        """Block until a captured log line satisfies predicate. Returns the
+        matching line. Raises TimeoutError otherwise.
+
+        `since` is an index from lines_count(). If omitted, defaults to the
+        line count just before the most recent CMD send, so common patterns
+        like `hold(...); wait_for(...)` aren't racy. Pass since=lines_count()
+        explicitly to scan only future lines, or since=0 to scan everything."""
+        deadline = time.time() + timeout
+        with self._cond:
+            start = since if since is not None else self._send_cursor
+            while True:
+                for _ts, text in list(self._lines)[start:]:
+                    if predicate(text):
+                        return text
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    raise TimeoutError(f"wait_for timed out after {timeout:.1f}s")
+                self._cond.wait(timeout=remaining)
+
+    _STATE_RE = re.compile(r"\[STATE\]\s+activity=(\S*)")
+    _REFRESH_RE = re.compile(r"\[REFRESH\]\s+done")
+    _HOME_MENU_RE = re.compile(r"\[HOME\]\s+menu=(\S+)\s+selector=(\d+)")
+
+    def wait_for_activity(self, name: str, timeout: float = 10.0, since: int | None = None) -> None:
+        def matches(text: str) -> bool:
+            m = self._STATE_RE.search(text)
+            return bool(m and m.group(1) == name)
+        self.wait_for(matches, timeout=timeout, since=since)
+
+    def wait_for_refresh(self, timeout: float = 5.0) -> None:
+        """Block until the next [REFRESH] done line emitted by the render task.
+        Use after a tap that should produce a visible change, before asserting
+        on the next state."""
+        self.wait_for(lambda text: bool(self._REFRESH_RE.search(text)), timeout=timeout)
+
+    def current_activity(self) -> str | None:
+        """Most-recent [STATE] activity, if any. Returns None if no [STATE] has
+        been seen yet; call request_state() to force one."""
+        with self._lock:
+            for _ts, text in reversed(self._lines):
+                m = self._STATE_RE.search(text)
+                if m:
+                    return m.group(1) or None
+        return None

--- a/scripts/devharness/device.py
+++ b/scripts/devharness/device.py
@@ -177,9 +177,13 @@ class Device:
         state. The firmware calls activityManager.goHome() so this works from
         any activity (Reader, FileBrowser, deep settings, etc.) without
         navigation guessing. Use at the start of each test for a clean
-        baseline."""
-        if self.current_activity() == "Home":
-            return
+        baseline.
+
+        Always sends CMD:HOME (no "already on Home" short-circuit) so the
+        post-call window contains a fresh [STATE] activity=Home and a fresh
+        [HOME] menu= line. Downstream callers like home_menu() rely on that
+        freshness; skipping the send saved ~1s but broke them on second
+        invocation from a Home baseline."""
         self._write("CMD:HOME\n")
         # _write snapshots _send_cursor; wait_for defaults to scanning from
         # that point so the [STATE] line emitted while we re-enter the

--- a/scripts/devharness/device.py
+++ b/scripts/devharness/device.py
@@ -25,13 +25,21 @@ PHYSICAL_BUTTONS = {"BACK", "CONFIRM", "LEFT", "RIGHT", "UP", "DOWN", "POWER"}
 
 def _autodetect_port() -> str:
     system = platform.system()
-    pattern = "/dev/tty.usbmodem*" if system == "Darwin" else "/dev/ttyACM*"
-    candidates = sorted(glob.glob(pattern.replace("tty", "cu")))
-    if not candidates:
-        candidates = sorted(glob.glob(pattern))
-    if not candidates:
-        raise RuntimeError("no /dev/cu.usbmodem* found; pass port=... explicitly")
-    return candidates[0]
+    if system == "Darwin":
+        # macOS exposes both /dev/cu.* and /dev/tty.* for the same USB CDC
+        # device. Prefer /dev/cu.* (call-out): pyserial's DTR/RTS handling is
+        # more reliable on cu.* than on tty.* under macOS.
+        patterns = ["/dev/cu.usbmodem*", "/dev/tty.usbmodem*"]
+    else:
+        patterns = ["/dev/ttyACM*", "/dev/ttyUSB*"]
+    for pat in patterns:
+        candidates = sorted(glob.glob(pat))
+        if candidates:
+            return candidates[0]
+    raise RuntimeError(
+        f"no serial device found (searched {', '.join(repr(p) for p in patterns)}); "
+        f"pass port=... explicitly"
+    )
 
 
 class Device:
@@ -53,10 +61,16 @@ class Device:
         self._lines: deque[tuple[float, str]] = deque(maxlen=4096)
         self._lock = threading.Lock()
         self._cond = threading.Condition(self._lock)
-        # Snapshot of len(_lines) taken just before the most recent CMD send.
-        # wait_for() defaults to this so common patterns like
+        # Absolute, monotonic count of lines appended over the session's
+        # lifetime. Diverges from len(self._lines) once the deque rotates
+        # past maxlen. Cursors (_send_cursor, since= args to wait_for) are
+        # also absolute, so they stay correct after rotation. _slice_since()
+        # translates absolute → deque-local for actual scanning.
+        self._lines_total: int = 0
+        # Absolute line index just before the most recent CMD send. wait_for()
+        # defaults to scanning from here so common patterns like
         # `hold(); wait_for(predicate)` aren't racy against the firmware
-        # processing the CMD faster than we can re-enter the Condition.
+        # processing the CMD faster than we re-enter the Condition.
         self._send_cursor: int = 0
 
     def __enter__(self) -> "Device":
@@ -106,17 +120,18 @@ class Device:
                     continue
                 with self._cond:
                     self._lines.append((time.time(), text))
+                    self._lines_total += 1
                     self._cond.notify_all()
 
     # ----- inputs -----
 
     def _write(self, payload: str) -> None:
-        """Send a CMD line. Snapshots the current line count first so the next
-        wait_for() can scan lines emitted in response to this send, even if
-        the firmware emits them before the host re-enters the Condition."""
+        """Send a CMD line. Snapshots the absolute line count first so the
+        next wait_for() can scan lines emitted in response to this send, even
+        if the firmware emits them before the host re-enters the Condition."""
         assert self._ser is not None
         with self._lock:
-            self._send_cursor = len(self._lines)
+            self._send_cursor = self._lines_total
         self._ser.write(payload.encode("utf-8"))
         self._ser.flush()
 
@@ -181,9 +196,8 @@ class Device:
         don't pick up a stale selector value from a previous Home entry; the
         wait timeout covers the ~100ms gap between [STATE] activity=Home and
         Home's first render."""
-        # Backward scan from latest line down to _send_cursor.
         with self._lock:
-            window = list(self._lines)[self._send_cursor:]
+            window = self._slice_since(self._send_cursor)
         for _ts, text in reversed(window):
             m = self._HOME_MENU_RE.search(text)
             if m:
@@ -222,25 +236,35 @@ class Device:
     # ----- observation -----
 
     def lines_count(self) -> int:
-        """Snapshot the current number of captured lines. Pair with wait_for's
-        `since=` to wait for events produced after a specific moment (e.g.
-        after sending a CMD)."""
+        """Absolute count of lines captured over the session lifetime. Pair
+        with wait_for's `since=` to wait for events produced after a specific
+        moment (e.g. after sending a CMD). Survives deque rotation: returns a
+        monotonically-increasing value even after older lines age out."""
         with self._lock:
-            return len(self._lines)
+            return self._lines_total
+
+    def _slice_since(self, since: int) -> list[tuple[float, str]]:
+        """Return _lines from absolute index `since` onwards. Caller must
+        hold _lock. Translates the absolute index to a deque-local one,
+        accounting for any lines that have aged out of the maxlen window."""
+        base = self._lines_total - len(self._lines)
+        local_start = max(0, since - base)
+        return list(self._lines)[local_start:]
 
     def wait_for(self, predicate, timeout: float = 5.0, since: int | None = None) -> str:
         """Block until a captured log line satisfies predicate. Returns the
         matching line. Raises TimeoutError otherwise.
 
-        `since` is an index from lines_count(). If omitted, defaults to the
-        line count just before the most recent CMD send, so common patterns
-        like `hold(...); wait_for(...)` aren't racy. Pass since=lines_count()
-        explicitly to scan only future lines, or since=0 to scan everything."""
+        `since` is an absolute index from lines_count(). If omitted, defaults
+        to the snapshot taken just before the most recent CMD send, so common
+        patterns like `hold(...); wait_for(...)` aren't racy. Pass
+        since=lines_count() explicitly to scan only future lines, or since=0
+        to scan everything still in the buffer."""
         deadline = time.time() + timeout
         with self._cond:
             start = since if since is not None else self._send_cursor
             while True:
-                for _ts, text in list(self._lines)[start:]:
+                for _ts, text in self._slice_since(start):
                     if predicate(text):
                         return text
                 remaining = deadline - time.time()

--- a/scripts/devharness/device.py
+++ b/scripts/devharness/device.py
@@ -154,6 +154,8 @@ class Device:
         button = button.upper()
         if button not in PHYSICAL_BUTTONS:
             raise ValueError(f"unknown physical button: {button}")
+        if not isinstance(hold_ms, int) or hold_ms <= 0:
+            raise ValueError(f"hold_ms must be a positive int, got {hold_ms!r}")
         self._write(f"CMD:BTN TAP {button}\n" if hold_ms == 80
                     else f"CMD:BTN HOLD {button} {hold_ms}\n")
 
@@ -164,6 +166,8 @@ class Device:
         button = button.upper()
         if button not in PHYSICAL_BUTTONS:
             raise ValueError(f"unknown physical button: {button}")
+        if not isinstance(ms, int) or ms <= 0:
+            raise ValueError(f"ms must be a positive int, got {ms!r}")
         self._write(f"CMD:BTN HOLD {button} {ms}\n")
 
     def request_state(self) -> None:
@@ -264,14 +268,14 @@ class Device:
         patterns like `hold(...); wait_for(...)` aren't racy. Pass
         since=lines_count() explicitly to scan only future lines, or since=0
         to scan everything still in the buffer."""
-        deadline = time.time() + timeout
+        deadline = time.monotonic() + timeout
         with self._cond:
             start = since if since is not None else self._send_cursor
             while True:
                 for _ts, text in self._slice_since(start):
                     if predicate(text):
                         return text
-                remaining = deadline - time.time()
+                remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise TimeoutError(f"wait_for timed out after {timeout:.1f}s")
                 self._cond.wait(timeout=remaining)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,4 @@ cairosvg>=2.9.0
 matplotlib>=3.10.9
 pyserial>=3.5
 colorama>=0.4.6
+pytest>=8.0.0

--- a/src/activities/Activity.cpp
+++ b/src/activities/Activity.cpp
@@ -2,7 +2,13 @@
 
 #include "ActivityManager.h"
 
-void Activity::onEnter() { LOG_DBG("ACT", "Entering activity: %s", name.c_str()); }
+void Activity::onEnter() {
+  LOG_DBG("ACT", "Entering activity: %s", name.c_str());
+#ifdef ENABLE_SERIAL_LOG
+  // Canonical activity-transition signal for the host test harness.
+  LOG_INF("STATE", "activity=%s", name.c_str());
+#endif
+}
 
 void Activity::onExit() { LOG_DBG("ACT", "Exiting activity: %s", name.c_str()); }
 

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -43,6 +43,11 @@ void ActivityManager::renderTaskLoop() {
       HalPowerManager::Lock powerLock;  // Ensure we don't go into low-power mode while rendering
       currentActivity->render(std::move(lock));
     }
+#ifdef ENABLE_SERIAL_LOG
+    // Host harness syncs on this line: a frame has just been pushed to the
+    // e-ink and is visible (or in the process of refreshing).
+    LOG_INF("REFRESH", "done");
+#endif
     // Notify any task blocked in requestUpdateAndWait() that the render is done.
     TaskHandle_t waiter = nullptr;
     taskENTER_CRITICAL(nullptr);
@@ -246,6 +251,16 @@ ScreenshotInfo ActivityManager::getScreenshotInfo() const {
   }
   return {};
 }
+
+#ifdef ENABLE_SERIAL_LOG
+void ActivityManager::emitStateForHarness() const {
+  if (currentActivity) {
+    LOG_INF("STATE", "activity=%s", currentActivity->name.c_str());
+  } else {
+    LOG_INF("STATE", "activity=");
+  }
+}
+#endif
 
 void ActivityManager::requestUpdate(bool immediate) {
   if (immediate) {

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -102,6 +102,12 @@ class ActivityManager {
   bool skipLoopDelay() const;
   ScreenshotInfo getScreenshotInfo() const;
 
+#ifdef ENABLE_SERIAL_LOG
+  // Re-emit the current activity name as a [STATE] line for the harness.
+  // No-op if there is no current activity (transient between replace/pop).
+  void emitStateForHarness() const;
+#endif
+
   // If immediate is true, the update will be triggered immediately.
   // Otherwise, it will be deferred until the end of the current loop iteration.
   void requestUpdate(bool immediate = false);

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -241,6 +241,24 @@ void HomeActivity::render(RenderLock&&) {
     menuIcons.insert(menuIcons.begin(), Book);
   }
 
+#ifdef ENABLE_SERIAL_LOG
+  // Emit the navigable menu for the test harness. Symbols are stable across
+  // locales (unlike the translated tr() strings above). The selector indexes
+  // into this list: 0..recentBooks.size()-1 open the matching recent book,
+  // the rest match the action handlers in loop() below.
+  String menuLine;
+  for (size_t i = 0; i < recentBooks.size(); i++) {
+    if (i > 0) menuLine += ",";
+    menuLine += "RecentBook";
+    menuLine += static_cast<int>(i);
+  }
+  if (!recentBooks.empty()) menuLine += ",";
+  menuLine += "FileBrowser,Recents,";
+  if (hasOpdsServers) menuLine += "OpdsBrowser,";
+  menuLine += "FileTransfer,Settings";
+  LOG_INF("HOME", "menu=%s selector=%d", menuLine.c_str(), selectorIndex);
+#endif
+
   GUI.drawButtonMenu(
       renderer,
       Rect{0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, pageWidth,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,13 +443,20 @@ void loop() {
             name = cmd.substring(secondSpace + 1);
           }
           int idx = -1;
-          if (name == "BACK") idx = HalGPIO::BTN_BACK;
-          else if (name == "CONFIRM") idx = HalGPIO::BTN_CONFIRM;
-          else if (name == "LEFT") idx = HalGPIO::BTN_LEFT;
-          else if (name == "RIGHT") idx = HalGPIO::BTN_RIGHT;
-          else if (name == "UP") idx = HalGPIO::BTN_UP;
-          else if (name == "DOWN") idx = HalGPIO::BTN_DOWN;
-          else if (name == "POWER") idx = HalGPIO::BTN_POWER;
+          if (name == "BACK")
+            idx = HalGPIO::BTN_BACK;
+          else if (name == "CONFIRM")
+            idx = HalGPIO::BTN_CONFIRM;
+          else if (name == "LEFT")
+            idx = HalGPIO::BTN_LEFT;
+          else if (name == "RIGHT")
+            idx = HalGPIO::BTN_RIGHT;
+          else if (name == "UP")
+            idx = HalGPIO::BTN_UP;
+          else if (name == "DOWN")
+            idx = HalGPIO::BTN_DOWN;
+          else if (name == "POWER")
+            idx = HalGPIO::BTN_POWER;
           if (idx >= 0) {
             const uint8_t btnIdx = static_cast<uint8_t>(idx);
             if (action == "PRESS") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -418,6 +418,71 @@ void loop() {
         logSerial.write(buf, bufferSize);
         logSerial.printf("SCREENSHOT_END\n");
       }
+#ifdef ENABLE_SERIAL_LOG
+      // Test harness commands. Gated together because the called APIs
+      // (simulateButton, simulateButtonTap, emitStateForHarness) are only
+      // declared under the same flag; non-harness builds wouldn't link.
+      else if (cmd.startsWith("BTN ")) {
+        // CMD:BTN PRESS <name>          -> inject button-down (held until RELEASE)
+        // CMD:BTN RELEASE <name>        -> inject button-up
+        // CMD:BTN TAP <name>            -> press, auto-release after 80ms
+        // CMD:BTN HOLD <name> <ms>      -> press, auto-release after <ms>
+        // <name> is the physical button: BACK, CONFIRM, LEFT, RIGHT, UP, DOWN, POWER
+        const int firstSpace = 3;
+        const int secondSpace = cmd.indexOf(' ', firstSpace + 1);
+        if (secondSpace > 0) {
+          const String action = cmd.substring(firstSpace + 1, secondSpace);
+          // For HOLD, the third token is the duration; clip name accordingly.
+          String name;
+          uint32_t holdMs = 80;
+          const int thirdSpace = cmd.indexOf(' ', secondSpace + 1);
+          if (thirdSpace > 0) {
+            name = cmd.substring(secondSpace + 1, thirdSpace);
+            holdMs = static_cast<uint32_t>(cmd.substring(thirdSpace + 1).toInt());
+          } else {
+            name = cmd.substring(secondSpace + 1);
+          }
+          int idx = -1;
+          if (name == "BACK") idx = HalGPIO::BTN_BACK;
+          else if (name == "CONFIRM") idx = HalGPIO::BTN_CONFIRM;
+          else if (name == "LEFT") idx = HalGPIO::BTN_LEFT;
+          else if (name == "RIGHT") idx = HalGPIO::BTN_RIGHT;
+          else if (name == "UP") idx = HalGPIO::BTN_UP;
+          else if (name == "DOWN") idx = HalGPIO::BTN_DOWN;
+          else if (name == "POWER") idx = HalGPIO::BTN_POWER;
+          if (idx >= 0) {
+            const uint8_t btnIdx = static_cast<uint8_t>(idx);
+            if (action == "PRESS") {
+              gpio.simulateButton(btnIdx, true);
+              LOG_INF("HARNESS", "btn %s down", name.c_str());
+            } else if (action == "RELEASE") {
+              gpio.simulateButton(btnIdx, false);
+              LOG_INF("HARNESS", "btn %s up", name.c_str());
+            } else if (action == "TAP") {
+              gpio.simulateButtonTap(btnIdx, holdMs);
+              LOG_INF("HARNESS", "btn %s tap %ums", name.c_str(), (unsigned)holdMs);
+            } else if (action == "HOLD") {
+              gpio.simulateButtonTap(btnIdx, holdMs);
+              LOG_INF("HARNESS", "btn %s hold %ums", name.c_str(), (unsigned)holdMs);
+            } else {
+              LOG_ERR("HARNESS", "unknown action: %s", action.c_str());
+            }
+          } else {
+            LOG_ERR("HARNESS", "unknown button: %s", name.c_str());
+          }
+        }
+      } else if (cmd == "STATE") {
+        // Re-emit the current activity so the host can resync without waiting
+        // for the next transition.
+        activityManager.emitStateForHarness();
+      } else if (cmd == "HOME") {
+        // Test-harness escape: drop whatever activity is current and land on
+        // Home. Equivalent to activityManager.goHome() from inside an
+        // activity, but reachable from any test starting state.
+        activityManager.goHome();
+        LOG_INF("HARNESS", "go home");
+      }
+#endif
     }
   }
 

--- a/test/device/README.md
+++ b/test/device/README.md
@@ -1,0 +1,40 @@
+# On-device validation tests
+
+Pytest tests that drive a connected X3/X4 over USB CDC.
+
+## Prereqs
+
+- Device flashed with an `ENABLE_SERIAL_LOG` build (default `pio run` env).
+- `pyserial` + `pytest` (already in `scripts/requirements.txt`).
+- USB cable connected to a `/dev/cu.usbmodem*` (macOS) or `/dev/ttyACM*` (Linux).
+
+## Run
+
+```bash
+uv run pytest test/device                       # autodetect port
+DEVHARNESS_PORT=/dev/cu.usbmodem101 uv run pytest test/device
+uv run pytest test/device/test_smoke.py -v      # one file
+```
+
+## How it works
+
+The harness opens the serial port once (`scripts/devharness/Device`) and runs
+a reader thread that captures every log line into a deque. CMDs are sent over
+the same connection. macOS DTR/RTS are forced off on open because the default
+pulse triggers `USB_UART_CHIP_RESET` on the C3.
+
+## Adding tests
+
+Use the `device` fixture (session-scoped) or `home` fixture (skips if not on
+Home). Pattern:
+
+```python
+def test_open_book(home):
+    home.navigate_home_to("RecentBook0")
+    home.wait_for_activity("Reader", timeout=15.0)
+    home.wait_for_refresh()
+    home.tap("BACK")
+    home.wait_for_activity("Home")
+```
+
+See `scripts/devharness/device.py` for the full Device API.

--- a/test/device/conftest.py
+++ b/test/device/conftest.py
@@ -1,0 +1,47 @@
+"""Pytest fixtures for on-device validation tests.
+
+Tests run against a connected X3/X4 that's been flashed with an
+ENABLE_SERIAL_LOG build (default `pio run` environment). One Device instance
+is shared across the test session because opening the port can briefly
+disturb the device on macOS, and re-opening per-test would also lose log
+history that wait_for relies on.
+
+Run from the repo root:
+    uv run pytest test/device
+
+Or against a specific port:
+    DEVHARNESS_PORT=/dev/cu.usbmodem101 uv run pytest test/device
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+
+import pytest
+
+# Make scripts/ importable without installing the package.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from devharness import Device  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def device():
+    port = os.environ.get("DEVHARNESS_PORT") or None
+    with Device(port=port) as d:
+        # Resync to a known state before the first test runs. wait_for_activity
+        # will either see a fresh transition or the request_state echo.
+        d.request_state()
+        d.wait_for(lambda text: "[STATE]" in text, timeout=10.0)
+        yield d
+
+
+@pytest.fixture
+def home(device):
+    """Reset the device to Home before the test runs. Lets every test start
+    from a known baseline regardless of what the previous test left behind,
+    so tests compose as 'go home, then drive somewhere, then assert'."""
+    device.go_home()
+    return device

--- a/test/device/test_navigation.py
+++ b/test/device/test_navigation.py
@@ -1,0 +1,68 @@
+"""Composable navigation tests.
+
+Each test starts from a known baseline (Home, via the `home` fixture which
+calls device.go_home()) and drives the device to a specific activity, then
+asserts on the transition. Tests are independent: any one can run by itself,
+and they don't depend on order because each fixture run resets state.
+
+navigate_home_to(symbol) reads the device's actual menu from a [HOME] log
+line, so tests work whether OPDS is configured, recent books are present,
+or the theme inlines Continue Reading. Symbols are stable across locales.
+
+Available menu symbols:
+    RecentBook<N>   one per recent book on disk
+    FileBrowser
+    Recents
+    OpdsBrowser     only when OPDS servers are configured
+    FileTransfer
+    Settings
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_navigate_to_file_browser(home):
+    home.navigate_home_to("FileBrowser")
+    home.wait_for_activity("FileBrowser", timeout=10.0)
+
+
+def test_navigate_to_recents(home):
+    home.navigate_home_to("Recents")
+    home.wait_for_activity("RecentBooks", timeout=10.0)
+
+
+def test_navigate_to_file_transfer(home):
+    home.navigate_home_to("FileTransfer")
+    home.wait_for_activity("CrossPointWebServer", timeout=10.0)
+
+
+def test_navigate_to_settings(home):
+    home.navigate_home_to("Settings")
+    home.wait_for_activity("Settings", timeout=10.0)
+
+
+def test_navigate_to_opds_when_configured(home):
+    """Skips on devices without OPDS configured."""
+    items, _ = home.home_menu()
+    if "OpdsBrowser" not in items:
+        pytest.skip("no OPDS servers configured on this device")
+    home.navigate_home_to("OpdsBrowser")
+    home.wait_for_activity("OpdsBookBrowser", timeout=10.0)
+
+
+def test_back_from_settings_returns_to_home(home):
+    """Round-trip: enter Settings, press Back, land on Home."""
+    home.navigate_home_to("Settings")
+    home.wait_for_activity("Settings", timeout=10.0)
+    home.tap("BACK")
+    home.wait_for_activity("Home", timeout=10.0)
+
+
+def test_open_first_recent_book(home):
+    """Skips on devices with no recent books."""
+    items, _ = home.home_menu()
+    if "RecentBook0" not in items:
+        pytest.skip("no recent books on device")
+    home.navigate_home_to("RecentBook0")
+    home.wait_for_activity("Reader", timeout=15.0)

--- a/test/device/test_smoke.py
+++ b/test/device/test_smoke.py
@@ -1,0 +1,40 @@
+"""Smoke tests for the serial control harness primitives.
+
+These verify each primitive (request_state, tap, hold, wait_for_refresh)
+round-trips against a live device. Navigation tests live in test_navigation.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_request_state_emits_fresh_state_line(device):
+    """CMD:STATE should make the firmware re-emit [STATE] without requiring a
+    transition. Wait for a [STATE] line emitted *after* the CMD so the test
+    actually exercises the round-trip, not just whatever stale line already
+    sits in the reader buffer from a previous transition."""
+    device.request_state()
+    # request_state's _write snapshots _send_cursor; wait_for defaults to
+    # scanning from there, so the matching line must be in response to the CMD.
+    line = device.wait_for(lambda text: "[STATE] activity=" in text, timeout=5.0)
+    activity = line.split("activity=", 1)[1].strip()
+    assert activity, "request_state produced an empty activity name"
+
+
+def test_wait_for_refresh_resolves_after_tap(home):
+    """A tap that changes the selector should produce a render-task
+    notification within the refresh window."""
+    home.tap("DOWN")
+    home.wait_for_refresh(timeout=5.0)
+
+
+@pytest.mark.parametrize("hold_ms", [50, 200, 500])
+def test_hold_durations_round_trip(device, hold_ms):
+    """Firmware should accept a range of HOLD durations and echo back the
+    [HARNESS] confirmation line for each, catching parser regressions."""
+    device.hold("DOWN", hold_ms)
+    matching = device.wait_for(
+        lambda text: f"hold {hold_ms}ms" in text,
+        timeout=2.0,
+    )
+    assert f"btn DOWN hold {hold_ms}ms" in matching


### PR DESCRIPTION
Lets a host Python script drive a connected X3/X4 over USB CDC: inject button events, observe activity transitions, and assert on screen state without touching the hardware. Pytest-runnable so device behaviour can join the rest of the development workflow.

Firmware side (all gated behind ENABLE_SERIAL_LOG so release/slim builds are unaffected):

- HalGPIO::simulateButton(idx, down) overlays a virtual button-down on top of the real InputManager state. update() OR's physical and virtual, so wasPressed/wasReleased edges fire for every activity exactly as if the user had pressed the button. simulateButtonTap(idx, ms) schedules an auto-release for one-shot taps without paying serial RTT on the release edge.

- main.cpp CMD parser extended:
    CMD:BTN PRESS|RELEASE|TAP|HOLD <name>   button injection
    CMD:STATE                               re-emit current activity
    CMD:HOME                                activityManager.goHome()
  CMD:SCREENSHOT is unchanged.

- Activity::onEnter emits '[STATE] activity=<name>'. Canonical activity- transition signal the host syncs on.

- ActivityManager render task emits '[REFRESH] done' after every frame push. Lets tests wait for the screen to settle rather than guessing with sleeps.

- HomeActivity::render emits '[HOME] menu=<symbols> selector=<n>' with stable, locale-independent symbols (RecentBook<i>, FileBrowser, Recents, OpdsBrowser, FileTransfer, Settings). Adapts to per-device config without hard-coded indices.

Host side:

- scripts/devharness/Device opens the USB CDC port once and runs a reader thread that captures every line into a bounded deque. Forces DTR/RTS off on open; the macOS default pulses the C3 USB peripheral and triggers USB_UART_CHIP_RESET.

  Methods: press, release, tap, hold, request_state, go_home, home_menu, navigate_home_to, wait_for, wait_for_activity, wait_for_refresh, current_activity. _write snapshots a send cursor before writing so wait_for can scan lines emitted in response to the send even if the firmware beats the host back into the Condition.

- test/device/ pytest fixtures (session-scoped Device, per-test home that resets via go_home), plus test_smoke (primitives round-trip) and test_navigation (each Home menu destination drives to its matching activity).

- scripts/requirements.txt += pytest.

Run: uv run pytest test/device. 12 passing live on X3 in ~33s.



Did you use AI tools to help write this code? partial
