### PR TITLE
feat: add structured HTTP User-Agent identifying device model and screen

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -1,6 +1,7 @@
 #include "KOReaderSyncClient.h"
 
 #include <ArduinoJson.h>
+#include <CrossPointInfo.h>
 #include <Logging.h>
 #include <esp_crt_bundle.h>
 #include <esp_http_client.h>
@@ -83,7 +84,8 @@ esp_http_client_handle_t createClient(const char* url, ResponseBuffer* buf,
   if (!client) return nullptr;
 
   // KOSync auth headers
-  if (esp_http_client_set_header(client, "Accept", "application/vnd.koreader.v1+json") != ESP_OK ||
+  if (esp_http_client_set_header(client, "User-Agent", getCrossPointHttpUserAgent()) != ESP_OK ||
+      esp_http_client_set_header(client, "Accept", "application/vnd.koreader.v1+json") != ESP_OK ||
       esp_http_client_set_header(client, "x-auth-user", KOREADER_STORE.getUsername().c_str()) != ESP_OK ||
       esp_http_client_set_header(client, "x-auth-key", KOREADER_STORE.getMd5Password().c_str()) != ESP_OK) {
     LOG_ERR("KOSync", "Failed to set auth headers");

--- a/lib/hal/CrossPointInfo.cpp
+++ b/lib/hal/CrossPointInfo.cpp
@@ -1,0 +1,21 @@
+#include "CrossPointInfo.h"
+
+#include <HalDisplay.h>
+#include <HalGPIO.h>
+
+#include <cstdio>
+
+const char* getCrossPointHttpUserAgent() {
+  // 80 bytes comfortably fits the longest expected UA string:
+  // "CrossPoint/1.3.0-dev+abc1234 (X3; esp32-c3; 528x800)" (~55 chars)
+  static char buf[80];
+  static bool built = false;
+  if (built) return buf;
+
+  const char* model = gpio.deviceIsX3() ? "X3" : "X4";
+
+  snprintf(buf, sizeof(buf), "CrossPoint/" CROSSPOINT_VERSION " (%s; " CROSSPOINT_MCU "; %ux%u)", model,
+           display.getDisplayWidth(), display.getDisplayHeight());
+  built = true;
+  return buf;
+}

--- a/lib/hal/CrossPointInfo.cpp
+++ b/lib/hal/CrossPointInfo.cpp
@@ -3,19 +3,22 @@
 #include <HalDisplay.h>
 #include <HalGPIO.h>
 
+#include <array>
+#include <cassert>
 #include <cstdio>
 
 const char* getCrossPointHttpUserAgent() {
+  // Thread-safe, one-time initialization guaranteed by C++ local static init.
   // 80 bytes comfortably fits the longest expected UA string:
   // "CrossPoint/1.3.0-dev+abc1234 (X3; esp32-c3; 528x800)" (~55 chars)
-  static char buf[80];
-  static bool built = false;
-  if (built) return buf;
-
-  const char* model = gpio.deviceIsX3() ? "X3" : "X4";
-
-  snprintf(buf, sizeof(buf), "CrossPoint/" CROSSPOINT_VERSION " (%s; " CROSSPOINT_MCU "; %ux%u)", model,
-           display.getDisplayWidth(), display.getDisplayHeight());
-  built = true;
-  return buf;
+  static const auto ua = []() {
+    std::array<char, 80> buf{};
+    const char* model = gpio.deviceIsX3() ? "X3" : "X4";
+    const int len =
+        snprintf(buf.data(), buf.size(), "CrossPoint/" CROSSPOINT_VERSION " (%s; " CROSSPOINT_MCU "; %ux%u)", model,
+                 display.getDisplayWidth(), display.getDisplayHeight());
+    assert(len > 0 && len < static_cast<int>(buf.size()));
+    return buf;
+  }();
+  return ua.data();
 }

--- a/lib/hal/CrossPointInfo.h
+++ b/lib/hal/CrossPointInfo.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// MCU is fixed across all supported hardware targets.
+#define CROSSPOINT_MCU "esp32-c3"
+
+// Returns the HTTP User-Agent string for this device, e.g.:
+//   "CrossPoint/1.3.0 (X4; esp32-c3; 480x800)"
+// Built once on first call using runtime GPIO and display state; safe to call
+// after hardware init. CROSSPOINT_VERSION is injected by platformio.ini.
+const char* getCrossPointHttpUserAgent();

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -1,5 +1,6 @@
 #include "HttpDownloader.h"
 
+#include <CrossPointInfo.h>
 #include <HTTPClient.h>
 #include <Logging.h>
 #include <NetworkClient.h>
@@ -72,7 +73,7 @@ bool HttpDownloader::fetchUrl(const std::string& url, Stream& outContent, const 
 
   http.begin(*client, url.c_str());
   http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  http.addHeader("User-Agent", getCrossPointHttpUserAgent());
 
   if (!username.empty() && !password.empty()) {
     std::string credentials = username + ":" + password;
@@ -123,7 +124,7 @@ HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& 
 
   http.begin(*client, url.c_str());
   http.setFollowRedirects(HTTPC_STRICT_FOLLOW_REDIRECTS);
-  http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  http.addHeader("User-Agent", getCrossPointHttpUserAgent());
 
   if (!username.empty() && !password.empty()) {
     std::string credentials = username + ":" + password;

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -1,5 +1,6 @@
 #include "OtaUpdater.h"
 
+#include <CrossPointInfo.h>
 #include <Logging.h>
 #include <ReleaseJsonParser.h>
 #include <esp_crt_bundle.h>
@@ -11,7 +12,7 @@ namespace {
 constexpr char latestReleaseUrl[] = "https://api.github.com/repos/crosspoint-reader/crosspoint-reader/releases/latest";
 
 esp_err_t http_client_set_header_cb(esp_http_client_handle_t http_client) {
-  return esp_http_client_set_header(http_client, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  return esp_http_client_set_header(http_client, "User-Agent", getCrossPointHttpUserAgent());
 }
 
 size_t totalBytesReceived = 0;
@@ -50,7 +51,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
     return INTERNAL_UPDATE_ERROR;
   }
 
-  esp_err = esp_http_client_set_header(client_handle, "User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+  esp_err = esp_http_client_set_header(client_handle, "User-Agent", getCrossPointHttpUserAgent());
   if (esp_err != ESP_OK) {
     LOG_ERR("OTA", "esp_http_client_set_header Failed : %s", esp_err_to_name(esp_err));
     esp_http_client_cleanup(client_handle);


### PR DESCRIPTION
Introduces CrossPointInfo (lib/hal/) as the single source of truth for the outbound User-Agent string and use that in all call HTTP call sites.

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)

The goal for this PR is to enrich and standardize the user agent that CrossPoint uses for HTTP requests. The standardization is not strictly necessary but I figured it doesn't hurt. The enrichment allows for OPDS servers to serve optimized epub files to the client based on the contents of the user agent string.

* **What changes are included?**

The UA format is:

  CrossPoint/\<version\> (\<model\>; esp32-c3; \<WxH\>)
  e.g. "CrossPoint/1.3.0 (X4; esp32-c3; 800x480)"

Device model (X3 vs X4) and screen dimensions are resolved at runtime via gpio.deviceIsX3() and display.getDisplayWidth/Height(), so the string is correct across all supported hardware without build-time variants. The string is built once into a static buffer on first call.

Previously each HTTP client (HttpDownloader, OtaUpdater, KOReaderSyncClient) had its own inline literal; they now all call getCrossPointHttpUserAgent().

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, 
  specific areas to focus on).

I am unsure if anyone depends on the existing user agent format; if so, this may risk breaking them. Moreover, I plan to add a dependency on this particular format moving forward which may be limiting for future changes. If you have alternative ideas for how to achieve the same goals, I am happy to hear them.

e.g. I had considered using [client hints](https://en.wikipedia.org/wiki/Client_Hints) instead but the complexity didn't seem obviously worth it to me in this context. Happy to be told otherwise.

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? YES, though I reviewed the changes directly and built the cross point binary to verify that the build continued to work as expected.
