### PR TITLE
fix: Enabled stack-overflow detection 

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,6 +29,7 @@ build_flags =
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
   -DXML_CONTEXT_BYTES=1024
+  -DCONFIG_FREERTOS_CHECK_STACKOVERFLOW=2
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1

--- a/src/FreeRtosHooks.cpp
+++ b/src/FreeRtosHooks.cpp
@@ -1,0 +1,12 @@
+#include <Logging.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include <cassert>
+
+extern "C" void vApplicationStackOverflowHook(TaskHandle_t task, char* taskName) {
+  (void)task;
+  const char* name = taskName ? taskName : "(unknown)";
+  LOG_ERR("RTOS", "Stack overflow in task: %s", name);
+  assert(false && "Stack overflow");
+}


### PR DESCRIPTION
## Summary

Enabled stack-overflow detection and added a FreeRTOS overflow hook so the panic report will identify the offending task.
should help diagnose #2047.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
