### PR TITLE
feat: Compress BW buffer to avoid AA fallback (save ~0.5s in page display time)

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -13,6 +13,7 @@
 namespace {
 
 const char* resolveVisualText(const char* text, std::string& visualBuffer, int paragraphLevel);
+constexpr uint32_t COMPRESSED_BW_BACKUP_CAP = 32 * 1024;
 
 /**
  * Resolves the requested style to the best available style in the given SD card font.
@@ -1379,6 +1380,119 @@ void GfxRenderer::freeBwBufferChunks() {
   }
 }
 
+void GfxRenderer::freeCompressedBwBuffer() {
+  free(compressedBwBuffer);
+  compressedBwBuffer = nullptr;
+  compressedBwBufferSize = 0;
+}
+
+bool GfxRenderer::storeCompressedBwBuffer(const uint32_t maxBytes) {
+  freeCompressedBwBuffer();
+  compressedBwBuffer = static_cast<uint8_t*>(malloc(maxBytes));
+  if (!compressedBwBuffer) {
+    lastBwBufferStats.compressedCapacity = maxBytes;
+    lastBwBufferStats.compressionAborted = 1;
+    return false;
+  }
+
+  auto emitLiteral = [&](const uint8_t* src, uint8_t len, uint32_t& out) {
+    if (len == 0) return true;
+    if (out + 1U + len > maxBytes) return false;
+    compressedBwBuffer[out++] = static_cast<uint8_t>(len - 1);
+    memcpy(&compressedBwBuffer[out], src, len);
+    out += len;
+    return true;
+  };
+
+  auto emitRun = [&](const uint8_t value, uint8_t len, uint32_t& out) {
+    if (len == 0) return true;
+    if (out + 2U > maxBytes) return false;
+    compressedBwBuffer[out++] = static_cast<uint8_t>(0x80 | (len - 1));
+    compressedBwBuffer[out++] = value;
+    return true;
+  };
+
+  uint32_t out = 0;
+  uint32_t i = 0;
+  while (i < frameBufferSize) {
+    uint32_t runLen = 1;
+    while (i + runLen < frameBufferSize && runLen < 128 && frameBuffer[i + runLen] == frameBuffer[i]) {
+      runLen++;
+    }
+
+    if (runLen >= 3) {
+      if (!emitRun(frameBuffer[i], static_cast<uint8_t>(runLen), out)) {
+        lastBwBufferStats.compressionAborted = 2;
+        freeCompressedBwBuffer();
+        return false;
+      }
+      i += runLen;
+      continue;
+    }
+
+    const uint32_t literalStart = i;
+    uint32_t literalLen = 0;
+    while (i < frameBufferSize && literalLen < 128) {
+      runLen = 1;
+      while (i + runLen < frameBufferSize && runLen < 128 && frameBuffer[i + runLen] == frameBuffer[i]) {
+        runLen++;
+      }
+      if (runLen >= 3 && literalLen > 0) break;
+      if (runLen >= 3) break;
+      i++;
+      literalLen++;
+    }
+
+    if (!emitLiteral(&frameBuffer[literalStart], static_cast<uint8_t>(literalLen), out)) {
+      lastBwBufferStats.compressionAborted = 2;
+      freeCompressedBwBuffer();
+      return false;
+    }
+  }
+
+  // A zero-byte marker is not part of the format; the expected output length is frameBufferSize.
+  // Keep compressedBwBufferSize explicit so restore can stop exactly at the encoded length.
+  if (out > 0 && out < maxBytes) {
+    if (auto* shrunk = static_cast<uint8_t*>(realloc(compressedBwBuffer, out))) {
+      compressedBwBuffer = shrunk;
+    }
+  }
+  compressedBwBufferSize = out;
+  lastBwBufferStats.backupKind = BwBufferStats::BackupKind::CompressedRle;
+  lastBwBufferStats.compressedBytes = out;
+  lastBwBufferStats.compressedCapacity = maxBytes;
+  lastBwBufferStats.allocatedBytes = out;
+  return true;
+}
+
+bool GfxRenderer::restoreCompressedBwBuffer() {
+  if (!compressedBwBuffer || compressedBwBufferSize == 0) return false;
+
+  uint32_t in = 0;
+  uint32_t out = 0;
+  while (in < compressedBwBufferSize && out < frameBufferSize) {
+    const uint8_t control = compressedBwBuffer[in++];
+    if (control & 0x80) {
+      if (in >= compressedBwBufferSize) break;
+      const uint8_t len = (control & 0x7F) + 1;
+      const uint8_t value = compressedBwBuffer[in++];
+      if (out + len > frameBufferSize) break;
+      memset(&frameBuffer[out], value, len);
+      out += len;
+    } else {
+      const uint8_t len = control + 1;
+      if (in + len > compressedBwBufferSize || out + len > frameBufferSize) break;
+      memcpy(&frameBuffer[out], &compressedBwBuffer[in], len);
+      in += len;
+      out += len;
+    }
+  }
+
+  const bool ok = out == frameBufferSize && in == compressedBwBufferSize;
+  freeCompressedBwBuffer();
+  return ok;
+}
+
 /**
  * This should be called before grayscale buffers are populated.
  * A `restoreBwBuffer` call should always follow the grayscale render if this method was called.
@@ -1386,6 +1500,23 @@ void GfxRenderer::freeBwBufferChunks() {
  * Returns true if buffer was stored successfully, false if allocation failed.
  */
 bool GfxRenderer::storeBwBuffer() {
+  freeBwBufferChunks();
+  freeCompressedBwBuffer();
+  lastBwBufferStats = {};
+  lastBwBufferStats.chunkCount = bwBufferChunks.size();
+  lastBwBufferStats.chunkSize = BW_BUFFER_CHUNK_SIZE;
+  lastBwBufferStats.bufferBytes = frameBufferSize;
+
+  // The BW backup only has to survive while the framebuffer is reused for AA
+  // planes. Try a bounded RLE copy first to reduce peak heap pressure; fall back
+  // to raw chunks when a page does not compress enough.
+  if (storeCompressedBwBuffer(COMPRESSED_BW_BACKUP_CAP)) {
+    LOG_DBG("GFX", "Stored BW buffer compressed (%lu/%lu bytes)",
+            static_cast<unsigned long>(lastBwBufferStats.compressedBytes),
+            static_cast<unsigned long>(lastBwBufferStats.compressedCapacity));
+    return true;
+  }
+
   // Allocate and copy each chunk
   for (size_t i = 0; i < bwBufferChunks.size(); i++) {
     // Check if any chunks are already allocated
@@ -1401,14 +1532,19 @@ bool GfxRenderer::storeBwBuffer() {
 
     if (!bwBufferChunks[i]) {
       LOG_ERR("GFX", "!! Failed to allocate BW buffer chunk %zu (%zu bytes)", i, chunkSize);
+      lastBwBufferStats.failedChunk = static_cast<int16_t>(i);
+      lastBwBufferStats.failedChunkSize = static_cast<uint16_t>(chunkSize);
       // Free previously allocated chunks
       freeBwBufferChunks();
       return false;
     }
 
     memcpy(bwBufferChunks[i], frameBuffer + offset, chunkSize);
+    lastBwBufferStats.allocatedChunks++;
+    lastBwBufferStats.allocatedBytes += chunkSize;
   }
 
+  lastBwBufferStats.backupKind = BwBufferStats::BackupKind::RawChunks;
   LOG_DBG("GFX", "Stored BW buffer in %zu chunks (%zu bytes each)", bwBufferChunks.size(), BW_BUFFER_CHUNK_SIZE);
   return true;
 }
@@ -1419,6 +1555,14 @@ bool GfxRenderer::storeBwBuffer() {
  * Uses chunked restoration to match chunked storage.
  */
 void GfxRenderer::restoreBwBuffer() {
+  if (compressedBwBuffer) {
+    const bool restored = restoreCompressedBwBuffer();
+    if (restored) {
+      display.cleanupGrayscaleBuffers(frameBuffer);
+    }
+    return;
+  }
+
   // Check if all chunks are allocated
   bool missingChunks = false;
   for (const auto& bwBufferChunk : bwBufferChunks) {

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -21,6 +21,22 @@ class GfxRenderer {
  public:
   enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
 
+  struct BwBufferStats {
+    enum class BackupKind : uint8_t { None, RawChunks, CompressedRle };
+
+    BackupKind backupKind = BackupKind::None;
+    uint16_t chunkCount = 0;
+    uint16_t chunkSize = 0;
+    uint32_t bufferBytes = 0;
+    uint16_t allocatedChunks = 0;
+    uint32_t allocatedBytes = 0;
+    int16_t failedChunk = -1;
+    uint16_t failedChunkSize = 0;
+    uint32_t compressedBytes = 0;
+    uint32_t compressedCapacity = 0;
+    uint16_t compressionAborted = 0;
+  };
+
   // Logical screen orientation from the perspective of callers
   enum Orientation {
     Portrait,                  // 480x800 logical coordinates (current default)
@@ -42,6 +58,9 @@ class GfxRenderer {
   uint16_t panelWidthBytes = HalDisplay::DISPLAY_WIDTH_BYTES;
   uint32_t frameBufferSize = HalDisplay::BUFFER_SIZE;
   std::vector<uint8_t*> bwBufferChunks;
+  BwBufferStats lastBwBufferStats;
+  uint8_t* compressedBwBuffer = nullptr;
+  uint32_t compressedBwBufferSize = 0;
   std::map<int, EpdFontFamily> fontMap;
   // Mutable because ensureSdCardFontReady() is const (called from layout code
   // that holds a const GfxRenderer&) but triggers SD card reads and heap
@@ -57,6 +76,9 @@ class GfxRenderer {
   void renderChar(const EpdFontFamily& fontFamily, uint32_t cp, int* x, int* y, bool pixelState,
                   EpdFontFamily::Style style) const;
   void freeBwBufferChunks();
+  void freeCompressedBwBuffer();
+  bool storeCompressedBwBuffer(uint32_t maxBytes);
+  bool restoreCompressedBwBuffer();
   template <Color color>
   void drawPixelDither(int x, int y) const;
   template <Color color>
@@ -65,7 +87,10 @@ class GfxRenderer {
  public:
   explicit GfxRenderer(HalDisplay& halDisplay)
       : display(halDisplay), renderMode(BW), orientation(Portrait), fadingFix(false) {}
-  ~GfxRenderer() { freeBwBufferChunks(); }
+  ~GfxRenderer() {
+    freeBwBufferChunks();
+    freeCompressedBwBuffer();
+  }
 
   static constexpr int VIEWABLE_MARGIN_TOP = 9;
   static constexpr int VIEWABLE_MARGIN_RIGHT = 3;
@@ -172,7 +197,8 @@ class GfxRenderer {
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer() const;
-  bool storeBwBuffer();    // Returns true if buffer was stored successfully
+  bool storeBwBuffer();  // Returns true if buffer was stored successfully
+  const BwBufferStats& getLastBwBufferStats() const { return lastBwBufferStats; }
   void restoreBwBuffer();  // Restore and free the stored buffer
   void cleanupGrayscaleWithFrameBuffer() const;
 


### PR DESCRIPTION
## Summary
RLE-compress the BW buffer to prevent OOM issues forcing the AA code from using the BW buffer fallback (which adds ~0.5 seconds in page display time) 

## Additional Context
When AA is turned on, page renders start with the BW pass, saving it to a buffer, running the grayscale AA passes, then restoring the BW buffer. With SD fonts, it's possible that "big" fonts combined with languages like CJK with many distinct glyphs will lead to the per-page glyph cache crowding out the BW buffer from memory forcing the AA code to use a slower fallback approach.

To prevent that, RLE-compress the BW buffer so less memory is needed. The compression/decompression adds <10ms of CPU time but saves potentially 0.5s in avoiding the AA pass doing a more complicated BW restore path. 

## Technical Details
`GfxRenderer::storeBwBuffer()` now tries a bounded RLE-compressed backup before falling back to the previous raw chunk backup:

1. Render and display the BW page.
2. Try to compress the BW framebuffer into a fixed 32KB RLE buffer.
3. If compression succeeds, preserve that backup through the AA passes.
4. Restore by decompressing into `frameBuffer`, then run the same grayscale cleanup path.
5. If compression allocation or size cap fails, try the previous raw chunk backup.
6. If raw backup also fails, keep the existing BW re-render fallback.

---

### AI Usage
Did you use AI tools to help write this code?  YES - Codex