### PR TITLE
feat: add the Libre Baskerville font family

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -129,10 +129,10 @@ families:
     intervals: latin-ext
     sizes: [12, 14, 16, 18]
     styles:
-      regular:    {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Regular.ttf"}
-      bold:       {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Bold.ttf"}
-      italic:     {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Italic.ttf"}
-      bolditalic: {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-BoldItalic.ttf"}
+      regular:    {url: "https://raw.githubusercontent.com/impallari/Libre-Baskerville/master/fonts/ttf/LibreBaskerville-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/impallari/Libre-Baskerville/master/fonts/ttf/LibreBaskerville-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/impallari/Libre-Baskerville/master/fonts/ttf/LibreBaskerville-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/impallari/Libre-Baskerville/master/fonts/ttf/LibreBaskerville-BoldItalic.ttf"}
     
 
   # ── Sans-serif ─────────────────────────────────────────────────────────

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -122,6 +122,17 @@ families:
       bold:       {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Bold.otf"}
       italic:     {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Italic.otf"}
       bolditalic: {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-BoldItalic.otf"}
+
+  
+  - name: LibreBaskerville
+    description: "A serif reimplementing the classic Baskerville (Latin)"
+    intervals: latin-ext
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Regular.ttf"}
+      bold:       {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Bold.ttf"}
+      italic:     {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-Italic.ttf"}
+      bolditalic: {url: "https://github.com/impallari/Libre-Baskerville/blob/master/fonts/ttf/LibreBaskerville-BoldItalic.ttf"}
     
 
   # ── Sans-serif ─────────────────────────────────────────────────────────

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -123,7 +123,6 @@ families:
       italic:     {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-Italic.otf"}
       bolditalic: {url: "https://mirrors.ctan.org/fonts/domitian/opentype/Domitian-BoldItalic.otf"}
 
-  
   - name: LibreBaskerville
     description: "A serif reimplementing the classic Baskerville (Latin)"
     intervals: latin-ext


### PR DESCRIPTION
## Summary

This PR adds the [Libre Baskerville ](https://github.com/impallari/Libre-Baskerville) font family to the fonts available for download in CrossPoint.


## Additional Context

Baskerville is a classic font family, widely available in some form or the other in most ereaders and widely used in publishing and in the academy.

Libre Baskerville is a libre (SIL Open Font License v1) implementation of it, which makes it possible for CrossPoint to ship it without issues.

![Vita-e-destino_ch30_p1_13pct_99220.bmp](https://github.com/user-attachments/files/28070672/Vita-e-destino_ch30_p1_13pct_99220.bmp)


---

### AI Usage

Did you use AI tools to help write this code? _**NO**_


