### PR TITLE
fix: store/restore bw buffer when drawing sleep screen

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -221,6 +221,8 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 
   if (hasGreyscale) {
+    renderer.storeBwBuffer();
+
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
@@ -234,6 +236,8 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap) const {
     renderer.copyGrayscaleMsbBuffers();
 
     renderer.displayGrayBuffer();
+
+    renderer.restoreBwBuffer(); 
     renderer.setRenderMode(GfxRenderer::BW);
   }
 }


### PR DESCRIPTION
## Summary

Stores and restores BW buffer when drawing sleep screen grayscale content (per GfxRenderer comments). This fixes BW buffer data rendering with the grayscale content.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_ 
