### PR TITLE
fix(epub): correct footnote page assignment when hyphenation is active

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -138,6 +138,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordStyles.push_back(baseStyle);
     wordContinues.push_back(attachToPrevious);
     wordIsFocusSuffix.push_back(false);
+    wordIsHyphenRemainder.push_back(false);
     if (wordStartsRtl) {
       hasRtlWord = true;
     }
@@ -167,6 +168,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordStyles.reserve(newCapacity);
     wordContinues.reserve(newCapacity);
     wordIsFocusSuffix.reserve(newCapacity);
+    wordIsHyphenRemainder.reserve(newCapacity);
   }
 
   // Lambda helper to process and push individual sub-segments of the string
@@ -178,6 +180,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
       wordStyles.push_back(baseStyle);
       wordContinues.push_back(attach);
       wordIsFocusSuffix.push_back(false);
+      wordIsHyphenRemainder.push_back(false);
     } else {
       size_t charCount = 0;
       const unsigned char* countPtr = reinterpret_cast<const unsigned char*>(segment.data());
@@ -199,6 +202,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordStyles.push_back(static_cast<EpdFontFamily::Style>(baseStyle | EpdFontFamily::BOLD));
         wordContinues.push_back(attach);
         wordIsFocusSuffix.push_back(false);
+        wordIsHyphenRemainder.push_back(false);
       } else {
         countPtr = reinterpret_cast<const unsigned char*>(segment.data());
         for (size_t i = 0; i < targetBoldChars; ++i) {
@@ -211,12 +215,14 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordStyles.push_back(static_cast<EpdFontFamily::Style>(baseStyle | EpdFontFamily::BOLD));
         wordContinues.push_back(attach);
         wordIsFocusSuffix.push_back(false);
+        wordIsHyphenRemainder.push_back(false);
 
         // Regular suffix - marked so extractLine can merge it back into single TextBlock entry
         words.emplace_back(segment.substr(splitByteOffset));
         wordStyles.push_back(baseStyle);
         wordContinues.push_back(true);
         wordIsFocusSuffix.push_back(true);
+        wordIsHyphenRemainder.push_back(false);
       }
     }
   };
@@ -270,7 +276,7 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine) const {
 }
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                                       const std::function<void(std::shared_ptr<TextBlock>, size_t)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
     return;
@@ -336,6 +342,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     wordStyles.erase(wordStyles.begin(), wordStyles.begin() + consumed);
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
     wordIsFocusSuffix.erase(wordIsFocusSuffix.begin(), wordIsFocusSuffix.begin() + consumed);
+    wordIsHyphenRemainder.erase(wordIsHyphenRemainder.begin(), wordIsHyphenRemainder.begin() + consumed);
   }
 }
 
@@ -605,6 +612,8 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
   // The hyphen remainder is not a focus suffix - it starts fresh on the next line.
   wordIsFocusSuffix.insert(wordIsFocusSuffix.begin() + wordIndex + 1, false);
+  // Mark as hyphen-inserted so word-index tracking ignores it when assigning footnotes to pages.
+  wordIsHyphenRemainder.insert(wordIsHyphenRemainder.begin() + wordIndex + 1, true);
 
   // Continuation flag handling after splitting a word into prefix + remainder.
   //
@@ -637,11 +646,19 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, size_t)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
+
+  // Count only non-hyphen-remainder words for footnote page-assignment tracking.
+  // Hyphenation inserts extra tokens (remainders) into words[], inflating the post-layout
+  // word count relative to the pre-layout count used when computing footnote wordIndex values.
+  size_t preHyphenWordCount = 0;
+  for (size_t i = lastBreakAt; i < lineBreak; ++i) {
+    if (!wordIsHyphenRemainder[i]) ++preHyphenWordCount;
+  }
 
   const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0);
 
@@ -919,7 +936,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   if (!lineHasFocusSplit) {
     processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
-                                            std::vector<uint8_t>{}, std::vector<uint16_t>{}, blockStyle));
+                                            std::vector<uint8_t>{}, std::vector<uint16_t>{}, blockStyle),
+                preHyphenWordCount);
     return;
   }
 
@@ -965,5 +983,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   }
 
   processLine(std::make_shared<TextBlock>(std::move(outWords), std::move(outXPos), std::move(outStyles),
-                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle));
+                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle),
+              preHyphenWordCount);
 }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -2,6 +2,7 @@
 
 #include <EpdFontFamily.h>
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>
@@ -15,8 +16,9 @@ class GfxRenderer;
 class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
-  std::vector<bool> wordContinues;      // true = word attaches to previous (no space before it)
-  std::vector<bool> wordIsFocusSuffix;  // true = token is the regular tail of a focus bold-prefix split
+  std::vector<bool> wordContinues;          // true = word attaches to previous (no space before it)
+  std::vector<bool> wordIsFocusSuffix;      // true = token is the regular tail of a focus bold-prefix split
+  std::vector<bool> wordIsHyphenRemainder;  // true = token was inserted by hyphenation (not an original word)
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;
@@ -40,8 +42,8 @@ class ParsedText {
                             std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks);
   void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
-                   int fontId);
+                   const std::function<void(std::shared_ptr<TextBlock>, size_t)>& processLine,
+                   const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
  public:
@@ -60,7 +62,10 @@ class ParsedText {
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
+  size_t preHyphenWordCount() const {
+    return static_cast<size_t>(std::count(wordIsHyphenRemainder.begin(), wordIsHyphenRemainder.end(), false));
+  }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, size_t)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1087,7 +1087,10 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
                                         : self->viewportWidth;
     self->currentTextBlock->layoutAndExtractLines(
         self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+        [self](const std::shared_ptr<TextBlock>& textBlock, const size_t preHyphenWords) {
+          self->addLineToPage(textBlock, preHyphenWords);
+        },
+        false);
   }
 }
 
@@ -1160,8 +1163,8 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       entry.number[sizeof(entry.number) - 1] = '\0';
       strncpy(entry.href, self->currentFootnote.href, sizeof(entry.href) - 1);
       entry.href[sizeof(entry.href) - 1] = '\0';
-      int wordIndex =
-          self->wordsExtractedInBlock + (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);
+      int wordIndex = self->wordsExtractedInBlock +
+                      (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->preHyphenWordCount()) : 0);
       self->pendingFootnotes.push_back({wordIndex, entry});
     }
     self->insideFootnoteLink = false;
@@ -1324,7 +1327,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   return true;
 }
 
-void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
+void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const size_t preHyphenWordCount) {
   const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
 
   if (!currentPage) {
@@ -1339,8 +1342,10 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
     currentPageNextY = 0;
   }
 
-  // Track cumulative words to assign footnotes to the page containing their anchor
-  wordsExtractedInBlock += line->wordCount();
+  // Track cumulative pre-hyphenation words to assign footnotes to the correct page.
+  // Using the pre-hyphenation count keeps this in the same coordinate system as the
+  // wordIndex stored in pendingFootnotes (computed before layout/hyphenation).
+  wordsExtractedInBlock += static_cast<int>(preHyphenWordCount);
   auto footnoteIt = pendingFootnotes.begin();
   while (footnoteIt != pendingFootnotes.end() && footnoteIt->first <= wordsExtractedInBlock) {
     currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href);
@@ -1383,7 +1388,9 @@ void ChapterHtmlSlimParser::makePages() {
 
   currentTextBlock->layoutAndExtractLines(
       renderer, fontId, effectiveWidth,
-      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
+      [this](const std::shared_ptr<TextBlock>& textBlock, const size_t preHyphenWords) {
+        addLineToPage(textBlock, preHyphenWords);
+      });
 
   // Fallback: transfer any remaining pending footnotes to current page.
   // Normally addLineToPage handles this via word-index tracking, but this catches

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -143,6 +143,6 @@ class ChapterHtmlSlimParser {
 
   ~ChapterHtmlSlimParser() = default;
   bool parseAndBuildPages();
-  void addLineToPage(std::shared_ptr<TextBlock> line);
+  void addLineToPage(std::shared_ptr<TextBlock> line, size_t preHyphenWordCount);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 };


### PR DESCRIPTION
Hyphenation inserts remainder tokens into ParsedText::words[], inflating the post-layout word count relative to the pre-layout index stored in pendingFootnotes. This caused footnotes whose anchor fell near a hyphenated word to be assigned to the wrong (earlier) page.

Track which words are hyphenation remainders via wordIsHyphenRemainder[]. extractLine() now computes a pre-hyphenation word count per line and passes it to addLineToPage(), which uses it to accumulate wordsExtractedInBlock. Both wordIndex and the accumulator now count in the same coordinate system, fixing the page assignment.

Bump SECTION_FILE_VERSION 23 → 24 to invalidate stale caches.

## Summary

* **What is the goal of this PR?** Fix a bug about the footnotes not being accessible in some cases when hyphenation is on.
* **What changes are included?**

## Additional Context

![bug footnotes](https://fau.re/crosspoint-bug-footnotes.jpg)
In this image, there are 2 footnotes: 22 and 23. When going to the footnotes pages, only 23 is listed.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES  >**_
