### PR TITLE
fix: restart web server after Wi-Fi reconnect

### DIFF
--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -274,7 +274,7 @@ void CrossPointWebServerActivity::loop() {
     }
 
     // STA mode: Monitor WiFi connection health
-    if (!isApMode && webServer && webServer->isRunning()) {
+    if (!isApMode && webServer) {
       static unsigned long lastWifiCheck = 0;
       if (millis() - lastWifiCheck > 2000) {  // Check every 2 seconds
         lastWifiCheck = millis();
@@ -290,6 +290,11 @@ void CrossPointWebServerActivity::loop() {
           consecutiveDisconnects++;
           LOG_DBG("WEBACT", "WiFi not connected (status=%d, consecutive=%d, total=%lu ms)", wifiStatus,
                   consecutiveDisconnects, millis() - firstDisconnectAt);
+          if (webServer->isRunning()) {
+            LOG_DBG("WEBACT", "Stopping web server while STA reconnects");
+            webServer->stop();
+            lastHandleClientTime = 0;
+          }
           if (millis() - firstDisconnectAt > WIFI_ABANDON_MS) {
             LOG_DBG("WEBACT", "WiFi unavailable for >%lu s; returning to network selection", WIFI_ABANDON_MS / 1000UL);
             state = WebServerActivityState::SHUTTING_DOWN;
@@ -301,6 +306,14 @@ void CrossPointWebServerActivity::loop() {
             LOG_DBG("WEBACT", "WiFi recovered after %d failed checks (%lu ms)", consecutiveDisconnects,
                     millis() - firstDisconnectAt);
             repaint = true;
+          }
+          if (!webServer->isRunning() && WiFi.localIP() != IPAddress(0, 0, 0, 0)) {
+            connectedIP = WiFi.localIP().toString().c_str();
+            LOG_DBG("WEBACT", "Restarting web server after STA reconnect: %s", connectedIP.c_str());
+            consecutiveDisconnects = 0;
+            firstDisconnectAt = 0;
+            startWebServer();
+            return;
           }
           consecutiveDisconnects = 0;
           firstDisconnectAt = 0;

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -10,6 +10,7 @@
 #include <cstddef>
 
 #include "MappedInputManager.h"
+#include "Memory.h"
 #include "NetworkModeSelectionActivity.h"
 #include "SilentRestart.h"
 #include "WifiSelectionActivity.h"
@@ -246,7 +247,14 @@ void CrossPointWebServerActivity::startWebServer() {
   LOG_DBG("WEBACT", "Starting web server...");
 
   // Create the web server instance
-  webServer.reset(new CrossPointWebServer());
+  auto nextWebServer = makeUniqueNoThrow<CrossPointWebServer>();
+  if (!nextWebServer) {
+    LOG_ERR("WEBACT", "ERROR: Failed to allocate web server!");
+    onGoHome();
+    return;
+  }
+
+  webServer = std::move(nextWebServer);
   webServer->begin();
 
   if (webServer->isRunning()) {

--- a/src/activities/network/CrossPointWebServerActivity.h
+++ b/src/activities/network/CrossPointWebServerActivity.h
@@ -13,8 +13,10 @@ enum class WebServerActivityState {
   MODE_SELECTION,  // Choosing between Join Network and Create Hotspot
   WIFI_SELECTION,  // WiFi selection subactivity is active (for Join Network mode)
   AP_STARTING,     // Starting Access Point mode
-  SERVER_RUNNING,  // Web server is running and handling requests
-  SHUTTING_DOWN    // Shutting down server and WiFi
+  // Activity is serving clients. In STA mode the server may be stopped briefly
+  // during WiFi reconnect; check webServer->isRunning() for socket state.
+  SERVER_RUNNING,
+  SHUTTING_DOWN  // Shutting down server and WiFi
 };
 
 /**


### PR DESCRIPTION
## Summary
- stop the STA web server when Wi-Fi drops so stale HTTP/WebSocket/UDP sockets are closed
- keep monitoring Wi-Fi while the server is stopped during reconnect
- recreate the web server and refresh the displayed IP after Wi-Fi returns

## Validation
- git diff --check
- pio check --fail-on-defect medium --fail-on-defect high
- pio run
- coderabbit review --agent -t uncommitted