### PR TITLE
perf: Speed up wifi reconnect

### DIFF
--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -263,6 +263,29 @@ bool JsonSettingsIO::saveWifi(const WifiCredentialStore& store, const char* path
     JsonObject obj = arr.add<JsonObject>();
     obj["ssid"] = cred.ssid;
     obj["password_obf"] = obfuscation::obfuscateToBase64(cred.password);
+    bool hasHint = cred.channel != 0;
+    for (int i = 0; i < 6 && !hasHint; i++) {
+      if (cred.bssid[i] != 0) hasHint = true;
+    }
+    if (hasHint) {
+      char bssidHex[13];
+      snprintf(bssidHex, sizeof(bssidHex), "%02x%02x%02x%02x%02x%02x", cred.bssid[0], cred.bssid[1], cred.bssid[2],
+               cred.bssid[3], cred.bssid[4], cred.bssid[5]);
+      obj["bssid"] = bssidHex;
+      obj["channel"] = cred.channel;
+    }
+    if (cred.ip[0] != 0) {
+      char buf[16];
+      snprintf(buf, sizeof(buf), "%d.%d.%d.%d", cred.ip[0], cred.ip[1], cred.ip[2], cred.ip[3]);
+      obj["ip"] = buf;
+      snprintf(buf, sizeof(buf), "%d.%d.%d.%d", cred.gateway[0], cred.gateway[1], cred.gateway[2], cred.gateway[3]);
+      obj["gw"] = buf;
+      snprintf(buf, sizeof(buf), "%d.%d.%d.%d", cred.mask[0], cred.mask[1], cred.mask[2], cred.mask[3]);
+      obj["mask"] = buf;
+      snprintf(buf, sizeof(buf), "%d.%d.%d.%d", cred.dns[0], cred.dns[1], cred.dns[2], cred.dns[3]);
+      obj["dns"] = buf;
+      obj["ts"] = cred.cacheTimestamp;
+    }
   }
 
   String json;
@@ -292,6 +315,52 @@ bool JsonSettingsIO::loadWifi(WifiCredentialStore& store, const char* json, bool
     if (!ok || cred.password.empty()) {
       cred.password = obj["password"] | std::string("");
       if (!cred.password.empty() && needsResave) *needsResave = true;
+    }
+    const std::string bssidHex = obj["bssid"] | std::string("");
+    const int channel = obj["channel"] | 0;
+    if (bssidHex.size() == 12 && channel > 0 && channel <= 14) {
+      bool parseOk = true;
+      uint8_t parsed[6] = {0};
+      for (int i = 0; i < 6 && parseOk; i++) {
+        unsigned int byte = 0;
+        if (sscanf(bssidHex.c_str() + i * 2, "%2x", &byte) != 1) {
+          parseOk = false;
+        } else {
+          parsed[i] = static_cast<uint8_t>(byte);
+        }
+      }
+      if (parseOk) {
+        std::memcpy(cred.bssid, parsed, 6);
+        cred.channel = static_cast<uint8_t>(channel);
+      }
+    }
+    const auto parseQuad = [](const std::string& s, uint8_t out[4]) -> bool {
+      unsigned int a = 0, b = 0, c = 0, d = 0;
+      int consumed = 0;
+      // %n stores characters consumed; require it to equal full string length so we
+      // reject inputs with trailing garbage like "192.168.1.10xyz".
+      if (sscanf(s.c_str(), "%u.%u.%u.%u%n", &a, &b, &c, &d, &consumed) != 4) return false;
+      if (consumed < 0 || static_cast<size_t>(consumed) != s.size()) return false;
+      if (a > 255 || b > 255 || c > 255 || d > 255) return false;
+      out[0] = a;
+      out[1] = b;
+      out[2] = c;
+      out[3] = d;
+      return true;
+    };
+    const std::string ipStr = obj["ip"] | std::string("");
+    const std::string gwStr = obj["gw"] | std::string("");
+    const std::string maskStr = obj["mask"] | std::string("");
+    const std::string dnsStr = obj["dns"] | std::string("");
+    if (!ipStr.empty()) {
+      uint8_t ip[4], gw[4], mask[4], dns[4];
+      if (parseQuad(ipStr, ip) && parseQuad(gwStr, gw) && parseQuad(maskStr, mask) && parseQuad(dnsStr, dns)) {
+        std::memcpy(cred.ip, ip, 4);
+        std::memcpy(cred.gateway, gw, 4);
+        std::memcpy(cred.mask, mask, 4);
+        std::memcpy(cred.dns, dns, 4);
+        cred.cacheTimestamp = obj["ts"] | 0u;
+      }
     }
     store.credentials.push_back(cred);
   }

--- a/src/WifiCredentialStore.cpp
+++ b/src/WifiCredentialStore.cpp
@@ -6,6 +6,8 @@
 #include <ObfuscationUtils.h>
 #include <Serialization.h>
 
+#include <cstring>
+
 // Initialize the static instance
 WifiCredentialStore WifiCredentialStore::instance;
 
@@ -149,6 +151,54 @@ const WifiCredential* WifiCredentialStore::findCredential(const std::string& ssi
 }
 
 bool WifiCredentialStore::hasSavedCredential(const std::string& ssid) const { return findCredential(ssid) != nullptr; }
+
+bool WifiCredentialStore::updateConnectionCache(const std::string& ssid, const uint8_t bssid[6], uint8_t channel,
+                                                const uint8_t ip[4], const uint8_t gateway[4], const uint8_t mask[4],
+                                                const uint8_t dns[4], uint32_t cacheTimestamp) {
+  const auto cred =
+      find_if(credentials.begin(), credentials.end(), [&ssid](const WifiCredential& c) { return c.ssid == ssid; });
+  if (cred == credentials.end()) {
+    return false;
+  }
+  const bool sameHint = (channel == cred->channel) && std::memcmp(bssid, cred->bssid, 6) == 0;
+  const bool sameIp = std::memcmp(ip, cred->ip, 4) == 0 && std::memcmp(gateway, cred->gateway, 4) == 0 &&
+                      std::memcmp(mask, cred->mask, 4) == 0 && std::memcmp(dns, cred->dns, 4) == 0;
+  // Timestamp updates are not worth a write on their own; only persist when topology changed.
+  if (sameHint && sameIp) {
+    return true;
+  }
+  std::memcpy(cred->bssid, bssid, 6);
+  cred->channel = channel;
+  std::memcpy(cred->ip, ip, 4);
+  std::memcpy(cred->gateway, gateway, 4);
+  std::memcpy(cred->mask, mask, 4);
+  std::memcpy(cred->dns, dns, 4);
+  cred->cacheTimestamp = cacheTimestamp;
+  return saveToFile();
+}
+
+bool WifiCredentialStore::clearConnectionCache(const std::string& ssid) {
+  const auto cred =
+      find_if(credentials.begin(), credentials.end(), [&ssid](const WifiCredential& c) { return c.ssid == ssid; });
+  if (cred == credentials.end()) {
+    return false;
+  }
+  bool empty = (cred->channel == 0) && (cred->ip[0] == 0);
+  for (int i = 0; i < 6 && empty; i++) {
+    if (cred->bssid[i] != 0) empty = false;
+  }
+  if (empty) {
+    return true;
+  }
+  std::memset(cred->bssid, 0, 6);
+  cred->channel = 0;
+  std::memset(cred->ip, 0, 4);
+  std::memset(cred->gateway, 0, 4);
+  std::memset(cred->mask, 0, 4);
+  std::memset(cred->dns, 0, 4);
+  cred->cacheTimestamp = 0;
+  return saveToFile();
+}
 
 void WifiCredentialStore::setLastConnectedSsid(const std::string& ssid) {
   if (lastConnectedSsid != ssid) {

--- a/src/WifiCredentialStore.h
+++ b/src/WifiCredentialStore.h
@@ -1,10 +1,24 @@
 #pragma once
+#include <cstdint>
 #include <string>
 #include <vector>
 
 struct WifiCredential {
   std::string ssid;
   std::string password;  // Plaintext in memory; obfuscated with hardware key on disk
+  // Connection hint cached on successful connect. All-zero BSSID or channel==0 means
+  // "no hint, do a full scan". Used to skip channel scanning on reconnect.
+  uint8_t bssid[6] = {0, 0, 0, 0, 0, 0};
+  uint8_t channel = 0;
+
+  // Cached IP configuration to skip DHCP on reconnect. Valid only when ip[0] != 0 AND
+  // we connect to the same BSSID (cached above). cacheTimestamp is epoch seconds at
+  // capture; 0 means "unknown time, no TTL enforced".
+  uint8_t ip[4] = {0, 0, 0, 0};
+  uint8_t gateway[4] = {0, 0, 0, 0};
+  uint8_t mask[4] = {0, 0, 0, 0};
+  uint8_t dns[4] = {0, 0, 0, 0};
+  uint32_t cacheTimestamp = 0;
 };
 
 class WifiCredentialStore;
@@ -51,6 +65,16 @@ class WifiCredentialStore {
   bool addCredential(const std::string& ssid, const std::string& password);
   bool removeCredential(const std::string& ssid);
   const WifiCredential* findCredential(const std::string& ssid) const;
+
+  // Update cached BSSID/channel hint AND IP configuration in one write. ip/gw/mask/dns
+  // may be all-zero to mean "no IP cache". cacheTimestamp is epoch seconds (0 if unsynced).
+  // Persists only if anything changed.
+  bool updateConnectionCache(const std::string& ssid, const uint8_t bssid[6], uint8_t channel, const uint8_t ip[4],
+                             const uint8_t gateway[4], const uint8_t mask[4], const uint8_t dns[4],
+                             uint32_t cacheTimestamp);
+  // Clear all cached hint + IP for this credential (after a hint-based connect failed
+  // and we want the next attempt to start fresh with full scan + DHCP).
+  bool clearConnectionCache(const std::string& ssid);
 
   // Get all stored credentials (for UI display)
   const std::vector<WifiCredential>& getCredentials() const { return credentials; }

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -6,6 +6,7 @@
 #include <Logging.h>
 #include <WiFi.h>
 
+#include <cstring>
 #include <map>
 
 #include "CrossPointSettings.h"
@@ -17,6 +18,20 @@
 
 void WifiSelectionActivity::onEnter() {
   Activity::onEnter();
+
+  // Timing instrumentation: split total connect time into association vs DHCP.
+  // STA_CONNECTED = association (auth + 4-way handshake done).
+  // STA_GOT_IP    = DHCP done (or static config applied).
+  evtIdConnected = WiFi.onEvent(
+      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
+        LOG_DBG("WIFI", "EVT associated at %lu ms", millis() - connectionStartTime);
+      },
+      ARDUINO_EVENT_WIFI_STA_CONNECTED);
+  evtIdGotIp = WiFi.onEvent(
+      [this](WiFiEvent_t /*event*/, WiFiEventInfo_t /*info*/) {
+        LOG_DBG("WIFI", "EVT got_ip at %lu ms", millis() - connectionStartTime);
+      },
+      ARDUINO_EVENT_WIFI_STA_GOT_IP);
 
   // Load saved WiFi credentials - SD card operations need lock as we use SPI
   // for both
@@ -74,6 +89,15 @@ void WifiSelectionActivity::onEnter() {
 
 void WifiSelectionActivity::onExit() {
   Activity::onExit();
+
+  if (evtIdConnected != 0) {
+    WiFi.removeEvent(evtIdConnected);
+    evtIdConnected = 0;
+  }
+  if (evtIdGotIp != 0) {
+    WiFi.removeEvent(evtIdGotIp);
+    evtIdGotIp = 0;
+  }
 
   LOG_DBG("WIFI", "Free heap at onExit start: %d bytes", ESP.getFreeHeap());
 
@@ -215,23 +239,85 @@ void WifiSelectionActivity::attemptConnection() {
   connectionStartTime = millis();
   connectedIP.clear();
   connectionError.clear();
+  hintFallbackDone = false;
   requestUpdate();
 
+  prepareForConnect();
+  issueWifiBegin(/*useHint=*/true);
+}
+
+void WifiSelectionActivity::prepareForConnect() {
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
-  WiFi.mode(WIFI_STA);
-  WiFi.disconnect(true, true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
-  delay(100);
+
+  // Only switch mode if we're not already STA — the mode setter touches the netif and
+  // can take 50+ ms even when "no change" semantically.
+  if (WiFi.getMode() != WIFI_STA) {
+    WiFi.mode(WIFI_STA);
+  }
+
+  // Only do the heavy disconnect(true,true) — which erases NVS and tears down the WPA
+  // state machine — when there's actually something to tear down. From a fresh/idle
+  // state it's a pure cost (~50–80 ms on this SoC).
+  const wl_status_t status = WiFi.status();
+  const bool needsReset = (status == WL_CONNECTED) || (status == WL_CONNECT_FAILED) || (status == WL_CONNECTION_LOST) ||
+                          (status == WL_NO_SSID_AVAIL);
+  if (needsReset) {
+    WiFi.disconnect(true, true);
+  }
 
   // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
   String mac = WiFi.macAddress();
   mac.replace(":", "");
   String hostname = "CrossPoint-Reader-" + mac;
   WiFi.setHostname(hostname.c_str());
+}
 
-  if (selectedRequiresPassword && !enteredPassword.empty()) {
-    WiFi.begin(selectedSSID.c_str(), enteredPassword.c_str());
+void WifiSelectionActivity::issueWifiBegin(bool useHint) {
+  std::memset(currentAttemptBssid, 0, 6);
+  currentAttemptChannel = 0;
+  bool appliedStaticIp = false;
+
+  if (useHint) {
+    const auto* cred = WIFI_STORE.findCredential(selectedSSID);
+    if (cred && cred->channel != 0) {
+      std::memcpy(currentAttemptBssid, cred->bssid, 6);
+      currentAttemptChannel = cred->channel;
+
+      // Apply cached static IP when present. Cache is keyed to BSSID; if the AP/router
+      // subnet changes the next hint attempt will either fail (BSSID mismatch surfaces
+      // as hint-attempt timeout, then we silently retry without hint+IP) or the new
+      // ground truth is captured on the success path.
+      if (cred->ip[0] != 0) {
+        IPAddress ip(cred->ip[0], cred->ip[1], cred->ip[2], cred->ip[3]);
+        IPAddress gw(cred->gateway[0], cred->gateway[1], cred->gateway[2], cred->gateway[3]);
+        IPAddress mask(cred->mask[0], cred->mask[1], cred->mask[2], cred->mask[3]);
+        IPAddress dns(cred->dns[0], cred->dns[1], cred->dns[2], cred->dns[3]);
+        WiFi.config(ip, gw, mask, dns);
+        appliedStaticIp = true;
+      }
+    }
+  }
+
+  if (!appliedStaticIp) {
+    // Reset to DHCP in case a previous attempt left a static config behind.
+    WiFi.config(IPAddress(), IPAddress(), IPAddress(), IPAddress());
+  }
+
+  const char* pwd = (selectedRequiresPassword && !enteredPassword.empty()) ? enteredPassword.c_str() : nullptr;
+  const unsigned long preBeginMs = millis() - connectionStartTime;
+  if (currentAttemptChannel != 0) {
+    LOG_DBG("WIFI", "WiFi.begin -> %s ch=%d bssid=%02x:%02x:%02x:%02x:%02x:%02x staticIp=%s (pre-begin %lu ms)",
+            selectedSSID.c_str(), currentAttemptChannel, currentAttemptBssid[0], currentAttemptBssid[1],
+            currentAttemptBssid[2], currentAttemptBssid[3], currentAttemptBssid[4], currentAttemptBssid[5],
+            appliedStaticIp ? "yes" : "no", preBeginMs);
+    WiFi.begin(selectedSSID.c_str(), pwd, currentAttemptChannel, currentAttemptBssid, true);
   } else {
-    WiFi.begin(selectedSSID.c_str());
+    LOG_DBG("WIFI", "WiFi.begin -> %s (no hint, pre-begin %lu ms)", selectedSSID.c_str(), preBeginMs);
+    if (pwd) {
+      WiFi.begin(selectedSSID.c_str(), pwd);
+    } else {
+      WiFi.begin(selectedSSID.c_str());
+    }
   }
 }
 
@@ -250,6 +336,10 @@ void WifiSelectionActivity::checkConnectionStatus() {
     connectedIP = ipStr;
     autoConnecting = false;
 
+    LOG_DBG("WIFI", "Connected to %s in %lu ms (rssi=%d ch=%d ip=%s, hint=%s)", selectedSSID.c_str(),
+            millis() - connectionStartTime, WiFi.RSSI(), WiFi.channel(), ipStr,
+            currentAttemptChannel != 0 ? "yes" : "no");
+
     // Sync RTC from NTP on the first successful WiFi connection only. The DS3231
     // drifts ~2 ppm so one sync is enough; users can force a re-sync from
     // Settings > Customise Status Bar > Sync clock now.
@@ -260,11 +350,25 @@ void WifiSelectionActivity::checkConnectionStatus() {
       }
     }
 
-    // Save this as the last connected network - SD card operations need lock as
-    // we use SPI for both
+    // Save this as the last connected network and cache the full connection profile
+    // (BSSID/channel + IP/gw/mask/dns) so the next reconnect can skip both channel
+    // scanning and DHCP. SD card operations need lock as we use SPI for both.
     {
       RenderLock lock(*this);
       WIFI_STORE.setLastConnectedSsid(selectedSSID);
+      const uint8_t* actualBssid = WiFi.BSSID();
+      const int actualChannel = WiFi.channel();
+      if (actualBssid && actualChannel > 0 && actualChannel <= 255) {
+        const IPAddress gw = WiFi.gatewayIP();
+        const IPAddress mask = WiFi.subnetMask();
+        const IPAddress dns = WiFi.dnsIP();
+        const uint8_t ipBytes[4] = {ip[0], ip[1], ip[2], ip[3]};
+        const uint8_t gwBytes[4] = {gw[0], gw[1], gw[2], gw[3]};
+        const uint8_t maskBytes[4] = {mask[0], mask[1], mask[2], mask[3]};
+        const uint8_t dnsBytes[4] = {dns[0], dns[1], dns[2], dns[3]};
+        WIFI_STORE.updateConnectionCache(selectedSSID, actualBssid, static_cast<uint8_t>(actualChannel), ipBytes,
+                                         gwBytes, maskBytes, dnsBytes, 0u);
+      }
     }
 
     // If we entered a new password, ask if user wants to save it
@@ -280,6 +384,31 @@ void WifiSelectionActivity::checkConnectionStatus() {
               "completing immediately");
       onComplete(true);
     }
+    return;
+  }
+
+  // If this attempt used a hint and the hint hasn't paid off (channel may have changed
+  // because the AP is part of a mesh / roamed), retry once with a full scan before
+  // surfacing failure. Triggered on either a hard failure status or a short timeout.
+  const bool usingHint = currentAttemptChannel != 0;
+  const bool hintHardFail =
+      usingHint && !hintFallbackDone && (status == WL_CONNECT_FAILED || status == WL_NO_SSID_AVAIL);
+  const bool hintTimedOut =
+      usingHint && !hintFallbackDone && (millis() - connectionStartTime > HINT_ATTEMPT_TIMEOUT_MS);
+  if (hintHardFail || hintTimedOut) {
+    LOG_DBG("WIFI", "Hint attempt did not connect (%s after %lu ms), retrying with full scan",
+            hintHardFail ? "hard fail" : "timeout", millis() - connectionStartTime);
+    hintFallbackDone = true;
+    // Wipe the stale cache before retrying. If the fallback succeeds, the success
+    // path writes a fresh cache. If it fails or is interrupted, we won't carry a
+    // known-bad hint into the next session.
+    {
+      RenderLock lock(*this);
+      WIFI_STORE.clearConnectionCache(selectedSSID);
+    }
+    WiFi.disconnect(true, false);
+    connectionStartTime = millis();
+    issueWifiBegin(/*useHint=*/false);
     return;
   }
 

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -81,7 +81,22 @@ class WifiSelectionActivity final : public Activity {
 
   // Connection timeout
   static constexpr unsigned long CONNECTION_TIMEOUT_MS = 15000;
+  // Faster timeout for the first hint-based attempt before falling back to full scan.
+  // Hint-based connect on the correct channel usually completes in <2 s; if it doesn't,
+  // the AP has likely moved (mesh roam, channel change) so it's cheaper to bail and rescan.
+  static constexpr unsigned long HINT_ATTEMPT_TIMEOUT_MS = 3000;
   unsigned long connectionStartTime = 0;
+
+  // BSSID/channel hint used on the current attempt (channel==0 means no hint).
+  uint8_t currentAttemptBssid[6] = {0};
+  uint8_t currentAttemptChannel = 0;
+  // Whether we've already done the silent fallback retry without the hint for this
+  // user-initiated connection. Prevents loops if the AP genuinely isn't reachable.
+  bool hintFallbackDone = false;
+
+  // WiFi event handler IDs so we can deregister on exit.
+  uint16_t evtIdConnected = 0;
+  uint16_t evtIdGotIp = 0;
 
   void renderNetworkList(const Rect* screen, const ThemeMetrics* metrics) const;
   void renderPasswordEntry(const Rect* screen, const ThemeMetrics* metrics) const;
@@ -96,6 +111,14 @@ class WifiSelectionActivity final : public Activity {
   void selectNetwork(int index);
   void attemptConnection();
   void checkConnectionStatus();
+  // Issues WiFi.begin() either with the cached BSSID/channel hint (fast path) or without
+  // (full scan fallback). `useHint=false` clears currentAttemptChannel so the success path
+  // doesn't double-store the same hint.
+  void issueWifiBegin(bool useHint);
+  // Prepares the WiFi stack for a connect attempt: ensures STA mode and a clean state,
+  // sets a deterministic hostname. Skips the expensive disconnect(true,true) when WiFi
+  // is already idle so the warm reconnect path doesn't pay an NVS-erase cost.
+  void prepareForConnect();
   std::string getSignalStrengthIndicator(int32_t rssi) const;
 
   void onComplete(bool connected);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Reduce the time spent connecting to a known
  Wi-Fi network from ~1200 ms to ~100 ms by caching per-credential
  BSSID/channel and IP configuration on first successful connect, and reusing
  them on subsequent attempts to skip channel scanning and DHCP.
* **What changes are included?**
  * Extend `WifiCredential` with `bssid[6]`, `channel`, `ip[4]`, `gateway[4]`,
    `mask[4]`, `dns[4]` (zero values mean "no cache, do a full scan +
    DHCP"). `WifiCredentialStore` gains `updateConnectionCache` /
    `clearConnectionCache`. Persisted to `wifi.json` alongside existing
    credential fields; existing files without these fields load unchanged.
  * `WiFi.begin(ssid, pwd, channel, bssid, true)` is used when a hint is
    cached, skipping the multi-channel scan inside the SDK.
  * `WiFi.config(ip, gw, mask, dns)` is applied before `WiFi.begin()` when a
    cached IP is available. Cache is keyed to the BSSID we're using, so a
    router subnet change is detected via BSSID mismatch + fallback.
  * Mesh / roam safety net: if the hint attempt hard-fails or doesn't
    complete in 3 s (`HINT_ATTEMPT_TIMEOUT_MS`), one silent retry with full
    scan + DHCP before surfacing failure. The stale cache is cleared so the
    next session starts fresh; on retry success the new ground truth
    overwrites it.
  * Drop the `delay(100)` previously inserted after `WiFi.disconnect(true,
    true)` — it was padding for an already-synchronous call.
  * Skip `WiFi.disconnect(true, true)` (which erases NVS) when WiFi status is
    already in an idle/uninitialised state — pure cost when there is nothing
    to tear down.
  * Add WiFi event handlers (`STA_CONNECTED` / `STA_GOT_IP`) plus per-attempt
    timing logs so the breakdown (pre-begin / association / DHCP) is visible
    in `LOG_DBG` output.

## Additional Context

Measured on an ESP32-C3 device against a stable home AP (RSSI ~ -70 dBm):

| Phase                | Before  | After  |
|----------------------|---------|--------|
| Pre-begin overhead   | ~106 ms | ~1 ms  |
| Channel scan + auth  | ~500 ms | ~75 ms |
| DHCP                 | ~1000 ms| ~1 ms  |
| **Total**            | **~1200 ms** | **~100 ms** |

The single biggest win is skipping DHCP via cached static IP; the BSSID hint
is essential to keep the static-IP path safe (cache invalidation depends on
detecting BSSID mismatch rather than a network-reachability probe, which
would cost most of the saved time).

Things worth a careful look:

* **Cache invalidation correctness.** The static IP is applied only when a
  BSSID hint is also present, and the hint-attempt timeout (3 s) plus silent
  retry without hint+IP handles the case where the cache is stale (mesh
  roam, channel change, ISP subnet change). The pathological case is "AP
  keeps the same BSSID but the router moves the subnet" — extremely rare in
  practice. If it happens, the user can hit "Forget network" to wipe the
  cache.
* **Per-credential JSON layout.** New `bssid` (12-char lowercase hex),
  `channel`, `ip`/`gw`/`mask`/`dns` (dotted-quad strings), and `ts` keys.
  Loader tolerates missing fields, rejects malformed dotted-quads
  (trailing-character check via `%n`), and otherwise ignores garbage.
* **NVS skip safety.** `prepareForConnect()` now skips `WiFi.disconnect(true, true)` (which erases the SDK-managed NVS copy of the AP config) when `WiFi.status()` indicates there's nothing to tear down. Upstream calls it unconditionally on every attempt. `WiFi.persistent(false)` is still called before each `WiFi.begin()`, and the SSID/password are always passed explicitly, so stale NVS state shouldn't influence which AP is chosen. If reviewers know of an IDF/SDK path that depends on a fresh NVS erase per connect, please flag it.

The added `LOG_DBG` lines (`WiFi.begin -> ... staticIp=...`,
`EVT associated`, `EVT got_ip`, `Connected to ... in NNN ms`) are gated by
`LOG_LEVEL=2` and suppressed in `gh_release` builds. They make this code
self-diagnosing for future regressions; happy to strip them if you prefer.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
