### PR TITLE
chore: Minor cleanup flagged by newer gcc

### DIFF
--- a/lib/FsHelpers/FsHelpers.cpp
+++ b/lib/FsHelpers/FsHelpers.cpp
@@ -59,8 +59,6 @@ void sortFileList(std::vector<std::string>& strs) {
       // Check if both are at the start of a number
       if (isdigit(*s1) && isdigit(*s2)) {
         // Skip leading zeros and track them
-        const char* start1 = s1;
-        const char* start2 = s2;
         while (*s1 == '0') s1++;
         while (*s2 == '0') s2++;
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -12,8 +12,6 @@
 
 namespace {
 
-const char* resolveVisualText(const char* text, std::string& visualBuffer, int paragraphLevel);
-
 /**
  * Resolves the requested style to the best available style in the given SD card font.
  * Falls back gracefully when the font lacks the requested variant.

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -24,26 +24,26 @@ static void readPod(FsFile& file, T& value) {
   file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T));
 }
 
-static void writeString(std::ostream& os, const std::string& s) {
+inline void writeString(std::ostream& os, const std::string& s) {
   const uint32_t len = s.size();
   writePod(os, len);
   os.write(s.data(), len);
 }
 
-static void writeString(FsFile& file, const std::string& s) {
+inline void writeString(FsFile& file, const std::string& s) {
   const uint32_t len = s.size();
   writePod(file, len);
   file.write(reinterpret_cast<const uint8_t*>(s.data()), len);
 }
 
-static void readString(std::istream& is, std::string& s) {
+inline void readString(std::istream& is, std::string& s) {
   uint32_t len;
   readPod(is, len);
   s.resize(len);
   is.read(&s[0], len);
 }
 
-static void readString(FsFile& file, std::string& s) {
+inline void readString(FsFile& file, std::string& s) {
   uint32_t len;
   readPod(file, len);
   s.resize(len);

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -5,22 +5,22 @@
 
 namespace serialization {
 template <typename T>
-static void writePod(std::ostream& os, const T& value) {
+void writePod(std::ostream& os, const T& value) {
   os.write(reinterpret_cast<const char*>(&value), sizeof(T));
 }
 
 template <typename T>
-static void writePod(FsFile& file, const T& value) {
+void writePod(FsFile& file, const T& value) {
   file.write(reinterpret_cast<const uint8_t*>(&value), sizeof(T));
 }
 
 template <typename T>
-static void readPod(std::istream& is, T& value) {
+void readPod(std::istream& is, T& value) {
   is.read(reinterpret_cast<char*>(&value), sizeof(T));
 }
 
 template <typename T>
-static void readPod(FsFile& file, T& value) {
+void readPod(FsFile& file, T& value) {
   file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T));
 }
 

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -269,7 +269,6 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   if (selectedIndex >= 0) {
     renderer.fillRect(rect.x, rect.y + selectedIndex % pageItems * rowHeight - 2, rect.width, rowHeight);
   }
-  constexpr int maxValueWidth = 200;
   constexpr int minValueGap = 10;
 
   // Draw all items
@@ -358,8 +357,6 @@ void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
 }
 
 void BaseTheme::drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label, const char* rightLabel) const {
-  constexpr int underlineHeight = 2;  // Height of selection underline
-  constexpr int underlineGap = 4;     // Gap between text and underline
   constexpr int maxListValueWidth = 200;
 
   int currentX = rect.x + BaseMetrics::values.contentSidePadding;


### PR DESCRIPTION
## Summary

Minor cleanup flagged by newer gcc:
- Removed unused variables
- Removed unimplemented function declaration
- `static` -> `inline` to avoid per-TU duplication

---

### AI Usage

Did you use AI tools to help write this code? _**NO**_
