### PR TITLE
fix: replace deprecated WebSockets flush call in ESP32 disconnect path

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,7 @@ extra_scripts =
   pre:scripts/gen_i18n.py
   pre:scripts/git_branch.py
   pre:scripts/patch_jpegdec.py
+  pre:scripts/patch_websockets.py
 
 ; Libraries
 lib_deps =

--- a/scripts/patch_websockets.py
+++ b/scripts/patch_websockets.py
@@ -1,0 +1,48 @@
+"""
+PlatformIO pre-build script: patch WebSockets for Arduino-ESP32 3.x.
+
+WebSockets 2.7.3 still calls WiFiClient::flush() in the client disconnect
+path. On Arduino-ESP32 3.x, WiFiClient is a typedef for NetworkClient and
+NetworkClient::flush() is deprecated in favor of clear(). The implementation
+currently delegates flush() to clear(), so this patch preserves behavior while
+removing the compiler warning.
+"""
+
+Import("env")  # noqa: F821 (SCons-injected global)
+import os
+
+
+OLD = """#if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+            client->tcp->flush();
+#endif"""
+
+NEW = """#if (WEBSOCKETS_NETWORK_TYPE == NETWORK_ESP32)
+            client->tcp->clear();
+#elif (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+            client->tcp->flush();
+#endif"""
+
+
+def patch_websockets(env):
+    libdeps_dir = os.path.join(env["PROJECT_DIR"], ".pio", "libdeps")
+    if not os.path.isdir(libdeps_dir):
+        return
+    for env_dir in os.listdir(libdeps_dir):
+        client_cpp = os.path.join(libdeps_dir, env_dir, "WebSockets", "src", "WebSocketsClient.cpp")
+        if os.path.isfile(client_cpp):
+            _patch_one(client_cpp)
+
+
+def _patch_one(path):
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    if NEW in content:
+        return
+    if OLD not in content:
+        raise RuntimeError("WebSockets patch does not apply cleanly: %s" % path)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        f.write(content.replace(OLD, NEW, 1))
+    print("Applied WebSockets NetworkClient::clear patch")
+
+
+patch_websockets(env)  # noqa: F821


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Keep Arduino-ESP32 3.x builds warning-clean without changing the current WebSockets disconnect behavior used by CrossPoint.

* **What changes are included?**
  Add a small pre-build patch script that rewrites the WebSockets 2.7.3 ESP32 disconnect path from `client->tcp->flush()` to `client->tcp->clear()`, and register that script in PlatformIO `extra_scripts`.

## Additional Context

WebSockets 2.7.3 still calls `flush()` in its client disconnect path. On Arduino-ESP32 3.x, `NetworkClient::flush()` is deprecated with the message `Use clear() instead.` The current implementation delegates `flush()` to `clear()`, so this change preserves the effective behavior while removing the deprecation warning.

The patch is intentionally narrow. It only changes the `NETWORK_ESP32` path, keeps the existing `flush()` path for other network types, and fails fast if the upstream WebSockets source no longer matches the expected pattern. That avoids silently patching an unexpected upstream revision.

This also follows the same local-libdep patch approach already used elsewhere in the project for JPEGDEC.

## Verification

Built locally with `pio run` on macOS using the default environment and confirmed the WebSockets deprecation warning no longer appears.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_
