### PR TITLE
feat: implement CSS enumeration through OPF directory when missing from manifest

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -387,6 +387,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
         if (!parseContentOpf(bookMetadataCache->coreMetadata)) {
           LOG_ERR("EBP", "Could not parse content.opf from cached bookMetadata for CSS files");
           // continue anyway - book will work without CSS and we'll still load any inline style CSS
+        } else {
+          // Handle case where CSS files are not listed in OPF manifest
+          // but are still referenced by HTML files - discover and parse them too
+          discoverCssFilesFromZip();
         }
         parseCssFiles();
         // Invalidate section caches so they are rebuilt with the new CSS

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -267,25 +267,23 @@ void Epub::discoverCssFilesFromZip() {
     return;
   }
 
-  const auto allFiles = zf.getFilePaths();
-
   size_t lastSlash = contentBasePath.find_last_of('/');
 
   std::string opfDir = (lastSlash != std::string::npos) ? contentBasePath.substr(0, lastSlash + 1) : "";
 
-  for (const auto& filePath : allFiles) {
+  zf.enumerateFilePaths([&](std::string_view filePath) {
     if (!opfDir.empty() && filePath.find(opfDir) != 0) {
-      continue;  // Skip files that are not in the same directory as content.opf, as CSS files are typically located
+      return;  // Skip files that are not in the same directory as OPF manifest, as CSS files are typically located
                  // there or in subfolders
     }
 
     if (FsHelpers::hasCssExtension(filePath)) {
       if (std::find(cssFiles.begin(), cssFiles.end(), filePath) == cssFiles.end()) {
-        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %s", filePath.c_str());
-        cssFiles.push_back(filePath);
+        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %s", filePath.data());
+        cssFiles.push_back(std::string{filePath});
       }
     }
-  }
+  });
 }
 
 void Epub::parseCssFiles() const {

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -362,9 +362,9 @@ void Epub::parseCssFiles() const {
   if (!cssParser->saveToCache()) {
     LOG_ERR("EBP", "Failed to save CSS rules to cache");
   }
-  cssParser->clear();
 
   LOG_DBG("EBP", "Loaded %zu CSS style rules from %zu files", cssParser->ruleCount(), cssFiles.size());
+  cssParser->clear();
 }
 
 // load in the meta data for the epub file

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -274,7 +274,7 @@ void Epub::discoverCssFilesFromZip() {
   zf.enumerateFilePaths([&](std::string_view filePath) {
     if (!opfDir.empty() && filePath.find(opfDir) != 0) {
       return;  // Skip files that are not in the same directory as OPF manifest, as CSS files are typically located
-                 // there or in subfolders
+               // there or in subfolders
     }
 
     if (FsHelpers::hasCssExtension(filePath)) {

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -279,7 +279,7 @@ void Epub::discoverCssFilesFromZip() {
 
     if (FsHelpers::hasCssExtension(filePath)) {
       if (std::find(cssFiles.begin(), cssFiles.end(), filePath) == cssFiles.end()) {
-        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %s", filePath.data());
+        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %.*s", (int)filePath.size(), filePath.data());
         cssFiles.push_back(std::string{filePath});
       }
     }

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -254,6 +254,40 @@ bool Epub::parseTocNavFile() const {
   return true;
 }
 
+void Epub::discoverCssFilesFromZip() {
+  if (!bookMetadataCache || !bookMetadataCache->isLoaded()) {
+    LOG_ERR("EBP", "Cannot discover CSS from ZIP because book metadata cache is not loaded");
+    return;
+  }
+
+  ZipFile zf(filepath);
+
+  if (!zf.loadAllFileStatSlims()) {
+    LOG_ERR("EBP", "Failed to load ZIP file stat slims for CSS discovery");
+    return;
+  }
+
+  const auto allFiles = zf.getFilePaths();
+
+  size_t lastSlash = contentBasePath.find_last_of('/');
+
+  std::string opfDir = (lastSlash != std::string::npos) ? contentBasePath.substr(0, lastSlash + 1) : "";
+
+  for (const auto& filePath : allFiles) {
+    if (!opfDir.empty() && filePath.find(opfDir) != 0) {
+      continue;  // Skip files that are not in the same directory as content.opf, as CSS files are typically located
+                 // there or in subfolders
+    }
+
+    if (FsHelpers::hasCssExtension(filePath)) {
+      if (std::find(cssFiles.begin(), cssFiles.end(), filePath) == cssFiles.end()) {
+        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %s", filePath.c_str());
+        cssFiles.push_back(filePath);
+      }
+    }
+  }
+}
+
 void Epub::parseCssFiles() const {
   // Maximum CSS file size we'll attempt to parse (uncompressed)
   // Larger files risk memory exhaustion on ESP32
@@ -456,6 +490,9 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   }
 
   if (!skipLoadingCss) {
+    // Handle case where CSS files are not listed in OPF manifest
+    // but are still referenced by HTML files - discover and parse them too
+    discoverCssFilesFromZip();
     // Parse CSS files after cache reload
     parseCssFiles();
     Storage.removeDir((cachePath + "/sections").c_str());

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -35,6 +35,7 @@ class Epub {
   bool parseTocNcxFile() const;
   bool parseTocNavFile() const;
   void parseCssFiles() const;
+  void discoverCssFilesFromZip();
 
  public:
   explicit Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {

--- a/lib/FsHelpers/FsHelpers.cpp
+++ b/lib/FsHelpers/FsHelpers.cpp
@@ -131,6 +131,8 @@ bool hasTxtExtension(std::string_view fileName) { return checkFileExtension(file
 
 bool hasMarkdownExtension(std::string_view fileName) { return checkFileExtension(fileName, ".md"); }
 
+bool hasCssExtension(std::string_view fileName) { return checkFileExtension(fileName, ".css"); }
+
 std::string extractFolderPath(const std::string& filePath) {
   const auto lastSlash = filePath.find_last_of('/');
   if (lastSlash == std::string::npos || lastSlash == 0) {

--- a/lib/FsHelpers/FsHelpers.h
+++ b/lib/FsHelpers/FsHelpers.h
@@ -58,6 +58,11 @@ inline bool hasTxtExtension(const String& fileName) {
 // Check for .md extension (case-insensitive)
 bool hasMarkdownExtension(std::string_view fileName);
 
+// Check for .css extension (case-insensitive)
+bool hasCssExtension(std::string_view fileName);
+inline bool hasCssExtension(const String& fileName) {
+  return hasCssExtension(std::string_view{fileName.c_str(), fileName.length()});
+}
 std::string extractFolderPath(const std::string& filePath);
 
 /**

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -560,13 +560,8 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
   return false;
 }
 
-std::vector<std::string> ZipFile::getFilePaths() const {
-  std::vector<std::string> files;
-  files.reserve(fileStatSlimCache.size());
-
+void ZipFile::enumerateFilePaths(std::function<void(std::string_view)> callback) const {
   for (const auto& entry : fileStatSlimCache) {
-    files.push_back(entry.first);
+    callback(entry.first);
   }
-
-  return files;
 }

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -559,3 +559,14 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
   LOG_ERR("ZIP", "Unsupported compression method");
   return false;
 }
+
+std::vector<std::string> ZipFile::getFilePaths() const {
+  std::vector<std::string> files;
+  files.reserve(fileStatSlimCache.size());
+
+  for (const auto& entry : fileStatSlimCache) {
+    files.push_back(entry.first);
+  }
+
+  return files;
+}

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -559,9 +559,3 @@ bool ZipFile::readFileToStream(const char* filename, Print& out, const size_t ch
   LOG_ERR("ZIP", "Unsupported compression method");
   return false;
 }
-
-void ZipFile::enumerateFilePaths(std::function<void(std::string_view)> callback) const {
-  for (const auto& entry : fileStatSlimCache) {
-    callback(entry.first);
-  }
-}

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -2,6 +2,7 @@
 #include <HalStorage.h>
 
 #include <deque>
+#include <functional>
 #include <string>
 #include <unordered_map>
 
@@ -69,5 +70,5 @@ class ZipFile {
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
   bool readFileToStream(const char* filename, Print& out, size_t chunkSize);
-  std::vector<std::string> getFilePaths() const;
+  void enumerateFilePaths(std::function<void(std::string_view)> callback) const;
 };

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -2,8 +2,8 @@
 #include <HalStorage.h>
 
 #include <deque>
-#include <functional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 class ZipFile {
@@ -70,5 +70,11 @@ class ZipFile {
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
   bool readFileToStream(const char* filename, Print& out, size_t chunkSize);
-  void enumerateFilePaths(std::function<void(std::string_view)> callback) const;
+
+  template <typename F>
+  void enumerateFilePaths(F&& callback) const {
+    for (const auto& entry : fileStatSlimCache) {
+      callback(std::string_view{entry.first});
+    }
+  }
 };

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -69,4 +69,5 @@ class ZipFile {
   // These functions will open and close the zip as needed
   uint8_t* readFileToMemory(const char* filename, size_t* size = nullptr, bool trailingNullByte = false);
   bool readFileToStream(const char* filename, Print& out, size_t chunkSize);
+  std::vector<std::string> getFilePaths() const;
 };


### PR DESCRIPTION
## Summary

I am new to the crosspoint-reader scene, and I have been using the firmware for a bit. Saw an issue yesterday that looked interesting and straight forward, which gave me an opportunity to get familiar with the codebase. Excited for the opportunity to contribute and enjoyed testing out on my own X4 😸 

- implement a fallback mechanism to enumerate directories in OPF directory for files that are missing from the OPF manifest
- Fixes https://github.com/crosspoint-reader/crosspoint-reader/issues/2124
- Fixed the order of the cssParser clear and the debug log for showing how many files were loaded
## Additional Context

I debated between the O(n) check for if the CSS file already exists in the vec versus an unordered set, but I chose the linear search because of a few reasons:
- less memory overhead
- small vec size generally for css files per epub

Attached is a screenshot showing the CSS applying now (example epub from #2124): 
![The-Doomed-City_ch2_p4_0pct_93248.bmp](https://github.com/user-attachments/files/28231375/The-Doomed-City_ch2_p4_0pct_93248.bmp)

Output from debug logs: 
```
[14:21:14] [DBG] [EBP] Discovered CSS file via ZIP enumeration: OEBPS/css/main.css
[14:21:14] [DBG] [EBP] CSS files to parse: 1
[14:21:14] [DBG] [EBP] Parsing CSS file: OEBPS/css/main.css
[14:21:15] [DBG] [ZIP] Decompressed 1301 bytes into 5045 bytes
```
---



### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**No**_

I used AI to explore the codebase to get familiar, but code is written by me 😸 
