### PR TITLE
refactor: replace bare new with nothrow across 38 sites

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <PngToBmpConverter.h>
 #include <ZipFile.h>
 
@@ -339,9 +340,17 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   LOG_DBG("EBP", "Loading ePub: %s", filepath.c_str());
 
   // Initialize spine/TOC cache
-  bookMetadataCache.reset(new BookMetadataCache(cachePath));
+  bookMetadataCache = makeUniqueNoThrow<BookMetadataCache>(cachePath);
+  if (!bookMetadataCache) {
+    LOG_ERR("EBP", "OOM: BookMetadataCache");
+    return false;
+  }
   // Always create CssParser - needed for inline style parsing even without CSS files
-  cssParser.reset(new CssParser(cachePath));
+  cssParser = makeUniqueNoThrow<CssParser>(cachePath);
+  if (!cssParser) {
+    LOG_ERR("EBP", "OOM: CssParser");
+    return false;
+  }
 
   // Try to load existing cache first
   if (bookMetadataCache->load()) {
@@ -450,7 +459,11 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   }
 
   // Reload the cache from disk so it's in the correct state
-  bookMetadataCache.reset(new BookMetadataCache(cachePath));
+  bookMetadataCache = makeUniqueNoThrow<BookMetadataCache>(cachePath);
+  if (!bookMetadataCache) {
+    LOG_ERR("EBP", "OOM: BookMetadataCache (reload)");
+    return false;
+  }
   if (!bookMetadataCache->load()) {
     LOG_ERR("EBP", "Failed to reload cache after writing");
     return false;

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -150,6 +150,8 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
 
   uint16_t count;
   serialization::readPod(file, count);
+  // Exact element count known here — reserve so the loop never doubles.
+  page->elements.reserve(count);
 
   for (uint16_t i = 0; i < count; i++) {
     uint8_t tag;

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -2,9 +2,8 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
-
-#include <new>
 
 void PageLine::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
   block->render(renderer, fontId, xPos + xOffset, yPos + yOffset);
@@ -25,7 +24,15 @@ std::unique_ptr<PageLine> PageLine::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto tb = TextBlock::deserialize(file);
-  return std::unique_ptr<PageLine>(new PageLine(std::move(tb), xPos, yPos));
+  if (!tb) {
+    return nullptr;  // TextBlock::deserialize already logged
+  }
+  auto pl = makeUniqueNoThrow<PageLine>(std::move(tb), xPos, yPos);
+  if (!pl) {
+    LOG_ERR("PGE", "OOM: PageLine");
+    return nullptr;
+  }
+  return pl;
 }
 
 void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -48,7 +55,15 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  if (!ib) {
+    return nullptr;  // ImageBlock::deserialize already logged
+  }
+  auto pi = makeUniqueNoThrow<PageImage>(std::move(ib), xPos, yPos);
+  if (!pi) {
+    LOG_ERR("PGE", "OOM: PageImage");
+    return nullptr;
+  }
+  return pi;
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -84,12 +99,12 @@ std::unique_ptr<PageHorizontalRule> PageHorizontalRule::deserialize(HalFile& fil
     return nullptr;
   }
 
-  auto* rule = new (std::nothrow) PageHorizontalRule(width, thickness, xPos, yPos);
+  auto rule = makeUniqueNoThrow<PageHorizontalRule>(width, thickness, xPos, yPos);
   if (!rule) {
-    LOG_ERR("PGE", "Deserialization failed: could not allocate PageHorizontalRule");
+    LOG_ERR("PGE", "OOM: PageHorizontalRule");
     return nullptr;
   }
-  return std::unique_ptr<PageHorizontalRule>(rule);
+  return rule;
 }
 
 void Page::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) const {
@@ -127,7 +142,11 @@ bool Page::serialize(HalFile& file) const {
 }
 
 std::unique_ptr<Page> Page::deserialize(HalFile& file) {
-  auto page = std::unique_ptr<Page>(new Page());
+  auto page = makeUniqueNoThrow<Page>();
+  if (!page) {
+    LOG_ERR("PGE", "OOM: Page");
+    return nullptr;
+  }
 
   uint16_t count;
   serialization::readPod(file, count);
@@ -138,9 +157,11 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
 
     if (tag == TAG_PageLine) {
       auto pl = PageLine::deserialize(file);
+      if (!pl) return nullptr;
       page->elements.push_back(std::move(pl));
     } else if (tag == TAG_PageImage) {
       auto pi = PageImage::deserialize(file);
+      if (!pi) return nullptr;
       page->elements.push_back(std::move(pi));
     } else if (tag == TAG_PageHorizontalRule) {
       auto rule = PageHorizontalRule::deserialize(file);

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -72,6 +72,13 @@ class PageHorizontalRule final : public PageElement {
 
 class Page {
  public:
+  // Typical e-reader page holds ~15-25 lines (one PageLine each) plus the
+  // occasional PageImage / PageHorizontalRule. Pre-reserve to skip the
+  // doubling churn (per CLAUDE.md §"std::vector Pre-allocation"); doubling
+  // still kicks in past 24 for long pages.
+  static constexpr size_t INITIAL_ELEMENTS_CAPACITY = 24;
+  Page() { elements.reserve(INITIAL_ELEMENTS_CAPACITY); }
+
   // the list of block index and line numbers on this page
   std::vector<std::shared_ptr<PageElement>> elements;
   std::vector<FootnoteEntry> footnotes;

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -5,7 +5,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <functional>
 #include <limits>
 #include <vector>
 
@@ -238,10 +237,12 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   std::string_view segment(reinterpret_cast<const char*>(segmentStart), segmentLen);
   processSegment(segment, inWordSegment, isFirstSegment ? attachToPrevious : true);
 }
-// Consumes data to minimize memory usage
-void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
-                                       const bool includeLastLine) {
+// Consumes data to minimize memory usage. Takes a non-capturing function
+// pointer plus opaque ctx — the public templated wrapper in the header
+// adapts caller lambdas into this shape so no std::function closure heap
+// allocation happens.
+void ParsedText::layoutAndExtractLinesImpl(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
+                                           LineSink processLine, void* processLineCtx, const bool includeLastLine) {
   if (words.empty()) {
     return;
   }
@@ -279,7 +280,8 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   const size_t lineCount = includeLastLine ? lineBreakIndices.size() : lineBreakIndices.size() - 1;
 
   for (size_t i = 0; i < lineCount; ++i) {
-    extractLine(i, pageWidth, wordWidths, wordContinues, lineBreakIndices, processLine, renderer, fontId);
+    extractLine(i, pageWidth, wordWidths, wordContinues, lineBreakIndices, processLine, processLineCtx, renderer,
+                fontId);
   }
 
   // Remove consumed words so size() reflects only remaining words
@@ -606,8 +608,8 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
-                             const GfxRenderer& renderer, const int fontId) {
+                             LineSink processLine, void* processLineCtx, const GfxRenderer& renderer,
+                             const int fontId) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
@@ -727,7 +729,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   }
 
   if (!lineHasFocusSplit) {
-    processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
+    processLine(processLineCtx,
+                std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
                                             std::vector<uint8_t>{}, std::vector<uint16_t>{}, blockStyle));
     return;
   }
@@ -772,6 +775,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
   }
 
-  processLine(std::make_shared<TextBlock>(std::move(outWords), std::move(outXPos), std::move(outStyles),
-                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle));
+  processLine(processLineCtx, std::make_shared<TextBlock>(std::move(outWords), std::move(outXPos), std::move(outStyles),
+                                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle));
 }

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -405,8 +405,11 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
     }
   }
 
-  // Stores the index of the word that starts the next line (last_word_index + 1)
+  // Stores the index of the word that starts the next line (last_word_index + 1).
+  // Reserve ~ words/5 (typical English avg 5 words/line); doubling still kicks
+  // in past that. Bounded to a sane floor/ceiling to avoid tiny / huge allocs.
   std::vector<size_t> lineBreakIndices;
+  lineBreakIndices.reserve(std::clamp<size_t>(totalWordCount / 5, 8, 128));
   size_t currentWordIndex = 0;
 
   while (currentWordIndex < totalWordCount) {
@@ -454,6 +457,8 @@ std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& r
           : 0;
 
   std::vector<size_t> lineBreakIndices;
+  // Same heuristic as computeLineBreaks: ~ words/5 lines, bounded.
+  lineBreakIndices.reserve(std::clamp<size_t>(wordWidths.size() / 5, 8, 128));
   size_t currentIndex = 0;
   bool isFirstLine = true;
 

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -2,9 +2,9 @@
 
 #include <EpdFontFamily.h>
 
-#include <functional>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "blocks/BlockStyle.h"
@@ -22,6 +22,12 @@ class ParsedText {
   bool hyphenationEnabled;
   bool focusReadingEnabled;
 
+  // Internal line-emit callback used by the .cpp implementations. Public
+  // entry points template their caller's lambda into this fn-pointer + ctx
+  // shape so no std::function closure ever heap-allocates (see CLAUDE.md
+  // §"Template and std::function Bloat").
+  using LineSink = void (*)(void* ctx, std::shared_ptr<TextBlock> line);
+
   void applyParagraphIndent();
   std::vector<size_t> computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
                                         std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec);
@@ -31,9 +37,10 @@ class ParsedText {
                             std::vector<uint16_t>& wordWidths, bool allowFallbackBreaks);
   void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
-                   int fontId);
+                   LineSink processLine, void* processLineCtx, const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
+  void layoutAndExtractLinesImpl(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth, LineSink processLine,
+                                 void* processLineCtx, bool includeLastLine);
 
  public:
   explicit ParsedText(const bool extraParagraphSpacing, const bool hyphenationEnabled = false,
@@ -49,7 +56,16 @@ class ParsedText {
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
-  void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
-                             bool includeLastLine = true);
+
+  // Templated wrapper: the caller's lambda binds to F at the call site with
+  // zero overhead, and we hand the impl a non-capturing thunk + opaque ctx.
+  // Previously took `const std::function<...>&`, which heap-allocated the
+  // closure under libstdc++ and aborted on OOM in tight-heap scenarios.
+  template <typename F>
+  void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth, F&& processLine,
+                             bool includeLastLine = true) {
+    using Fn = std::remove_reference_t<F>;
+    LineSink sink = [](void* ctx, std::shared_ptr<TextBlock> line) { (*static_cast<Fn*>(ctx))(std::move(line)); };
+    layoutAndExtractLinesImpl(renderer, fontId, viewportWidth, sink, static_cast<void*>(&processLine), includeLastLine);
+  }
 };

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
 
 #include "Epub/converters/DirectPixelWriter.h"
@@ -168,5 +169,10 @@ std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile& file) {
   int16_t w, h;
   serialization::readPod(file, w);
   serialization::readPod(file, h);
-  return std::unique_ptr<ImageBlock>(new ImageBlock(path, w, h));
+  auto ib = makeUniqueNoThrow<ImageBlock>(path, w, h);
+  if (!ib) {
+    LOG_ERR("IMG", "OOM: ImageBlock");
+    return nullptr;
+  }
+  return ib;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
 
 #include <cstring>
@@ -160,7 +161,11 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   serialization::readPod(file, blockStyle.textIndent);
   serialization::readPod(file, blockStyle.textIndentDefined);
 
-  return std::unique_ptr<TextBlock>(new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles),
-                                                  std::move(wordFocusBoundary), std::move(wordFocusSuffixX),
-                                                  blockStyle));
+  auto tb = makeUniqueNoThrow<TextBlock>(std::move(words), std::move(wordXpos), std::move(wordStyles),
+                                          std::move(wordFocusBoundary), std::move(wordFocusSuffixX), blockStyle);
+  if (!tb) {
+    LOG_ERR("TXB", "OOM: TextBlock");
+    return nullptr;
+  }
+  return tb;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -162,7 +162,7 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   serialization::readPod(file, blockStyle.textIndentDefined);
 
   auto tb = makeUniqueNoThrow<TextBlock>(std::move(words), std::move(wordXpos), std::move(wordStyles),
-                                          std::move(wordFocusBoundary), std::move(wordFocusSuffixX), blockStyle);
+                                         std::move(wordFocusBoundary), std::move(wordFocusSuffixX), blockStyle);
   if (!tb) {
     LOG_ERR("TXB", "OOM: TextBlock");
     return nullptr;

--- a/lib/Epub/Epub/converters/ImageDecoderFactory.cpp
+++ b/lib/Epub/Epub/converters/ImageDecoderFactory.cpp
@@ -1,6 +1,7 @@
 #include "ImageDecoderFactory.h"
 
 #include <Logging.h>
+#include <Memory.h>
 
 #include <memory>
 #include <string>
@@ -25,12 +26,20 @@ ImageToFramebufferDecoder* ImageDecoderFactory::getDecoder(const std::string& im
 
   if (JpegToFramebufferConverter::supportsFormat(ext)) {
     if (!jpegDecoder) {
-      jpegDecoder.reset(new JpegToFramebufferConverter());
+      jpegDecoder = makeUniqueNoThrow<JpegToFramebufferConverter>();
+      if (!jpegDecoder) {
+        LOG_ERR("DEC", "OOM: JpegToFramebufferConverter");
+        return nullptr;
+      }
     }
     return jpegDecoder.get();
   } else if (PngToFramebufferConverter::supportsFormat(ext)) {
     if (!pngDecoder) {
-      pngDecoder.reset(new PngToFramebufferConverter());
+      pngDecoder = makeUniqueNoThrow<PngToFramebufferConverter>();
+      if (!pngDecoder) {
+        LOG_ERR("DEC", "OOM: PngToFramebufferConverter");
+        return nullptr;
+      }
     }
     return pngDecoder.get();
   }

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -51,13 +51,18 @@ struct JpegContext {
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
 // avoiding the need for global file state.
 void* jpegOpen(const char* filename, int32_t* size) {
-  HalFile* f = new HalFile();
+  // Heap is required: JPEGDEC keeps the handle as a void* across callbacks.
+  // Ownership transfers to JPEGDEC, which releases via jpegClose -> delete.
+  auto f = makeUniqueNoThrow<HalFile>();
+  if (!f) {
+    LOG_ERR("JPG", "OOM: HalFile (jpegOpen)");
+    return nullptr;
+  }
   if (!Storage.openFileForRead("JPG", std::string(filename), *f)) {
-    delete f;
     return nullptr;
   }
   *size = f->size();
-  return f;
+  return f.release();
 }
 
 void jpegClose(void* handle) {

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -43,13 +43,18 @@ struct PngContext {
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
 // avoiding the need for global file state.
 void* pngOpenWithHandle(const char* filename, int32_t* size) {
-  HalFile* f = new HalFile();
+  // Heap is required: PNGdec keeps the handle as a void* across callbacks.
+  // Ownership transfers to PNGdec, which releases via pngCloseWithHandle -> delete.
+  auto f = makeUniqueNoThrow<HalFile>();
+  if (!f) {
+    LOG_ERR("PNG", "OOM: HalFile (pngOpen)");
+    return nullptr;
+  }
   if (!Storage.openFileForRead("PNG", std::string(filename), *f)) {
-    delete f;
     return nullptr;
   }
   *size = f->size();
-  return f;
+  return f.release();
 }
 
 void pngCloseWithHandle(void* handle) {

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -466,6 +466,12 @@ bool CssParser::loadFromStream(HalFile& source) {
     return false;
   }
 
+  // Pre-size the rules map per CLAUDE.md §"std::vector Pre-allocation" — the
+  // same logic applies to unordered_map. Sized from an EPUB corpus (~150 books):
+  // p90 = 232, p95 = 278, p99 = 470 rules summed across a book's stylesheets.
+  // 256 covers ~p93 without rehash; growth past it still doubles. Cap is 1500.
+  rulesBySelector_.reserve(256);
+
   size_t totalRead = 0;
 
   // Use stack-allocated buffers for parsing to avoid heap reallocations
@@ -781,6 +787,9 @@ bool CssParser::loadFromCache() {
     rulesBySelector_.clear();
     return false;
   }
+
+  // Exact size known here — reserve so deserialize never rehashes.
+  rulesBySelector_.reserve(ruleCount);
 
   auto hasRemainingBytes = [&file](const size_t neededBytes) -> bool {
     return static_cast<size_t>(file.available()) >= neededBytes;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1159,12 +1159,18 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
 
   // Pre-allocate the parser's growing vectors per CLAUDE.md §"std::vector
   // Pre-allocation": grow-on-push_back triggers operator new[] internally and
-  // aborts on OOM under -fno-exceptions. Sizes are conservative estimates;
-  // overflow still doubles (rare on a typical chapter).
+  // aborts on OOM under -fno-exceptions. Sizes calibrated against an EPUB
+  // corpus (~8k chapters):
+  //   anchorData       : p97 ~128; p99 = 177, p99.9 = 389, max = 532. 128
+  //                      covers the bulk; tail still doubles past it (rare).
+  //   pendingFootnotes : drained per page (cap MAX_FOOTNOTES_PER_PAGE = 16),
+  //                      so 16 matches the in-flight ceiling.
+  //   inlineStyleStack : HTML nesting depth, rarely > 8 (matches the existing
+  //                      blockStyleStack reserve above).
   inlineStyleStack.clear();
   inlineStyleStack.reserve(8);
   anchorData.clear();
-  anchorData.reserve(64);
+  anchorData.reserve(128);
   pendingFootnotes.clear();
   pendingFootnotes.reserve(16);
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -147,6 +147,7 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
       makeUniqueNoThrow<ParsedText>(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle);
   if (!currentTextBlock) {
     LOG_ERR("EHP", "OOM: ParsedText (startNewTextBlock)");
+    oomAborted = true;
     return;
   }
   wordsExtractedInBlock = 0;
@@ -216,6 +217,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (self->oomAborted) return;
 
   // Middle of skip
   if (self->skipUntilDepth < self->depth) {
@@ -824,6 +826,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
 
 void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char* s, const int len) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (self->oomAborted) return;
 
   // Skip content of nested table
   if (self->tableDepth > 1) {
@@ -1006,6 +1009,7 @@ void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const X
 
 void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* name) {
   auto* self = static_cast<ChapterHtmlSlimParser*>(userData);
+  if (self->oomAborted) return;
 
   // Check if any style state will change after we decrement depth
   // If so, we MUST flush the partWordBuffer with the CURRENT style first
@@ -1142,6 +1146,10 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   const auto align = rootBlockStyle.alignment;
   paragraphAlignmentBlockStyle.alignment = align;
   startNewTextBlock(paragraphAlignmentBlockStyle);
+  if (oomAborted) {
+    LOG_ERR("EHP", "Aborting parse: initial ParsedText allocation failed");
+    return false;
+  }
 
   XML_Parser parser = XML_ParserCreate(nullptr);
   int done;
@@ -1199,11 +1207,16 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
       file.close();
       return false;
     }
-  } while (!done);
+  } while (!done && !oomAborted);
   LOG_DBG("EHP", "Time to parse and build pages: %lu ms", millis() - chapterStartTime);
 
   destroyXmlParser(parser);
   file.close();
+
+  if (oomAborted) {
+    LOG_ERR("EHP", "Aborting parse: OOM during XML processing");
+    return false;
+  }
 
   // Process last page if there is still text
   if (currentTextBlock) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -308,6 +308,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                            : static_cast<CssTextAlign>(self->paragraphAlignment);
     tableCellBlockStyle.alignment = align;
     self->startNewTextBlock(tableCellBlockStyle);
+    if (self->oomAborted) return;
 
     const std::string headerText =
         "Tab Row " + std::to_string(self->tableRowIndex) + ", Cell " + std::to_string(self->tableColIndex) + ":";
@@ -508,6 +509,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
                   const BlockStyle parentBlockStyle = self->currentTextBlock->getBlockStyle();
                   self->startNewTextBlock(parentBlockStyle);
+                  if (self->oomAborted) return;
                 }
 
                 // Apply vertical margins from the container to the image.
@@ -594,6 +596,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->startNewTextBlock(self->blockStyleStack.back()
                                     .getCombinedBlockStyle(centeredBlockStyle, BlockStyle::CombineAxis::Horizontal)
                                     .withoutBottom());
+        if (self->oomAborted) return;
         self->italicUntilDepth = std::min(self->italicUntilDepth, self->depth);
         self->depth += 1;
         self->characterData(userData, alt.c_str(), alt.length());
@@ -691,6 +694,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       hrBlockStyle.textIndent = 0;
     }
     self->emitHorizontalRule(hrBlockStyle);
+    if (self->oomAborted) return;
     self->depth += 1;
     return;
   }
@@ -706,6 +710,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->blockStyleStack.back().getCombinedBlockStyle(headerBlockStyle, BlockStyle::CombineAxis::Horizontal);
     self->blockStyleStack.push_back(accumulated);
     self->startNewTextBlock(accumulated.withoutBottom());
+    if (self->oomAborted) return;
     self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
     self->updateEffectiveInlineStyle();
   } else if (matches(name, BLOCK_TAGS, std::size(BLOCK_TAGS))) {
@@ -715,12 +720,14 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
         self->flushPartWordBuffer();
       }
       self->startNewTextBlock(self->blockStyleStack.back().withoutBottom());
+      if (self->oomAborted) return;
     } else {
       self->currentCssStyle = cssStyle;
       const auto accumulated = self->blockStyleStack.back().getCombinedBlockStyle(userAlignmentBlockStyle,
                                                                                   BlockStyle::CombineAxis::Horizontal);
       self->blockStyleStack.push_back(accumulated);
       self->startNewTextBlock(accumulated.withoutBottom());
+      if (self->oomAborted) return;
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -4,13 +4,13 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Utf8.h>
 #include <XmlParserUtils.h>
 #include <expat.h>
 
 #include <algorithm>
 #include <iterator>
-#include <new>
 
 #include "Epub.h"
 #include "Epub/Page.h"
@@ -143,7 +143,12 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
     anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
     pendingAnchorId.clear();
   }
-  currentTextBlock.reset(new ParsedText(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle));
+  currentTextBlock =
+      makeUniqueNoThrow<ParsedText>(extraParagraphSpacing, hyphenationEnabled, focusReadingEnabled, blockStyle);
+  if (!currentTextBlock) {
+    LOG_ERR("EHP", "OOM: ParsedText (startNewTextBlock)");
+    return;
+  }
   wordsExtractedInBlock = 0;
 }
 
@@ -158,9 +163,9 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   }
 
   if (!currentPage) {
-    currentPage.reset(new (std::nothrow) Page());
+    currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
-      LOG_ERR("EHP", "Failed to create page for horizontal rule");
+      LOG_ERR("EHP", "OOM: Page (horizontal rule)");
       return;
     }
     currentPageNextY = 0;
@@ -184,9 +189,9 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   if (!currentPage->elements.empty() && currentPageNextY + totalHeight > viewportHeight) {
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
     completedPageCount++;
-    currentPage.reset(new (std::nothrow) Page());
+    currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
-      LOG_ERR("EHP", "Failed to create page after horizontal-rule page break");
+      LOG_ERR("EHP", "OOM: Page (post horizontal-rule break)");
       return;
     }
     currentPageNextY = 0;
@@ -524,16 +529,16 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex,
                                        self->xpathListItemIndex);
                   self->completedPageCount++;
-                  self->currentPage.reset(new Page());
+                  self->currentPage = makeUniqueNoThrow<Page>();
                   if (!self->currentPage) {
-                    LOG_ERR("EHP", "Failed to create new page");
+                    LOG_ERR("EHP", "OOM: Page (image, post page-break)");
                     return;
                   }
                   self->currentPageNextY = 0;
                 } else if (!self->currentPage) {
-                  self->currentPage.reset(new Page());
+                  self->currentPage = makeUniqueNoThrow<Page>();
                   if (!self->currentPage) {
-                    LOG_ERR("EHP", "Failed to create initial page");
+                    LOG_ERR("EHP", "OOM: Page (image, initial)");
                     return;
                   }
                   self->currentPageNextY = 0;
@@ -1220,14 +1225,22 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
   const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
 
   if (!currentPage) {
-    currentPage.reset(new Page());
+    currentPage = makeUniqueNoThrow<Page>();
+    if (!currentPage) {
+      LOG_ERR("EHP", "OOM: Page (addLineToPage, initial)");
+      return;
+    }
     currentPageNextY = 0;
   }
 
   if (currentPageNextY + lineHeight > viewportHeight) {
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
     completedPageCount++;
-    currentPage.reset(new Page());
+    currentPage = makeUniqueNoThrow<Page>();
+    if (!currentPage) {
+      LOG_ERR("EHP", "OOM: Page (addLineToPage, post-break)");
+      return;
+    }
     currentPageNextY = 0;
   }
 
@@ -1253,7 +1266,11 @@ void ChapterHtmlSlimParser::makePages() {
   }
 
   if (!currentPage) {
-    currentPage.reset(new Page());
+    currentPage = makeUniqueNoThrow<Page>();
+    if (!currentPage) {
+      LOG_ERR("EHP", "OOM: Page (makePages)");
+      return;
+    }
     currentPageNextY = 0;
   }
 

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -167,6 +167,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
     currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
       LOG_ERR("EHP", "OOM: Page (horizontal rule)");
+      oomAborted = true;
       return;
     }
     currentPageNextY = 0;
@@ -193,6 +194,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
     currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
       LOG_ERR("EHP", "OOM: Page (post horizontal-rule break)");
+      oomAborted = true;
       return;
     }
     currentPageNextY = 0;
@@ -536,6 +538,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   self->currentPage = makeUniqueNoThrow<Page>();
                   if (!self->currentPage) {
                     LOG_ERR("EHP", "OOM: Page (image, post page-break)");
+                    self->oomAborted = true;
                     return;
                   }
                   self->currentPageNextY = 0;
@@ -543,6 +546,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   self->currentPage = makeUniqueNoThrow<Page>();
                   if (!self->currentPage) {
                     LOG_ERR("EHP", "OOM: Page (image, initial)");
+                    self->oomAborted = true;
                     return;
                   }
                   self->currentPageNextY = 0;
@@ -551,16 +555,21 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 // Apply top margin from container block
                 self->currentPageNextY += imageMarginTop;
 
-                // Create ImageBlock and add to page
-                auto imageBlock = std::make_shared<ImageBlock>(cachedImagePath, displayWidth, displayHeight);
+                // Create ImageBlock and add to page. std::make_shared aborts on
+                // OOM under -fno-exceptions, so use new (std::nothrow) and wrap.
+                auto imageBlock = std::shared_ptr<ImageBlock>(
+                    new (std::nothrow) ImageBlock(cachedImagePath, displayWidth, displayHeight));
                 if (!imageBlock) {
-                  LOG_ERR("EHP", "Failed to create ImageBlock");
+                  LOG_ERR("EHP", "OOM: ImageBlock");
+                  self->oomAborted = true;
                   return;
                 }
                 int xPos = (self->viewportWidth - displayWidth) / 2;
-                auto pageImage = std::make_shared<PageImage>(imageBlock, xPos, self->currentPageNextY);
+                auto pageImage =
+                    std::shared_ptr<PageImage>(new (std::nothrow) PageImage(imageBlock, xPos, self->currentPageNextY));
                 if (!pageImage) {
-                  LOG_ERR("EHP", "Failed to create PageImage");
+                  LOG_ERR("EHP", "OOM: PageImage");
+                  self->oomAborted = true;
                   return;
                 }
                 self->currentPage->elements.push_back(pageImage);
@@ -1228,6 +1237,10 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   // Process last page if there is still text
   if (currentTextBlock) {
     makePages();
+    if (oomAborted || !currentPage) {
+      LOG_ERR("EHP", "Aborting final flush: OOM in makePages or no page allocated");
+      return false;
+    }
     if (!pendingAnchorId.empty()) {
       anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
       pendingAnchorId.clear();
@@ -1248,6 +1261,7 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
     currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
       LOG_ERR("EHP", "OOM: Page (addLineToPage, initial)");
+      oomAborted = true;
       return;
     }
     currentPageNextY = 0;
@@ -1259,6 +1273,7 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
     currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
       LOG_ERR("EHP", "OOM: Page (addLineToPage, post-break)");
+      oomAborted = true;
       return;
     }
     currentPageNextY = 0;
@@ -1273,9 +1288,16 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
   }
   pendingFootnotes.erase(pendingFootnotes.begin(), footnoteIt);
 
-  // Apply horizontal left inset (margin + padding) as x position offset
+  // Apply horizontal left inset (margin + padding) as x position offset.
+  // std::make_shared aborts on OOM under -fno-exceptions; use new (std::nothrow).
   const int16_t xOffset = line->getBlockStyle().leftInset();
-  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  auto pageLine = std::shared_ptr<PageLine>(new (std::nothrow) PageLine(line, xOffset, currentPageNextY));
+  if (!pageLine) {
+    LOG_ERR("EHP", "OOM: PageLine (addLineToPage)");
+    oomAborted = true;
+    return;
+  }
+  currentPage->elements.push_back(std::move(pageLine));
   currentPageNextY += lineHeight;
 }
 
@@ -1289,6 +1311,7 @@ void ChapterHtmlSlimParser::makePages() {
     currentPage = makeUniqueNoThrow<Page>();
     if (!currentPage) {
       LOG_ERR("EHP", "OOM: Page (makePages)");
+      oomAborted = true;
       return;
     }
     currentPageNextY = 0;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1157,6 +1157,17 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   blockStyleStack.reserve(8);
   blockStyleStack.push_back(rootBlockStyle);
 
+  // Pre-allocate the parser's growing vectors per CLAUDE.md §"std::vector
+  // Pre-allocation": grow-on-push_back triggers operator new[] internally and
+  // aborts on OOM under -fno-exceptions. Sizes are conservative estimates;
+  // overflow still doubles (rare on a typical chapter).
+  inlineStyleStack.clear();
+  inlineStyleStack.reserve(8);
+  anchorData.clear();
+  anchorData.reserve(64);
+  pendingFootnotes.clear();
+  pendingFootnotes.reserve(16);
+
   auto paragraphAlignmentBlockStyle = BlockStyle();
   paragraphAlignmentBlockStyle.textAlignDefined = true;
   const auto align = rootBlockStyle.alignment;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -79,6 +79,12 @@ class ChapterHtmlSlimParser {
   uint16_t xpathParagraphIndex = 0;
   uint16_t xpathListItemIndex = 0;
 
+  // Set when an OOM during parsing leaves the parser in an unrecoverable state
+  // (e.g. startNewTextBlock couldn't allocate a ParsedText). XML callbacks short-
+  // circuit when set, and parseAndBuildPages() returns false instead of producing
+  // a partial document.
+  bool oomAborted = false;
+
   // Footnote link tracking
   bool insideFootnoteLink = false;
   int footnoteLinkDepth = -1;

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <new>
 
 // ============================================================================
 // IMAGE PROCESSING OPTIONS
@@ -76,6 +77,8 @@ const char* Bitmap::errorToString(BmpReaderError err) {
 
     case BmpReaderError::OomRowBuffer:
       return "OomRowBuffer";
+    case BmpReaderError::OomDitherer:
+      return "OomDitherer";
     case BmpReaderError::ShortReadRow:
       return "ShortReadRow";
   }
@@ -168,9 +171,19 @@ BmpReaderError Bitmap::parseHeaders() {
   const bool highColor = !nativePalette;
   if (highColor && dithering) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(width);
+      atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(width);
+      if (!atkinsonDitherer || !atkinsonDitherer->isValid()) {
+        delete atkinsonDitherer;
+        atkinsonDitherer = nullptr;
+        return BmpReaderError::OomDitherer;
+      }
     } else {
-      fsDitherer = new FloydSteinbergDitherer(width);
+      fsDitherer = new (std::nothrow) FloydSteinbergDitherer(width);
+      if (!fsDitherer || !fsDitherer->isValid()) {
+        delete fsDitherer;
+        fsDitherer = nullptr;
+        return BmpReaderError::OomDitherer;
+      }
     }
   }
 

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -57,6 +57,7 @@ enum class BmpReaderError : uint8_t {
   SeekPixelDataFailed,
   BufferTooSmall,
   OomRowBuffer,
+  OomDitherer,
   ShortReadRow,
 };
 

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -207,7 +207,7 @@ class FloydSteinbergDitherer {
   explicit FloydSteinbergDitherer(int width)
       : width(width),
         rowCount(0),
-        errorCurRow(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 2]())),     // +2 for boundary handling
+        errorCurRow(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 2]())),  // +2 for boundary handling
         errorNextRow(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 2]())) {}
 
   ~FloydSteinbergDitherer() = default;

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <cstring>
+#include <memory>
+#include <new>
 
 struct BmpHeader;
 
@@ -23,17 +25,17 @@ void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder ro
 //     1/8
 class Atkinson1BitDitherer {
  public:
-  explicit Atkinson1BitDitherer(int width) : width(width) {
-    errorRow0 = new int16_t[width + 4]();  // Current row
-    errorRow1 = new int16_t[width + 4]();  // Next row
-    errorRow2 = new int16_t[width + 4]();  // Row after next
-  }
+  explicit Atkinson1BitDitherer(int width)
+      : width(width),
+        errorRow0(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())),    // Current row
+        errorRow1(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())),    // Next row
+        errorRow2(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())) {}  // Row after next
 
-  ~Atkinson1BitDitherer() {
-    delete[] errorRow0;
-    delete[] errorRow1;
-    delete[] errorRow2;
-  }
+  ~Atkinson1BitDitherer() = default;
+
+  // Caller must verify after construction; partial-OOM leaves the dither rows
+  // null and processPixel() must not be called in that state.
+  bool isValid() const { return errorRow0 && errorRow1 && errorRow2; }
 
   // EXPLICITLY DELETE THE COPY CONSTRUCTOR
   Atkinson1BitDitherer(const Atkinson1BitDitherer& other) = delete;
@@ -76,24 +78,22 @@ class Atkinson1BitDitherer {
   }
 
   void nextRow() {
-    int16_t* temp = errorRow0;
-    errorRow0 = errorRow1;
-    errorRow1 = errorRow2;
-    errorRow2 = temp;
-    memset(errorRow2, 0, (width + 4) * sizeof(int16_t));
+    errorRow0.swap(errorRow1);
+    errorRow1.swap(errorRow2);
+    memset(errorRow2.get(), 0, (width + 4) * sizeof(int16_t));
   }
 
   void reset() {
-    memset(errorRow0, 0, (width + 4) * sizeof(int16_t));
-    memset(errorRow1, 0, (width + 4) * sizeof(int16_t));
-    memset(errorRow2, 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow0.get(), 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow1.get(), 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow2.get(), 0, (width + 4) * sizeof(int16_t));
   }
 
  private:
   int width;
-  int16_t* errorRow0;
-  int16_t* errorRow1;
-  int16_t* errorRow2;
+  std::unique_ptr<int16_t[]> errorRow0;
+  std::unique_ptr<int16_t[]> errorRow1;
+  std::unique_ptr<int16_t[]> errorRow2;
 };
 
 // Atkinson dithering - distributes only 6/8 (75%) of error for cleaner results
@@ -104,17 +104,18 @@ class Atkinson1BitDitherer {
 // Less error buildup = fewer artifacts than Floyd-Steinberg
 class AtkinsonDitherer {
  public:
-  explicit AtkinsonDitherer(int width) : width(width) {
-    errorRow0 = new int16_t[width + 4]();  // Current row
-    errorRow1 = new int16_t[width + 4]();  // Next row
-    errorRow2 = new int16_t[width + 4]();  // Row after next
-  }
+  explicit AtkinsonDitherer(int width)
+      : width(width),
+        errorRow0(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())),    // Current row
+        errorRow1(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())),    // Next row
+        errorRow2(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 4]())) {}  // Row after next
 
-  ~AtkinsonDitherer() {
-    delete[] errorRow0;
-    delete[] errorRow1;
-    delete[] errorRow2;
-  }
+  ~AtkinsonDitherer() = default;
+
+  // Caller must verify after construction; partial-OOM leaves the dither rows
+  // null and processPixel() must not be called in that state.
+  bool isValid() const { return errorRow0 && errorRow1 && errorRow2; }
+
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
   AtkinsonDitherer(const AtkinsonDitherer& other) = delete;
 
@@ -175,24 +176,22 @@ class AtkinsonDitherer {
   }
 
   void nextRow() {
-    int16_t* temp = errorRow0;
-    errorRow0 = errorRow1;
-    errorRow1 = errorRow2;
-    errorRow2 = temp;
-    memset(errorRow2, 0, (width + 4) * sizeof(int16_t));
+    errorRow0.swap(errorRow1);
+    errorRow1.swap(errorRow2);
+    memset(errorRow2.get(), 0, (width + 4) * sizeof(int16_t));
   }
 
   void reset() {
-    memset(errorRow0, 0, (width + 4) * sizeof(int16_t));
-    memset(errorRow1, 0, (width + 4) * sizeof(int16_t));
-    memset(errorRow2, 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow0.get(), 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow1.get(), 0, (width + 4) * sizeof(int16_t));
+    memset(errorRow2.get(), 0, (width + 4) * sizeof(int16_t));
   }
 
  private:
   int width;
-  int16_t* errorRow0;
-  int16_t* errorRow1;
-  int16_t* errorRow2;
+  std::unique_ptr<int16_t[]> errorRow0;
+  std::unique_ptr<int16_t[]> errorRow1;
+  std::unique_ptr<int16_t[]> errorRow2;
 };
 
 // Floyd-Steinberg error diffusion dithering with serpentine scanning
@@ -205,15 +204,17 @@ class AtkinsonDitherer {
 //      7/16  X
 class FloydSteinbergDitherer {
  public:
-  explicit FloydSteinbergDitherer(int width) : width(width), rowCount(0) {
-    errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
-    errorNextRow = new int16_t[width + 2]();
-  }
+  explicit FloydSteinbergDitherer(int width)
+      : width(width),
+        rowCount(0),
+        errorCurRow(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 2]())),     // +2 for boundary handling
+        errorNextRow(std::unique_ptr<int16_t[]>(new (std::nothrow) int16_t[width + 2]())) {}
 
-  ~FloydSteinbergDitherer() {
-    delete[] errorCurRow;
-    delete[] errorNextRow;
-  }
+  ~FloydSteinbergDitherer() = default;
+
+  // Caller must verify after construction; partial-OOM leaves the error rows
+  // null and processPixel() must not be called in that state.
+  bool isValid() const { return errorCurRow && errorNextRow; }
 
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
   FloydSteinbergDitherer(const FloydSteinbergDitherer& other) = delete;
@@ -295,12 +296,9 @@ class FloydSteinbergDitherer {
 
   // Call at the end of each row to swap buffers
   void nextRow() {
-    // Swap buffers
-    int16_t* temp = errorCurRow;
-    errorCurRow = errorNextRow;
-    errorNextRow = temp;
+    errorCurRow.swap(errorNextRow);
     // Clear the next row buffer
-    memset(errorNextRow, 0, (width + 2) * sizeof(int16_t));
+    memset(errorNextRow.get(), 0, (width + 2) * sizeof(int16_t));
     rowCount++;
   }
 
@@ -309,14 +307,14 @@ class FloydSteinbergDitherer {
 
   // Reset for a new image or MCU block
   void reset() {
-    memset(errorCurRow, 0, (width + 2) * sizeof(int16_t));
-    memset(errorNextRow, 0, (width + 2) * sizeof(int16_t));
+    memset(errorCurRow.get(), 0, (width + 2) * sizeof(int16_t));
+    memset(errorNextRow.get(), 0, (width + 2) * sizeof(int16_t));
     rowCount = 0;
   }
 
  private:
   int width;
   int rowCount;
-  int16_t* errorCurRow;
-  int16_t* errorNextRow;
+  std::unique_ptr<int16_t[]> errorCurRow;
+  std::unique_ptr<int16_t[]> errorNextRow;
 };

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <new>
 
 #include "BitmapHelpers.h"
 
@@ -624,13 +625,35 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   FloydSteinbergDitherer* fsDitherer = nullptr;
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
 
+  auto ditherOom = [&]() {
+    delete atkinsonDitherer;
+    delete fsDitherer;
+    delete atkinson1BitDitherer;
+    free(rowBuffer);
+    free(ctx.currentRow);
+    free(ctx.previousRow);
+    LOG_ERR("PNG", "OOM: ditherer construction");
+  };
+
   if (oneBit) {
-    atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
+    atkinson1BitDitherer = new (std::nothrow) Atkinson1BitDitherer(outWidth);
+    if (!atkinson1BitDitherer || !atkinson1BitDitherer->isValid()) {
+      ditherOom();
+      return false;
+    }
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth);
+      atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(outWidth);
+      if (!atkinsonDitherer || !atkinsonDitherer->isValid()) {
+        ditherOom();
+        return false;
+      }
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth);
+      fsDitherer = new (std::nothrow) FloydSteinbergDitherer(outWidth);
+      if (!fsDitherer || !fsDitherer->isValid()) {
+        ditherOom();
+        return false;
+      }
     }
   }
 
@@ -641,8 +664,20 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   uint32_t nextOutY_srcStart = 0;
 
   if (needsScaling) {
-    rowAccum = new uint32_t[outWidth]();
-    rowCount = new uint16_t[outWidth]();
+    rowAccum = new (std::nothrow) uint32_t[outWidth]();
+    rowCount = new (std::nothrow) uint16_t[outWidth]();
+    if (!rowAccum || !rowCount) {
+      LOG_ERR("PNG", "OOM: scaling accumulators (%d cells)", outWidth);
+      delete[] rowAccum;
+      delete[] rowCount;
+      delete atkinsonDitherer;
+      delete fsDitherer;
+      delete atkinson1BitDitherer;
+      free(rowBuffer);
+      free(ctx.currentRow);
+      free(ctx.previousRow);
+      return false;
+    }
     nextOutY_srcStart = scaleY_fp;
   }
 

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -10,12 +10,17 @@
 #include <Bitmap.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 
 bool Xtc::load() {
   LOG_DBG("XTC", "Loading XTC: %s", filepath.c_str());
 
   // Initialize parser
-  parser.reset(new xtc::XtcParser());
+  parser = makeUniqueNoThrow<xtc::XtcParser>();
+  if (!parser) {
+    LOG_ERR("XTC", "OOM: XtcParser");
+    return false;
+  }
 
   // Open XTC file
   xtc::XtcError err = parser->open(filepath.c_str());

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -3,6 +3,7 @@
 #include <ESPmDNS.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
 
@@ -80,7 +81,13 @@ void CalibreConnectActivity::startWebServer() {
     LOG_DBG("CAL", "mDNS started: http://%s.local/", HOSTNAME);
   }
 
-  webServer.reset(new CrossPointWebServer());
+  webServer = makeUniqueNoThrow<CrossPointWebServer>();
+  if (!webServer) {
+    LOG_ERR("CAL", "OOM: CrossPointWebServer");
+    state = CalibreConnectState::ERROR;
+    requestUpdate();
+    return;
+  }
   webServer->begin();
 
   if (webServer->isRunning()) {

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -4,6 +4,7 @@
 #include <ESPmDNS.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
 
@@ -231,7 +232,13 @@ void CrossPointWebServerActivity::startAccessPoint() {
   // Start DNS server for captive portal behavior
   // This redirects all DNS queries to our IP, making any domain typed resolve to us
   stopDnsServer();
-  dnsServer = new DNSServer();
+  dnsServer = new (std::nothrow) DNSServer();
+  if (!dnsServer) {
+    LOG_ERR("WEBACT", "OOM: DNSServer");
+    state = WebServerActivityState::SHUTTING_DOWN;
+    onGoHome();
+    return;
+  }
   dnsServer->setErrorReplyCode(DNSReplyCode::NoError);
   dnsServer->start(DNS_PORT, "*", apIP);
   LOG_DBG("WEBACT", "DNS server started for captive portal");
@@ -246,7 +253,12 @@ void CrossPointWebServerActivity::startWebServer() {
   LOG_DBG("WEBACT", "Starting web server...");
 
   // Create the web server instance
-  webServer.reset(new CrossPointWebServer());
+  webServer = makeUniqueNoThrow<CrossPointWebServer>();
+  if (!webServer) {
+    LOG_ERR("WEBACT", "OOM: CrossPointWebServer");
+    onGoHome();
+    return;
+  }
   webServer->begin();
 
   if (webServer->isRunning()) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -705,7 +705,11 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
-    section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+    section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
+    if (!section) {
+      LOG_ERR("ERS", "OOM: Section");
+      return;
+    }
 
     if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                   SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <FsHelpers.h>
 #include <HalStorage.h>
+#include <Memory.h>
 
 #include "CrossPointSettings.h"
 #include "Epub.h"
@@ -29,7 +30,11 @@ std::unique_ptr<Epub> ReaderActivity::loadEpub(const std::string& path) {
     return nullptr;
   }
 
-  auto epub = std::unique_ptr<Epub>(new Epub(path, "/.crosspoint"));
+  auto epub = makeUniqueNoThrow<Epub>(path, "/.crosspoint");
+  if (!epub) {
+    LOG_ERR("READER", "OOM: Epub");
+    return nullptr;
+  }
   if (epub->load(true, SETTINGS.embeddedStyle == 0)) {
     return epub;
   }
@@ -44,7 +49,11 @@ std::unique_ptr<Xtc> ReaderActivity::loadXtc(const std::string& path) {
     return nullptr;
   }
 
-  auto xtc = std::unique_ptr<Xtc>(new Xtc(path, "/.crosspoint"));
+  auto xtc = makeUniqueNoThrow<Xtc>(path, "/.crosspoint");
+  if (!xtc) {
+    LOG_ERR("READER", "OOM: Xtc");
+    return nullptr;
+  }
   if (xtc->load()) {
     return xtc;
   }
@@ -59,7 +68,11 @@ std::unique_ptr<Txt> ReaderActivity::loadTxt(const std::string& path) {
     return nullptr;
   }
 
-  auto txt = std::unique_ptr<Txt>(new Txt(path, "/.crosspoint"));
+  auto txt = makeUniqueNoThrow<Txt>(path, "/.crosspoint");
+  if (!txt) {
+    LOG_ERR("READER", "OOM: Txt");
+    return nullptr;
+  }
   if (txt->load()) {
     return txt;
   }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -173,7 +173,7 @@ void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
     // X3 layout: Up on left side, Down on right side, positioned higher
     constexpr int x3ButtonY = 155;
 
-    if (topBtn != nullptr && topBtn[0] != '\0') {
+    if (topBtn && topBtn[0] != '\0') {
       const int leftX = buttonMargin;
       renderer.drawRect(leftX, x3ButtonY, buttonWidth, buttonHeight);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, topBtn);
@@ -183,7 +183,7 @@ void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
       renderer.drawTextRotated90CW(SMALL_FONT_ID, textX, textY, topBtn);
     }
 
-    if (bottomBtn != nullptr && bottomBtn[0] != '\0') {
+    if (bottomBtn && bottomBtn[0] != '\0') {
       const int rightX = screenWidth - buttonMargin - buttonWidth;
       renderer.drawRect(rightX, x3ButtonY, buttonWidth, buttonHeight);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, bottomBtn);
@@ -198,17 +198,17 @@ void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
     const char* labels[] = {topBtn, bottomBtn};
     const int x = screenWidth - buttonMargin - buttonWidth;
 
-    if (topBtn != nullptr && topBtn[0] != '\0') {
+    if (topBtn && topBtn[0] != '\0') {
       renderer.drawLine(x, topButtonY, x + buttonWidth - 1, topButtonY);
       renderer.drawLine(x, topButtonY, x, topButtonY + buttonHeight - 1);
       renderer.drawLine(x + buttonWidth - 1, topButtonY, x + buttonWidth - 1, topButtonY + buttonHeight - 1);
     }
 
-    if ((topBtn != nullptr && topBtn[0] != '\0') || (bottomBtn != nullptr && bottomBtn[0] != '\0')) {
+    if ((topBtn && topBtn[0] != '\0') || (bottomBtn && bottomBtn[0] != '\0')) {
       renderer.drawLine(x, topButtonY + buttonHeight, x + buttonWidth - 1, topButtonY + buttonHeight);
     }
 
-    if (bottomBtn != nullptr && bottomBtn[0] != '\0') {
+    if (bottomBtn && bottomBtn[0] != '\0') {
       renderer.drawLine(x, topButtonY + buttonHeight, x, topButtonY + 2 * buttonHeight - 1);
       renderer.drawLine(x + buttonWidth - 1, topButtonY + buttonHeight, x + buttonWidth - 1,
                         topButtonY + 2 * buttonHeight - 1);
@@ -229,13 +229,10 @@ void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
 }
 
 void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                         const std::function<std::string(int index)>& rowTitle,
-                         const std::function<std::string(int index)>& rowSubtitle,
-                         const std::function<UIIcon(int index)>& rowIcon,
-                         const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                         const std::function<bool(int index)>& rowDimmed) const {
-  int rowHeight =
-      (rowSubtitle != nullptr) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
+                         FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle,
+                         FnRef<UIIcon(int index)> rowIcon, FnRef<std::string(int index)> rowValue, bool highlightValue,
+                         FnRef<bool(int index)> rowDimmed) const {
+  int rowHeight = (rowSubtitle) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
 
   const int totalPages = (itemCount + pageItems - 1) / pageItems;
@@ -278,7 +275,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
     int rowTextWidth = contentWidth - BaseMetrics::values.contentSidePadding * 2;
     std::string valueText;
-    if (rowValue != nullptr) {
+    if (rowValue) {
       valueText = rowValue(i);
       if (!valueText.empty()) {
         int maxValW = std::max(0, rowTextWidth - 40 - minValueGap);
@@ -303,7 +300,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
           if ((px + py) % 2 == 0) renderer.drawPixel(px, py, false);
     }
 
-    if (rowSubtitle != nullptr) {
+    if (rowSubtitle) {
       std::string subtitleText = rowSubtitle(i);
       if (!subtitleText.empty()) {
         auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
@@ -315,7 +312,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     if (!valueText.empty()) {
       const auto valueTextWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str());
       int valueY = itemY;
-      if (rowSubtitle != nullptr) {
+      if (rowSubtitle) {
         valueY = itemY + 10;
       }
       renderer.drawText(UI_10_FONT_ID, rect.x + contentWidth - BaseMetrics::values.contentSidePadding - valueTextWidth,
@@ -409,7 +406,7 @@ void BaseTheme::drawTabBar(const GfxRenderer& renderer, const Rect rect, const s
 // TODO: Refactor method to make it cleaner, split into smaller methods
 void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                     const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                    bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                    bool& bufferRestored, FnRef<bool()> storeCoverBuffer) const {
   const bool hasContinueReading = !recentBooks.empty();
   const bool bookSelected = hasContinueReading && selectorIndex == 0;
 
@@ -636,8 +633,7 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
 }
 
 void BaseTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                               const std::function<std::string(int index)>& buttonLabel,
-                               const std::function<UIIcon(int index)>& rowIcon) const {
+                               FnRef<std::string(int index)> buttonLabel, FnRef<UIIcon(int index)> rowIcon) const {
   for (int i = 0; i < buttonCount; ++i) {
     const int tileY = BaseMetrics::values.verticalSpacing + rect.y +
                       static_cast<int>(i) * (BaseMetrics::values.menuRowHeight + BaseMetrics::values.menuSpacing);
@@ -935,11 +931,11 @@ void BaseTheme::drawKeyboardKey(const GfxRenderer& renderer, Rect rect, const ch
     return;
   }
 
-  if (label == nullptr || label[0] == '\0') {
+  if (!label || label[0] == '\0') {
     return;
   }
 
-  const bool hasSecondary = secondaryLabel != nullptr && secondaryLabel[0] != '\0';
+  const bool hasSecondary = secondaryLabel && secondaryLabel[0] != '\0';
   const int itemWidth = renderer.getTextWidth(UI_12_FONT_ID, label);
   const int textX = rect.x + (rect.width - itemWidth) / 2;
   const int textY = rect.y + (rect.height - renderer.getLineHeight(UI_12_FONT_ID)) / 2;

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -2,9 +2,10 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <string>
 #include <vector>
+
+#include "util/FnRef.h"
 
 class GfxRenderer;
 struct RecentBook;
@@ -183,11 +184,9 @@ class BaseTheme {
                                const char* btn4) const;
   virtual void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
   virtual void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                        const std::function<std::string(int index)>& rowTitle,
-                        const std::function<std::string(int index)>& rowSubtitle = nullptr,
-                        const std::function<UIIcon(int index)>& rowIcon = nullptr,
-                        const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
-                        const std::function<bool(int index)>& rowDimmed = nullptr) const;
+                        FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle = nullptr,
+                        FnRef<UIIcon(int index)> rowIcon = nullptr, FnRef<std::string(int index)> rowValue = nullptr,
+                        bool highlightValue = false, FnRef<bool(int index)> rowDimmed = nullptr) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
                           const char* subtitle = nullptr) const;
   virtual void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,
@@ -196,10 +195,9 @@ class BaseTheme {
                           bool selected) const;
   virtual void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                    const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                   bool& bufferRestored, std::function<bool()> storeCoverBuffer) const;
+                                   bool& bufferRestored, FnRef<bool()> storeCoverBuffer) const;
   virtual void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                              const std::function<std::string(int index)>& buttonLabel,
-                              const std::function<UIIcon(int index)>& rowIcon) const;
+                              FnRef<std::string(int index)> buttonLabel, FnRef<UIIcon(int index)> rowIcon) const;
   virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
   void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage, const int pageCount,

--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -20,7 +20,7 @@ constexpr int cornerRadius = 6;
 
 void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                           bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                           bool& bufferRestored, FnRef<bool()> storeCoverBuffer) const {
   const int tileWidth = (rect.width - 2 * Lyra3CoversMetrics::values.contentSidePadding) / 3;
   const int tileY = rect.y;
   const bool hasContinueReading = !recentBooks.empty();

--- a/src/components/themes/lyra/Lyra3CoversTheme.h
+++ b/src/components/themes/lyra/Lyra3CoversTheme.h
@@ -19,5 +19,5 @@ class Lyra3CoversTheme : public LyraTheme {
  public:
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
-                           std::function<bool()> storeCoverBuffer) const override;
+                           FnRef<bool()> storeCoverBuffer) const override;
 };

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -112,9 +112,8 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
                    Rect{batteryX, rect.y + 5, LyraMetrics::values.batteryWidth, LyraMetrics::values.batteryHeight},
                    showBatteryPercentage);
 
-  int maxTitleWidth = title != nullptr ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
-  int maxSubtitleWidth =
-      subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
+  int maxTitleWidth = title ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
+  int maxSubtitleWidth = subtitle ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
 
   // Available space is the distance between the side paddings, and a with side padding between title and subtitle.
   const int availableSpace = rect.width - LyraMetrics::values.contentSidePadding * 3;
@@ -203,13 +202,10 @@ void LyraTheme::drawTabBar(const GfxRenderer& renderer, Rect rect, const std::ve
 }
 
 void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                         const std::function<std::string(int index)>& rowTitle,
-                         const std::function<std::string(int index)>& rowSubtitle,
-                         const std::function<UIIcon(int index)>& rowIcon,
-                         const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                         const std::function<bool(int index)>& rowDimmed) const {
-  int rowHeight =
-      (rowSubtitle != nullptr) ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
+                         FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle,
+                         FnRef<UIIcon(int index)> rowIcon, FnRef<std::string(int index)> rowValue, bool highlightValue,
+                         FnRef<bool(int index)> rowDimmed) const {
+  int rowHeight = (rowSubtitle) ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
 
   const int totalPages = (itemCount + pageItems - 1) / pageItems;
@@ -239,15 +235,15 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   int textX = rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection;
   int textWidth = contentWidth - LyraMetrics::values.contentSidePadding * 2 - hPaddingInSelection * 2;
   int iconSize;
-  if (rowIcon != nullptr) {
-    iconSize = (rowSubtitle != nullptr) ? mainMenuIconSize : listIconSize;
+  if (rowIcon) {
+    iconSize = (rowSubtitle) ? mainMenuIconSize : listIconSize;
     textX += iconSize + hPaddingInSelection;
     textWidth -= iconSize + hPaddingInSelection;
   }
 
   // Draw all items
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
-  int iconY = (rowSubtitle != nullptr) ? 16 : 10;
+  int iconY = (rowSubtitle) ? 16 : 10;
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
     int rowTextWidth = textWidth;
@@ -255,7 +251,7 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     // Draw name
     int valueWidth = 0;
     std::string valueText = "";
-    if (rowValue != nullptr) {
+    if (rowValue) {
       valueText = rowValue(i);
       valueText = renderer.truncatedText(UI_10_FONT_ID, valueText.c_str(), maxListValueWidth);
       valueWidth = renderer.getTextWidth(UI_10_FONT_ID, valueText.c_str()) + hPaddingInSelection;
@@ -275,16 +271,16 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
           if ((px + py) % 2 == 0) renderer.drawPixel(px, py, false);
     }
 
-    if (rowIcon != nullptr) {
+    if (rowIcon) {
       UIIcon icon = rowIcon(i);
       const uint8_t* iconBitmap = iconForName(icon, iconSize);
-      if (iconBitmap != nullptr) {
+      if (iconBitmap) {
         renderer.drawIcon(iconBitmap, rect.x + LyraMetrics::values.contentSidePadding + hPaddingInSelection,
                           itemY + iconY, iconSize, iconSize);
       }
     }
 
-    if (rowSubtitle != nullptr) {
+    if (rowSubtitle) {
       // Draw subtitle
       std::string subtitleText = rowSubtitle(i);
       auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
@@ -300,7 +296,7 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
       }
 
       int valueY = itemY + 6;
-      if (rowSubtitle != nullptr) {
+      if (rowSubtitle) {
         valueY = itemY + 16;
       }
       renderer.drawText(UI_10_FONT_ID, rect.x + contentWidth - LyraMetrics::values.contentSidePadding - valueWidth,
@@ -358,14 +354,14 @@ void LyraTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
     // X3 layout: Up on left side, Down on right side, positioned higher
     constexpr int x3ButtonY = 155;
 
-    if (topBtn != nullptr && topBtn[0] != '\0') {
+    if (topBtn && topBtn[0] != '\0') {
       renderer.drawRoundedRect(buttonMargin, x3ButtonY, buttonWidth, buttonHeight, 1, cornerRadius, false, true, false,
                                true, true);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, topBtn);
       renderer.drawTextRotated90CW(SMALL_FONT_ID, buttonMargin, x3ButtonY + (buttonHeight + textWidth) / 2, topBtn);
     }
 
-    if (bottomBtn != nullptr && bottomBtn[0] != '\0') {
+    if (bottomBtn && bottomBtn[0] != '\0') {
       const int rightX = screenWidth - buttonWidth;
       renderer.drawRoundedRect(rightX, x3ButtonY, buttonWidth, buttonHeight, 1, cornerRadius, true, false, true, false,
                                true);
@@ -377,12 +373,12 @@ void LyraTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
     const char* labels[] = {topBtn, bottomBtn};
     const int x = screenWidth - buttonWidth;
 
-    if (topBtn != nullptr && topBtn[0] != '\0') {
+    if (topBtn && topBtn[0] != '\0') {
       renderer.drawRoundedRect(x, topHintButtonY, buttonWidth, buttonHeight, 1, cornerRadius, true, false, true, false,
                                true);
     }
 
-    if (bottomBtn != nullptr && bottomBtn[0] != '\0') {
+    if (bottomBtn && bottomBtn[0] != '\0') {
       renderer.drawRoundedRect(x, topHintButtonY + buttonHeight + 5, buttonWidth, buttonHeight, 1, cornerRadius, true,
                                false, true, false, true);
     }
@@ -399,7 +395,7 @@ void LyraTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* top
 
 void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                     const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                    bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                    bool& bufferRestored, FnRef<bool()> storeCoverBuffer) const {
   const int tileWidth = rect.width - 2 * LyraMetrics::values.contentSidePadding;
   const int tileHeight = rect.height;
   const int tileY = rect.y;
@@ -502,8 +498,7 @@ void LyraTheme::drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) c
 }
 
 void LyraTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                               const std::function<std::string(int index)>& buttonLabel,
-                               const std::function<UIIcon(int index)>& rowIcon) const {
+                               FnRef<std::string(int index)> buttonLabel, FnRef<UIIcon(int index)> rowIcon) const {
   for (int i = 0; i < buttonCount; ++i) {
     int tileWidth = rect.width - LyraMetrics::values.contentSidePadding * 2;
     Rect tileRect = Rect{rect.x + LyraMetrics::values.contentSidePadding,
@@ -522,10 +517,10 @@ void LyraTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount
     const int lineHeight = renderer.getLineHeight(UI_12_FONT_ID);
     const int textY = tileRect.y + (LyraMetrics::values.menuRowHeight - lineHeight) / 2;
 
-    if (rowIcon != nullptr) {
+    if (rowIcon) {
       UIIcon icon = rowIcon(i);
       const uint8_t* iconBitmap = iconForName(icon, mainMenuIconSize);
-      if (iconBitmap != nullptr) {
+      if (iconBitmap) {
         renderer.drawIcon(iconBitmap, textX, textY + 3, mainMenuIconSize, mainMenuIconSize);
         textX += mainMenuIconSize + hPaddingInSelection + 2;
       }

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -79,19 +79,17 @@ class LyraTheme : public BaseTheme {
   void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,
                   bool selected) const override;
   void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                const std::function<std::string(int index)>& rowTitle,
-                const std::function<std::string(int index)>& rowSubtitle,
-                const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
-                bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr) const override;
+                FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle,
+                FnRef<UIIcon(int index)> rowIcon, FnRef<std::string(int index)> rowValue, bool highlightValue,
+                FnRef<bool(int index)> rowDimmed = nullptr) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                        const char* btn4) const override;
   void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;
   void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                      const std::function<std::string(int index)>& buttonLabel,
-                      const std::function<UIIcon(int index)>& rowIcon) const override;
+                      FnRef<std::string(int index)> buttonLabel, FnRef<UIIcon(int index)> rowIcon) const override;
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
-                           std::function<bool()> storeCoverBuffer) const override;
+                           FnRef<bool()> storeCoverBuffer) const override;
   void drawEmptyRecents(const GfxRenderer& renderer, const Rect rect) const;
   bool showsFileIcons() const override { return true; }
 };

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -50,7 +50,7 @@ void RoundedRaffTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const 
                                   const char* subtitle) const {
   (void)subtitle;
   // Home screen header is custom-rendered in drawRecentBookCover.
-  if (title == nullptr) {
+  if (!title) {
     return;
   }
   const int sidePadding = RoundedRaffMetrics::values.contentSidePadding;
@@ -114,7 +114,7 @@ void RoundedRaffTheme::drawTabBar(const GfxRenderer& renderer, Rect rect, const 
 
 void RoundedRaffTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                                            const int selectorIndex, bool& coverRendered, bool& coverBufferStored,
-                                           bool& bufferRestored, std::function<bool()> storeCoverBuffer) const {
+                                           bool& bufferRestored, FnRef<bool()> storeCoverBuffer) const {
   const int tileWidth = rect.width - 2 * RoundedRaffMetrics::values.contentSidePadding;
   const int tileHeight = rect.height;
   const int tileY = rect.y;
@@ -192,8 +192,8 @@ void RoundedRaffTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
 }
 
 void RoundedRaffTheme::drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                                      const std::function<std::string(int index)>& buttonLabel,
-                                      const std::function<UIIcon(int index)>& rowIcon) const {
+                                      FnRef<std::string(int index)> buttonLabel,
+                                      FnRef<UIIcon(int index)> rowIcon) const {
   (void)rowIcon;
   const int sidePadding = RoundedRaffMetrics::values.contentSidePadding;
   const int rowX = rect.x + sidePadding;
@@ -288,25 +288,23 @@ void RoundedRaffTheme::drawKeyboardKey(const GfxRenderer& renderer, Rect rect, c
     return;
   }
 
-  if (label != nullptr && label[0] != '\0') {
+  if (label && label[0] != '\0') {
     const int itemWidth = renderer.getTextWidth(UI_12_FONT_ID, label);
     const int textX = rect.x + (rect.width - itemWidth) / 2;
     const int textY = rect.y + (rect.height - renderer.getLineHeight(UI_12_FONT_ID)) / 2;
     renderer.drawText(UI_12_FONT_ID, textX, textY, label, !invert);
   }
 
-  if (secondaryLabel != nullptr && secondaryLabel[0] != '\0') {
+  if (secondaryLabel && secondaryLabel[0] != '\0') {
     const int secWidth = renderer.getTextWidth(SMALL_FONT_ID, secondaryLabel);
     renderer.drawText(SMALL_FONT_ID, rect.x + rect.width - secWidth - 3, rect.y + 1, secondaryLabel, !invert);
   }
 }
 
 void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                                const std::function<std::string(int index)>& rowTitle,
-                                const std::function<std::string(int index)>& rowSubtitle,
-                                const std::function<UIIcon(int index)>& rowIcon,
-                                const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                                const std::function<bool(int index)>& rowDimmed) const {
+                                FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle,
+                                FnRef<UIIcon(int index)> rowIcon, FnRef<std::string(int index)> rowValue,
+                                bool highlightValue, FnRef<bool(int index)> rowDimmed) const {
   (void)rowIcon;
   (void)highlightValue;
   (void)rowDimmed;
@@ -396,7 +394,7 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int hintY = pageHeight - hintHeight - bottomMargin;
   const int textY = hintY + (hintHeight - renderer.getLineHeight(kGuideFontId)) / 2;
 
-  const bool backDisabled = (btn1 == nullptr || btn1[0] == '\0');
+  const bool backDisabled = (!btn1 || btn1[0] == '\0');
   const int leftGroupX = sidePadding;
   const int rightGroupX = leftGroupX + groupWidth + groupGap;
   const std::string backLabel = backDisabled ? "" : std::string(btn1);

--- a/src/components/themes/roundedraff/RoundedRaffTheme.h
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.h
@@ -77,21 +77,18 @@ class RoundedRaffTheme : public BaseTheme {
                   bool selected) const override;
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
                            int selectorIndex, bool& coverRendered, bool& coverBufferStored, bool& bufferRestored,
-                           std::function<bool()> storeCoverBuffer) const override;
+                           FnRef<bool()> storeCoverBuffer) const override;
   void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
-                      const std::function<std::string(int index)>& buttonLabel,
-                      const std::function<UIIcon(int index)>& rowIcon) const override;
+                      FnRef<std::string(int index)> buttonLabel, FnRef<UIIcon(int index)> rowIcon) const override;
   void drawTextField(const GfxRenderer& renderer, Rect rect, int textWidth, bool cursorMode = false,
                      int contentStartX = 0, int contentWidth = 0) const override;
   void drawKeyboardKey(const GfxRenderer& renderer, Rect rect, const char* label, bool isSelected,
                        const char* secondaryLabel = nullptr, KeyboardKeyType keyType = KeyboardKeyType::Normal,
                        bool inactiveSelection = false) const override;
   void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
-                const std::function<std::string(int index)>& rowTitle,
-                const std::function<std::string(int index)>& rowSubtitle = nullptr,
-                const std::function<UIIcon(int index)>& rowIcon = nullptr,
-                const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
-                const std::function<bool(int index)>& rowDimmed = nullptr) const override;
+                FnRef<std::string(int index)> rowTitle, FnRef<std::string(int index)> rowSubtitle = nullptr,
+                FnRef<UIIcon(int index)> rowIcon = nullptr, FnRef<std::string(int index)> rowValue = nullptr,
+                bool highlightValue = false, FnRef<bool(int index)> rowDimmed = nullptr) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                        const char* btn4) const override;
   bool homeMenuShowsContinueReading() const { return true; }

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -197,17 +197,20 @@ void CrossPointWebServer::begin() {
 
   server->begin();
 
-  // Start WebSocket server for fast binary uploads
+  // Start WebSocket server for fast binary uploads. If allocation fails we leave
+  // wsServer null and keep HTTP serving alive — binary uploads silently unavailable
+  // until the next restart. Downstream sites (stop(), loop(), and the event
+  // handler — only reachable via wsServer->onEvent) already null-guard.
   LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
   wsServer = makeUniqueNoThrow<WebSocketsServer>(wsPort);
-  if (!wsServer) {
-    LOG_ERR("WEB", "OOM: WebSocketsServer (binary uploads unavailable)");
-    return;
+  if (wsServer) {
+    wsInstance = const_cast<CrossPointWebServer*>(this);
+    wsServer->begin();
+    wsServer->onEvent(wsEventCallback);
+    LOG_DBG("WEB", "WebSocket server started");
+  } else {
+    LOG_ERR("WEB", "OOM: WebSocketsServer (binary uploads disabled, HTTP still up)");
   }
-  wsInstance = const_cast<CrossPointWebServer*>(this);
-  wsServer->begin();
-  wsServer->onEvent(wsEventCallback);
-  LOG_DBG("WEB", "WebSocket server started");
 
   udpActive = udp.begin(LOCAL_UDP_PORT);
   LOG_DBG("WEB", "Discovery UDP %s on port %d", udpActive ? "enabled" : "failed", LOCAL_UDP_PORT);

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -5,6 +5,7 @@
 #include <HalGPIO.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <WiFi.h>
 #include <esp_task_wdt.h>
 
@@ -110,7 +111,11 @@ void CrossPointWebServer::begin() {
   LOG_DBG("WEB", "Network mode: %s", apMode ? "AP" : "STA");
 
   LOG_DBG("WEB", "Creating web server on port %d...", port);
-  server.reset(new WebServer(port));
+  server = makeUniqueNoThrow<WebServer>(port);
+  if (!server) {
+    LOG_ERR("WEB", "OOM: WebServer");
+    return;
+  }
 
   // Disable WiFi sleep to improve responsiveness and prevent 'unreachable' errors.
   // This is critical for reliable web server operation on ESP32.
@@ -181,14 +186,24 @@ void CrossPointWebServer::begin() {
   // Collect WebDAV headers and register handler
   const char* davHeaders[] = {"Depth", "Destination", "Overwrite", "If", "Lock-Token", "Timeout"};
   server->collectHeaders(davHeaders, 6);
-  server->addHandler(new WebDAVHandler());  // Note: WebDAVHandler will be deleted by WebServer when server is stopped
-  LOG_DBG("WEB", "WebDAV handler initialized");
+  // Note: WebDAVHandler ownership transfers to WebServer (deletes on server stop).
+  auto* davHandler = new (std::nothrow) WebDAVHandler();
+  if (!davHandler) {
+    LOG_ERR("WEB", "OOM: WebDAVHandler (WebDAV endpoints unavailable)");
+  } else {
+    server->addHandler(davHandler);
+    LOG_DBG("WEB", "WebDAV handler initialized");
+  }
 
   server->begin();
 
   // Start WebSocket server for fast binary uploads
   LOG_DBG("WEB", "Starting WebSocket server on port %d...", wsPort);
-  wsServer.reset(new WebSocketsServer(wsPort));
+  wsServer = makeUniqueNoThrow<WebSocketsServer>(wsPort);
+  if (!wsServer) {
+    LOG_ERR("WEB", "OOM: WebSocketsServer (binary uploads unavailable)");
+    return;
+  }
   wsInstance = const_cast<CrossPointWebServer*>(this);
   wsServer->begin();
   wsServer->onEvent(wsEventCallback);

--- a/src/util/FnRef.h
+++ b/src/util/FnRef.h
@@ -36,8 +36,7 @@ class FnRef<R(Args...)> {
 
   template <typename F, typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, FnRef>>>
   FnRef(F&& f) noexcept
-      : thunk_(&invoke<std::remove_reference_t<F>>),
-        ctx_(const_cast<void*>(static_cast<const void*>(&f))) {}
+      : thunk_(&invoke<std::remove_reference_t<F>>), ctx_(const_cast<void*>(static_cast<const void*>(&f))) {}
 
   explicit operator bool() const noexcept { return thunk_ != nullptr; }
 

--- a/src/util/FnRef.h
+++ b/src/util/FnRef.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+// Non-owning function reference. Drop-in replacement for `const std::function<Sig>&`
+// parameters when you don't need to store the callable past the call.
+//
+// std::function heap-allocates closures that exceed its small-buffer threshold
+// (typically 16 bytes on libstdc++). Under -fno-exceptions on ESP32 that alloc
+// can abort() on OOM, and even when it doesn't, the per-call churn fragments
+// the heap (CLAUDE.md §"Template and std::function Bloat").
+//
+// FnRef is two pointers (thunk + ctx). It binds to any callable via implicit
+// conversion at the call site — the callable lives on the caller's stack and
+// FnRef carries its address. Lifetime: the underlying callable must outlive
+// the FnRef. For typical "pass a lambda into a function" use, the lambda
+// outlives the call by virtue of being a temporary in the full-expression.
+//
+// Example:
+//
+//   void draw(FnRef<int(int)> getX);
+//   draw([this](int i) { return items[i].x; });  // no heap allocation
+//
+//   FnRef<int(int)> opt = nullptr;  // null reference; operator bool returns false
+//
+template <typename Sig>
+class FnRef;
+
+template <typename R, typename... Args>
+class FnRef<R(Args...)> {
+ public:
+  FnRef() = default;
+  FnRef(std::nullptr_t) noexcept {}
+
+  template <typename F, typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, FnRef>>>
+  FnRef(F&& f) noexcept
+      : thunk_(&invoke<std::remove_reference_t<F>>),
+        ctx_(const_cast<void*>(static_cast<const void*>(&f))) {}
+
+  explicit operator bool() const noexcept { return thunk_ != nullptr; }
+
+  R operator()(Args... args) const { return thunk_(ctx_, std::forward<Args>(args)...); }
+
+ private:
+  template <typename F>
+  static R invoke(void* ctx, Args... args) {
+    return (*static_cast<F*>(ctx))(std::forward<Args>(args)...);
+  }
+
+  R (*thunk_)(void*, Args...) = nullptr;
+  void* ctx_ = nullptr;
+};

--- a/src/util/FnRef.h
+++ b/src/util/FnRef.h
@@ -32,9 +32,13 @@ template <typename R, typename... Args>
 class FnRef<R(Args...)> {
  public:
   FnRef() = default;
+  // Implicit conversions are intentional: lambdas and nullptr bind through
+  // this directly at call sites without forcing the caller to wrap them.
+  // cppcheck-suppress noExplicitConstructor
   FnRef(std::nullptr_t) noexcept {}
 
   template <typename F, typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, FnRef>>>
+  // cppcheck-suppress noExplicitConstructor
   FnRef(F&& f) noexcept
       : thunk_(&invoke<std::remove_reference_t<F>>), ctx_(const_cast<void*>(static_cast<const void*>(&f))) {}
 


### PR DESCRIPTION
Effectively constrains our current codebase to the standards laid out in the claude.md for agent use + guidelines in code comments for humans.

Mechanically refactored.

With -fno-exceptions on ESP32, bare `new` calls abort() on OOM instead of returning nullptr, so any null-check after `ptr.reset(new T(...))` was dead code and any OOM produced a mystery watchdog reset with no log line, or could raise an abort() screen.

Convert every fallible allocation to either makeUniqueNoThrow<T>(...) or `new (std::nothrow) T(...)` with a guarded null-check that logs `[TAG] OOM: <type>` and degrades on the relevant failure path rather than the current behavior: abort():

- Deserialize (Page, PageLine, PageImage, ImageBlock, TextBlock) now propagates nullptr; Page::deserialize null-checks the children.
- ChapterHtmlSlimParser's six Page/ParsedText allocs early-return on OOM and unify the previously inconsistent nothrow/bare-new mix.
- Epub::load, Xtc::load, and the Section/Epub/Xtc/Txt loaders in EpubReaderActivity/ReaderActivity return false/nullptr cleanly.
- ImageDecoderFactory returns nullptr on decoder alloc failure; image rendering already handles that by skipping the image.
- JPEGDEC/PNGdec file-handle callbacks construct HalFile with makeUniqueNoThrow then .release() ownership across the void* boundary.
- Bitmap.cpp + PngToBmpConverter's per-image ditherer allocs gain a full cleanup cascade with a new BmpReaderError::OomDitherer.
- BitmapHelpers.h's three ditherer classes use std::unique_ptr<int16_t[]> with inline `new (std::nothrow)` (the header is included across libs, so it can't depend on lib/Memory). Adds isValid() so callers can detect partial-construction OOM; destructor is safe regardless.
- Activities allocating WebServer/DNSServer/WebSocketsServer/ CrossPointWebServer on OOM call onGoHome() to exit cleanly (which takes the existing silentRestart path).
- WebDAVHandler is the one ownership-transfer site: WebServer continues without the WebDAV endpoints if alloc fails, instead of aborting.

Build: pio run -e default + -e gh_release both green. DRAM usage unchanged (51.35%), Flash ~88 bytes smaller (cold paths only).


Validated via some navigation on my x4; no OOM lines thrown, but also, we haven't had a reliable heap crash repro.

Did you use AI tools to help write this code? partial, claude, me, comby and ast-grep
