### PR TITLE
fix: cache underline word widths for faster SD font page renders

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -708,10 +708,19 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   std::vector<std::string> lineWords(std::make_move_iterator(words.begin() + lastBreakAt),
                                      std::make_move_iterator(words.begin() + lineBreak));
   std::vector<EpdFontFamily::Style> lineWordStyles(wordStyles.begin() + lastBreakAt, wordStyles.begin() + lineBreak);
+  std::vector<uint16_t> lineWordWidths(wordWidths.begin() + lastBreakAt, wordWidths.begin() + lineBreak);
 
   for (auto& word : lineWords) {
     if (containsSoftHyphen(word)) {
       stripSoftHyphensInPlace(word);
+    }
+  }
+
+  bool lineHasUnderline = false;
+  for (auto style : lineWordStyles) {
+    if ((style & EpdFontFamily::UNDERLINE) != 0) {
+      lineHasUnderline = true;
+      break;
     }
   }
 
@@ -728,7 +737,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   if (!lineHasFocusSplit) {
     processLine(std::make_shared<TextBlock>(std::move(lineWords), std::move(lineXPos), std::move(lineWordStyles),
-                                            std::vector<uint8_t>{}, std::vector<uint16_t>{}, blockStyle));
+                                            std::vector<uint8_t>{}, std::vector<uint16_t>{}, blockStyle,
+                                            lineHasUnderline ? std::move(lineWordWidths) : std::vector<uint16_t>{}));
     return;
   }
 
@@ -737,11 +747,13 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   // applied at render time, cutting the token count significantly when the feature is active.
   std::vector<std::string> outWords;
   std::vector<int16_t> outXPos;
+  std::vector<uint16_t> outWidths;
   std::vector<EpdFontFamily::Style> outStyles;
   std::vector<uint8_t> outBoundaries;
   std::vector<uint16_t> outSuffixX;
   outWords.reserve(lineWordCount);
   outXPos.reserve(lineWordCount);
+  outWidths.reserve(lineWordCount);
   outStyles.reserve(lineWordCount);
   outBoundaries.reserve(lineWordCount);
   outSuffixX.reserve(lineWordCount);
@@ -750,6 +762,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     if (wordIsFocusSuffix[lastBreakAt + i] && !outWords.empty()) {
       // Focus suffix: merge string into the preceding bold-prefix entry.
       outWords.back() += lineWords[i];
+      outWidths.back() =
+          static_cast<uint16_t>(std::min<int>(UINT16_MAX, lineXPos[i] - outXPos.back() + lineWordWidths[i]));
     } else {
       // Normal word: check for a following focus suffix to record the byte boundary.
       uint8_t boundary = 0;
@@ -761,6 +775,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       }
       outWords.push_back(std::move(lineWords[i]));
       outXPos.push_back(lineXPos[i]);
+      outWidths.push_back(lineWordWidths[i]);
       // For focus entries with a suffix, strip BOLD from the stored style.
       // Render re-applies it to the prefix portion only, via the boundary field.
       const EpdFontFamily::Style storedStyle =
@@ -773,5 +788,6 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   }
 
   processLine(std::make_shared<TextBlock>(std::move(outWords), std::move(outXPos), std::move(outStyles),
-                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle));
+                                          std::move(outBoundaries), std::move(outSuffixX), blockStyle,
+                                          lineHasUnderline ? std::move(outWidths) : std::vector<uint16_t>{}));
 }

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 24;
+constexpr uint8_t SECTION_FILE_VERSION = 25;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -48,7 +48,7 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
       const std::string& w = words[i];
       const int fullWordWidth = !wordWidths.empty() && i < wordWidths.size()
                                     ? wordWidths[i]
-                                    : renderer.getTextWidth(fontId, w.c_str(), currentStyle);
+                                    : renderer.getTextAdvanceX(fontId, w.c_str(), currentStyle);
       // y is the top of the text line; add ascender to reach baseline, then offset 2px below
       const int underlineY = y + renderer.getFontAscenderSize(fontId) + 2;
 

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -11,10 +11,11 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
   // When present, they must be sized in lockstep with words[].
   const bool hasFocus = !wordFocusBoundary.empty();
   if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
-      (hasFocus && (words.size() != wordFocusBoundary.size() || words.size() != wordFocusSuffixX.size()))) {
-    LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u, boundary=%u, suffixX=%u)\n",
+      (hasFocus && (words.size() != wordFocusBoundary.size() || words.size() != wordFocusSuffixX.size())) ||
+      (!wordWidths.empty() && words.size() != wordWidths.size())) {
+    LOG_ERR("TXB", "Render skipped: size mismatch (words=%u, xpos=%u, styles=%u, boundary=%u, suffixX=%u, widths=%u)\n",
             (uint32_t)words.size(), (uint32_t)wordXpos.size(), (uint32_t)wordStyles.size(),
-            (uint32_t)wordFocusBoundary.size(), (uint32_t)wordFocusSuffixX.size());
+            (uint32_t)wordFocusBoundary.size(), (uint32_t)wordFocusSuffixX.size(), (uint32_t)wordWidths.size());
     return;
   }
 
@@ -45,7 +46,9 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
 
     if ((currentStyle & EpdFontFamily::UNDERLINE) != 0) {
       const std::string& w = words[i];
-      const int fullWordWidth = renderer.getTextWidth(fontId, w.c_str(), currentStyle);
+      const int fullWordWidth = !wordWidths.empty() && i < wordWidths.size()
+                                    ? wordWidths[i]
+                                    : renderer.getTextWidth(fontId, w.c_str(), currentStyle);
       // y is the top of the text line; add ascender to reach baseline, then offset 2px below
       const int underlineY = y + renderer.getFontAscenderSize(fontId) + 2;
 
@@ -72,11 +75,13 @@ bool TextBlock::serialize(HalFile& file) const {
   // or sized in lockstep with words[].
   const bool hasFocus = !wordFocusBoundary.empty();
   if (words.size() != wordXpos.size() || words.size() != wordStyles.size() ||
-      (hasFocus && (words.size() != wordFocusBoundary.size() || words.size() != wordFocusSuffixX.size()))) {
-    LOG_ERR("TXB", "Serialization failed: size mismatch (words=%u, xpos=%u, styles=%u, boundary=%u, suffixX=%u)\n",
+      (hasFocus && (words.size() != wordFocusBoundary.size() || words.size() != wordFocusSuffixX.size())) ||
+      (!wordWidths.empty() && words.size() != wordWidths.size())) {
+    LOG_ERR("TXB",
+            "Serialization failed: size mismatch (words=%u, xpos=%u, styles=%u, boundary=%u, suffixX=%u, widths=%u)\n",
             static_cast<uint32_t>(words.size()), static_cast<uint32_t>(wordXpos.size()),
             static_cast<uint32_t>(wordStyles.size()), static_cast<uint32_t>(wordFocusBoundary.size()),
-            static_cast<uint32_t>(wordFocusSuffixX.size()));
+            static_cast<uint32_t>(wordFocusSuffixX.size()), static_cast<uint32_t>(wordWidths.size()));
     return false;
   }
 
@@ -91,6 +96,10 @@ bool TextBlock::serialize(HalFile& file) const {
   if (hasFocus) {
     for (auto b : wordFocusBoundary) serialization::writePod(file, b);
     for (auto sx : wordFocusSuffixX) serialization::writePod(file, sx);
+  }
+  serialization::writePod(file, static_cast<uint8_t>(wordWidths.empty() ? 0 : 1));
+  if (!wordWidths.empty()) {
+    for (auto width : wordWidths) serialization::writePod(file, width);
   }
 
   // Style (alignment + margins/padding/indent)
@@ -145,6 +154,13 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
     for (auto& b : wordFocusBoundary) serialization::readPod(file, b);
     for (auto& sx : wordFocusSuffixX) serialization::readPod(file, sx);
   }
+  uint8_t hasWordWidths = 0;
+  serialization::readPod(file, hasWordWidths);
+  std::vector<uint16_t> wordWidths;
+  if (hasWordWidths) {
+    wordWidths.resize(wc);
+    for (auto& width : wordWidths) serialization::readPod(file, width);
+  }
 
   // Style (alignment + margins/padding/indent)
   serialization::readPod(file, blockStyle.alignment);
@@ -161,6 +177,6 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   serialization::readPod(file, blockStyle.textIndentDefined);
 
   return std::unique_ptr<TextBlock>(new TextBlock(std::move(words), std::move(wordXpos), std::move(wordStyles),
-                                                  std::move(wordFocusBoundary), std::move(wordFocusSuffixX),
-                                                  blockStyle));
+                                                  std::move(wordFocusBoundary), std::move(wordFocusSuffixX), blockStyle,
+                                                  std::move(wordWidths)));
 }

--- a/lib/Epub/Epub/blocks/TextBlock.h
+++ b/lib/Epub/Epub/blocks/TextBlock.h
@@ -26,17 +26,22 @@ class TextBlock final : public Block {
   // Eliminates getTextAdvanceX from the render path. 0 when boundary == 0.
   // Empty in lockstep with wordFocusBoundary.
   std::vector<uint16_t> wordFocusSuffixX;
+  // Layout-time word widths, stored only for lines with underlined text so render()
+  // does not need to remeasure every link word on each page flip.
+  std::vector<uint16_t> wordWidths;
   BlockStyle blockStyle;
 
  public:
   explicit TextBlock(std::vector<std::string> words, std::vector<int16_t> word_xpos,
                      std::vector<EpdFontFamily::Style> word_styles, std::vector<uint8_t> focus_boundary,
-                     std::vector<uint16_t> focus_suffix_x, const BlockStyle& blockStyle = BlockStyle())
+                     std::vector<uint16_t> focus_suffix_x, const BlockStyle& blockStyle = BlockStyle(),
+                     std::vector<uint16_t> word_widths = {})
       : words(std::move(words)),
         wordXpos(std::move(word_xpos)),
         wordStyles(std::move(word_styles)),
         wordFocusBoundary(std::move(focus_boundary)),
         wordFocusSuffixX(std::move(focus_suffix_x)),
+        wordWidths(std::move(word_widths)),
         blockStyle(blockStyle) {}
   ~TextBlock() override = default;
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }


### PR DESCRIPTION
## Summary
- Lazily persist layout-time word widths for lines containing underlined text, so page renders can draw underlines without remeasuring each word.
- With SD fonts, pages full of underlined links can slow to a crawl because underline rendering currently asks the font for every underlined word width during each page draw. This is common in TOC/contents sections where chapter links are underlined.
- Tested with the attached synthetic epub full of underlined text: without the fix, a page flip takes >5s; with the fix, it is <1s.
[test_underlined_text.zip](https://github.com/user-attachments/files/28245239/test_underlined_text.zip)

---

### AI Usage
While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code?  YES - Codex
