### PR TITLE
fix: handle SD font advance cache overflow for CJK

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -965,6 +965,9 @@ void SdCardFont::clearPersistentCache() {
     delete[] advanceTable_[i];
     advanceTable_[i] = nullptr;
     advanceTableSize_[i] = 0;
+    delete[] overflowAdvance_[i];
+    overflowAdvance_[i] = nullptr;
+    overflowAdvanceSize_[i] = 0;
   }
 }
 
@@ -1021,19 +1024,10 @@ void SdCardFont::mergeIntoAdvanceTable(uint8_t styleIdx, const AdvanceEntry* sor
   advanceTableSize_[styleIdx] = k;
 }
 
-bool SdCardFont::hasAdvanceTable() const {
-  for (uint8_t i = 0; i < MAX_STYLES; i++) {
-    if (advanceTable_[i]) return true;
-  }
-  return false;
-}
-
-uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
-  style &= (MAX_STYLES - 1);
-  if (!advanceTable_[style]) return 0;
-  const AdvanceEntry* table = advanceTable_[style];
-  const uint32_t size = advanceTableSize_[style];
-  // Binary search sorted by codepoint
+bool SdCardFont::overflowAdvanceLookup(uint8_t styleIdx, uint32_t codepoint, uint16_t* outAdvance) const {
+  const AdvanceEntry* table = overflowAdvance_[styleIdx];
+  const uint32_t size = overflowAdvanceSize_[styleIdx];
+  if (!table || size == 0) return false;
   uint32_t lo = 0, hi = size;
   while (lo < hi) {
     uint32_t mid = lo + (hi - lo) / 2;
@@ -1044,9 +1038,86 @@ uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
     }
   }
   if (lo < size && table[lo].codepoint == codepoint) {
-    return table[lo].advanceX;
+    if (outAdvance) *outAdvance = table[lo].advanceX;
+    return true;
   }
-  return 0;
+  return false;
+}
+
+void SdCardFont::replaceOverflowAdvance(uint8_t styleIdx, const AdvanceEntry* sortedNew, uint32_t newCount) {
+  delete[] overflowAdvance_[styleIdx];
+  overflowAdvance_[styleIdx] = nullptr;
+  overflowAdvanceSize_[styleIdx] = 0;
+  if (newCount == 0 || !sortedNew) return;
+  AdvanceEntry* fresh = new (std::nothrow) AdvanceEntry[newCount];
+  if (!fresh) {
+    LOG_ERR("SDCF", "replaceOverflowAdvance: alloc failed (%u entries) style %u", newCount, styleIdx);
+    return;
+  }
+  memcpy(fresh, sortedNew, newCount * sizeof(AdvanceEntry));
+  overflowAdvance_[styleIdx] = fresh;
+  overflowAdvanceSize_[styleIdx] = newCount;
+}
+
+bool SdCardFont::readSingleAdvanceFromSd(uint8_t styleIdx, int32_t globalGlyphIndex, uint16_t* outAdvance) const {
+  if (!outAdvance || styleIdx >= MAX_STYLES || !styles_[styleIdx].present || globalGlyphIndex < 0) return false;
+  const auto& s = styles_[styleIdx];
+  HalFile file;
+  if (!Storage.openFileForRead("SDCF", filePath_, file)) {
+    LOG_ERR("SDCF", "Last-resort advance: failed to open .cpfont");
+    return false;
+  }
+  const uint32_t fileOff = s.glyphsFileOffset + static_cast<uint32_t>(globalGlyphIndex) * sizeof(EpdGlyph);
+  if (!file.seekSet(fileOff)) {
+    LOG_ERR("SDCF", "Last-resort advance: seek failed (style %u, gIdx %d)", styleIdx, globalGlyphIndex);
+    return false;
+  }
+  EpdGlyph g;
+  if (file.read(reinterpret_cast<uint8_t*>(&g), sizeof(EpdGlyph)) != sizeof(EpdGlyph)) {
+    LOG_ERR("SDCF", "Last-resort advance: short read (style %u, gIdx %d)", styleIdx, globalGlyphIndex);
+    return false;
+  }
+  *outAdvance = g.advanceX;
+  return true;
+}
+
+bool SdCardFont::hasAdvanceTable() const {
+  for (uint8_t i = 0; i < MAX_STYLES; i++) {
+    if (advanceTable_[i] || overflowAdvance_[i]) return true;
+  }
+  return false;
+}
+
+uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
+  style &= (MAX_STYLES - 1);
+  // Tier 1: persistent table (bulk of common codepoints).
+  if (advanceTable_[style]) {
+    const AdvanceEntry* table = advanceTable_[style];
+    const uint32_t size = advanceTableSize_[style];
+    uint32_t lo = 0, hi = size;
+    while (lo < hi) {
+      uint32_t mid = lo + (hi - lo) / 2;
+      if (table[mid].codepoint < codepoint) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    if (lo < size && table[lo].codepoint == codepoint) {
+      return table[lo].advanceX;
+    }
+  }
+  // Tier 2: per-call overflow table (codepoints the persistent table couldn't hold).
+  uint16_t adv = 0;
+  if (overflowAdvanceLookup(style, codepoint, &adv)) return adv;
+  // Tier 3: last-resort SD read. Only reachable when the codepoint was never
+  // collected by buildAdvanceTableRange (paragraph hit MAX_UNIQUE_CODEPOINTS)
+  // or a batch SD read previously failed. If the font really lacks this glyph,
+  // returning 0 is correct.
+  if (!styles_[style].present || !styles_[style].fullIntervals) return 0;
+  const int32_t gIdx = findGlobalGlyphIndex(styles_[style], codepoint);
+  if (gIdx < 0) return 0;
+  return readSingleAdvanceFromSd(style, gIdx, &adv) ? adv : 0;
 }
 
 // Given a sorted array of unique codepoints, resolve glyph indices per style,
@@ -1058,10 +1129,11 @@ int SdCardFont::fetchAdvancesForCodepoints(uint32_t* codepoints, uint32_t cpCoun
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
     const auto& s = styles_[si];
 
-    // Stop fetching once the cache is full — further inserts would be dropped
-    // by the merge anyway. The renderer fast path tolerates missing entries
-    // (returns 0); the slow path is still correct for those codepoints.
-    if (advanceTableSize_[si] >= ADVANCE_CACHE_LIMIT) continue;
+    // Reset this call's overflow first. Anything the persistent table can't
+    // hold from this paragraph will be routed back into overflow below;
+    // anything the previous paragraph put here that isn't needed now is
+    // safely dropped. This keeps overflow scoped to one layout pass.
+    replaceOverflowAdvance(si, nullptr, 0);
 
     // For each codepoint in `codepoints`, skip those already cached, then
     // resolve to a glyph index. Build a parallel array sorted by glyph index
@@ -1141,14 +1213,25 @@ int SdCardFont::fetchAdvancesForCodepoints(uint32_t* codepoints, uint32_t cpCoun
     file.close();
 
     if (fetched > 0) {
-      // Sort staged by codepoint, then merge into the persistent table.
+      // Sort staged by codepoint, then split between persistent and overflow.
+      // Persistent fills first (so common codepoints encountered early stay
+      // cached for the lifetime of the font); anything past the cap goes into
+      // overflow for this paragraph only.
       std::sort(staged.get(), staged.get() + fetched,
                 [](const AdvanceEntry& a, const AdvanceEntry& b) { return a.codepoint < b.codepoint; });
-      mergeIntoAdvanceTable(si, staged.get(), fetched);
+      const uint32_t persistentRoom =
+          advanceTableSize_[si] < ADVANCE_CACHE_LIMIT ? ADVANCE_CACHE_LIMIT - advanceTableSize_[si] : 0;
+      const uint32_t toPersistent = fetched < persistentRoom ? fetched : persistentRoom;
+      const uint32_t toOverflow = fetched - toPersistent;
+      if (toPersistent > 0) {
+        mergeIntoAdvanceTable(si, staged.get(), toPersistent);
+      }
+      if (toOverflow > 0) {
+        replaceOverflowAdvance(si, staged.get() + toPersistent, toOverflow);
+      }
+      LOG_DBG("SDCF", "Advance table style %u: +%u from SD (persistent=%u/%u, overflow=%u)", si, fetched,
+              advanceTableSize_[si], ADVANCE_CACHE_LIMIT, overflowAdvanceSize_[si]);
     }
-
-    LOG_DBG("SDCF", "Advance table style %u: +%u from SD, total=%u/%u", si, fetched, advanceTableSize_[si],
-            ADVANCE_CACHE_LIMIT);
   }
 
   return totalMissed;

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -217,6 +217,11 @@ class SdCardFont {
   // Bounded to ADVANCE_CACHE_LIMIT entries; persists across layout passes
   // (across calls to clearCache()) so repeated indexing of the same font
   // amortizes SD reads. Cleared only on font unload or clearPersistentCache().
+  //
+  // The cap was originally sized for Latin-script books. CJK text routinely
+  // exceeds 768 unique codepoints; once full, codepoints that don't fit are
+  // routed through the per-call overflow table below, and any remaining
+  // pathological misses fall through to a one-shot SD read in getAdvance().
   static constexpr uint32_t ADVANCE_CACHE_LIMIT = 768;
   AdvanceEntry* advanceTable_[MAX_STYLES] = {};
   uint32_t advanceTableSize_[MAX_STYLES] = {};
@@ -224,6 +229,26 @@ class SdCardFont {
   // Merge sortedNew (sorted by codepoint, no overlap with existing) into the
   // advance table for styleIdx, preserving sort order; cap-truncates the tail.
   void mergeIntoAdvanceTable(uint8_t styleIdx, const AdvanceEntry* sortedNew, uint32_t newCount);
+
+  // Per-call overflow table for advances that did not fit in the persistent
+  // ADVANCE_CACHE_LIMIT-capped table. Replaced (not merged) on each
+  // fetchAdvancesForCodepoints call — sized to exactly the codepoints this
+  // pass needs that the persistent table couldn't hold. Typical Chinese
+  // paragraph adds <100 bytes per style after the persistent cache fills.
+  // Sorted by codepoint for binary lookup.
+  AdvanceEntry* overflowAdvance_[MAX_STYLES] = {};
+  uint32_t overflowAdvanceSize_[MAX_STYLES] = {};
+  bool overflowAdvanceLookup(uint8_t styleIdx, uint32_t codepoint, uint16_t* outAdvance) const;
+  // Free any existing overflow for styleIdx, then take ownership of a fresh
+  // copy of sortedNew[0..newCount). newCount==0 clears the slot.
+  void replaceOverflowAdvance(uint8_t styleIdx, const AdvanceEntry* sortedNew, uint32_t newCount);
+
+  // Last-resort path for getAdvance(): read advanceX for one glyph directly
+  // from SD without caching. Triggered only when both persistent and overflow
+  // tables miss — i.e., the codepoint was never collected by
+  // buildAdvanceTableRange (paragraph exceeded MAX_UNIQUE_CODEPOINTS) or a
+  // batch SD read failed mid-flight. Returns false on I/O error.
+  bool readSingleAdvanceFromSd(uint8_t styleIdx, int32_t globalGlyphIndex, uint16_t* outAdvance) const;
 
   Stats stats_;
   uint32_t contentHash_ = 0;


### PR DESCRIPTION
# Summary

- SD card font's persistent advance cache silently dropped codepoints past its 768-entry cap, making `getAdvance()` return 0 for the missing chars. The renderer fast-path summed these zeros into wildly wrong word widths, which fed Knuth-Plass line-breaking and broke CJK layouts after ~2 chapters of reading.
- Add a per-call overflow table for cap-exceeding codepoints, plus a last-resort single-glyph SD read as a safety net. Persistent cache size unchanged — Latin-script books pay no baseline memory cost.

## Background

I started reading Chinese EPUBs after 1.3.0 shipped SD card font support — loaded a CJK font via the SD-card font flow and immediately ran into irregular line-break breakage that got worse the further I read:

- single characters orphaned on their own line
- characters overflowing the right margin
- characters overlapping each other

Symptoms became frequent (almost every line) by chapter 2-3. Triggered specifically by SD card fonts; built-in fonts unaffected.

## Root cause

`SdCardFont::buildAdvanceTable()` maintains a persistent `advanceTable_` per style, capped at `ADVANCE_CACHE_LIMIT = 768`. Two compounding gates silently dropped codepoints once full:

1. `fetchAdvancesForCodepoints()` did `if (advanceTableSize_[si] >= ADVANCE_CACHE_LIMIT) continue;` — never even attempted SD reads for new codepoints once the cap was hit.
2. `mergeIntoAdvanceTable()` tail-truncates merges, so any high codepoints that did make it through got dropped during merge.

The cap was Latin-sized — typical Chinese novels exceed 768 unique codepoints within the first two chapters. Once exceeded:

`getAdvance(cp)` → `0` (silent miss) → `getTextAdvanceX(word)` sums to underestimated word width → `computeLineBreaks()` runs Knuth-Plass DP on wrong widths → orphans / overflow / overlaps.

## Fix

Three-tier lookup. Persistent cache size unchanged so Latin-script books incur no baseline memory regression:

| Tier | Source | Lifetime |
|------|--------|----------|
| 1 | `advanceTable_` (existing, 768 cap) | font lifetime |
| 2 | `overflowAdvance_` (new) | one `fetchAdvancesForCodepoints` call (per-paragraph), replaced on each call |
| 3 | `readSingleAdvanceFromSd()` (new) | none — single SD read on demand |

`fetchAdvancesForCodepoints()` no longer skips when the cap is hit; it batch-reads everything needed and splits the result between persistent (fills first, preserving the original "early codepoints stay cached" intent) and overflow (per-call leftover). `getAdvance()` chains the three tiers. `hasAdvanceTable()` also considers overflow so the renderer fast-path stays enabled if persistent allocation ever fails.

`getAdvance()` stays `const` — the Tier 3 SD read opens a file through `HalStorage` but does not mutate `SdCardFont` state.

## Memory impact

- **Persistent:** unchanged, ≤24 KB across all four styles (lazy-allocated per style).
- **Overflow:** exact-sized per call; typically <500 B per style for a Chinese paragraph after the persistent cache fills. Bounded by `MAX_UNIQUE_CODEPOINTS = 4096` worst case.
- **Tier 3:** zero — single SD read, no caching.

## Test plan

- Host gtest suites pass (`ctest --test-dir build/test --output-on-failure`) — 79/79.
- `pio run -e default` builds clean.
- Read affected Chinese EPUB on real hardware (X4) with a CJK SD font through past chapter 3:
  - Right-margin overflow gone.
  - Overlapping characters gone.
  - Orphan characters still present — separate issue, see below.

## Out of scope (follow-up work for separate PRs)

Noticed during testing but unrelated to this advance-table bug:

1. **Orphan characters in CJK layout** — single Chinese chars still occasionally get pushed to the start of a line. Likely a `ParsedText::computeLineBreaks()` issue around CJK break rules — Chinese has no inter-word spaces and almost every char is a legal break point, so Knuth-Plass needs different penalty weights / forbidden-break-before rules than the Latin defaults. Independent of advance widths (orphans persist even with correct widths).
2. **UI text doesn't pick up the SD card font** — chapter-select dialog, status bar title, and home screen book title / author still render through the built-in font path. Chinese titles in those surfaces show as missing glyphs even when a CJK SD font is loaded for the reader. These code paths don't go through the SD font registry and would need a separate plumbing change to route UI strings through the active SD font.