### PR TITLE
perf: optimise `normalisePath`

### DIFF
--- a/lib/FsHelpers/FsHelpers.cpp
+++ b/lib/FsHelpers/FsHelpers.cpp
@@ -8,12 +8,14 @@
 namespace FsHelpers {
 
 std::string normalisePath(const std::string& path) {
-  std::vector<std::string> components;
-  std::string component;
+  std::vector<std::string_view> components;
+  components.reserve(8);  // Eight nested folders is more than we might expect
 
-  for (const auto c : path) {
-    if (c == '/') {
-      if (!component.empty()) {
+  size_t start = 0;
+  for (size_t i = 0; i <= path.length(); ++i) {
+    if (i == path.length() || path[i] == '/') {
+      if (i > start) {
+        std::string_view component(path.data() + start, i - start);
         if (component == "..") {
           if (!components.empty()) {
             components.pop_back();
@@ -21,23 +23,28 @@ std::string normalisePath(const std::string& path) {
         } else {
           components.push_back(component);
         }
-        component.clear();
       }
-    } else {
-      component += c;
+      start = i + 1;
     }
   }
 
-  if (!component.empty()) {
-    components.push_back(component);
+  if (components.empty()) {
+    return "";
+  }
+
+  size_t total_len = 0;
+  for (const auto& c : components) {
+    total_len += c.length() + 1;
   }
 
   std::string result;
-  for (const auto& c : components) {
-    if (!result.empty()) {
-      result += "/";
+  result.reserve(total_len - 1);
+
+  for (size_t i = 0; i < components.size(); ++i) {
+    if (i > 0) {
+      result += '/';
     }
-    result += c;
+    result.append(components[i].data(), components[i].length());
   }
 
   return result;

--- a/lib/FsHelpers/FsHelpers.cpp
+++ b/lib/FsHelpers/FsHelpers.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstring>
+#include <string_view>
 #include <vector>
 
 namespace FsHelpers {


### PR DESCRIPTION
## Summary

**perf: optimise `normalisePath` to eliminate intermediate allocations**

Replaces character-by-character string building with index-based parsing using `string_view`, avoiding a heap allocation per path segment. Also pre-reserves vector capacity (8 slots) and the final result string to reduce reallocations.

**Changes:**
- `vector<string>` → `vector<string_view>`: components are now zero-copy views into the input string
- Single loop handles both `/` delimiters and end-of-string, removing the post-loop special case
- Result string capacity pre-calculated before assembly

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
