### PR TITLE
docs: sync book.bin/section.bin version refs to source

### DIFF
--- a/.skills/SKILL.md
+++ b/.skills/SKILL.md
@@ -898,7 +898,7 @@ rm -rf /path/to/sd/.crosspoint/epub_<hash>/sections/
 
 **Current Versions** (as of docs/file-formats.md):
 - `book.bin`: **Version 5** (metadata structure)
-- `section.bin`: **Version 12** (layout structure)
+- `section.bin`: **Version 24** (layout structure)
 
 **Version Increment Rules**:
 1. **ALWAYS increment version** BEFORE changing binary structure
@@ -908,7 +908,7 @@ rm -rf /path/to/sd/.crosspoint/epub_<hash>/sections/
 **Example** (incrementing section format version):
 ```cpp
 // lib/Epub/Epub/Section.cpp
-static constexpr uint8_t SECTION_FILE_VERSION = 13;  // Was 12, now 13
+static constexpr uint8_t SECTION_FILE_VERSION = 25;  // Was 24, now 25
 
 // Add new field to structure
 struct PageLine {

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -2,7 +2,7 @@
 
 ## `book.bin`
 
-### Version 3
+### Version 5
 
 ImHex Pattern:
 
@@ -12,7 +12,7 @@ import std.string;
 import std.core;
 
 // === Configuration ===
-#define EXPECTED_VERSION 3
+#define EXPECTED_VERSION 5
 #define MAX_STRING_LENGTH 65535
 
 // === String Structure ===
@@ -34,6 +34,7 @@ fn format_string(String s) {
 struct Metadata {
     String title [[comment("Book title")]];
     String author [[comment("Book author")]];
+    String language [[comment("Book language code")]];
     String coverItemHref [[comment("Path to cover image")]];
     String textReferenceHref [[comment("Path to guided first text reference")]];
 } [[comment("Book metadata information")]];


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Reconcile the cache-format version numbers cited in two project docs with what the source actually defines, so contributors don't bump from a stale baseline when they next change either binary format.
* **What changes are included?**
  * `.skills/SKILL.md` (the target of the `CLAUDE.md` symlink): `section.bin` reference bumped from v12 → v24. The illustrative example constant in the "Version Increment Rules" snippet updated from `12 → 13` to `24 → 25` so the example stays consistent with current state.
  * `docs/file-formats.md`: `book.bin` block bumped from v3 → v5 (heading + `EXPECTED_VERSION`), and `String language` added to the `Metadata` struct between `author` and `coverItemHref` — that's the actual structural diff between v3 and v5.

## Additional Context

Source of truth verified directly:
* `BOOK_CACHE_VERSION = 5` — `lib/Epub/Epub/BookMetadataCache.cpp:12`
* `SECTION_FILE_VERSION = 24` — `lib/Epub/Epub/Section.cpp:13`

The `language` field placement was verified against `BookMetadataCache.cpp:135-139` (write order) and `:392-396` (read order). No code changes — docs only.

---

### AI Usage

Did you use AI tools to help write this code? **YES**