### PR TITLE
fix: Fix OOM Crashes on Large EPUBs during CSS Discovery #2170

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -44,7 +44,7 @@ bool Epub::findContentOpfFile(std::string* contentOpfFile) const {
   return true;
 }
 
-bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata) {
+bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata, const bool skipSpine) {
   std::string contentOpfFilePath;
   if (!findContentOpfFile(&contentOpfFilePath)) {
     LOG_ERR("EBP", "Could not find content.opf in zip");
@@ -61,7 +61,8 @@ bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata) {
     return false;
   }
 
-  ContentOpfParser opfParser(getCachePath(), getBasePath(), contentOpfSize, bookMetadataCache.get());
+  ContentOpfParser opfParser(getCachePath(), getBasePath(), contentOpfSize,
+                             skipSpine ? nullptr : bookMetadataCache.get());
   if (!opfParser.setup()) {
     LOG_ERR("EBP", "Could not setup content.opf parser");
     return false;
@@ -263,28 +264,23 @@ void Epub::discoverCssFilesFromZip() {
 
   ZipFile zf(filepath);
 
-  if (!zf.loadAllFileStatSlims()) {
-    LOG_ERR("EBP", "Failed to load ZIP file stat slims for CSS discovery");
-    return;
+  const size_t lastSlash = contentBasePath.find_last_of('/');
+  const std::string opfDir = (lastSlash != std::string::npos) ? contentBasePath.substr(0, lastSlash + 1) : "";
+
+  if (!zf.streamFilePaths([&](std::string_view filePath) {
+        if (!opfDir.empty() && filePath.find(opfDir) != 0) {
+          return;
+        }
+
+        if (FsHelpers::hasCssExtension(filePath)) {
+          if (std::find(cssFiles.begin(), cssFiles.end(), filePath) == cssFiles.end()) {
+            LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %.*s", (int)filePath.size(), filePath.data());
+            cssFiles.push_back(std::string{filePath});
+          }
+        }
+      })) {
+    LOG_ERR("EBP", "Failed to stream ZIP file paths for CSS discovery");
   }
-
-  size_t lastSlash = contentBasePath.find_last_of('/');
-
-  std::string opfDir = (lastSlash != std::string::npos) ? contentBasePath.substr(0, lastSlash + 1) : "";
-
-  zf.enumerateFilePaths([&](std::string_view filePath) {
-    if (!opfDir.empty() && filePath.find(opfDir) != 0) {
-      return;  // Skip files that are not in the same directory as OPF manifest, as CSS files are typically located
-               // there or in subfolders
-    }
-
-    if (FsHelpers::hasCssExtension(filePath)) {
-      if (std::find(cssFiles.begin(), cssFiles.end(), filePath) == cssFiles.end()) {
-        LOG_DBG("EBP", "Discovered CSS file via ZIP enumeration: %.*s", (int)filePath.size(), filePath.data());
-        cssFiles.push_back(std::string{filePath});
-      }
-    }
-  });
 }
 
 void Epub::parseCssFiles() const {
@@ -383,7 +379,7 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
         LOG_DBG("EBP", "CSS rules cache missing or stale, attempting to parse CSS files");
         cssParser->deleteCache();
 
-        if (!parseContentOpf(bookMetadataCache->coreMetadata)) {
+        if (!parseContentOpf(bookMetadataCache->coreMetadata, true)) {
           LOG_ERR("EBP", "Could not parse content.opf from cached bookMetadata for CSS files");
           // continue anyway - book will work without CSS and we'll still load any inline style CSS
         } else {

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -31,7 +31,7 @@ class Epub {
   std::vector<std::string> cssFiles;
 
   bool findContentOpfFile(std::string* contentOpfFile) const;
-  bool parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata);
+  bool parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata, bool skipSpine = false);
   bool parseTocNcxFile() const;
   bool parseTocNavFile() const;
   void parseCssFiles() const;

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -77,4 +77,50 @@ class ZipFile {
       callback(std::string_view{entry.first});
     }
   }
+
+  // Stream file paths from the ZIP central directory without caching all entries in memory.
+  // Calls callback(std::string_view) for each file path found. Returns false on open/read failure.
+  template <typename F>
+  bool streamFilePaths(F&& callback) {
+    if (!isOpen()) {
+      if (!open()) return false;
+      bool result = streamFilePathsImpl(std::forward<F>(callback));
+      close();
+      return result;
+    }
+    return streamFilePathsImpl(std::forward<F>(callback));
+  }
+
+ private:
+  template <typename F>
+  bool streamFilePathsImpl(F&& callback) {
+    if (!loadZipDetails()) return false;
+
+    file.seek(zipDetails.centralDirOffset);
+
+    uint32_t sig;
+    char itemName[256];
+
+    while (file.available()) {
+      if (file.read(&sig, 4) != 4 || sig != 0x02014b50) break;
+
+      file.seekCur(22);
+      uint16_t nameLen, m, k;
+      file.read(&nameLen, 2);
+      file.read(&m, 2);
+      file.read(&k, 2);
+      file.seekCur(12);
+
+      if (nameLen < sizeof(itemName)) {
+        file.read(itemName, nameLen);
+        itemName[nameLen] = '\0';
+        callback(std::string_view{itemName, nameLen});
+      } else {
+        file.seekCur(nameLen);
+      }
+
+      file.seekCur(m + k);
+    }
+    return true;
+  }
 };

--- a/lib/ZipFile/ZipFile.h
+++ b/lib/ZipFile/ZipFile.h
@@ -104,7 +104,7 @@ class ZipFile {
     while (file.available()) {
       if (file.read(&sig, 4) != 4 || sig != 0x02014b50) break;
 
-      file.seekCur(22);
+      file.seekCur(24);
       uint16_t nameLen, m, k;
       file.read(&nameLen, 2);
       file.read(&m, 2);


### PR DESCRIPTION
## Summary

**The Issue**
Opening large EPUBs with a stale CSS cache caused memory exhaustion and application crashes (`abort()`) due to two compounding inefficiencies:

* **Unnecessary Spine Processing:** When parsing `content.opf` solely to rebuild the CSS cache, the system was unnecessarily processing spine entries. This resulted in wasted CPU cycles and significant memory drain from building in-memory item indices, resolving lookups, and allocating strings for thousands of items.
* **Heavy Heap Allocations in ZIP Scanning:** The `discoverCssFilesFromZip()` method used `loadAllFileStatSlims()`, which loaded every ZIP central directory entry into heap memory at once. For large books with thousands of files, this allocated 200KB+ of RAM, ultimately triggering an out-of-memory abort.

**The Fix**
This PR optimizes the CSS parsing path to be entirely memory-efficient:

* **Bypass OPF Spine Processing:** Added a `skipSpine` parameter to `parseContentOpf()`. When scanning for CSS, the method now passes a `nullptr` cache pointer to the parser, instructing it to completely skip spine work (avoiding temp files, indices, and string allocations).
* **Zero-Allocation ZIP Streaming:** Implemented a new `streamFilePaths()` method in the `ZipFile` class. This replaces the heap-heavy directory loading by streaming ZIP central directory entries sequentially, utilizing only a lightweight 256-byte stack buffer.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
