### PR TITLE
fix: bookmark percentage always 0% and page number starts at 0

### DIFF
--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -186,7 +186,7 @@ void EpubReaderBookmarksActivity::render(RenderLock&&) {
     auto bookmark = bookmarks.at(confirmingDelete >= DELETE_MODE_DISPLAY ? selectorIndex : index);
     auto tocIndex = epub->getTocIndexForSpineIndex(bookmark.computedSpineIndex);
     auto tocTitle = (tocIndex >= 0) ? (epub->getTocItem(tocIndex)).title : tr(STR_UNNAMED);
-    return std::to_string((int)bookmark.percentage) + "% - " + std::to_string(bookmark.computedChapterProgress) + "/" +
+    return std::to_string((int)(bookmark.percentage * 100)) + "% - " + std::to_string(bookmark.computedChapterProgress + 1) + "/" +
            std::to_string(bookmark.computedChapterPageCount) + " - " + tocTitle;
   };
   const auto getBookmarkIcon = [isPortrait](int index) {

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -186,7 +186,8 @@ void EpubReaderBookmarksActivity::render(RenderLock&&) {
     auto bookmark = bookmarks.at(confirmingDelete >= DELETE_MODE_DISPLAY ? selectorIndex : index);
     auto tocIndex = epub->getTocIndexForSpineIndex(bookmark.computedSpineIndex);
     auto tocTitle = (tocIndex >= 0) ? (epub->getTocItem(tocIndex)).title : tr(STR_UNNAMED);
-    return std::to_string((int)(bookmark.percentage * 100)) + "% - " + std::to_string(bookmark.computedChapterProgress + 1) + "/" +
+    return std::to_string((int)(bookmark.percentage * 100)) + "% - " +
+           std::to_string(bookmark.computedChapterProgress + 1) + "/" +
            std::to_string(bookmark.computedChapterPageCount) + " - " + tocTitle;
   };
   const auto getBookmarkIcon = [isPortrait](int index) {

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -186,7 +186,7 @@ void EpubReaderBookmarksActivity::render(RenderLock&&) {
     auto bookmark = bookmarks.at(confirmingDelete >= DELETE_MODE_DISPLAY ? selectorIndex : index);
     auto tocIndex = epub->getTocIndexForSpineIndex(bookmark.computedSpineIndex);
     auto tocTitle = (tocIndex >= 0) ? (epub->getTocItem(tocIndex)).title : tr(STR_UNNAMED);
-    return std::to_string((int)(bookmark.percentage * 100)) + "% - " +
+    return std::to_string((int)(std::clamp(bookmark.percentage, 0.0f, 1.0f) * 100.0f + 0.5f)) + "% - " +
            std::to_string(bookmark.computedChapterProgress + 1) + "/" +
            std::to_string(bookmark.computedChapterPageCount) + " - " + tocTitle;
   };


### PR DESCRIPTION
## Summary

* Fix the issue described in #2176 where bookmark percentages are always 0%
* Also fixed the page number rendering to +1 because they are 0 index based, but should be rendered starting from 1

---

### AI Usage

Did you use AI tools to help write this code? _**< NO >**_
