### PR TITLE
fix: WebDAV hidden files 

### DIFF
--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 #include <esp_task_wdt.h>
 
+#include "SettingsList.h"
 #include "util/BookCacheUtils.h"
 
 namespace {
@@ -228,7 +229,7 @@ void WebDAVHandler::handlePropfind(WebServer& s) {
       String fileName(name);
 
       // Skip hidden/protected items
-      bool shouldHide = fileName.startsWith(".");
+      bool shouldHide = !SETTINGS.showHiddenFiles && fileName.startsWith(".");
       if (!shouldHide) {
         for (const auto* item : HIDDEN_ITEMS) {
           if (fileName.equals(item)) {


### PR DESCRIPTION
## Summary

WebDAV ignores the system settings for showing hidden files
This PR fixes the issue 

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
