### PR TITLE
Update websocket compile orange warning flush (there is a websocket function that is going to be deprecated)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -53,6 +53,7 @@ extra_scripts =
   pre:scripts/gen_i18n.py
   pre:scripts/git_branch.py
   pre:scripts/patch_jpegdec.py
+  pre:scripts/patch_websockets.py
   post:scripts/register_unit_tests_target.py
 
 ; Libraries

--- a/scripts/patch_websockets.py
+++ b/scripts/patch_websockets.py
@@ -1,0 +1,103 @@
+"""
+PlatformIO pre-build script: apply CrossPoint's WebSockets patches via
+`git apply`.
+
+The upstream links2004/WebSockets 2.7.3 pin calls the deprecated
+`NetworkClient::flush()` in `WebSocketsClient::clientDisconnect`. Recent
+arduino-esp32 cores tag that method `[[deprecated("Use clear() instead.")]]`,
+so every release build emits a -Wdeprecated-declarations warning. The patch
+in `scripts/websockets_patches/` swaps it for the non-deprecated `clear()`,
+which has the same RX-discard semantics the disconnect path wants.
+
+Unlike JPEGDEC (a git checkout), the WebSockets libdep is an extracted
+registry tarball with no `.git` directory, so we locate it by its source
+file instead. `git apply` itself does not require a git working tree.
+
+Each patch's idempotency is decided by git itself:
+  * `git apply --check --reverse` succeeds  -> already applied, skip
+  * `git apply --check`            succeeds  -> apply
+  * neither succeeds                          -> abort the build
+
+Patches live in `scripts/websockets_patches/` as one-commit-per-fix files.
+Applied in lexical order.
+"""
+
+Import("env")  # noqa: F821 (SCons-injected global)
+import os
+import subprocess
+import sys
+
+
+PATCH_DIR = os.path.join(env["PROJECT_DIR"], "scripts", "websockets_patches")  # noqa: F821
+
+# Sentinel file used to locate the WebSockets libdep working tree. `git apply`
+# is run with this directory as cwd, matching the `a/src/...` paths in the
+# patch (default -p1 strips the leading component).
+SENTINEL = os.path.join("src", "WebSocketsClient.cpp")
+
+
+def patch_websockets(env):
+    libdeps_dir = os.path.join(env["PROJECT_DIR"], ".pio", "libdeps")
+    if not os.path.isdir(libdeps_dir):
+        return
+    patches = _patch_files()
+    for env_dir in os.listdir(libdeps_dir):
+        ws_dir = os.path.join(libdeps_dir, env_dir, "WebSockets")
+        if not os.path.isfile(os.path.join(ws_dir, SENTINEL)):
+            continue
+        for patch in patches:
+            _apply_one(ws_dir, patch)
+
+
+def _patch_files():
+    if not os.path.isdir(PATCH_DIR):
+        raise RuntimeError(
+            "WebSockets patches missing -- aborting build (expected directory %s)"
+            % PATCH_DIR
+        )
+    patches = sorted(
+        os.path.join(PATCH_DIR, name)
+        for name in os.listdir(PATCH_DIR)
+        if name.endswith(".patch")
+    )
+    if not patches:
+        raise RuntimeError(
+            "WebSockets patches missing -- aborting build (no .patch files in %s)"
+            % PATCH_DIR
+        )
+    return patches
+
+
+def _apply_one(ws_dir, patch_path):
+    name = os.path.basename(patch_path)
+    if _git_apply_succeeds(ws_dir, patch_path, reverse=True):
+        return
+    if not _git_apply_succeeds(ws_dir, patch_path, reverse=False):
+        # Not applied, not appliable -- the libdep source has diverged from
+        # what the patch expects. Don't write a half-patched file.
+        result = subprocess.run(
+            ["git", "apply", "--check", patch_path],
+            cwd=ws_dir,
+            capture_output=True,
+            text=True,
+        )
+        sys.stderr.write(
+            "ERROR: WebSockets patch %s does not apply cleanly:\n%s%s\n"
+            % (name, result.stdout, result.stderr)
+        )
+        raise SystemExit(1)
+    subprocess.run(["git", "apply", patch_path], cwd=ws_dir, check=True)
+    print("Applied WebSockets patch: %s" % name)
+
+
+def _git_apply_succeeds(ws_dir, patch_path, *, reverse):
+    cmd = ["git", "apply", "--check"]
+    if reverse:
+        cmd.append("--reverse")
+    cmd.append(patch_path)
+    return subprocess.run(
+        cmd, cwd=ws_dir, capture_output=True, text=True
+    ).returncode == 0
+
+
+patch_websockets(env)  # noqa: F821

--- a/scripts/patch_websockets.py
+++ b/scripts/patch_websockets.py
@@ -1,6 +1,5 @@
 """
-PlatformIO pre-build script: apply CrossPoint's WebSockets patches via
-`git apply`.
+PlatformIO pre-build script: apply CrossPoint's WebSockets patches.
 
 The upstream links2004/WebSockets 2.7.3 pin calls the deprecated
 `NetworkClient::flush()` in `WebSocketsClient::clientDisconnect`. Recent
@@ -9,14 +8,20 @@ so every release build emits a -Wdeprecated-declarations warning. The patch
 in `scripts/websockets_patches/` swaps it for the non-deprecated `clear()`,
 which has the same RX-discard semantics the disconnect path wants.
 
-Unlike JPEGDEC (a git checkout), the WebSockets libdep is an extracted
-registry tarball with no `.git` directory, so we locate it by its source
-file instead. `git apply` itself does not require a git working tree.
+We use GNU `patch`, not `git apply`, on purpose. The WebSockets libdep lives
+under `.pio/libdeps/<env>/WebSockets`, which sits *inside* the project's own
+git work tree (`.pio` is gitignored, but git still owns the path). `git apply`
+resolves against that enclosing repo rather than the libdep, so it silently
+no-ops -- both the forward and reverse `--check` "succeed" without touching
+the file. (JPEGDEC dodges this only because it is installed as its own git
+checkout with a private `.git`.) GNU `patch` ignores git entirely and edits
+the file in place, which is what we need here.
 
-Each patch's idempotency is decided by git itself:
-  * `git apply --check --reverse` succeeds  -> already applied, skip
-  * `git apply --check`            succeeds  -> apply
-  * neither succeeds                          -> abort the build
+Patches are read with `-i` so stdin stays free; stdin is fed from /dev/null
+so any prompt defaults to "no". That yields clean three-state detection:
+  * reverse dry-run succeeds  -> already applied, skip
+  * forward dry-run succeeds  -> apply
+  * neither succeeds          -> source diverged, abort the build
 
 Patches live in `scripts/websockets_patches/` as one-commit-per-fix files.
 Applied in lexical order.
@@ -30,9 +35,9 @@ import sys
 
 PATCH_DIR = os.path.join(env["PROJECT_DIR"], "scripts", "websockets_patches")  # noqa: F821
 
-# Sentinel file used to locate the WebSockets libdep working tree. `git apply`
-# is run with this directory as cwd, matching the `a/src/...` paths in the
-# patch (default -p1 strips the leading component).
+# Sentinel file used to locate the WebSockets libdep working tree. `patch` is
+# run with this directory as cwd, matching the `a/src/...` paths in the patch
+# (default -p1 strips the leading component).
 SENTINEL = os.path.join("src", "WebSocketsClient.cpp")
 
 
@@ -70,34 +75,40 @@ def _patch_files():
 
 def _apply_one(ws_dir, patch_path):
     name = os.path.basename(patch_path)
-    if _git_apply_succeeds(ws_dir, patch_path, reverse=True):
-        return
-    if not _git_apply_succeeds(ws_dir, patch_path, reverse=False):
+    if _patch_succeeds(ws_dir, patch_path, dry_run=True, reverse=True):
+        return  # already applied
+    if not _patch_succeeds(ws_dir, patch_path, dry_run=True, reverse=False):
         # Not applied, not appliable -- the libdep source has diverged from
         # what the patch expects. Don't write a half-patched file.
-        result = subprocess.run(
-            ["git", "apply", "--check", patch_path],
-            cwd=ws_dir,
-            capture_output=True,
-            text=True,
-        )
+        result = _run_patch(ws_dir, patch_path, dry_run=True, reverse=False)
         sys.stderr.write(
             "ERROR: WebSockets patch %s does not apply cleanly:\n%s%s\n"
             % (name, result.stdout, result.stderr)
         )
         raise SystemExit(1)
-    subprocess.run(["git", "apply", patch_path], cwd=ws_dir, check=True)
+    if not _patch_succeeds(ws_dir, patch_path, dry_run=False, reverse=False):
+        sys.stderr.write("ERROR: WebSockets patch %s failed to apply\n" % name)
+        raise SystemExit(1)
     print("Applied WebSockets patch: %s" % name)
 
 
-def _git_apply_succeeds(ws_dir, patch_path, *, reverse):
-    cmd = ["git", "apply", "--check"]
+def _patch_succeeds(ws_dir, patch_path, *, dry_run, reverse):
+    return _run_patch(ws_dir, patch_path, dry_run=dry_run, reverse=reverse).returncode == 0
+
+
+def _run_patch(ws_dir, patch_path, *, dry_run, reverse):
+    # -i reads the patch from a file so stdin is free; feeding stdin from
+    # /dev/null makes any GNU patch prompt default to "no" (skip), which is
+    # exactly the non-destructive behaviour we want for the dry-run probes.
+    cmd = ["patch", "-p1", "-i", patch_path]
+    if dry_run:
+        cmd.append("--dry-run")
     if reverse:
         cmd.append("--reverse")
-    cmd.append(patch_path)
-    return subprocess.run(
-        cmd, cwd=ws_dir, capture_output=True, text=True
-    ).returncode == 0
+    with open(os.devnull, "rb") as devnull:
+        return subprocess.run(
+            cmd, cwd=ws_dir, stdin=devnull, capture_output=True, text=True
+        )
 
 
 patch_websockets(env)  # noqa: F821

--- a/scripts/websockets_patches/0001-use-clear-instead-of-deprecated-flush.patch
+++ b/scripts/websockets_patches/0001-use-clear-instead-of-deprecated-flush.patch
@@ -1,0 +1,29 @@
+From 0d27554ac3aad0b59d2f2c15363a542ebf6cb79f Mon Sep 17 00:00:00 2001
+From: patch <patch@local>
+Date: Mon, 1 Jun 2026 14:21:53 +0000
+Subject: [PATCH] Use clear() instead of deprecated NetworkClient::flush() in
+ clientDisconnect
+
+---
+ src/WebSocketsClient.cpp | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/src/WebSocketsClient.cpp b/src/WebSocketsClient.cpp
+index 713e344..379a447 100644
+--- a/src/WebSocketsClient.cpp
++++ b/src/WebSocketsClient.cpp
+@@ -570,7 +570,10 @@ void WebSocketsClient::clientDisconnect(WSclient_t * client, const char * reason
+     if(client->tcp) {
+         if(client->tcp->connected()) {
+ #if (WEBSOCKETS_NETWORK_TYPE != NETWORK_ESP8266_ASYNC)
+-            client->tcp->flush();
++            // CrossPoint patch: NetworkClient::flush() is deprecated on
++            // arduino-esp32 ("Use clear() instead."). clear() drops any
++            // unread RX bytes, which is the intent right before stop().
++            client->tcp->clear();
+ #endif
+             client->tcp->stop();
+         }
+-- 
+2.43.0
+


### PR DESCRIPTION
## Summary
* **What is the goal of this PR?** Silence the compile-time `-Wdeprecated-declarations` warning from the `links2004/WebSockets @ 2.7.3` dependency. On recent arduino-esp32 cores, `WebSocketsClient::clientDisconnect` calls `NetworkClient::flush()`, which is now marked `[[deprecated("Use clear() instead.")]]`, so every release build prints a warning.
* **What changes are included?** A pre-build patch that swaps the deprecated `flush()` for `clear()` in the WebSockets libdep, applied via a hook following the existing `patch_jpegdec.py` convention. Specifically: `scripts/websockets_patches/0001-use-clear-instead-of-deprecated-flush.patch` (the one-line `flush()` → `clear()` change), `scripts/patch_websockets.py` (idempotent pre-build apply using GNU `patch`), and a `pre:scripts/patch_websockets.py` registration in `platformio.ini`.

## Additional Context

* The file lives in gitignored `.pio/libdeps/` (re-downloaded every build), so it's patched at build time rather than edited directly — same approach the repo already uses for JPEGDEC. The script uses GNU `patch` instead of `git apply` because the libdep sits inside the project's own git work tree, where `git apply` resolves against the enclosing repo and silently no-ops (JPEGDEC dodges this only because it's its own `.git` checkout). Risk is very low: the change is effectively compile-time only — CrossPoint uses `WebSocketsServer`, never `WebSocketsClient`, and `clear()`/`flush()` are behavior-equivalent before `stop()`. Verified with a full `pio run -e gh_release`: 0 warnings, `Applied WebSockets patch` printed, and the unpatched source still reproduces the warning when compiled directly. Suggested focus for review: the idempotency logic in `patch_websockets.py`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
