### PR TITLE
fix: long-press back should move to the start of chapter

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -338,17 +338,20 @@ void EpubReaderActivity::loop() {
   }
 
   if (longPress && SETTINGS.longPressButtonBehavior == SETTINGS.CHAPTER_SKIP) {
+    if (!nextTriggered && section && section->currentPage > 0) {
+      section->currentPage = 0;
+      requestUpdate();
+      return;
+    }
+
     // We don't want to delete the section mid-render, so grab the semaphore
     {
       RenderLock lock(*this);
       nextPageNumber = 0;
       if (nextTriggered) {
         currentSpineIndex++;
-      } else {
-        const bool isInsideCurrentChapter = section && section->currentPage > 0;
-        if (!isInsideCurrentChapter && currentSpineIndex > 0) {
-          currentSpineIndex--;
-        }
+      } else if (currentSpineIndex > 0) {
+        currentSpineIndex--;
       }
       section.reset();
     }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -342,7 +342,14 @@ void EpubReaderActivity::loop() {
     {
       RenderLock lock(*this);
       nextPageNumber = 0;
-      currentSpineIndex = nextTriggered ? currentSpineIndex + 1 : currentSpineIndex - 1;
+      if (nextTriggered) {
+        currentSpineIndex++;
+      } else {
+        const bool isInsideCurrentChapter = section && section->currentPage > 0;
+        if (!isInsideCurrentChapter && currentSpineIndex > 0) {
+          currentSpineIndex--;
+        }
+      }
       section.reset();
     }
     requestUpdate();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** fix issue #1674

## Additional Context

`EpubReaderActivity.cpp:340-357` — In the `CHAPTER_SKIP` long-press handler, when pressing "back" (`!nextTriggered`): if the current section exists and we're not already on its first page (`currentPage > 0`), reset `currentPage` to 0. Only when we're already on page 0 (or going forward) does it behave as before — skipping to the adjacent chapter.

---

### AI Usage

Did you use AI tools to help write this code? _**< PARTIALLY >**_
