### PR TITLE
fix: apply progress bar offset from top instead of bottom edge

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -763,7 +763,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     const int barMarginRight = fillMargin ? 0 : orientedMarginRight;
     const int progressBarMaxWidth = renderer.getScreenWidth() - barMarginLeft - barMarginRight;
     const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom -
-                             ((SETTINGS.statusBarProgressBarThickness + 1) * 2) - paddingBottom;
+                             ((SETTINGS.statusBarProgressBarThickness + 1) * 2) - paddingBottom + (fillMargin ? 1 : 0);
     size_t progress;
     if (SETTINGS.statusBarProgressBar == CrossPointSettings::STATUS_BAR_PROGRESS_BAR::BOOK_PROGRESS) {
       progress = static_cast<size_t>(bookProgress);


### PR DESCRIPTION
Continuing #2138, the -1px thinning offset 5d93a3791f0231e70e322f7ad3145f67654dcfb9 was applied to the wrong end of the bar. Subtracting it from `orientedMarginBottom` trimmed the bottom, creating a 1px gap at the screen edge. 

This fix shifts `progressBarY` by down 1px so that the bar height is properly reduced and matched the appearance in 1.3.0.

Also tested with 3px thinning to 100% confirm correct behavior.