### PR TITLE
fix: scale SUP/SUB underline to match 50%-scaled glyphs

### DIFF
--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -78,6 +78,13 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
         underlineWidth = visibleWidth;
       }
 
+      // SUP/SUB words are rendered at 50% glyph scale (see the baseline comment
+      // above and drawText), but getTextWidth reports the full-size width, so the
+      // underline would be drawn ~2x too long. Halve it to match the scaled glyphs.
+      if ((currentStyle & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0) {
+        underlineWidth = (underlineWidth + 1) / 2;
+      }
+
       renderer.drawLine(startX, underlineY, startX + underlineWidth, underlineY, true);
     }
   }


### PR DESCRIPTION
## Problem

Fixes #2191. Since `<sup>`/`<sub>` support landed (c5e861d), the underline drawn under a superscripted footnote marker is noticeably longer than the marker itself — it overflows to roughly twice the glyph width.

## Root cause

SUP/SUB glyphs are rendered at **50% scale** inside `GfxRenderer::drawText`, and the metrics functions used for layout/cursor advance halve the advance to match:

- `drawText` halves `prevAdvanceFP` for SUP/SUB ([GfxRenderer.cpp:458](https://github.com/crosspoint-reader/crosspoint-reader/blob/master/lib/GfxRenderer/GfxRenderer.cpp))
- `getTextAdvanceX` halves the advance for SUP/SUB ([GfxRenderer.cpp:1442](https://github.com/crosspoint-reader/crosspoint-reader/blob/master/lib/GfxRenderer/GfxRenderer.cpp))

But the underline width in [`TextBlock::render`](https://github.com/crosspoint-reader/crosspoint-reader/blob/master/lib/Epub/Epub/blocks/TextBlock.cpp) is taken from `getTextWidth`, which resolves to `EpdFontFamily::getTextDimensions` — and that path **ignores the SUP/SUB style bits entirely**, returning the full-size width. So the underline is measured at 100% while the glyphs render at 50%, hence the ~2× overflow.

A footnote link is both `UNDERLINE` and `SUP`, which is exactly when this shows.

## Fix

Halve the underline width when the word is SUP/SUB, matching the 50% glyph scale. Full-size underlines (regular links, `<u>`) are untouched — the new branch only fires when the SUP or SUB style bit is set.

```cpp
if ((currentStyle & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0) {
  underlineWidth = (underlineWidth + 1) / 2;
}
```

## Verification

This is a rendering-geometry change, so the proof is by the code's own documented contract: TextBlock.cpp:31 already notes "the glyph is also scaled 50% inside drawText", and both `drawText` and `getTextAdvanceX` apply that halving while `getTextWidth` does not — the underline simply wasn't following the same rule. The change reuses the same `(x + 1) / 2` rounding the renderer uses for the advance.

🔲 Not tested on hardware — a maintainer with the EPUB from #2191 confirming the underline now matches the marker width would be appreciated.

Supported by Claude Opus 4.8