### PR TITLE
fix(epub): decode footnote href path before spine lookup

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -900,10 +900,10 @@ float Epub::calculateProgress(const int currentSpineIndex, const float currentSp
 int Epub::resolveHrefToSpineIndex(const std::string& href) const {
   if (!bookMetadataCache || !bookMetadataCache->isLoaded()) return -1;
 
-  // Extract filename (remove #anchor)
-  std::string target = href;
-  size_t hashPos = target.find('#');
-  if (hashPos != std::string::npos) target = target.substr(0, hashPos);
+  // Split before decoding so escaped '#' characters in filenames stay part of the path.
+  const size_t hashPos = href.find('#');
+  const std::string rawTarget = hashPos != std::string::npos ? href.substr(0, hashPos) : href;
+  const std::string target = FsHelpers::normalisePath(FsHelpers::decodeUriEscapes(rawTarget));
 
   // Same-file reference (anchor-only)
   if (target.empty()) return -1;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
  * Fix encoded cross-chapter footnote/cross-reference links after spine hrefs are stored decoded.
* **What changes are included?**
  * Updates `Epub::resolveHrefToSpineIndex()` to split the raw href on `#` before decoding.
  * Decodes and normalizes only the path portion before comparing it to cached spine hrefs.
  * Keeps escaped `#` characters in filenames safe, since `%23` is decoded only after the real fragment split.

## Additional Context

* This is a follow-up to the encoded EPUB path handling work (#2249). Without this, a raw footnote href like `chapter%202.xhtml#fn1` can fail to match a decoded spine href like `chapter 2.xhtml`.
* Example path handling:

| Input href | Raw path before `#` | Lookup path after decode + normalize |
|---|---|---|
| `chapter%202.xhtml#fn1` | `chapter%202.xhtml` | `chapter 2.xhtml` |
| `OPS/chapter%202.xhtml#fn1` | `OPS/chapter%202.xhtml` | `OPS/chapter 2.xhtml` |
| `OPS/../Text/chapter%202.xhtml#fn1` | `OPS/../Text/chapter%202.xhtml` | `Text/chapter 2.xhtml` |
| `chapter%23bonus.xhtml#fn1` | `chapter%23bonus.xhtml` | `chapter#bonus.xhtml` |
| `chapter.xhtml#fn1` | `chapter.xhtml` | `chapter.xhtml` |
| `#fn1` | empty | returns `-1` here; same-file anchors are handled before this resolver |

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
