### PR TITLE
feat(epub): basic table support for row/colspan and for solid/none border style

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
 
 #include <new>
@@ -31,6 +32,35 @@ std::unique_ptr<PageLine> PageLine::deserialize(HalFile& file) {
 void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
   // Images don't use fontId or text rendering
   imageBlock->render(renderer, xPos + xOffset, yPos + yOffset);
+}
+
+void PageTable::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
+  tableBlock->render(renderer, fontId, xPos + xOffset, yPos + yOffset);
+}
+
+bool PageTable::serialize(HalFile& file) {
+  serialization::writePod(file, xPos);
+  serialization::writePod(file, yPos);
+  serialization::writePod(file, tableHeight);
+  return tableBlock->serialize(file);
+}
+
+std::unique_ptr<PageTable> PageTable::deserialize(HalFile& file) {
+  int16_t xPos = 0, yPos = 0, tableHeight = 0;
+  serialization::readPod(file, xPos);
+  serialization::readPod(file, yPos);
+  serialization::readPod(file, tableHeight);
+  auto tb = TableBlock::deserialize(file);
+  if (!tb) {
+    LOG_ERR("PGE", "Failed to deserialize TableBlock");
+    return nullptr;
+  }
+  auto pt = makeUniqueNoThrow<PageTable>(std::move(tb), xPos, yPos, tableHeight);
+  if (!pt) {
+    LOG_ERR("PGE", "OOM: PageTable");
+    return nullptr;
+  }
+  return pt;
 }
 
 bool PageImage::serialize(HalFile& file) {
@@ -148,6 +178,10 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
         return nullptr;
       }
       page->elements.push_back(std::move(rule));
+    } else if (tag == TAG_PageTable) {
+      auto pt = PageTable::deserialize(file);
+      if (!pt) return nullptr;
+      page->elements.push_back(std::move(pt));
     } else {
       LOG_ERR("PGE", "Deserialization failed: Unknown tag %u", tag);
       return nullptr;

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -8,12 +8,14 @@
 
 #include "FootnoteEntry.h"
 #include "blocks/ImageBlock.h"
+#include "blocks/TableBlock.h"
 #include "blocks/TextBlock.h"
 
 enum PageElementTag : uint8_t {
   TAG_PageLine = 1,
   TAG_PageImage = 2,
   TAG_PageHorizontalRule = 3,
+  TAG_PageTable = 4,
 };
 
 // represents something that has been added to a page
@@ -68,6 +70,21 @@ class PageHorizontalRule final : public PageElement {
   bool serialize(HalFile& file) override;
   PageElementTag getTag() const override { return TAG_PageHorizontalRule; }
   static std::unique_ptr<PageHorizontalRule> deserialize(HalFile& file);
+};
+
+// A pre-laid-out table placed at a fixed position on the page.
+class PageTable final : public PageElement {
+  std::unique_ptr<TableBlock> tableBlock;
+  int16_t tableHeight;  // pre-computed total pixel height
+
+ public:
+  PageTable(std::unique_ptr<TableBlock> block, const int16_t xPos, const int16_t yPos, const int16_t height)
+      : PageElement(xPos, yPos), tableBlock(std::move(block)), tableHeight(height) {}
+  void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
+  bool serialize(HalFile& file) override;
+  PageElementTag getTag() const override { return TAG_PageTable; }
+  int16_t getHeight() const { return tableHeight; }
+  static std::unique_ptr<PageTable> deserialize(HalFile& file);
 };
 
 class Page {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 25;
+constexpr uint8_t SECTION_FILE_VERSION = 26;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +

--- a/lib/Epub/Epub/blocks/Block.h
+++ b/lib/Epub/Epub/blocks/Block.h
@@ -2,7 +2,7 @@
 
 class GfxRenderer;
 
-typedef enum { TEXT_BLOCK, IMAGE_BLOCK } BlockType;
+typedef enum { TEXT_BLOCK, IMAGE_BLOCK, TABLE_BLOCK } BlockType;
 
 // a block of content in the html - either a paragraph or an image
 class Block {

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -113,6 +113,7 @@ void TableBlock::render(GfxRenderer& renderer, int fontId, int x, int y) const {
         {
           uint8_t lc = 0;
           for (const auto& nc : rows[ri + 1].cells) {
+            if (lc >= numCols) break;
             if (nc.rowspan == 0) phantomAt[lc] = true;
             lc = static_cast<uint8_t>(lc + ((nc.rowspan == 0) ? 1 : nc.colspan));
           }
@@ -219,6 +220,7 @@ std::unique_ptr<TableBlock> TableBlock::deserialize(HalFile& file) {
     uint8_t numCells = 0;
     serialization::readPod(file, numCells);
     row.cells.resize(numCells);
+    uint16_t rowSpanTotal = 0;
     for (auto& cell : row.cells) {
       serialization::readPod(file, cell.paddingLeft);
       serialization::readPod(file, cell.paddingRight);
@@ -230,6 +232,7 @@ std::unique_ptr<TableBlock> TableBlock::deserialize(HalFile& file) {
         cell.colspan = 1;  // phantom cells always span 1 column
       else if (cell.colspan == 0)
         cell.colspan = 1;  // guard against corrupt data
+      rowSpanTotal += cell.colspan;
       constexpr uint16_t kMaxCellLines = 4096;
       uint16_t numLines = 0;
       serialization::readPod(file, numLines);
@@ -246,6 +249,10 @@ std::unique_ptr<TableBlock> TableBlock::deserialize(HalFile& file) {
         }
         cell.lines.push_back(std::move(line));
       }
+    }
+    if (rowSpanTotal != tb->numCols) {
+      LOG_ERR("TBL", "Row span %u != numCols %u", rowSpanTotal, tb->numCols);
+      return nullptr;
     }
   }
   return tb;

--- a/lib/Epub/Epub/blocks/TableBlock.cpp
+++ b/lib/Epub/Epub/blocks/TableBlock.cpp
@@ -1,0 +1,252 @@
+#include "TableBlock.h"
+
+#include <GfxRenderer.h>
+#include <Logging.h>
+#include <Memory.h>
+#include <Serialization.h>
+
+// Layout:
+//   1px top border
+//   For each row:
+//     maxPaddingTop + row.maxLines * lineHeight + maxPaddingBottom  pixels of content
+//     1px bottom border (doubles as top border of next row)
+int16_t TableBlock::totalHeight() const {
+  if (rows.empty()) return 0;
+  int16_t h = static_cast<int16_t>(rows.size() + 1);  // (numRows+1) 1px borders
+  for (const auto& row : rows) {
+    h = static_cast<int16_t>(h + row.maxLines * lineHeight + row.maxPaddingTop + row.maxPaddingBottom);
+  }
+  return h;
+}
+
+void TableBlock::render(GfxRenderer& renderer, int fontId, int x, int y) const {
+  if (rows.empty() || numCols == 0) return;
+  if (numCols > MAX_COLS) {
+    LOG_ERR("TBL", "Skipping table render: too many cols=%u", numCols);
+    return;
+  }
+
+  // Build cumulative column X positions (numCols+1 values: left edge of each col + right edge of last).
+  // numCols <= MAX_COLS (64) validated above, so MAX_COLS+1 entries fit on the stack (130 bytes).
+  int16_t colX[MAX_COLS + 1];
+  auto cx = static_cast<int16_t>(x);
+  for (uint8_t c = 0; c <= numCols; c++) {
+    colX[c] = cx;
+    if (c < numCols) cx = static_cast<int16_t>(cx + getColWidth(c));
+  }
+  const int tableWidth = static_cast<int>(colX[numCols]) - x;
+
+  int curY = y;
+  if (!rows.empty() && rows.front().drawBorderTop)
+    renderer.drawLine(x, curY, x + tableWidth, curY, true);  // top border
+  curY += 1;
+
+  // A vertical divider is the right edge of one column and the left edge of the next.
+  // Draw it if either the left or right side has borders enabled.
+  const bool drawAnyVertical = drawBorderLeft || drawBorderRight || drawInnerColDividers;
+
+  for (size_t ri = 0; ri < rows.size(); ri++) {
+    const auto& row = rows[ri];
+    const int rowContentH = row.maxLines * lineHeight + row.maxPaddingTop + row.maxPaddingBottom;
+
+    // Vertical column lines — skip interior boundaries of spanning cells.
+    // Phantom cells (rowspan==0) are single-column and do not suppress any borders.
+    {
+      // drawBorderAt[i] == true means draw a vertical line at colX[i].
+      // numCols <= MAX_COLS validated above, so MAX_COLS+1 entries are safe on the stack.
+      bool drawBorderAt[MAX_COLS + 1] = {};
+      // Left edge, interior dividers, and right edge each use their respective flags.
+      for (int i = 0; i <= static_cast<int>(numCols); i++) {
+        if (i == 0)
+          drawBorderAt[i] = drawBorderLeft;
+        else if (i == static_cast<int>(numCols))
+          drawBorderAt[i] = drawBorderRight;
+        else
+          drawBorderAt[i] = drawInnerColDividers;  // interior column: cell-border-driven only
+      }
+      if (drawAnyVertical) {
+        uint8_t logCol = 0;
+        for (size_t ci = 0; ci < row.cells.size() && logCol < numCols; ci++) {
+          const auto& cell = row.cells[ci];
+          const uint8_t span = (cell.rowspan == 0) ? 1 : cell.colspan;
+          // Interior column positions within this span must not have a divider.
+          for (uint8_t k = 1; k < span && (logCol + k) <= numCols; k++) {
+            drawBorderAt[logCol + k] = false;
+          }
+          logCol = static_cast<uint8_t>(logCol + span);
+        }
+        for (int col = 0; col <= static_cast<int>(numCols); col++) {
+          if (drawBorderAt[col]) {
+            renderer.drawLine(colX[col], curY, colX[col], curY + rowContentH, true);
+          }
+        }
+      }
+    }
+
+    // Cell text — advance logical column by each cell's colspan.
+    // Phantom cells (rowspan==0) have no lines, so the inner loop is a no-op for them.
+    {
+      uint8_t logCol = 0;
+      for (size_t ci = 0; ci < row.cells.size() && logCol < numCols; ci++) {
+        const auto& cell = row.cells[ci];
+        const int cellTextX = static_cast<int>(colX[logCol]) + 1 + cell.paddingLeft;  // +1 for left border
+        int lineY = curY + row.maxPaddingTop;
+        for (const auto& line : cell.lines) {
+          line->render(renderer, fontId, cellTextX, lineY);
+          lineY += lineHeight;
+        }
+        logCol = static_cast<uint8_t>(logCol + ((cell.rowspan == 0) ? 1 : cell.colspan));
+      }
+    }
+
+    curY += rowContentH;
+    // Determine whether to draw a horizontal separator below this row.
+    // Inter-row: draw if either the row below has a top border or this row has a bottom border.
+    // Last row: draw only if this row has a bottom border.
+    const bool drawThisSeparator =
+        (ri + 1 < rows.size()) ? (row.drawBorderBottom || rows[ri + 1].drawBorderTop) : row.drawBorderBottom;
+    if (drawThisSeparator) {
+      // Suppress the bottom border at columns where the next row has phantom cells
+      // (those columns are visually spanned by a rowspan cell continuing from this row).
+      if (ri + 1 < rows.size()) {
+        bool phantomAt[MAX_COLS] = {};
+        {
+          uint8_t lc = 0;
+          for (const auto& nc : rows[ri + 1].cells) {
+            if (nc.rowspan == 0) phantomAt[lc] = true;
+            lc = static_cast<uint8_t>(lc + ((nc.rowspan == 0) ? 1 : nc.colspan));
+          }
+        }
+        int segStart = x;
+        for (int col = 0; col < static_cast<int>(numCols); col++) {
+          if (phantomAt[col]) {
+            if (segStart < colX[col]) renderer.drawLine(segStart, curY, colX[col], curY, true);
+            segStart = colX[col + 1];
+          }
+        }
+        if (segStart < colX[numCols]) renderer.drawLine(segStart, curY, colX[numCols], curY, true);
+      } else {
+        renderer.drawLine(x, curY, x + tableWidth, curY, true);  // last row bottom edge
+      }
+    }
+    curY += 1;
+  }
+}
+
+bool TableBlock::serialize(HalFile& file) const {
+  serialization::writePod(file, numCols);
+  serialization::writePod(file, colWidth);
+  serialization::writePod(file, lineHeight);
+  const uint8_t flags = static_cast<uint8_t>(drawBorderLeft) | static_cast<uint8_t>(drawBorderRight) << 1 |
+                        static_cast<uint8_t>(drawInnerColDividers) << 2;
+  serialization::writePod(file, flags);
+
+  // Per-column widths
+  const auto numColWidths = static_cast<uint8_t>(std::min(colWidths.size(), size_t(255)));
+  serialization::writePod(file, numColWidths);
+  for (uint8_t c = 0; c < numColWidths; c++) serialization::writePod(file, colWidths[c]);
+
+  const auto numRows = static_cast<uint16_t>(rows.size());
+  serialization::writePod(file, numRows);
+
+  for (const auto& row : rows) {
+    serialization::writePod(file, row.maxLines);
+    serialization::writePod(file, row.maxPaddingTop);
+    serialization::writePod(file, row.maxPaddingBottom);
+    const uint8_t rowFlags = static_cast<uint8_t>(row.drawBorderTop) | static_cast<uint8_t>(row.drawBorderBottom) << 1;
+    serialization::writePod(file, rowFlags);
+    const auto numCells = static_cast<uint8_t>(std::min(row.cells.size(), size_t(255)));
+    serialization::writePod(file, numCells);
+    for (uint8_t c = 0; c < numCells; c++) {
+      const auto& cell = row.cells[c];
+      serialization::writePod(file, cell.paddingLeft);
+      serialization::writePod(file, cell.paddingRight);
+      serialization::writePod(file, cell.paddingTop);
+      serialization::writePod(file, cell.paddingBottom);
+      serialization::writePod(file, cell.colspan);
+      serialization::writePod(file, cell.rowspan);
+      const auto numLines = static_cast<uint16_t>(std::min(cell.lines.size(), size_t(65535)));
+      serialization::writePod(file, numLines);
+      for (uint16_t l = 0; l < numLines; l++) {
+        if (!cell.lines[l]->serialize(file)) {
+          LOG_ERR("TBL", "Failed to serialize cell[%u] line %u", c, l);
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
+std::unique_ptr<TableBlock> TableBlock::deserialize(HalFile& file) {
+  auto tb = makeUniqueNoThrow<TableBlock>();
+  if (!tb) {
+    LOG_ERR("TBL", "OOM: TableBlock");
+    return nullptr;
+  }
+  serialization::readPod(file, tb->numCols);
+  serialization::readPod(file, tb->colWidth);
+  serialization::readPod(file, tb->lineHeight);
+  uint8_t flags = 0;
+  serialization::readPod(file, flags);
+  tb->drawBorderLeft = (flags & 1) != 0;
+  tb->drawBorderRight = (flags & 2) != 0;
+  tb->drawInnerColDividers = (flags & 4) != 0;
+
+  // Per-column widths
+  uint8_t numColWidths = 0;
+  serialization::readPod(file, numColWidths);
+  tb->colWidths.resize(numColWidths);
+  for (auto& w : tb->colWidths) serialization::readPod(file, w);
+
+  uint16_t numRows = 0;
+  serialization::readPod(file, numRows);
+
+  if (numRows > 1000 || tb->numCols > MAX_COLS) {
+    LOG_ERR("TBL", "Sanity check failed: rows=%u cols=%u", numRows, tb->numCols);
+    return nullptr;
+  }
+
+  tb->rows.resize(numRows);
+  for (auto& row : tb->rows) {
+    serialization::readPod(file, row.maxLines);
+    serialization::readPod(file, row.maxPaddingTop);
+    serialization::readPod(file, row.maxPaddingBottom);
+    uint8_t rowFlags = 0;
+    serialization::readPod(file, rowFlags);
+    row.drawBorderTop = (rowFlags & 1) != 0;
+    row.drawBorderBottom = (rowFlags & 2) != 0;
+    uint8_t numCells = 0;
+    serialization::readPod(file, numCells);
+    row.cells.resize(numCells);
+    for (auto& cell : row.cells) {
+      serialization::readPod(file, cell.paddingLeft);
+      serialization::readPod(file, cell.paddingRight);
+      serialization::readPod(file, cell.paddingTop);
+      serialization::readPod(file, cell.paddingBottom);
+      serialization::readPod(file, cell.colspan);
+      serialization::readPod(file, cell.rowspan);
+      if (cell.rowspan == 0)
+        cell.colspan = 1;  // phantom cells always span 1 column
+      else if (cell.colspan == 0)
+        cell.colspan = 1;  // guard against corrupt data
+      constexpr uint16_t kMaxCellLines = 4096;
+      uint16_t numLines = 0;
+      serialization::readPod(file, numLines);
+      if (numLines > kMaxCellLines) {
+        LOG_ERR("TBL", "Sanity check failed: cell lines=%u", numLines);
+        return nullptr;
+      }
+      cell.lines.reserve(numLines);
+      for (uint16_t l = 0; l < numLines; l++) {
+        auto line = TextBlock::deserialize(file);
+        if (!line) {
+          LOG_ERR("TBL", "Failed to deserialize cell line");
+          return nullptr;
+        }
+        cell.lines.push_back(std::move(line));
+      }
+    }
+  }
+  return tb;
+}

--- a/lib/Epub/Epub/blocks/TableBlock.h
+++ b/lib/Epub/Epub/blocks/TableBlock.h
@@ -2,6 +2,7 @@
 
 #include <HalStorage.h>
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -52,10 +53,8 @@ class TableBlock final : public Block {
   // Returns true if any border side is enabled.
   bool drawAnyBorder() const {
     if (drawBorderLeft || drawBorderRight || drawInnerColDividers) return true;
-    for (const auto& r : rows) {
-      if (r.drawBorderTop || r.drawBorderBottom) return true;
-    }
-    return false;
+    return std::any_of(rows.begin(), rows.end(),
+                       [](const TableRow& r) { return r.drawBorderTop || r.drawBorderBottom; });
   }
 
   BlockType getType() override { return TABLE_BLOCK; }

--- a/lib/Epub/Epub/blocks/TableBlock.h
+++ b/lib/Epub/Epub/blocks/TableBlock.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <HalStorage.h>
+
+#include <memory>
+#include <vector>
+
+#include "Block.h"
+#include "TextBlock.h"
+
+// One cell in a table row — holds pre-laid-out text lines and its own CSS-resolved padding.
+struct TableCell {
+  std::vector<std::shared_ptr<TextBlock>> lines;
+  int16_t paddingLeft = 2;  // default: TableBlock::CELL_PADDING_X
+  int16_t paddingRight = 2;
+  int16_t paddingTop = 1;  // default: TableBlock::CELL_PADDING_Y
+  int16_t paddingBottom = 1;
+  uint8_t colspan = 1;  // number of logical columns this cell spans
+  uint8_t rowspan =
+      1;  // 0 = phantom (column occupied by rowspan from above), 1 = normal, >1 = spans rows; HTML "0" mapped to 64
+};
+
+// One row in a table — holds cells and aggregated height metrics.
+struct TableRow {
+  std::vector<TableCell> cells;
+  uint8_t maxLines = 0;           // max text lines across all cells in this row
+  int16_t maxPaddingTop = 1;      // max paddingTop  across all cells
+  int16_t maxPaddingBottom = 1;   // max paddingBottom across all cells
+  bool drawBorderTop = false;     // draw top edge of this row (and top of table for first row)
+  bool drawBorderBottom = false;  // draw bottom edge of this row (and bottom of table for last row)
+};
+
+class GfxRenderer;
+
+// A fully pre-laid-out table. Column widths can be per-column (CSS) or uniform.
+// Line heights are pre-computed and stored so rendering does not need to re-query the font.
+class TableBlock final : public Block {
+ public:
+  static constexpr int16_t CELL_PADDING_X = 2;  // horizontal padding default
+  static constexpr int16_t CELL_PADDING_Y = 1;  // vertical padding default
+  static constexpr uint8_t MAX_COLS = 64;       // maximum supported column count
+
+  std::vector<TableRow> rows;
+  uint8_t numCols = 0;
+  int16_t colWidth = 0;            // equal-width fallback (used when colWidths is empty)
+  std::vector<int16_t> colWidths;  // per-column pixel widths; if size()==numCols overrides colWidth
+  int16_t lineHeight = 0;
+  bool drawBorderLeft = false;        // draw left outer edge of table
+  bool drawBorderRight = false;       // draw right outer edge of table
+  bool drawInnerColDividers = false;  // draw interior column-divider lines (cell-border-driven)
+
+  // Returns true if any border side is enabled.
+  bool drawAnyBorder() const {
+    if (drawBorderLeft || drawBorderRight || drawInnerColDividers) return true;
+    for (const auto& r : rows) {
+      if (r.drawBorderTop || r.drawBorderBottom) return true;
+    }
+    return false;
+  }
+
+  BlockType getType() override { return TABLE_BLOCK; }
+  bool isEmpty() override { return rows.empty(); }
+
+  // Pixel width of column `col` (0-based).
+  int16_t getColWidth(uint8_t col) const {
+    if (col < static_cast<uint8_t>(colWidths.size())) return colWidths[col];
+    return colWidth;
+  }
+
+  // Total pixel height occupied by this table (borders + padding + text lines).
+  int16_t totalHeight() const;
+
+  void render(GfxRenderer& renderer, int fontId, int x, int y) const;
+  bool serialize(HalFile& file) const;
+  static std::unique_ptr<TableBlock> deserialize(HalFile& file);
+};

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -155,6 +155,36 @@ std::string_view stripTrailingImportant(std::string_view value) {
   return value;
 }
 
+bool isBorderStyleKeyword(std::string_view token) {
+  return iequalsAscii(token, "none") || iequalsAscii(token, "hidden") || iequalsAscii(token, "solid") ||
+         iequalsAscii(token, "dotted") || iequalsAscii(token, "dashed") || iequalsAscii(token, "double") ||
+         iequalsAscii(token, "groove") || iequalsAscii(token, "ridge") || iequalsAscii(token, "inset") ||
+         iequalsAscii(token, "outset");
+}
+
+enum class BorderSide { Top, Right, Bottom, Left };
+
+void applyBorderWidth(CssStyle& s, BorderSide side, bool isZero) {
+  switch (side) {
+    case BorderSide::Top:
+      s.defined.borderTopWidthZero = isZero;
+      s.defined.borderTopWidthSet = !isZero;
+      break;
+    case BorderSide::Right:
+      s.defined.borderRightWidthZero = isZero;
+      s.defined.borderRightWidthSet = !isZero;
+      break;
+    case BorderSide::Bottom:
+      s.defined.borderBottomWidthZero = isZero;
+      s.defined.borderBottomWidthSet = !isZero;
+      break;
+    case BorderSide::Left:
+      s.defined.borderLeftWidthZero = isZero;
+      s.defined.borderLeftWidthSet = !isZero;
+      break;
+  }
+}
+
 }  // anonymous namespace
 
 // Transparent case-insensitive hash/equal. Bodies live here (rather than
@@ -257,6 +287,11 @@ CssTextDecoration CssParser::interpretDecoration(std::string_view val) {
     return CssTextDecoration::Underline;
   }
   return CssTextDecoration::None;
+}
+
+CssBorderStyle CssParser::interpretBorderStyle(std::string_view val) {
+  if (iequalsAscii(val, "none") || iequalsAscii(val, "hidden")) return CssBorderStyle::None;
+  return CssBorderStyle::Solid;
 }
 
 CssLength CssParser::interpretLength(std::string_view val) {
@@ -406,6 +441,104 @@ void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style
     } else if (iequalsAscii(value, "sub")) {
       style.verticalAlign = CssVerticalAlign::Sub;
       style.defined.verticalAlign = 1;
+    }
+  } else if (iequalsAscii(name, "border-top-style")) {
+    style.borderTopStyle = interpretBorderStyle(value);
+    style.defined.borderTopStyle = 1;
+  } else if (iequalsAscii(name, "border-bottom-style")) {
+    style.borderBottomStyle = interpretBorderStyle(value);
+    style.defined.borderBottomStyle = 1;
+  } else if (iequalsAscii(name, "border-left-style")) {
+    style.borderLeftStyle = interpretBorderStyle(value);
+    style.defined.borderLeftStyle = 1;
+  } else if (iequalsAscii(name, "border-right-style")) {
+    style.borderRightStyle = interpretBorderStyle(value);
+    style.defined.borderRightStyle = 1;
+  } else if (iequalsAscii(name, "border-top-width")) {
+    // Track zero-width vs non-zero-width independently from style;
+    // combined at check time via isBorderTopVisible().
+    CssLength len;
+    if (tryInterpretLength(value, len)) applyBorderWidth(style, BorderSide::Top, len.value == 0.0f);
+  } else if (iequalsAscii(name, "border-bottom-width")) {
+    CssLength len;
+    if (tryInterpretLength(value, len)) applyBorderWidth(style, BorderSide::Bottom, len.value == 0.0f);
+  } else if (iequalsAscii(name, "border-left-width")) {
+    CssLength len;
+    if (tryInterpretLength(value, len)) applyBorderWidth(style, BorderSide::Left, len.value == 0.0f);
+  } else if (iequalsAscii(name, "border-right-width")) {
+    CssLength len;
+    if (tryInterpretLength(value, len)) applyBorderWidth(style, BorderSide::Right, len.value == 0.0f);
+  } else if (iequalsAscii(name, "border-width")) {
+    // Shorthand: 1–4 values (top right bottom left). Track zero vs non-zero width per side.
+    std::string_view toks[4];
+    const size_t count = collectEdgeValueTokens(value, toks);
+    if (count > 0) {
+      std::string_view top = toks[0];
+      std::string_view right = count >= 2 ? toks[1] : toks[0];
+      std::string_view bottom = count >= 3 ? toks[2] : toks[0];
+      std::string_view left = count >= 4 ? toks[3] : right;
+      CssLength len;
+      if (tryInterpretLength(top, len)) applyBorderWidth(style, BorderSide::Top, len.value == 0.0f);
+      if (tryInterpretLength(right, len)) applyBorderWidth(style, BorderSide::Right, len.value == 0.0f);
+      if (tryInterpretLength(bottom, len)) applyBorderWidth(style, BorderSide::Bottom, len.value == 0.0f);
+      if (tryInterpretLength(left, len)) applyBorderWidth(style, BorderSide::Left, len.value == 0.0f);
+    }
+  } else if (iequalsAscii(name, "border-style")) {
+    std::string_view toks[4];
+    const size_t count = collectEdgeValueTokens(value, toks);
+    if (count > 0) {
+      style.borderTopStyle = interpretBorderStyle(toks[0]);
+      style.borderRightStyle = count >= 2 ? interpretBorderStyle(toks[1]) : style.borderTopStyle;
+      style.borderBottomStyle = count >= 3 ? interpretBorderStyle(toks[2]) : style.borderTopStyle;
+      style.borderLeftStyle = count >= 4 ? interpretBorderStyle(toks[3]) : style.borderRightStyle;
+      style.defined.borderTopStyle = style.defined.borderRightStyle = style.defined.borderBottomStyle =
+          style.defined.borderLeftStyle = 1;
+    }
+  } else if (iequalsAscii(name, "border") || iequalsAscii(name, "border-top") || iequalsAscii(name, "border-bottom") ||
+             iequalsAscii(name, "border-left") || iequalsAscii(name, "border-right")) {
+    // Parse compound border shorthand: <width> <style> <color> in any order.
+    // Width keywords (thin/medium/thick) and color values are recognized but ignored beyond
+    // determining whether the width is non-zero.
+    CssBorderStyle parsedStyle = CssBorderStyle::None;
+    bool hasStyle = false;
+    bool widthIsZero = false;
+    bool hasWidth = false;
+
+    forEachDelimitedToken(value, isCssWhitespace, [&](std::string_view token) {
+      CssLength len;
+      if (tryInterpretLength(token, len)) {
+        hasWidth = true;
+        widthIsZero = (len.value == 0.0f);
+      } else if (iequalsAscii(token, "thin") || iequalsAscii(token, "medium") || iequalsAscii(token, "thick")) {
+        hasWidth = true;
+        widthIsZero = false;
+      } else if (isBorderStyleKeyword(token)) {
+        hasStyle = true;
+        parsedStyle = interpretBorderStyle(token);
+      }
+      // Any remaining tokens are colors — ignored for monochrome e-ink rendering.
+    });
+
+    if (iequalsAscii(name, "border-top") || iequalsAscii(name, "border")) {
+      style.borderTopStyle = parsedStyle;
+      style.defined.borderTopStyle = 1;
+      // hasWidth wins; else if hasStyle, CSS default width is medium (non-zero)
+      if (hasWidth || hasStyle) applyBorderWidth(style, BorderSide::Top, hasWidth && widthIsZero);
+    }
+    if (iequalsAscii(name, "border-bottom") || iequalsAscii(name, "border")) {
+      style.borderBottomStyle = parsedStyle;
+      style.defined.borderBottomStyle = 1;
+      if (hasWidth || hasStyle) applyBorderWidth(style, BorderSide::Bottom, hasWidth && widthIsZero);
+    }
+    if (iequalsAscii(name, "border-left") || iequalsAscii(name, "border")) {
+      style.borderLeftStyle = parsedStyle;
+      style.defined.borderLeftStyle = 1;
+      if (hasWidth || hasStyle) applyBorderWidth(style, BorderSide::Left, hasWidth && widthIsZero);
+    }
+    if (iequalsAscii(name, "border-right") || iequalsAscii(name, "border")) {
+      style.borderRightStyle = parsedStyle;
+      style.defined.borderRightStyle = 1;
+      if (hasWidth || hasStyle) applyBorderWidth(style, BorderSide::Right, hasWidth && widthIsZero);
     }
   }
 }
@@ -737,6 +870,10 @@ bool CssParser::saveToCache() const {
     writeLength(style.imageWidth);
     file.write(static_cast<uint8_t>(style.display));
     file.write(static_cast<uint8_t>(style.verticalAlign));
+    file.write(static_cast<uint8_t>(style.borderTopStyle));
+    file.write(static_cast<uint8_t>(style.borderBottomStyle));
+    file.write(static_cast<uint8_t>(style.borderLeftStyle));
+    file.write(static_cast<uint8_t>(style.borderRightStyle));
 
     // Write defined flags as uint32_t
     uint32_t definedBits = 0;
@@ -758,6 +895,18 @@ bool CssParser::saveToCache() const {
     if (style.defined.display) definedBits |= 1 << 15;
     if (style.defined.direction) definedBits |= 1 << 16;
     if (style.defined.verticalAlign) definedBits |= 1 << 17;
+    if (style.defined.borderTopStyle) definedBits |= 1 << 18;
+    if (style.defined.borderBottomStyle) definedBits |= 1 << 19;
+    if (style.defined.borderLeftStyle) definedBits |= 1 << 20;
+    if (style.defined.borderRightStyle) definedBits |= 1 << 21;
+    if (style.defined.borderTopWidthZero) definedBits |= 1 << 22;
+    if (style.defined.borderBottomWidthZero) definedBits |= 1 << 23;
+    if (style.defined.borderLeftWidthZero) definedBits |= 1 << 24;
+    if (style.defined.borderRightWidthZero) definedBits |= 1 << 25;
+    if (style.defined.borderTopWidthSet) definedBits |= 1 << 26;
+    if (style.defined.borderBottomWidthSet) definedBits |= 1 << 27;
+    if (style.defined.borderLeftWidthSet) definedBits |= 1 << 28;
+    if (style.defined.borderRightWidthSet) definedBits |= 1 << 29;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
   }
 
@@ -808,7 +957,10 @@ bool CssParser::loadFromCache() {
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
   constexpr size_t CSS_FIXED_STYLE_BYTES =
-      5 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) + sizeof(uint32_t);
+      sizeof(CssTextAlign) + sizeof(CssFontStyle) + sizeof(CssFontWeight) + sizeof(CssTextDecoration) +
+      sizeof(CssTextDirection) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(CssDisplay) +
+      sizeof(CssVerticalAlign) + 4 * sizeof(CssBorderStyle) +  // border{Top,Bottom,Left,Right}Style
+      sizeof(uint32_t);                                        // definedBits
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
@@ -912,6 +1064,27 @@ bool CssParser::loadFromCache() {
       return false;
     }
     style.verticalAlign = static_cast<CssVerticalAlign>(verticalAlignVal);
+    uint8_t borderStyleVal;
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderTopStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderBottomStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderLeftStyle = static_cast<CssBorderStyle>(borderStyleVal);
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderRightStyle = static_cast<CssBorderStyle>(borderStyleVal);
 
     // Read defined flags
     uint32_t definedBits = 0;
@@ -937,6 +1110,18 @@ bool CssParser::loadFromCache() {
     style.defined.display = (definedBits & 1 << 15) != 0;
     style.defined.direction = (definedBits & 1 << 16) != 0;
     style.defined.verticalAlign = (definedBits & 1 << 17) != 0;
+    style.defined.borderTopStyle = (definedBits & 1 << 18) != 0;
+    style.defined.borderBottomStyle = (definedBits & 1 << 19) != 0;
+    style.defined.borderLeftStyle = (definedBits & 1 << 20) != 0;
+    style.defined.borderRightStyle = (definedBits & 1 << 21) != 0;
+    style.defined.borderTopWidthZero = (definedBits & 1 << 22) != 0;
+    style.defined.borderBottomWidthZero = (definedBits & 1 << 23) != 0;
+    style.defined.borderLeftWidthZero = (definedBits & 1 << 24) != 0;
+    style.defined.borderRightWidthZero = (definedBits & 1 << 25) != 0;
+    style.defined.borderTopWidthSet = (definedBits & 1 << 26) != 0;
+    style.defined.borderBottomWidthSet = (definedBits & 1 << 27) != 0;
+    style.defined.borderLeftWidthSet = (definedBits & 1 << 28) != 0;
+    style.defined.borderRightWidthSet = (definedBits & 1 << 29) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -33,7 +33,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 6;
+  static constexpr uint8_t CSS_CACHE_VERSION = 7;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;
@@ -152,6 +152,7 @@ class CssParser {
   static CssFontStyle interpretFontStyle(std::string_view val);
   static CssFontWeight interpretFontWeight(std::string_view val);
   static CssTextDecoration interpretDecoration(std::string_view val);
+  static CssBorderStyle interpretBorderStyle(std::string_view val);
   static CssLength interpretLength(std::string_view val);
   /** Returns true only when a numeric length was parsed (e.g. 2em, 50%). False for auto/inherit/initial. */
   static bool tryInterpretLength(std::string_view val, CssLength& out);

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -61,26 +61,45 @@ enum class CssDisplay : uint8_t { Block = 0, None = 1 };
 // Vertical alignment options for inline elements (e.g. superscript/subscript)
 enum class CssVerticalAlign : uint8_t { Baseline = 0, Super = 1, Sub = 2 };
 
+// Border style options - controls table border rendering
+enum class CssBorderStyle : uint8_t { Solid = 0, None = 1 };
+
 // Bitmask for tracking which properties have been explicitly set
 struct CssPropertyFlags {
-  uint16_t textAlign : 1;
-  uint16_t fontStyle : 1;
-  uint16_t fontWeight : 1;
-  uint16_t textDecoration : 1;
-  uint16_t textIndent : 1;
-  uint16_t marginTop : 1;
-  uint16_t marginBottom : 1;
-  uint16_t marginLeft : 1;
-  uint16_t marginRight : 1;
-  uint16_t paddingTop : 1;
-  uint16_t paddingBottom : 1;
-  uint16_t paddingLeft : 1;
-  uint16_t paddingRight : 1;
-  uint16_t imageHeight : 1;
-  uint16_t imageWidth : 1;
-  uint16_t display : 1;
-  uint16_t direction : 1;
-  uint16_t verticalAlign : 1;
+  uint32_t textAlign : 1;
+  uint32_t fontStyle : 1;
+  uint32_t fontWeight : 1;
+  uint32_t textDecoration : 1;
+  uint32_t textIndent : 1;
+  uint32_t marginTop : 1;
+  uint32_t marginBottom : 1;
+  uint32_t marginLeft : 1;
+  uint32_t marginRight : 1;
+  uint32_t paddingTop : 1;
+  uint32_t paddingBottom : 1;
+  uint32_t paddingLeft : 1;
+  uint32_t paddingRight : 1;
+  uint32_t imageHeight : 1;
+  uint32_t imageWidth : 1;
+  uint32_t display : 1;
+  uint32_t direction : 1;
+  uint32_t verticalAlign : 1;
+  uint32_t borderTopStyle : 1;
+  uint32_t borderBottomStyle : 1;
+  uint32_t borderLeftStyle : 1;
+  uint32_t borderRightStyle : 1;
+  // Set when the corresponding border-*-width was explicitly parsed as 0.
+  // A side is invisible when style==Solid but this bit is set.
+  uint32_t borderTopWidthZero : 1;
+  uint32_t borderBottomWidthZero : 1;
+  uint32_t borderLeftWidthZero : 1;
+  uint32_t borderRightWidthZero : 1;
+  // Set when the corresponding border-*-width was explicitly parsed as non-zero.
+  // Used during cascade to clear a lower-priority WidthZero flag.
+  uint32_t borderTopWidthSet : 1;
+  uint32_t borderBottomWidthSet : 1;
+  uint32_t borderLeftWidthSet : 1;
+  uint32_t borderRightWidthSet : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -100,12 +119,27 @@ struct CssPropertyFlags {
         imageWidth(0),
         display(0),
         direction(0),
-        verticalAlign(0) {}
+        verticalAlign(0),
+        borderTopStyle(0),
+        borderBottomStyle(0),
+        borderLeftStyle(0),
+        borderRightStyle(0),
+        borderTopWidthZero(0),
+        borderBottomWidthZero(0),
+        borderLeftWidthZero(0),
+        borderRightWidthZero(0),
+        borderTopWidthSet(0),
+        borderBottomWidthSet(0),
+        borderLeftWidthSet(0),
+        borderRightWidthSet(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display || direction || verticalAlign;
+           imageWidth || display || direction || verticalAlign || borderTopStyle || borderBottomStyle ||
+           borderLeftStyle || borderRightStyle || borderTopWidthZero || borderBottomWidthZero || borderLeftWidthZero ||
+           borderRightWidthZero || borderTopWidthSet || borderBottomWidthSet || borderLeftWidthSet ||
+           borderRightWidthSet;
   }
 
   void clearAll() {
@@ -113,6 +147,9 @@ struct CssPropertyFlags {
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
     imageHeight = imageWidth = display = direction = verticalAlign = 0;
+    borderTopStyle = borderBottomStyle = borderLeftStyle = borderRightStyle = 0;
+    borderTopWidthZero = borderBottomWidthZero = borderLeftWidthZero = borderRightWidthZero = 0;
+    borderTopWidthSet = borderBottomWidthSet = borderLeftWidthSet = borderRightWidthSet = 0;
   }
 };
 
@@ -143,6 +180,10 @@ struct CssStyle {
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;                       // display property (Block or None)
   CssVerticalAlign verticalAlign = CssVerticalAlign::Baseline;  // vertical-align (super/sub positioning)
+  CssBorderStyle borderTopStyle = CssBorderStyle::None;
+  CssBorderStyle borderBottomStyle = CssBorderStyle::None;
+  CssBorderStyle borderLeftStyle = CssBorderStyle::None;
+  CssBorderStyle borderRightStyle = CssBorderStyle::None;
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -221,6 +262,52 @@ struct CssStyle {
       verticalAlign = base.verticalAlign;
       defined.verticalAlign = 1;
     }
+    if (base.hasBorderTopStyle()) {
+      borderTopStyle = base.borderTopStyle;
+      defined.borderTopStyle = 1;
+    }
+    if (base.hasBorderBottomStyle()) {
+      borderBottomStyle = base.borderBottomStyle;
+      defined.borderBottomStyle = 1;
+    }
+    if (base.hasBorderLeftStyle()) {
+      borderLeftStyle = base.borderLeftStyle;
+      defined.borderLeftStyle = 1;
+    }
+    if (base.hasBorderRightStyle()) {
+      borderRightStyle = base.borderRightStyle;
+      defined.borderRightStyle = 1;
+    }
+    // Width flags: propagate from base (inline/overriding style) when explicitly set.
+    // WidthSet (non-zero) and WidthZero are mutually exclusive; the incoming style wins.
+    if (base.defined.borderTopWidthSet) {
+      defined.borderTopWidthSet = 1;
+      defined.borderTopWidthZero = 0;
+    } else if (base.defined.borderTopWidthZero) {
+      defined.borderTopWidthZero = 1;
+      defined.borderTopWidthSet = 0;
+    }
+    if (base.defined.borderBottomWidthSet) {
+      defined.borderBottomWidthSet = 1;
+      defined.borderBottomWidthZero = 0;
+    } else if (base.defined.borderBottomWidthZero) {
+      defined.borderBottomWidthZero = 1;
+      defined.borderBottomWidthSet = 0;
+    }
+    if (base.defined.borderLeftWidthSet) {
+      defined.borderLeftWidthSet = 1;
+      defined.borderLeftWidthZero = 0;
+    } else if (base.defined.borderLeftWidthZero) {
+      defined.borderLeftWidthZero = 1;
+      defined.borderLeftWidthSet = 0;
+    }
+    if (base.defined.borderRightWidthSet) {
+      defined.borderRightWidthSet = 1;
+      defined.borderRightWidthZero = 0;
+    } else if (base.defined.borderRightWidthZero) {
+      defined.borderRightWidthZero = 1;
+      defined.borderRightWidthSet = 0;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -241,6 +328,30 @@ struct CssStyle {
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
   [[nodiscard]] bool hasDirection() const { return defined.direction; }
   [[nodiscard]] bool hasVerticalAlign() const { return defined.verticalAlign; }
+  [[nodiscard]] bool hasBorderTopStyle() const { return defined.borderTopStyle; }
+  [[nodiscard]] bool hasBorderBottomStyle() const { return defined.borderBottomStyle; }
+  [[nodiscard]] bool hasBorderLeftStyle() const { return defined.borderLeftStyle; }
+  [[nodiscard]] bool hasBorderRightStyle() const { return defined.borderRightStyle; }
+  [[nodiscard]] bool hasBorderTopWidthSet() const { return defined.borderTopWidthSet; }
+  [[nodiscard]] bool hasBorderBottomWidthSet() const { return defined.borderBottomWidthSet; }
+  [[nodiscard]] bool hasBorderLeftWidthSet() const { return defined.borderLeftWidthSet; }
+  [[nodiscard]] bool hasBorderRightWidthSet() const { return defined.borderRightWidthSet; }
+  // Returns true if the border side is both styled solid AND has a non-zero width.
+  [[nodiscard]] bool isBorderTopVisible() const {
+    return borderTopStyle != CssBorderStyle::None && !defined.borderTopWidthZero;
+  }
+  [[nodiscard]] bool isBorderBottomVisible() const {
+    return borderBottomStyle != CssBorderStyle::None && !defined.borderBottomWidthZero;
+  }
+  [[nodiscard]] bool isBorderLeftVisible() const {
+    return borderLeftStyle != CssBorderStyle::None && !defined.borderLeftWidthZero;
+  }
+  [[nodiscard]] bool isBorderRightVisible() const {
+    return borderRightStyle != CssBorderStyle::None && !defined.borderRightWidthZero;
+  }
+  [[nodiscard]] bool hasBorderStyle() const {
+    return defined.borderTopStyle || defined.borderBottomStyle || defined.borderLeftStyle || defined.borderRightStyle;
+  }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -254,6 +365,7 @@ struct CssStyle {
     imageHeight = imageWidth = CssLength{};
     display = CssDisplay::Block;
     verticalAlign = CssVerticalAlign::Baseline;
+    borderTopStyle = borderBottomStyle = borderLeftStyle = borderRightStyle = CssBorderStyle::None;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -4,6 +4,7 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Utf8.h>
 #include <XmlParserUtils.h>
 #include <expat.h>
@@ -14,6 +15,7 @@
 
 #include "Epub.h"
 #include "Epub/Page.h"
+#include "Epub/blocks/TableBlock.h"
 #include "Epub/converters/ImageDecoderFactory.h"
 #include "Epub/converters/ImageToFramebufferDecoder.h"
 #include "Epub/htmlEntities.h"
@@ -29,6 +31,27 @@ constexpr const char* ITALIC_TAGS[] = {"i", "em"};
 constexpr const char* UNDERLINE_TAGS[] = {"u", "ins"};
 constexpr const char* IMAGE_TAGS[] = {"img"};
 constexpr const char* SKIP_TAGS[] = {"head"};
+
+static int16_t parseHtmlWidthAttr(const char* s, int16_t viewportWidth, float emSize) {
+  if (!s || !*s) return 0;
+  char* end;
+  const float val = strtof(s, &end);
+  if (end == s) return 0;  // no numeric part
+  while (*end == ' ') ++end;
+  if (*end == '%') {
+    return static_cast<int16_t>(val * viewportWidth / 100.0f);
+  }
+  if (strncmp(end, "em", 2) == 0) {
+    return static_cast<int16_t>(val * emSize);
+  }
+  if (strncmp(end, "rem", 3) == 0) {
+    return static_cast<int16_t>(val * emSize);
+  }
+  if (strncmp(end, "pt", 2) == 0) {
+    return static_cast<int16_t>(val * 1.33f);
+  }
+  return static_cast<int16_t>(val);  // treat bare number or px as pixels
+}
 
 bool isWhitespace(const char c) { return c == ' ' || c == '\r' || c == '\n' || c == '\t'; }
 
@@ -178,6 +201,11 @@ void ChapterHtmlSlimParser::flushPartWordBuffer() {
 // start a new text block if needed
 void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
   nextWordContinues = false;  // New block = new paragraph, no continuation
+  if (inTableCellMode) {
+    // Inside a table cell: merge all content into the single cell ParsedText without resetting.
+    flushPendingAnchor();
+    return;
+  }
   if (currentTextBlock) {
     // already have a text block running and it is empty - just reuse it
     if (currentTextBlock->isEmpty()) {
@@ -340,9 +368,8 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     return;
   }
 
-  // Special handling for tables/cells: flatten into per-cell paragraphs with a prefixed header.
   if (strcmp(name, "table") == 0) {
-    // skip nested tables
+    // Nested tables are not supported — skip their content
     if (self->tableDepth > 0) {
       self->tableDepth += 1;
       return;
@@ -351,53 +378,159 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
     }
+    if (self->currentTextBlock && !self->currentTextBlock->isEmpty()) {
+      self->makePages();
+    }
     self->tableDepth += 1;
-    self->tableRowIndex = 0;
-    self->tableColIndex = 0;
+    self->tableAccumRows.clear();
+    self->tableAccumRows.reserve(8);  // conservative estimate; avoids reallocation for typical tables
+    self->tableTotalCols = 0;
+    self->tableRowspanTracker.clear();
+    self->tableTruncated = false;
+    self->tableHasFlushedRows = false;
+    // Border declared on the <table> element itself.
+    // Handles e.g. <table style="border: 1px solid"> or a CSS rule like
+    // "table { border-style: solid }" that targets the table directly.
+    self->tableDrawBorderTop = cssStyle.isBorderTopVisible();
+    self->tableDrawBorderBottom = cssStyle.isBorderBottomVisible();
+    self->tableDrawBorderLeft = cssStyle.isBorderLeftVisible();
+    self->tableDrawBorderRight = cssStyle.isBorderRightVisible();
     self->depth += 1;
     return;
   }
 
   if (self->tableDepth == 1 && strcmp(name, "tr") == 0) {
-    self->tableRowIndex += 1;
-    self->tableColIndex = 0;
+    // OOM heap guard: stop accumulating rows if free heap is critically low.
+    // The rows accumulated so far will still be emitted at </table>.
+    if (!self->tableTruncated && ESP.getFreeHeap() < 60000) {
+      LOG_ERR("EHP", "Table truncated: low heap (%u bytes free)", ESP.getFreeHeap());
+      self->tableTruncated = true;
+    }
+    if (self->tableTruncated) {
+      self->depth += 1;
+      return;
+    }
+    self->tableAccumRows.emplace_back();
+    auto& row = self->tableAccumRows.back();
+    row.drawBorderTop |= cssStyle.isBorderTopVisible();
+    row.drawBorderBottom |= cssStyle.isBorderBottomVisible();
+    self->tableDrawInnerColDividers |= (cssStyle.isBorderLeftVisible() || cssStyle.isBorderRightVisible());
     self->depth += 1;
     return;
   }
 
   if (self->tableDepth == 1 && (strcmp(name, "td") == 0 || strcmp(name, "th") == 0)) {
+    if (self->tableTruncated) {
+      self->depth += 1;
+      return;
+    }
     if (self->partWordBufferIndex > 0) {
       self->flushPartWordBuffer();
     }
-    self->tableColIndex += 1;
 
-    auto tableCellBlockStyle = BlockStyle();
-    tableCellBlockStyle.textAlignDefined = true;
-    const auto align = (self->paragraphAlignment == static_cast<uint8_t>(CssTextAlign::None))
-                           ? CssTextAlign::Justify
-                           : static_cast<CssTextAlign>(self->paragraphAlignment);
-    tableCellBlockStyle.alignment = align;
-    self->startNewTextBlock(tableCellBlockStyle);
-
-    const std::string headerText =
-        "Tab Row " + std::to_string(self->tableRowIndex) + ", Cell " + std::to_string(self->tableColIndex) + ":";
-    StyleStackEntry headerStyle;
-    headerStyle.depth = self->depth;
-    headerStyle.hasBold = true;
-    headerStyle.bold = false;
-    headerStyle.hasItalic = true;
-    headerStyle.italic = true;
-    headerStyle.hasUnderline = true;
-    headerStyle.underline = false;
-    self->inlineStyleStack.push_back(headerStyle);
-    self->updateEffectiveInlineStyle();
-    self->characterData(userData, headerText.c_str(), static_cast<int>(headerText.length()));
-    if (self->partWordBufferIndex > 0) {
-      self->flushPartWordBuffer();
+    // Guard against malformed HTML where <td> appears without a prior <tr>
+    if (self->tableAccumRows.empty()) {
+      self->tableAccumRows.emplace_back();
     }
-    self->nextWordContinues = false;
-    self->inlineStyleStack.pop_back();
-    self->updateEffectiveInlineStyle();
+
+    const float emSize = static_cast<float>(self->renderer.getFontAscenderSize(self->fontId));
+    const float vw = static_cast<float>(self->viewportWidth);
+
+    const int16_t defPadX = TableBlock::CELL_PADDING_X;
+    const int16_t defPadY = TableBlock::CELL_PADDING_Y;
+    const int16_t padLeft = cssStyle.hasPaddingLeft() ? cssStyle.paddingLeft.toPixelsInt16(emSize, vw) : defPadX;
+    const int16_t padRight = cssStyle.hasPaddingRight() ? cssStyle.paddingRight.toPixelsInt16(emSize, vw) : defPadX;
+    const int16_t padTop = cssStyle.hasPaddingTop() ? cssStyle.paddingTop.toPixelsInt16(emSize, vw) : defPadY;
+    const int16_t padBottom = cssStyle.hasPaddingBottom() ? cssStyle.paddingBottom.toPixelsInt16(emSize, vw) : defPadY;
+
+    int16_t reqWidth = 0;
+    uint8_t cellColspan = 1;
+    uint8_t cellRowspan = 1;
+    if (atts != nullptr) {
+      for (int i = 0; atts[i]; i += 2) {
+        if (strcmp(atts[i], "width") == 0) {
+          reqWidth = parseHtmlWidthAttr(atts[i + 1], static_cast<int16_t>(self->viewportWidth), emSize);
+        } else if (strcmp(atts[i], "colspan") == 0) {
+          const int cs = atoi(atts[i + 1]);
+          if (cs > 1 && cs <= TableBlock::MAX_COLS) cellColspan = static_cast<uint8_t>(cs);
+        } else if (strcmp(atts[i], "rowspan") == 0) {
+          const int rs = atoi(atts[i + 1]);
+          if (rs == 0)
+            cellRowspan = TableBlock::MAX_COLS;  // HTML rowspan="0" = span to end of table group
+          else if (rs > 1 && rs <= TableBlock::MAX_COLS)
+            // Reject rowspan values outside the range of [1, MAX_COLS] to
+            // prevent the phantom-cell loop in layout from running out of memory or looping excessively.
+            cellRowspan = static_cast<uint8_t>(rs);
+        }
+      }
+    }
+    if (reqWidth == 0 && cssStyle.hasImageWidth()) {
+      reqWidth = cssStyle.imageWidth.toPixelsInt16(emSize, vw);
+    }
+
+    CssTextAlign cellAlign;
+    if (cssStyle.hasTextAlign()) {
+      cellAlign = cssStyle.textAlign;
+    } else if (self->paragraphAlignment != static_cast<uint8_t>(CssTextAlign::None)) {
+      cellAlign = static_cast<CssTextAlign>(self->paragraphAlignment);
+    } else {
+      cellAlign = CssTextAlign::Justify;
+    }
+
+    BlockStyle cellBlockStyle;
+    cellBlockStyle.textAlignDefined = true;
+    cellBlockStyle.alignment = cellAlign;
+
+    self->tableAccumRows.back().cells.emplace_back();
+    auto& newCell = self->tableAccumRows.back().cells.back();
+    newCell.paddingLeft = padLeft;
+    newCell.paddingRight = padRight;
+    newCell.paddingTop = padTop;
+    newCell.paddingBottom = padBottom;
+    newCell.requestedWidth = reqWidth;
+    newCell.colspan = cellColspan;
+    newCell.rowspan = cellRowspan;
+
+    auto cellText = makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled,
+                                                  self->focusReadingEnabled, cellBlockStyle);
+    if (!cellText) {
+      LOG_ERR("EHP", "OOM: ParsedText");
+      self->tableAccumRows.back().cells.pop_back();  // undo emplace_back to keep state consistent
+      return;
+    }
+    self->currentTextBlock = std::move(cellText);
+    self->inTableCellMode = true;
+
+    if (cssStyle.hasFontWeight()) {
+      StyleStackEntry entry;
+      entry.depth = self->depth;
+      entry.hasBold = true;
+      entry.bold = (cssStyle.fontWeight == CssFontWeight::Bold);
+      self->inlineStyleStack.push_back(entry);
+      self->updateEffectiveInlineStyle();
+    } else if (strcmp(name, "th") == 0) {
+      self->boldUntilDepth = std::min(self->boldUntilDepth, self->depth);
+      self->updateEffectiveInlineStyle();
+    }
+    if (cssStyle.hasFontStyle()) {
+      StyleStackEntry entry;
+      entry.depth = self->depth;
+      entry.hasItalic = true;
+      entry.italic = (cssStyle.fontStyle == CssFontStyle::Italic);
+      self->inlineStyleStack.push_back(entry);
+      self->updateEffectiveInlineStyle();
+    }
+
+    // Border declared on individual <td>/<th> cells rather than on <table>.
+    // Some EPUBs use border-collapse:collapse on the table
+    // with no border-style on the table element; the actual borders live on each cell.
+    // Top/bottom accumulate per-row (finalized in </tr>); left/right remain table-wide.
+    self->tableAccumRows.back().drawBorderTop |= cssStyle.isBorderTopVisible();
+    self->tableAccumRows.back().drawBorderBottom |= cssStyle.isBorderBottomVisible();
+    self->tableDrawBorderLeft |= cssStyle.isBorderLeftVisible();
+    self->tableDrawBorderRight |= cssStyle.isBorderRightVisible();
+    // Inner column dividers are cell-driven (not table-element-driven), so track separately.
+    self->tableDrawInnerColDividers |= (cssStyle.isBorderLeftVisible() || cssStyle.isBorderRightVisible());
 
     self->depth += 1;
     return;
@@ -1075,11 +1208,9 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
     self->partWordBuffer[self->partWordBufferIndex++] = s[i];
   }
 
-  // If we have > 750 words buffered up, perform the layout and consume out all but the last line
-  // There should be enough here to build out 1-2 full pages and doing this will free up a lot of
-  // memory.
-  // Spotted when reading Intermezzo, there are some really long text blocks in there.
-  if (self->currentTextBlock->size() > 750) {
+  // If we have > 750 words buffered up, perform the layout and consume out all but the last line.
+  // Skip this optimisation inside table cells — cells are laid out in bulk at </tr>.
+  if (!self->inTableCellMode && self->currentTextBlock->size() > 750) {
     LOG_DBG("EHP", "Text block too long, splitting into multiple pages");
     const int horizontalInset = self->currentTextBlock->getBlockStyle().totalHorizontalInset();
     const uint16_t effectiveWidth = (horizontalInset < self->viewportWidth)
@@ -1105,6 +1236,201 @@ void XMLCALL ChapterHtmlSlimParser::defaultHandlerExpand(void* userData, const X
     return;
   }
   // Not an entity we recognize - skip it
+}
+
+void ChapterHtmlSlimParser::recomputeRowMetrics(TableRowAccum& row) {
+  uint8_t maxLines = 0;
+  int16_t maxPadTop = TableBlock::CELL_PADDING_Y;
+  int16_t maxPadBot = TableBlock::CELL_PADDING_Y;
+  for (const auto& ca : row.cells) {
+    const auto lc = static_cast<uint8_t>(std::min(ca.lines.size(), size_t(255)));
+    if (lc > maxLines) maxLines = lc;
+    if (ca.paddingTop > maxPadTop) maxPadTop = ca.paddingTop;
+    if (ca.paddingBottom > maxPadBot) maxPadBot = ca.paddingBottom;
+  }
+  row.maxLines = maxLines;
+  row.maxPaddingTop = maxPadTop;
+  row.maxPaddingBottom = maxPadBot;
+}
+
+void ChapterHtmlSlimParser::emitTablePageSlices(ChapterHtmlSlimParser* self, bool applyTopBorder,
+                                                bool applyBottomBorder, bool isLastFlush) {
+  if (self->tableAccumRows.empty() || self->tableTotalCols == 0) return;
+
+  const auto numCols = static_cast<uint8_t>(self->tableTotalCols);
+  const bool hasPerColWidths = (static_cast<int>(self->tableColWidths.size()) == numCols);
+  const auto colWidthFallback = static_cast<int16_t>(numCols > 0 ? self->viewportWidth / numCols : self->viewportWidth);
+  const auto lh = static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
+
+  size_t rowStart = 0;
+  size_t totalRows = self->tableAccumRows.size();  // non-const: may grow if a row is split
+
+  while (rowStart < totalRows) {
+    // For incremental (non-final) flushes: if all remaining rows fit on the current page,
+    // stop here — leave them in the accumulator so future rows can join them.
+    if (!isLastFlush) {
+      int32_t remainH = 1;  // top border
+      for (size_t r = rowStart; r < totalRows; r++) {
+        const auto& ra = self->tableAccumRows[r];
+        remainH += 1 + ra.maxLines * lh + ra.maxPaddingTop + ra.maxPaddingBottom;
+      }
+      if (remainH <= self->viewportHeight - self->currentPageNextY) break;
+    }
+
+    // Apply outer-table border to the correct rows — deferred until after the early-exit
+    // check so accumulator state is not mutated when nothing is emitted.
+    if (rowStart == 0 && applyTopBorder) {
+      self->tableAccumRows.front().drawBorderTop |= self->tableDrawBorderTop;
+    }
+    if (rowStart == 0 && applyBottomBorder) {
+      self->tableAccumRows.back().drawBorderBottom |= self->tableDrawBorderBottom;
+    }
+
+    if (!self->currentPage) {
+      self->currentPage = makeUniqueNoThrow<Page>();
+      if (!self->currentPage) {
+        LOG_ERR("EHP", "OOM: Page");
+        return;
+      }
+      self->currentPageNextY = 0;
+    }
+
+    if (self->currentPageNextY >= self->viewportHeight) {
+      self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
+      self->completedPageCount++;
+      self->currentPage = makeUniqueNoThrow<Page>();
+      if (!self->currentPage) {
+        LOG_ERR("EHP", "OOM: Page");
+        return;
+      }
+      self->currentPageNextY = 0;
+    }
+
+    const int16_t available = static_cast<int16_t>(self->viewportHeight - self->currentPageNextY);
+
+    // Greedily fit as many rows as possible into `available` pixels.
+    // The first row is always included even if it doesn't fit (avoids infinite loop).
+    // Height accounting matches TableBlock::totalHeight():
+    //   (numRows + 1) border px  +  sum(maxPaddingTop + maxLines * lh + maxPaddingBottom)
+    int16_t accumulated = 1;  // top border of the slice
+    size_t rowEnd = rowStart;
+    while (rowEnd < totalRows) {
+      const auto& ra = self->tableAccumRows[rowEnd];
+      const int16_t rowCost = static_cast<int16_t>(1 + ra.maxLines * lh + ra.maxPaddingTop + ra.maxPaddingBottom);
+      // Only break if at least one row has already been included.
+      if (rowEnd > rowStart && accumulated + rowCost > available) {
+        break;
+      }
+      accumulated += rowCost;
+      rowEnd++;
+    }
+
+    // If the sole row overflows on a non-empty page, flush first so that the
+    // row-splitting code below runs on a fresh page where available == viewportHeight.
+    if (rowEnd == rowStart + 1 && accumulated > available && self->currentPageNextY > 0) {
+      self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
+      self->completedPageCount++;
+      self->currentPage = makeUniqueNoThrow<Page>();
+      if (!self->currentPage) {
+        LOG_ERR("EHP", "OOM: Page");
+        return;
+      }
+      self->currentPageNextY = 0;
+      continue;  // re-evaluate available on the new page
+    }
+
+    // If the sole row to emit is taller than the full page, split it line by line
+    // so the overflow continues on the next page rather than rendering off-screen.
+    if (rowEnd == rowStart + 1 && accumulated > available) {
+      auto& accumRow = self->tableAccumRows[rowStart];
+      const int16_t contentAvail =
+          static_cast<int16_t>(available - 2 - accumRow.maxPaddingTop - accumRow.maxPaddingBottom);
+      const int16_t fittableLines = static_cast<int16_t>(std::max(int16_t(1), static_cast<int16_t>(contentAvail / lh)));
+
+      if (fittableLines < static_cast<int16_t>(accumRow.maxLines)) {
+        TableRowAccum remainder;
+        remainder.maxPaddingTop = accumRow.maxPaddingTop;
+        remainder.maxPaddingBottom = accumRow.maxPaddingBottom;
+        uint8_t remMaxLines = 0;
+
+        for (auto& ca : accumRow.cells) {
+          TableCellAccum remCell;
+          ca.copySpanAndPaddingTo(remCell);
+
+          const auto splitAt = static_cast<size_t>(fittableLines);
+          if (ca.lines.size() > splitAt) {
+            remCell.lines.assign(std::make_move_iterator(ca.lines.begin() + static_cast<ptrdiff_t>(splitAt)),
+                                 std::make_move_iterator(ca.lines.end()));
+            ca.lines.resize(splitAt);
+          }
+          const auto remCount = static_cast<uint8_t>(std::min(remCell.lines.size(), size_t(255)));
+          if (remCount > remMaxLines) remMaxLines = remCount;
+          remainder.cells.push_back(std::move(remCell));
+        }
+        remainder.maxLines = remMaxLines;
+        accumRow.maxLines = static_cast<uint8_t>(fittableLines);
+
+        // Insert remainder immediately after the current row.
+        self->tableAccumRows.insert(self->tableAccumRows.begin() + static_cast<ptrdiff_t>(rowStart + 1),
+                                    std::move(remainder));
+        totalRows++;  // one more row to process
+        // rowEnd stays at rowStart+1; fall through to emit the trimmed row.
+      }
+    }
+
+    auto tableBlock = makeUniqueNoThrow<TableBlock>();
+    if (!tableBlock) {
+      LOG_ERR("EHP", "OOM: TableBlock");
+      return;
+    }
+    tableBlock->numCols = numCols;
+    tableBlock->colWidth = colWidthFallback;
+    tableBlock->lineHeight = lh;
+    tableBlock->drawBorderLeft = self->tableDrawBorderLeft;
+    tableBlock->drawBorderRight = self->tableDrawBorderRight;
+    tableBlock->drawInnerColDividers = self->tableDrawInnerColDividers;
+    if (hasPerColWidths) tableBlock->colWidths = self->tableColWidths;
+    tableBlock->rows.reserve(rowEnd - rowStart);
+    for (size_t r = rowStart; r < rowEnd; r++) {
+      TableRow row;
+      row.maxLines = self->tableAccumRows[r].maxLines;
+      row.maxPaddingTop = self->tableAccumRows[r].maxPaddingTop;
+      row.maxPaddingBottom = self->tableAccumRows[r].maxPaddingBottom;
+      row.drawBorderTop = self->tableAccumRows[r].drawBorderTop;
+      row.drawBorderBottom = self->tableAccumRows[r].drawBorderBottom;
+      row.cells.reserve(self->tableAccumRows[r].cells.size());
+      for (auto& ca : self->tableAccumRows[r].cells) {
+        TableCell cell = ca.toTableCell();
+        cell.lines = std::move(ca.lines);
+        row.cells.push_back(std::move(cell));
+      }
+      tableBlock->rows.push_back(std::move(row));
+    }
+
+    const int16_t tableHeight = tableBlock->totalHeight();
+    auto* ptRaw = new (std::nothrow) PageTable(std::move(tableBlock), 0, self->currentPageNextY, tableHeight);
+    if (!ptRaw) {
+      LOG_ERR("EHP", "OOM: PageTable");
+      return;
+    }
+    self->currentPage->elements.push_back(std::shared_ptr<PageTable>(ptRaw));
+    self->currentPageNextY += tableHeight;
+
+    rowStart = rowEnd;
+
+    if (rowStart < totalRows) {
+      self->completePageFn(std::move(self->currentPage), self->xpathParagraphIndex, self->xpathListItemIndex);
+      self->completedPageCount++;
+      self->currentPage.reset();
+      self->currentPageNextY = 0;
+    }
+  }
+
+  if (rowStart > 0) {
+    self->tableAccumRows.erase(self->tableAccumRows.begin(),
+                               self->tableAccumRows.begin() + static_cast<ptrdiff_t>(rowStart));
+    self->tableHasFlushedRows = true;
+  }
 }
 
 void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* name) {
@@ -1173,18 +1499,286 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   }
 
   if (self->tableDepth == 1 && (strcmp(name, "td") == 0 || strcmp(name, "th") == 0)) {
+    // Move the accumulated cell ParsedText into the cell accumulator for later layout
+    if (!self->tableAccumRows.empty()) {
+      auto& cell = self->tableAccumRows.back().cells.back();
+      cell.text = std::move(self->currentTextBlock);
+    }
+    self->inTableCellMode = false;
+    // Reset currentTextBlock for any content between </td> and next <td>/<tr>
+    auto interCellText =
+        makeUniqueNoThrow<ParsedText>(self->extraParagraphSpacing, self->hyphenationEnabled, self->focusReadingEnabled);
+    if (!interCellText) {
+      LOG_ERR("EHP", "OOM: ParsedText");
+      return;
+    }
+    self->currentTextBlock = std::move(interCellText);
     self->nextWordContinues = false;
   }
 
-  if (self->tableDepth == 1 && (strcmp(name, "tr") == 0)) {
+  if (self->tableDepth == 1 && strcmp(name, "tr") == 0) {
+    // Layout all cells in this row now that we know the column count
+    if (!self->tableAccumRows.empty() && !self->tableTruncated) {
+      auto& row = self->tableAccumRows.back();
+
+      // Interleave phantom cells for columns occupied by rowspan cells from previous rows.
+      {
+        std::vector<TableCellAccum> interleaved;
+        interleaved.reserve(row.cells.size() + self->tableRowspanTracker.size());
+        uint8_t lc = 0;
+        for (auto& ca : row.cells) {
+          // Insert a phantom for each occupied column before this cell.
+          while (lc < static_cast<uint8_t>(self->tableRowspanTracker.size()) && self->tableRowspanTracker[lc] > 0) {
+            TableCellAccum phantom;
+            phantom.rowspan = 0;
+            interleaved.push_back(std::move(phantom));
+            self->tableRowspanTracker[lc]--;
+            lc++;
+          }
+          // If this cell has rowspan > 1, mark covered columns for future rows.
+          if (ca.rowspan > 1) {
+            for (uint8_t k = 0; k < ca.colspan; k++) {
+              const uint8_t c = static_cast<uint8_t>(lc + k);
+              if (c >= static_cast<uint8_t>(self->tableRowspanTracker.size()))
+                self->tableRowspanTracker.resize(c + 1, 0);
+              self->tableRowspanTracker[c] = ca.rowspan - 1;
+            }
+          }
+          lc = static_cast<uint8_t>(std::min(255, lc + ca.colspan));
+          interleaved.push_back(std::move(ca));
+        }
+        // Trailing phantom columns after all actual cells.
+        while (lc < static_cast<uint8_t>(self->tableRowspanTracker.size()) && self->tableRowspanTracker[lc] > 0) {
+          TableCellAccum phantom;
+          phantom.rowspan = 0;
+          interleaved.push_back(std::move(phantom));
+          self->tableRowspanTracker[lc]--;
+          lc++;
+        }
+        row.cells = std::move(interleaved);
+      }
+
+      int logicalColCount = 0;
+      for (const auto& ca : row.cells) logicalColCount += ca.colspan;
+      const auto numCols = static_cast<uint8_t>(std::min(logicalColCount, 255));
+      if (numCols > self->tableTotalCols) {
+        self->tableTotalCols = numCols;
+      }
+
+      // Determine per-column widths for this row.
+      // Only colspan=1 cells with an explicit requestedWidth contribute to column width establishment;
+      // spanning cells' widths are ambiguous and skipped.
+      if (self->tableColWidths.empty() && numCols > 0) {
+        bool anyExplicit = false;
+        for (const auto& ca : row.cells) {
+          if (ca.colspan == 1 && ca.requestedWidth > 0) {
+            anyExplicit = true;
+            break;
+          }
+        }
+        if (anyExplicit) {
+          // Build per-logical-column widths, distributing remainder to unspecified slots.
+          std::vector<int16_t> slotWidths(numCols, 0);
+          int16_t totalExplicit = 0;
+          int unspecifiedCount = 0;
+          uint8_t logCol = 0;
+          for (const auto& ca : row.cells) {
+            if (ca.colspan == 1 && ca.requestedWidth > 0) {
+              if (logCol < numCols) {
+                // CSS width is content-box; column width must include horizontal padding
+                // so that textWidth = cellColWidth - 1 - padL - padR ≈ requestedWidth - 1
+                const int16_t colW = static_cast<int16_t>(ca.requestedWidth + ca.paddingLeft + ca.paddingRight);
+                slotWidths[logCol] = colW;
+                totalExplicit += colW;
+              }
+            } else {
+              // Spanning or unspecified: leave slots as 0 (unspecified).
+              for (uint8_t k = 0; k < ca.colspan && (logCol + k) < numCols; k++) {
+                ++unspecifiedCount;
+              }
+            }
+            logCol = static_cast<uint8_t>(std::min(255, logCol + ca.colspan));
+          }
+          const int16_t remaining = static_cast<int16_t>(self->viewportWidth - totalExplicit);
+          const int16_t fallback = (unspecifiedCount > 0)
+                                       ? static_cast<int16_t>(std::max(1, remaining / unspecifiedCount))
+                                       : static_cast<int16_t>(self->viewportWidth / numCols);
+          self->tableColWidths.reserve(numCols);
+          for (auto w : slotWidths) {
+            self->tableColWidths.push_back(w > 0 ? w : fallback);
+          }
+          // Scale columns proportionally to fit viewport
+          // (must happen here so text layout uses the scaled widths)
+          int16_t totalColW = 0;
+          for (auto w : self->tableColWidths) totalColW += w;
+          if (totalColW > 0 && totalColW != self->viewportWidth) {
+            const float scale = static_cast<float>(self->viewportWidth) / totalColW;
+            for (auto& w : self->tableColWidths) {
+              w = static_cast<int16_t>(std::max(1.0f, w * scale));
+            }
+          }
+        }
+      }
+
+      {
+        uint8_t logCol = 0;
+        for (auto& ca : row.cells) {
+          // Phantom cells (rowspan==0) occupy one column with no content — skip layout.
+          if (ca.rowspan == 0) {
+            logCol++;
+            continue;
+          }
+          int16_t cellColWidth = 0;
+          for (uint8_t k = 0; k < ca.colspan; k++) {
+            const uint8_t c = logCol + k;
+            if (c < static_cast<uint8_t>(self->tableColWidths.size())) {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->tableColWidths[c]);
+            } else if (numCols > 0) {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->viewportWidth / numCols);
+            } else {
+              cellColWidth = static_cast<int16_t>(cellColWidth + self->viewportWidth);
+            }
+          }
+          // CSS width is content-box; subtract left border (1px) + padding; ensure at least 1px.
+          const int16_t textWidth =
+              static_cast<int16_t>(std::max(1, cellColWidth - 1 - ca.paddingLeft - ca.paddingRight));
+
+          if (ca.text && !ca.text->isEmpty()) {
+            ca.text->layoutAndExtractLines(self->renderer, self->fontId, textWidth,
+                                           [&ca](const std::shared_ptr<TextBlock>& line) { ca.lines.push_back(line); });
+          }
+          ca.text.reset();  // raw word buffer no longer needed after layout; free it now
+
+          logCol = static_cast<uint8_t>(std::min(255, logCol + ca.colspan));
+        }
+      }
+      recomputeRowMetrics(row);
+
+      // Incremental page flush — emit complete pages now rather than waiting for </table>.
+      // Only safe when no rowspans are pending (rowspan distribution at </table> won't need to
+      // reach back into already-flushed rows). Column widths must also be established so early
+      // TableBlocks use the same numCols as later ones.
+      const bool noActiveRowspans = self->tableRowspanTracker.empty() ||
+                                    std::all_of(self->tableRowspanTracker.begin(), self->tableRowspanTracker.end(),
+                                                [](uint8_t v) { return v == 0; });
+      const bool colWidthsEstablished =
+          !self->tableColWidths.empty() && static_cast<int>(self->tableColWidths.size()) == self->tableTotalCols;
+      if (noActiveRowspans && colWidthsEstablished) {
+        const auto lhCheck = static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
+        int32_t accumH = 1;  // top border
+        for (const auto& r : self->tableAccumRows) {
+          accumH += 1 + r.maxLines * lhCheck + r.maxPaddingTop + r.maxPaddingBottom;
+        }
+        const int32_t pageAvail = self->viewportHeight - self->currentPageNextY;
+        if (accumH > pageAvail) {
+          emitTablePageSlices(self, !self->tableHasFlushedRows, false, false);
+        }
+      }
+    }
     self->nextWordContinues = false;
   }
 
   if (self->tableDepth == 1 && strcmp(name, "table") == 0) {
     self->tableDepth -= 1;
-    self->tableRowIndex = 0;
-    self->tableColIndex = 0;
     self->nextWordContinues = false;
+
+    if (!self->tableAccumRows.empty() && self->tableTotalCols > 0) {
+      // Distribute spanning cell lines evenly across the rows they span.
+      // Without this, all content sits in the first row, making it extremely
+      // tall while spanned rows are tiny — causing uneven heights in adjacent
+      // columns and poor page splits.
+      for (size_t ri = 0; ri < self->tableAccumRows.size(); ri++) {
+        uint8_t logCol = 0;
+        for (auto& ca : self->tableAccumRows[ri].cells) {
+          if (ca.rowspan > 1) {
+            const size_t endRow = std::min(ri + static_cast<size_t>(ca.rowspan), self->tableAccumRows.size());
+            const size_t numSpanned = endRow - ri;
+            if (!ca.lines.empty() && numSpanned > 1) {
+              const uint8_t linesPerRow =
+                  std::max(uint8_t(1), static_cast<uint8_t>((ca.lines.size() + numSpanned - 1) / numSpanned));
+              const uint8_t targetLogCol = logCol;
+              std::vector<std::shared_ptr<TextBlock>> allLines = std::move(ca.lines);
+              std::vector<std::shared_ptr<TextBlock>> chunk;
+              chunk.reserve(linesPerRow);
+              size_t srcIdx = 0;
+              for (size_t i = 0; i < numSpanned && srcIdx < allLines.size(); i++) {
+                const size_t r = ri + i;
+                const uint8_t count = std::min(linesPerRow, static_cast<uint8_t>(allLines.size() - srcIdx));
+                chunk.clear();
+                for (uint8_t j = 0; j < count; j++) {
+                  chunk.push_back(std::move(allLines[srcIdx++]));
+                }
+                if (i == 0) {
+                  ca.lines = std::move(chunk);
+                } else {
+                  uint8_t plc = 0;
+                  for (auto& pca : self->tableAccumRows[r].cells) {
+                    if (plc == targetLogCol && pca.rowspan == 0) {
+                      pca.lines = std::move(chunk);
+                      pca.paddingLeft = ca.paddingLeft;
+                      pca.paddingRight = ca.paddingRight;
+                      pca.paddingTop = ca.paddingTop;
+                      pca.paddingBottom = ca.paddingBottom;
+                      break;
+                    }
+                    plc = static_cast<uint8_t>(plc + ((pca.rowspan == 0) ? 1 : pca.colspan));
+                  }
+                }
+              }
+            }
+          }
+          logCol = static_cast<uint8_t>(logCol + ((ca.rowspan == 0) ? 1 : ca.colspan));
+        }
+      }
+
+      for (auto& row : self->tableAccumRows) recomputeRowMetrics(row);
+
+      const auto numCols = static_cast<uint8_t>(self->tableTotalCols);
+      const bool hasPerColWidths = (static_cast<int>(self->tableColWidths.size()) == numCols);
+      const auto colWidthFallback =
+          static_cast<int16_t>(numCols > 0 ? self->viewportWidth / numCols : self->viewportWidth);
+      const auto lh = static_cast<int16_t>(self->renderer.getLineHeight(self->fontId) * self->lineCompression);
+
+      if (numCols > TableBlock::MAX_COLS) {
+        LOG_ERR("EHP", "Table too wide (%u cols), rendering placeholder", numCols);
+        if (!self->currentPage) {
+          self->currentPage = makeUniqueNoThrow<Page>();
+          if (!self->currentPage) {
+            LOG_ERR("EHP", "OOM: Page");
+            return;
+          }
+          self->currentPageNextY = 0;
+        }
+        std::vector<std::string> words = {"[Table too wide]"};
+        std::vector<int16_t> xpos = {0};
+        std::vector<EpdFontFamily::Style> styles = {EpdFontFamily::REGULAR};
+        BlockStyle placeholderStyle;
+        placeholderStyle.textAlignDefined = true;
+        placeholderStyle.alignment = CssTextAlign::Center;
+
+        auto placeholder =
+            std::make_shared<TextBlock>(std::move(words), std::move(xpos), std::move(styles), std::vector<uint8_t>{},
+                                        std::vector<uint16_t>{}, placeholderStyle);
+        self->currentPage->elements.push_back(std::make_shared<PageLine>(placeholder, 0, self->currentPageNextY));
+        self->currentPageNextY += lh;
+
+        self->tableAccumRows.clear();
+      }
+
+      emitTablePageSlices(self, !self->tableHasFlushedRows, true, true);
+    }
+
+    self->tableAccumRows.clear();
+    self->tableTotalCols = 0;
+    self->tableColWidths.clear();
+    self->tableRowspanTracker.clear();
+    self->tableTruncated = false;
+    self->tableHasFlushedRows = false;
+    self->tableDrawBorderTop = false;
+    self->tableDrawBorderBottom = false;
+    self->tableDrawBorderLeft = false;
+    self->tableDrawBorderRight = false;
+    self->tableDrawInnerColDividers = false;
   }
 
   // Leaving bold tag

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -11,6 +11,7 @@
 #include "Epub/FootnoteEntry.h"
 #include "Epub/ParsedText.h"
 #include "Epub/blocks/ImageBlock.h"
+#include "Epub/blocks/TableBlock.h"
 #include "Epub/blocks/TextBlock.h"
 #include "Epub/css/CssParser.h"
 #include "Epub/css/CssStyle.h"
@@ -77,8 +78,60 @@ class ChapterHtmlSlimParser {
   bool effectiveSup = false;
   bool effectiveSub = false;
   int tableDepth = 0;
-  int tableRowIndex = 0;
-  int tableColIndex = 0;
+
+  // Table accumulation: cells are collected per-row, laid out at </tr>.
+  struct TableCellAccum {
+    std::unique_ptr<ParsedText> text;               // raw words; laid out at </tr>
+    std::vector<std::shared_ptr<TextBlock>> lines;  // filled after layout
+    int16_t paddingLeft = TableBlock::CELL_PADDING_X;
+    int16_t paddingRight = TableBlock::CELL_PADDING_X;
+    int16_t paddingTop = TableBlock::CELL_PADDING_Y;
+    int16_t paddingBottom = TableBlock::CELL_PADDING_Y;
+    int16_t requestedWidth = 0;  // 0 = unspecified (equal distribution)
+    uint8_t colspan = 1;         // number of logical columns this cell spans
+    uint8_t rowspan =
+        1;  // 0 = phantom (occupied by rowspan above), 1 = normal, >1 = rowspan cell; HTML "0" mapped to 64
+
+    void copySpanAndPaddingTo(TableCellAccum& dst) const {
+      dst.colspan = colspan;
+      dst.rowspan = rowspan;
+      dst.paddingLeft = paddingLeft;
+      dst.paddingRight = paddingRight;
+      dst.paddingTop = paddingTop;
+      dst.paddingBottom = paddingBottom;
+    }
+    TableCell toTableCell() const {
+      TableCell c;
+      c.colspan = colspan;
+      c.rowspan = rowspan;
+      c.paddingLeft = paddingLeft;
+      c.paddingRight = paddingRight;
+      c.paddingTop = paddingTop;
+      c.paddingBottom = paddingBottom;
+      return c;
+    }
+  };
+  struct TableRowAccum {
+    std::vector<TableCellAccum> cells;
+    uint8_t maxLines = 0;
+    int16_t maxPaddingTop = TableBlock::CELL_PADDING_Y;
+    int16_t maxPaddingBottom = TableBlock::CELL_PADDING_Y;
+    bool drawBorderTop = false;     // OR of all cells' isBorderTopVisible() in this row
+    bool drawBorderBottom = false;  // OR of all cells' isBorderBottomVisible() in this row
+  };
+  bool inTableCellMode = false;
+  std::vector<TableRowAccum> tableAccumRows;
+  int tableTotalCols = 0;                    // max columns seen across all rows
+  std::vector<int16_t> tableColWidths;       // per-column widths once established (first row with explicit widths)
+  std::vector<uint8_t> tableRowspanTracker;  // remaining rowspan rows per logical column
+  bool tableDrawBorderTop = false;           // baseline from <table> element CSS only; not modified by cells
+  bool tableDrawBorderBottom = false;        // baseline from <table> element CSS only; not modified by cells
+  bool tableDrawBorderLeft = false;          // accumulated from <table>/<td>/<th> CSS: draw left edge
+  bool tableDrawBorderRight = false;         // accumulated from <table>/<td>/<th> CSS: draw right edge
+  bool tableDrawInnerColDividers =
+      false;                         // set when any cell has visible left/right border; gates interior column lines
+  bool tableTruncated = false;       // set by OOM heap guard; suppresses further row/cell parsing
+  bool tableHasFlushedRows = false;  // set after the first incremental page-flush
 
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
@@ -103,6 +156,9 @@ class ChapterHtmlSlimParser {
   void makePages();
   static void applyDirectionToEntry(StyleStackEntry& entry, const CssStyle& css);
   void emitHorizontalRule(const BlockStyle& blockStyle);
+  static void emitTablePageSlices(ChapterHtmlSlimParser* self, bool applyTopBorder, bool applyBottomBorder,
+                                  bool isLastFlush);
+  static void recomputeRowMetrics(TableRowAccum& row);
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);
   static void XMLCALL characterData(void* userData, const XML_Char* s, int len);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Implements basic EPUB table rendering support in the reader, including row/colspan handling and border rendering for `solid`/`none` border styles.

* **What changes are included?**  
  * Added `TableBlock` and `PageTable` support for table rendering and page serialization.
  * Extended `ChapterHtmlSlimParser` to parse `<table>`, `<tr>`, `<td>`, and `<th>` with cell padding, width, colspan, rowspan, and border style accumulation.
  * Added CSS parsing for `border-style`, `border-width`, and shorthand `border`/`border-top`/`border-bottom`/`border-left`/`border-right`.
  * Added `CssBorderStyle` support and visibility checks in `CssStyle`.
  * Added table serialization/deserialization and page element tagging in Page.cpp / `Page.h`.

## Additional Context

1. Basic two-column table


| Table  | Screenshot  | 
|--------|--------|
| <img width="914" height="758" alt="image" src="https://github.com/user-attachments/assets/3593a7b0-4185-49ad-8755-0158ed51cf98" /> | <img width="241" height="401" alt="image" src="https://github.com/user-attachments/assets/37cad2e3-4ace-450b-8cae-afdae5b4f831" /> |

2. Basic three-column table

| Table | Screenshot | 
|--------|--------|
| <img width="921" height="472" alt="image" src="https://github.com/user-attachments/assets/6a64afca-008a-4cc3-b31b-49bcf056d45d" /> | <img width="242" height="404" alt="image" src="https://github.com/user-attachments/assets/bf9f6b4f-6e83-4845-8f13-23e59d9cae9f" />|

3. Center-aligned table with no border


|  Table  | Screenshot | 
|--------|--------|
| <img width="911" height="471" alt="image" src="https://github.com/user-attachments/assets/dfae3d64-9d32-49d3-8ac8-2cbea5d601b6" /> | <img width="241" height="404" alt="image" src="https://github.com/user-attachments/assets/0dadec44-fe06-41f8-ad63-1205cb270e2b" /> |

4. Table with no border

| Table | Screenshot | 
|--------|--------|
|<img width="920" height="473" alt="image" src="https://github.com/user-attachments/assets/6d7b9a5f-ed4b-43a3-8734-9f2590f296a6" /> | <img width="241" height="403" alt="image" src="https://github.com/user-attachments/assets/df5d1bd0-1f85-4a77-8597-9c874dd416a8" />|

5. Table with border-{top,bottom} style

| Table | Screenshot | 
|--------|--------|
| <img width="733" height="549" alt="image" src="https://github.com/user-attachments/assets/bc8a8ac5-acac-4617-a14e-4a56ced6c9bb" /> | <img width="241" height="401" alt="image" src="https://github.com/user-attachments/assets/c0b1b261-19b3-46df-9931-36ec90dd2649" /> |

6. Table with border-{top,bottom} style and center-aligned text



| Table | Screenshot | 
|--------|--------|
| <img width="740" height="573" alt="image" src="https://github.com/user-attachments/assets/2c5123b8-7f2b-49a0-8427-9ddb89960b3d" />  | <img width="242" height="402" alt="image" src="https://github.com/user-attachments/assets/ccdd4074-fad8-49df-9938-233c191b359f" />|

7. Table with row/colspan

| Table | Screenshot | 
|--------|--------|
| <img width="734" height="665" alt="image" src="https://github.com/user-attachments/assets/703a6049-307e-4a12-8cbf-0a25d2b72adc" /> | <img width="242" height="404" alt="image" src="https://github.com/user-attachments/assets/9c02205e-6363-443f-bec5-c71283bfa9bc" /> |

8. Table with border shorthands style
<img width="737" height="1016" alt="image" src="https://github.com/user-attachments/assets/2eb261e0-3f53-494f-a477-ca1c9cee7f4d" />

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|--------|--------|--------|
| <img width="242" height="397" alt="image" src="https://github.com/user-attachments/assets/ad305e30-e1bf-4123-acfc-5bcc51ce0a9b" /> | <img width="240" height="399" alt="image" src="https://github.com/user-attachments/assets/8b06bf27-282a-4ea0-b725-fa9ce4337bb9" /> |  <img width="242" height="400" alt="image" src="https://github.com/user-attachments/assets/6cd92df4-b93c-4725-8486-f0b68bb7bd7d" /> | 

9. Table with border shorthands style (postive pixels + none)

<img width="746" height="1017" alt="image" src="https://github.com/user-attachments/assets/0c9c566c-b059-42c0-b1d3-9924ef826c66" />

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|--------|--------|--------|
| <img width="242" height="401" alt="image" src="https://github.com/user-attachments/assets/9be9ffae-af77-4cd6-8800-7658f7c4a5de" /> |<img width="239" height="401" alt="image" src="https://github.com/user-attachments/assets/f746c8b4-2cbf-44c2-8a7a-8d2e0b6ed38d" /> | <img width="240" height="401" alt="image" src="https://github.com/user-attachments/assets/7f3978e1-8a8e-49c8-95a4-96c25215263e" /> |

10. Table with border shorthands style (none + postive pixels)

<img width="739" height="1009" alt="image" src="https://github.com/user-attachments/assets/bd1408fc-b5ac-4f5c-a636-88b70d965d73" />

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|--------|--------|--------|
| <img width="237" height="399" alt="image" src="https://github.com/user-attachments/assets/b2ec9af2-e344-4ba4-bf03-c7f581c0dcf1" /> |  <img width="242" height="404" alt="image" src="https://github.com/user-attachments/assets/89f4eca9-1aca-46d0-a762-67e40fa9defa" /> | <img width="240" height="401" alt="image" src="https://github.com/user-attachments/assets/ef7a21c9-a599-4b65-b6a5-963a99c9e57e" /> |

11. Table with special case of rowspan="0"

Note: colspan must be a positive number, only rowspan can be zero or a positive number.

<img width="748" height="1082" alt="image" src="https://github.com/user-attachments/assets/93f29319-deda-4771-adb2-c45e074fc1c2" />

| Screenshot 1 | Screenshot 2 | Screenshot 3 |
|--------|--------|--------|
| <img width="239" height="401" alt="image" src="https://github.com/user-attachments/assets/e261e390-9657-4762-8fe5-7f3cfa82d04d" /> | <img width="242" height="401" alt="image" src="https://github.com/user-attachments/assets/10af6e60-0573-4c40-9e49-803a471ba102" /> | <img width="240" height="404" alt="image" src="https://github.com/user-attachments/assets/2df58dc1-e306-495f-a26d-bc2b04bbb665" /> |

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**PARTIALLY**_
