### PR TITLE
chore: Update version to 1.4.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ build_cache_dir = .cache
 extra_configs = platformio.local.ini
 
 [crosspoint]
-version = 1.3.0
+version = 1.4.0
 
 [base]
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip


### PR DESCRIPTION
# CrossPoint 1.4.0

110 changes from 37 contributors, 20 of whom are new to the project.

**EPUB Reading Upgrades**

- Bookmarks are now available in EPUBs. Long-press confirm on any page to drop a bookmark, browse them from the reader menu, and jump back instantly. 
- AA on X3 now has improved page turn speed and a quality bump
- Large images load faster & don't freeze up the reader
- Images no longer ghost on the next page when using AA mode
- SD fonts got a nice speed bump during indexing and page turns
- Missing images and broken footnote links were fixed
- Sub-chapter TOC navigation now lands at the correct anchor instead of always jumping to page 0.
- Cover images listed in OPF manifests are now validated as actual images before use.
- OPDS downloads now prefer EPUB format over KEPUB and other derived formats.
- KOSync no longer glitches when you sync from the first page of a new chapter.
- Support for superscript and subscript has been added as well as horizontal rules (`<hr>`)


**RTL Language Support**
Right-to-left text rendering is now supported in both the EPUB and TXT readers. Hebrew UI localization added as well.

**Major Memory & Speed Improvements**
We landed several major stability improvements this cycle:

- WiFi/LWIP teardown after any network-using activity now happens via a silent reboot, clearing the ~50KB of heap fragmentation that LWIP scatters and can't recover without a reset. The reboot skips the splash screen and routes you back where you came from but visually it looks like a screen refresh.
- The home screen cover cache shrinks from ~52KB (full framebuffer clone) to ~16KB (rotated sub-region only), freeing headroom for HTTPS handshakes.
- OTA install buffer sizes are trimmed and progress callbacks are throttled to whole-percent steps, keeping the heap floor ~19KB vs ~7.7KB during a full firmware download.
- Tiled grayscale rendering streams each band directly to controller RAM without saving/restoring the BW framebuffer, dropping the peak contiguous allocation from ~114KB to ~82–90KB.
- Prevented a number of OOM crashes on books with thousands of ZIP entries.
- CSS parsing now does zero heap allocations on the hot `resolveStyle` path, eliminating ~12,000 small short-lived allocations per page render.
- Underline calculations are skipped during the font cache scan pass, preventing hundreds of individual SD card reads on pages with heavy underline use (such as tables of contents).

**Font Updates**
The Domitian font was added to the SD fonts list along with OpenDyslexic which removes it flash freeing up 30% of our space.

## New Features

**X3 Clock**
The X3 now includes a built-in clock with automatic time updates.

**Themed Reader Menus**
Reader menus now follow the active theme, giving the reading experience a consistent look end-to-end.

**Custom Sleep Timer**
The sleep timeout is now a free-entry picker from 1 to 30 minutes (or never) instead of fixed pre-set options

**Recent Books**
You can now remove individual books with a long-press confirm, and auto-remove a book from the list once you finish reading it.

**Quick Resume**
A new Quick Resume option has been added to the sleep settings which lets your device display the last screen/page you were on when you sleep instead of a custom sleep image or book cover

---

## What's Changed

### Features

- feat: epub bookmarks by @vedi0boy and @Uri-Tauber in #1337
- feat: add RTL support in epub and txt readers by @Uri-Tauber in #1700
- feat: Themed reader menus by @CaptainFrito in #1072
- feat: Add Polish hyphenation support by @IjonFryderyk in #1590
- feat: X3 clock display with DS3231 RTC and NTP sync by @juicecultus in #1612
- feat: Add swedish hyphenation by @sbkarlsson in #1637
- feat: Seamless sleep/wake screens (Quick Resume) by @Eloren1 in #2064
- feat(settings): Quick Resume sleep screen option by @uxjulia in #2089
- feat: add custom sleep timer picker by @WuTofu and @uxjulia in #2206
- feat: add setting to remove books from recent list when read by @mcrosson in #2043
- feat: allow removing book from recent list by @mcrosson in #2045
- feat: tiled grayscale rendering to drop storeBwBuffer peak by @jeremydk in #2106
- feat: sup and sub support by @Uri-Tauber and @jpirnay in #2131
- feat: ports hr tag rendering from crossink by @uxjulia in #2117
- feat: Allow disabling side buttons in reader by @Joseph-DiGiovanni in #2105
- feat: add image auto-cropping in web epub optimizer by @leecming82 in #2139
- feat: implement CSS enumeration through OPF directory by @jlatonis in #2148
- feat: Make page turn naturally follow orientation by @jacksongoode in #2023
- feat: port crossink read book move feature to crosspoint by @mcrosson in #2032
- feat: add the Domitian font family by @matteoscopel in #2016
- feat: Hebrew localization by @Uri-Tauber in #2068
- feat: update Russian translation by @muhas in #2017
- feat(lang): Russian translate for new strings by @muhas in #2173

### Fixes

- fix: silent-reboot on wifi activity exit to clear heap fragmentation by @jeremydk in #1908
- fix: silent-restart on exit from KOReader auth and OTA update by @jeremydk in #2036
- fix: sleep from a WiFi activity instead of silent-rebooting by @jeremydk in #2092
- fix: wire through silent restart clear resume state with sdk by @jeremydk in #2033
- fix: keep wifi OTA off the heap floor by @jeremydk in #2074
- fix: stabilize deep sleep wake on USB power by @jeremydk in #2060
- fix: 0 -> 1 deep-sleep serial underflow by @jeremydk in #2073
- fix: guard DC writes in JPEGDEC MCU_SKIP path by @jeremydk in #2058
- fix: USB serial logs now flow on cold+warm boot without jiggle by @jeremydk in #2034
- fix: serialize SdFat FsFile close through HalStorage mutex by @jeremydk in #2135
- fix: bump open-x4-sdk to clear grayscale state after AA cleanup by @itsthisjustin in #2022
- fix: Replace full-image cache buffer with streaming band buffer by @itsthisjustin in #2230
- fix: avoid zip-wide css scan for large epubs by @uxjulia in #2213
- fix: KOReader sync drift when syncing at chapter start by @uxjulia in #2245
- fix(settings): preserve quick resume timeout preference by @uxjulia in #2101
- fix(epub): decode percent-encoded internal asset paths by @uxjulia in #2249
- fix(epub): decode footnote href path before spine lookup by @uxjulia in #2271
- fix: redesign X3 UTC offset picker by @uxjulia in #2205
- fix: navigate to TOC anchor when selecting sub-chapters by @vadimkaushan in #1981
- fix: Skip Underline Calculations During Font Cache Scan Pass by @Uri-Tauber in #2237
- fix: harden EPUB optimiser UI gating, size reporting, and picker teardown by @zgredex in #1947
- fix: bookmark percentage always 0% and page number starts at 0 by @nathanaelmaher in #2188
- fix: long-press back should move to the start of chapter by @Uri-Tauber in #2243
- fix: return to last selected menu location by @Uri-Tauber in #1629
- fix: Crash on invalid font filename by @Uri-Tauber in #2253
- fix: scale SUP/SUB underline to match 50%-scaled glyphs by @SurprisedDuck in #2255
- fix: validate OPF cover items as images by @lpla in #2062
- fix: Prefer epub format over derived formats when downloading from OPDS by @jpirnay in #1480
- fix: update URL-encoded image during EPUB optimization by @Blue in #1985
- fix: use power button held time for shutdown logic by @marcinoktawian in #1890
- fix: several QoL updates for SD font UI (cancel button, overall progress, prevent sleep during download) by @WuTofu in #1965
- fix: prune books missing from sd card in recent books list by @mcrosson in #1959
- fix: clear cache when deleting folders in FileBrowserActivity by @WuTofu in #1892
- fix: take orientation into account for border in ScreenshotUtil by @vadimkaushan in #1977
- fix: prevent card overflow on screens by @Kirillka8996 in #1943
- fix: improves edge case font/glyph handling by @itsthisjustin in #2100
- fix: apply progress bar offset from top instead of bottom edge by @Eloren1 in #2250
- fix: Fill the gap under the screen for the progress bar by @Eloren1 in #2138
- fix: Fix ghosting on pages following images in grayscale by @itsthisjustin in #2226
- fix: SLEEP_TIMEOUT enum mismatch by @Uri-Tauber in #2137
- fix: BOOK_CACHE_VERSION jump by @Uri-Tauber in #2161
- fix: close leaked resource handles by @sabraman in #2040
- fix: normalize Wi-Fi spelling across remaining locales by @lpla in #2094
- fix: refresh Catalan, add Valencian locale, complete Spanish clock strings by @lpla in #2063
- fix: complete Spanish, Catalan and Valencian strings by @lpla in #2203
- fix: update Swedish translations and remove unused strings by @sbkarlsson in #2090
- fix: swedish translation for new strings by @sbkarlsson in #2197
- fix: update German translation by @wilhelmschuster in #2224
- fix: german translation for STR_INVERTED by @Uri-Tauber in #2269

### Performance

- perf: shrink HomeActivity cover cache from 48KB to 16KB region by @jeremydk in #2035
- perf: Minimize string allocations in CSS parsing by @znelson in #2263
- perf: right-size by @OrbisAI in #2093

### Internal

- refactor: move HttpDownloader onto esp_http_client by @jeremydk in #2075
- refactor: route OTA version check through HttpDownloader by @jeremydk in #2076
- refactor: Consolidate theme rendering into ThemeMetrics by @Uri-Tauber in #1868
- refactor: unify book cache clearing for epub, txt, and xtc files by @WuTofu in #1875
- refactor: Drop FsFile alias, use HalFile in downstream code by @znelson in #2141
- test: Migrate unit tests to gtest, integrate with CI by @znelson in #2144
- ci: Cache PlatformIO packages between runs by @znelson in #2142
- chore: Move opendyslexic from flash to SD by @Uri-Tauber in #2231

## New Contributors

- @alan0ford made their first contribution in #1970
- @marcinoktawian made their first contribution in #1890
- @Kirillka8996 made their first contribution in #1943
- @SimoneFelici made their first contribution in #1985
- @matteoscopel made their first contribution in #2016
- @muhas made their first contribution in #2017
- @jacksongoode made their first contribution in #2023
- @Disasm made their first contribution in #1977
- @lpla made their first contribution in #2062
- @sabraman made their first contribution in #2040
- @OrbisAI made their first contribution in #2093
- @jhuebel made their first contribution in #2134
- @Joseph-DiGiovanni made their first contribution in #2105
- @latonis made their first contribution in #2148
- @vedi0boy made their first contribution in #1337
- @Djef0o made their first contribution in #2187
- @angadkandhari made their first contribution in #2169
- @mateuscomh made their first contribution in #2195
- @wlhlm made their first contribution in #2223
- @SurprisedDuck made their first contribution in #2255

**Full Changelog**: https://github.com/crosspoint-reader/crosspoint-reader/compare/release/1.3.0...release/1.4.0