### PR TITLE
chore: Initial multi-core compatibility

### DIFF
--- a/src/CrossPointSettings.cpp
+++ b/src/CrossPointSettings.cpp
@@ -6,6 +6,7 @@
 #include <Serialization.h>
 
 #include <cstring>
+#include <mutex>
 #include <string>
 
 #include "I18nKeys.h"
@@ -96,6 +97,7 @@ uint8_t CrossPointSettings::sleepTimeoutEnumToMinutes(const uint8_t legacyValue)
 }
 
 bool CrossPointSettings::saveToFile() const {
+  std::lock_guard<std::mutex> lock(_mutex);
   Storage.mkdir("/.crosspoint");
   return JsonSettingsIO::saveSettings(*this, SETTINGS_FILE_JSON);
 }
@@ -106,7 +108,11 @@ bool CrossPointSettings::loadFromFile() {
     String json = Storage.readFile(SETTINGS_FILE_JSON);
     if (!json.isEmpty()) {
       bool resave = false;
-      bool result = JsonSettingsIO::loadSettings(*this, json.c_str(), &resave);
+      bool result;
+      {
+        std::lock_guard<std::mutex> lock(_mutex);
+        result = JsonSettingsIO::loadSettings(*this, json.c_str(), &resave);
+      }
       if (result && resave) {
         if (saveToFile()) {
           LOG_DBG("CPS", "Resaved settings to update format");
@@ -166,6 +172,7 @@ bool CrossPointSettings::loadFromBinaryFile() {
   if (!Storage.openFileForRead("CPS", SETTINGS_FILE_BIN, inputFile)) {
     return false;
   }
+  std::lock_guard<std::mutex> lock(_mutex);
 
   uint8_t version;
   serialization::readPod(inputFile, version);

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -3,9 +3,12 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <mutex>
 
 class CrossPointSettings {
  private:
+  mutable std::mutex _mutex;
+
   // Private constructor for singleton
   CrossPointSettings() = default;
 
@@ -16,6 +19,10 @@ class CrossPointSettings {
   // Delete copy constructor and assignment
   CrossPointSettings(const CrossPointSettings&) = delete;
   CrossPointSettings& operator=(const CrossPointSettings&) = delete;
+
+  // Access the settings mutex for protecting multi-field reads/writes from other cores.
+  // Callers must not re-enter SETTINGS methods that lock _mutex while holding it.
+  std::mutex& getMutex() const { return _mutex; }
 
   enum SLEEP_SCREEN_MODE {
     DARK = 0,

--- a/src/CrossPointState.cpp
+++ b/src/CrossPointState.cpp
@@ -6,6 +6,7 @@
 #include <Serialization.h>
 
 #include <algorithm>
+#include <mutex>
 
 namespace {
 constexpr uint8_t STATE_FILE_VERSION = 4;
@@ -32,6 +33,7 @@ void CrossPointState::pushRecentSleep(uint16_t idx) {
 }
 
 bool CrossPointState::saveToFile() const {
+  std::lock_guard<std::mutex> lock(_mutex);
   Storage.mkdir("/.crosspoint");
   return JsonSettingsIO::saveState(*this, STATE_FILE_JSON);
 }
@@ -41,6 +43,7 @@ bool CrossPointState::loadFromFile() {
   if (Storage.exists(STATE_FILE_JSON)) {
     String json = Storage.readFile(STATE_FILE_JSON);
     if (!json.isEmpty()) {
+      std::lock_guard<std::mutex> lock(_mutex);
       return JsonSettingsIO::loadState(*this, json.c_str());
     }
   }
@@ -67,6 +70,7 @@ bool CrossPointState::loadFromBinaryFile() {
   if (!Storage.openFileForRead("CPS", STATE_FILE_BIN, inputFile)) {
     return false;
   }
+  std::lock_guard<std::mutex> lock(_mutex);
 
   uint8_t version;
   serialization::readPod(inputFile, version);

--- a/src/CrossPointState.h
+++ b/src/CrossPointState.h
@@ -1,12 +1,18 @@
 #pragma once
 #include <cstdint>
+#include <mutex>
 #include <string>
 
 class CrossPointState {
+  mutable std::mutex _mutex;
+
   // Static instance
   static CrossPointState instance;
 
  public:
+  // Access the state mutex for protecting multi-field reads/writes from other cores.
+  std::mutex& getMutex() const { return _mutex; }
+
   static constexpr uint8_t SLEEP_RECENT_COUNT = 16;
 
   std::string openEpubPath;

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -18,12 +18,15 @@
 #include "settings/SettingsActivity.h"
 #include "util/FullScreenMessageActivity.h"
 
+static portMUX_TYPE activityManagerSpinlock = portMUX_INITIALIZER_UNLOCKED;
+
 void ActivityManager::begin() {
-  xTaskCreate(&renderTaskTrampoline, "ActivityManagerRender",
-              8192,              // Stack size
-              this,              // Parameters
-              1,                 // Priority
-              &renderTaskHandle  // Task handle
+  xTaskCreatePinnedToCore(&renderTaskTrampoline, "ActivityManagerRender",
+                          8192,               // Stack size
+                          this,               // Parameters
+                          1,                  // Priority
+                          &renderTaskHandle,  // Task handle
+                          0                   // Pin to core 0 (PRO_CPU)
   );
   assert(renderTaskHandle != nullptr && "Failed to create render task");
 }
@@ -45,10 +48,10 @@ void ActivityManager::renderTaskLoop() {
     }
     // Notify any task blocked in requestUpdateAndWait() that the render is done.
     TaskHandle_t waiter = nullptr;
-    taskENTER_CRITICAL(nullptr);
+    taskENTER_CRITICAL(&activityManagerSpinlock);
     waiter = waitingTaskHandle;
     waitingTaskHandle = nullptr;
-    taskEXIT_CRITICAL(nullptr);
+    taskEXIT_CRITICAL(&activityManagerSpinlock);
     if (waiter) {
       xTaskNotify(waiter, 1, eIncrement);
     }
@@ -136,8 +139,7 @@ void ActivityManager::loop() {
     }
   }
 
-  if (requestedUpdate) {
-    requestedUpdate = false;
+  if (requestedUpdate.exchange(false)) {
     // Using direct notification to signal the render task to update
     // Increment counter so multiple rapid calls won't be lost
     if (renderTaskHandle) {
@@ -279,7 +281,7 @@ void ActivityManager::requestUpdateAndWait() {
   }
 
   // Atomic section to perform checks
-  taskENTER_CRITICAL(nullptr);
+  taskENTER_CRITICAL(&activityManagerSpinlock);
   auto currTaskHandler = xTaskGetCurrentTaskHandle();
   auto mutexHolder = xSemaphoreGetMutexHolder(renderingMutex);
   bool isRenderTask = (currTaskHandler == renderTaskHandle);
@@ -288,7 +290,7 @@ void ActivityManager::requestUpdateAndWait() {
   if (!alreadyWaiting && !isRenderTask && !holdingRenderLock) {
     waitingTaskHandle = currTaskHandler;
   }
-  taskEXIT_CRITICAL(nullptr);
+  taskEXIT_CRITICAL(&activityManagerSpinlock);
 
   // Render task cannot call requestUpdateAndWait() or it will cause a deadlock
   assert(!isRenderTask && "Render task cannot call requestUpdateAndWait()");

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -4,6 +4,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 
+#include <atomic>
 #include <cassert>
 #include <memory>
 #include <string>
@@ -63,7 +64,7 @@ class ActivityManager {
 
   // Whether to trigger a render after the current loop()
   // This variable must only be set by the main loop, to avoid race conditions
-  bool requestedUpdate = false;
+  std::atomic<bool> requestedUpdate{false};
 
  public:
   explicit ActivityManager(GfxRenderer& renderer, MappedInputManager& mappedInput)


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** This is the first step towards ESP32-S3 support (M5stack paper, Lilygo T5, de-link, Morphy M3...). I focused here solely on support for multi-core devices. 

##   Changes Made 

  Problem 1: `requestedUpdate` data race

  - `ActivityManager.h`: Changed `bool requestedUpdate` to `std::atomic<bool> requestedUpdate{false}`
  - `ActivityManager.cpp`: Changed `if (requestedUpdate) { requestedUpdate = false; ...}` to `if (requestedUpdate.exchange(false)) { ... }` — a single atomic
  read-modify-write that's safe across cores

  Problem 2: Critical sections pass `nullptr` (`no-op` on dual-core)

  - `ActivityManager.cpp`: Added static `portMUX_TYPE activityManagerSpinlock = portMUX_INITIALIZER_UNLOCKED`;
  - Both `taskENTER_CRITICAL(nullptr)` / `taskEXIT_CRITICAL(nullptr)` call sites now use `&activityManagerSpinlock` — this provides actual cross-core mutual
  exclusion on ESP32-S3 (spinlock) while remaining backward-compatible on ESP32-C3 (just disables interrupts)

  Problem 3: No core affinity

  - `ActivityManager.cpp`: Changed `xTaskCreate` to `xTaskCreatePinnedToCore(..., 0)` — pins render task to core 0 (`PRO_CPU`). On ESP32-S3 Arduino, the main loop runs
   on core 1 by default, so the two tasks get clean separation without contention

  Problem 4: Unprotected singletons

  - `CrossPointSettings.h/.cpp`: Added mutable `std::mutex _mutex` + `getMutex()` accessor. Protected `saveToFile()`, `loadFromFile()`, and `loadFromBinaryFile()` with
  `std::lock_guard`
  - `CrossPointState.h/.cpp`: Same pattern — mutex guards around `saveToFile()`, `loadFromFile()`, and `loadFromBinaryFile()`

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
