### PR TITLE
feat: Battery, EPD, SD, and Touch support for m5paper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
-[submodule "open-x4-sdk"]
-	path = open-x4-sdk
-	url = https://github.com/crosspoint-reader/community-sdk.git
+[submodule "freeink-sdk"]
+	path = freeink-sdk
+	url = https://github.com/Free-Ink/freeink-sdk.git
+	branch = main

--- a/lib/Logging/Logging.h
+++ b/lib/Logging/Logging.h
@@ -27,7 +27,10 @@ won't trigger deprecation warnings.
 #define LOG_LEVEL 0
 #endif
 
-static HWCDC& logSerial = Serial;
+// The concrete Serial type differs by MCU: HWCDC (native USB CDC on C3/S3) vs
+// HardwareSerial (UART0 on the classic ESP32 / M5Paper). Bind to whatever the
+// real Serial is here — this is before the `#define Serial` shim below.
+static decltype(Serial)& logSerial = Serial;
 
 void logPrintf(const char* level, const char* origin, const char* format, ...);
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -192,7 +192,13 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 
 void HalGPIO::begin() {
   inputMgr.begin();
+#if !(defined(FREEINK_DEVICE_M5PAPER) && FREEINK_DEVICE_M5PAPER)
+  // Claim the shared SPI bus with the X4/X3 display+SD pins. On M5Paper the SDK's
+  // IT8951 driver and SDCardManager each bring up SPI from BoardConfig::ACTIVE
+  // pins; pre-claiming VSPI here would stick (SPIClass::begin early-returns if the
+  // bus is already started) and leave the SD card on the wrong pins.
   SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
+#endif
 
   _deviceType = detectDeviceTypeWithFingerprint();
 
@@ -232,12 +238,29 @@ void HalGPIO::startDeepSleep() {
     inputMgr.update();
   }
   // Arm the wakeup trigger *after* the button is released
+#if SOC_PM_SUPPORT_EXT1_WAKEUP
+  // Xtensa (classic ESP32 / S3): GPIO deep-sleep wake is via RTC ext1.
+  esp_sleep_enable_ext1_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_EXT1_WAKEUP_ALL_LOW);
+#else
+  // RISC-V (C3): direct GPIO deep-sleep wakeup source.
   esp_deep_sleep_enable_gpio_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
+#endif
   // Enter Deep Sleep
   esp_deep_sleep_start();
 }
 
 void HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPressAllowed) {
+  if (BoardConfig::ACTIVE.input.power < 0) {
+    // No readable power-button input pin: can't verify a hold, so don't sleep.
+    return;
+  }
+#if defined(FREEINK_DEVICE_M5PAPER) && FREEINK_DEVICE_M5PAPER
+  // M5Paper: power-on is a hardware latch and the "power button" is the rotary
+  // push (G38), shared with Confirm. A USB/flash cold boot is indistinguishable
+  // from an intentional power-on hold here, so skip the X4-style anti-accidental-
+  // wake check and always boot. G38 still serves as the deep-sleep wake source.
+  return;
+#endif
   if (shortPressAllowed) {
     // Fast path - no duration check needed
     return;

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -231,6 +231,8 @@ unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 
 unsigned long HalGPIO::getPowerButtonHeldTime() const { return inputMgr.getPowerButtonHeldTime(); }
 
+bool HalGPIO::wasTouchTap(float& nx, float& ny) const { return inputMgr.wasTouchTap(nx, ny); }
+
 void HalGPIO::startDeepSleep() {
   // Ensure that the power button has been released to avoid immediately turning back on if you're holding it
   while (inputMgr.isPressed(BTN_POWER)) {

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -192,11 +192,13 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
 
 void HalGPIO::begin() {
   inputMgr.begin();
-#if !(defined(FREEINK_DEVICE_M5PAPER) && FREEINK_DEVICE_M5PAPER)
-  // Claim the shared SPI bus with the X4/X3 display+SD pins. On M5Paper the SDK's
-  // IT8951 driver and SDCardManager each bring up SPI from BoardConfig::ACTIVE
-  // pins; pre-claiming VSPI here would stick (SPIClass::begin early-returns if the
-  // bus is already started) and leave the SD card on the wrong pins.
+#if FREEINK_MCU_C3
+  // Claim the shared SPI bus with the X4/X3 display+SD pins. These EPD_* pin
+  // macros are hardcoded C3/Xteink values, so this pre-claim is only valid on the
+  // C3 family. On other boards (M5Paper's IT8951, Sticky's SSD1677, ...) the SDK
+  // driver and SDCardManager bring up SPI from BoardConfig::ACTIVE pins; pre-
+  // claiming here would stick (SPIClass::begin early-returns once the bus is
+  // started) and leave the display/SD on the wrong pins.
   SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 #endif
 

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -72,6 +72,11 @@ class HalGPIO {
   unsigned long getHeldTime() const;
   unsigned long getPowerButtonHeldTime() const;
 
+  // Touch: one-shot tap with the release position normalized 0..1 in the panel's
+  // native orientation. Returns false on non-touch devices. (Reusable gesture
+  // primitive; see MappedInputManager for the top-left = Back mapping.)
+  bool wasTouchTap(float& nx, float& ny) const;
+
   // Setup wake up GPIO and enter deep sleep
   void startDeepSleep();
 

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -18,7 +18,9 @@ void HalPowerManager::begin() {
     Wire.setTimeOut(4);
     _batteryUseI2C = true;
   } else {
-    pinMode(BAT_GPIO0, INPUT);
+    // Battery ADC pin from the active board profile (X4: GPIO0, M5Paper: GPIO35),
+    // not a hardcoded X4 pin.
+    pinMode(BoardConfig::ACTIVE.batteryAdc, INPUT);
   }
   normalFreq = getCpuFrequencyMhz();
   modeMutex = xSemaphoreCreateMutex();
@@ -76,8 +78,10 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
 #endif
 
   // Pre-sleep routines from the original firmware
+#if !SOC_PM_SUPPORT_EXT1_WAKEUP  // RISC-V (C3 / X4)
   // GPIO13 is connected to battery latch MOSFET, we need to make sure it's low during sleep
   // Note that this means the MCU will be completely powered off during sleep, including RTC
+  // (X4-specific: on classic ESP32/M5Paper GPIO13 is SD MISO, so this is skipped.)
   constexpr gpio_num_t GPIO_SPIWP = GPIO_NUM_13;
   gpio_set_direction(GPIO_SPIWP, GPIO_MODE_OUTPUT);
   gpio_set_level(GPIO_SPIWP, 0);
@@ -90,6 +94,10 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   // power button is hard-wired to briefly provide power to the MCU, waking it up regardless of the wakeup source
   // configuration
   esp_deep_sleep_enable_gpio_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
+#else  // Xtensa (classic ESP32 / S3): RTC ext1 GPIO wake
+  pinMode(InputManager::POWER_BUTTON_PIN, INPUT_PULLUP);
+  esp_sleep_enable_ext1_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_EXT1_WAKEUP_ALL_LOW);
+#endif
   // Enter Deep Sleep
   esp_deep_sleep_start();
 }
@@ -121,7 +129,8 @@ uint16_t HalPowerManager::getBatteryPercentage() const {
     _batteryLastPollMs = now;
     return _batteryCachedPercent;
   }
-  static const BatteryMonitor battery = BatteryMonitor(BAT_GPIO0);
+  // ADC pin from the active profile (X4 GPIO0 / M5Paper GPIO35); default 2:1 divider.
+  static const BatteryMonitor battery = BatteryMonitor(BoardConfig::ACTIVE.batteryAdc);
 
   // smooth the battery %.
   if (_batteryCachedPercent == 0) {

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -28,7 +28,16 @@ class HalPowerManager {
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
 
  public:
-  static constexpr int LOW_POWER_FREQ = 10;                    // MHz
+  // On PSRAM boards (classic ESP32 / M5Paper) the APB clock follows the CPU below
+  // 80 MHz, and APB clocks both the SD SPI bus and the 80 MHz PSRAM (which holds
+  // the framebuffer). Dropping to 10 MHz breaks SD writes and PSRAM, so floor the
+  // low-power CPU at 80 MHz (APB stays pinned at 80 for CPU 80/160/240, so power
+  // still drops from the 240 MHz default while SD/PSRAM stay stable).
+#if defined(BOARD_HAS_PSRAM)
+  static constexpr int LOW_POWER_FREQ = 80;  // MHz (APB-safe floor for PSRAM/SD)
+#else
+  static constexpr int LOW_POWER_FREQ = 10;  // MHz
+#endif
   static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms
   static constexpr unsigned long BATTERY_POLL_MS = 1500;       // ms
 

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -38,6 +38,13 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
     __real_panic_print_backtrace(frame, core);
     return;
   }
+#if !__riscv
+  // RvExcFrame and the flat SP scan below are RISC-V-only (C3). On Xtensa
+  // (classic ESP32 / S3) the exception frame is XtExcFrame with windowed-register
+  // unwinding, so fall back to the default backtrace.
+  __real_panic_print_backtrace(frame, core);
+  return;
+#else
   for (size_t i = 0; i < MAX_PANIC_STACK_DEPTH; i++) {
     panicStack[i].sp = 0;
   }
@@ -65,6 +72,7 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
   }
 
   __real_panic_print_backtrace(frame, core);
+#endif  // __riscv
 }
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,47 +55,93 @@ extra_scripts =
   pre:scripts/patch_jpegdec.py
   post:scripts/register_unit_tests_target.py
 
-; Libraries
+; Libraries — FreeInk SDK (git submodule at ./freeink-sdk). The left-hand names
+; are the include paths the firmware already uses (<EInkDisplay.h>, etc.); FreeInk's
+; compat shim preserves them. BoardConfig + PowerManager are FreeInk-only and
+; required (device profiles + the SoC-correct deep-sleep wakeup the HAL relies on).
 lib_deps =
-  BatteryMonitor=symlink://open-x4-sdk/libs/hardware/BatteryMonitor
-  InputManager=symlink://open-x4-sdk/libs/hardware/InputManager
-  EInkDisplay=symlink://open-x4-sdk/libs/display/EInkDisplay
-  SDCardManager=symlink://open-x4-sdk/libs/hardware/SDCardManager
+  BatteryMonitor=symlink://freeink-sdk/libs/hardware/BatteryMonitor
+  InputManager=symlink://freeink-sdk/libs/hardware/InputManager
+  EInkDisplay=symlink://freeink-sdk/libs/display/FreeInkDisplay
+  SDCardManager=symlink://freeink-sdk/libs/hardware/SDCardManager
+  BoardConfig=symlink://freeink-sdk/libs/hardware/BoardConfig
+  PowerManager=symlink://freeink-sdk/libs/hardware/PowerManager
   bblanchon/ArduinoJson @ 7.4.2
   ricmoo/QRCode @ 0.0.1
   bitbank2/PNGdec @ 1.1.6
   https://github.com/bitbank2/JPEGDEC.git#86282979224c8a32fd51e091ed5a35b0c699a52b
   links2004/WebSockets @ 2.7.3
 
-[env:default]
+; ESP32-C3 device set: X3 + X4 compiled into one binary, runtime-selected after
+; the I2C fingerprint. FreeInk requires an explicit device selection, so the C3
+; envs extend this instead of [base] directly. (M5Paper is a different MCU family
+; and selects its own device below.)
+[c3]
 extends = base
 build_flags =
   ${base.build_flags}
+  -DFREEINK_DEVICE_X3=1
+  -DFREEINK_DEVICE_X4=1
+
+[env:default]
+extends = c3
+build_flags =
+  ${c3.build_flags}
   ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2 ; Set log level to debug for development builds
 
 
 [env:gh_release]
-extends = base
+extends = c3
 build_flags =
-  ${base.build_flags}
+  ${c3.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
 
 [env:gh_release_rc]
-extends = base
+extends = c3
 build_flags =
-  ${base.build_flags}
+  ${c3.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
 
 [env:slim]
-extends = base
+extends = c3
 build_flags =
-  ${base.build_flags}
+  ${c3.build_flags}
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-slim\"
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
+
+; --- M5Paper v1.1 (classic ESP32-D0WDQ6, 4.7" 540x960 / IT8951E) -------------
+; Different MCU family than the C3 base: override board/mcu/flash, disable the
+; C3-only native-USB CDC (logs over UART0), and select the M5Paper device.
+;   pio run -e m5paper_v11 -t upload --upload-port /dev/tty.usbserial-XXXX
+[env:m5paper_v11]
+extends = base
+board = esp32dev
+board_build.mcu = esp32
+board_build.flash_mode = qio
+; CP2104 bridge: 460800 is ~4x the 115200 fallback and reliable; drop if a flash
+; stalls. (921600 usually works too.)
+upload_speed = 460800
+build_flags =
+  ${base.build_flags}
+  -UARDUINO_USB_MODE
+  -UARDUINO_USB_CDC_ON_BOOT
+  -DBOARD_HAS_PSRAM
+  -DFREEINK_DEVICE_M5PAPER=1
+  ; git_branch.py only injects CROSSPOINT_VERSION for the default env; set it here.
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-m5paper_v11\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2
+  ; Touch + rotary: no physical button row, so hide on-screen button hints.
+  -DCROSSPOINT_SHOW_BUTTON_HINTS=0
+  ; Archive-order workarounds for the classic-ESP32 link (see freeink-sdk
+  ; platformio.crosspoint.sample.ini): force Arduino startup + the I2C HAL members.
+  -Wl,.pio/build/m5paper_v11/FrameworkArduino/main.cpp.o
+  -Wl,-u,i2cInit
+  -Wl,-u,i2cSlaveInit

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -54,9 +54,29 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
   return false;
 }
 
-bool MappedInputManager::wasPressed(const Button button) const { return mapButton(button, &HalGPIO::wasPressed); }
+// Top-left corner of the panel (panel-native, normalized). Generous so it's easy
+// to hit; v1 is not yet orientation-mapped (see wasBackGesture NOTE in header).
+static constexpr float BACK_GESTURE_FRAC_X = 0.22f;
+static constexpr float BACK_GESTURE_FRAC_Y = 0.12f;
 
-bool MappedInputManager::wasReleased(const Button button) const { return mapButton(button, &HalGPIO::wasReleased); }
+bool MappedInputManager::wasBackGesture() const {
+  float nx = 0.0f, ny = 0.0f;
+  if (!gpio.wasTouchTap(nx, ny)) return false;
+  return nx <= BACK_GESTURE_FRAC_X && ny <= BACK_GESTURE_FRAC_Y;
+}
+
+bool MappedInputManager::wasPressed(const Button button) const {
+  // A top-left tap fires on the release frame; expose it on Back's press edge too
+  // so menus that act on wasPressed(Back) also respond. Deliberately NOT folded
+  // into isPressed, so a quick tap never satisfies the readers' long-press-home.
+  if (button == Button::Back && wasBackGesture()) return true;
+  return mapButton(button, &HalGPIO::wasPressed);
+}
+
+bool MappedInputManager::wasReleased(const Button button) const {
+  if (button == Button::Back && wasBackGesture()) return true;
+  return mapButton(button, &HalGPIO::wasReleased);
+}
 
 bool MappedInputManager::isPressed(const Button button) const { return mapButton(button, &HalGPIO::isPressed); }
 

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -19,6 +19,11 @@ class MappedInputManager {
   bool wasPressed(Button button) const;
   bool wasReleased(Button button) const;
   bool isPressed(Button button) const;
+  // Reusable touch "back" gesture: a tap released in the top-left corner. Folded
+  // into Back's press/release edges, so every screen gets it with no per-activity
+  // code and no coordinates passed. False on non-touch devices.
+  // NOTE: v1 uses panel-native coordinates (not yet orientation-mapped).
+  bool wasBackGesture() const;
   bool wasAnyPressed() const;
   bool wasAnyReleased() const;
   unsigned long getHeldTime() const;

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -18,6 +18,13 @@
 #include "settings/SettingsActivity.h"
 #include "util/FullScreenMessageActivity.h"
 
+// taskENTER_CRITICAL needs a real spinlock on dual-core targets (classic ESP32,
+// e.g. M5Paper). On the single-core ESP32-C3 a nullptr mux was tolerated, but
+// the dual-core port acquires an inter-core spinlock and asserts on a null
+// pointer (spinlock_acquire, spinlock.h:84). One shared spinlock guards the
+// short waitingTaskHandle critical sections below.
+static portMUX_TYPE activityMux = portMUX_INITIALIZER_UNLOCKED;
+
 void ActivityManager::begin() {
   xTaskCreate(&renderTaskTrampoline, "ActivityManagerRender",
               8192,              // Stack size
@@ -45,10 +52,10 @@ void ActivityManager::renderTaskLoop() {
     }
     // Notify any task blocked in requestUpdateAndWait() that the render is done.
     TaskHandle_t waiter = nullptr;
-    taskENTER_CRITICAL(nullptr);
+    taskENTER_CRITICAL(&activityMux);
     waiter = waitingTaskHandle;
     waitingTaskHandle = nullptr;
-    taskEXIT_CRITICAL(nullptr);
+    taskEXIT_CRITICAL(&activityMux);
     if (waiter) {
       xTaskNotify(waiter, 1, eIncrement);
     }
@@ -279,7 +286,7 @@ void ActivityManager::requestUpdateAndWait() {
   }
 
   // Atomic section to perform checks
-  taskENTER_CRITICAL(nullptr);
+  taskENTER_CRITICAL(&activityMux);
   auto currTaskHandler = xTaskGetCurrentTaskHandle();
   auto mutexHolder = xSemaphoreGetMutexHolder(renderingMutex);
   bool isRenderTask = (currTaskHandler == renderTaskHandle);
@@ -288,7 +295,7 @@ void ActivityManager::requestUpdateAndWait() {
   if (!alreadyWaiting && !isRenderTask && !holdingRenderLock) {
     waitingTaskHandle = currTaskHandler;
   }
-  taskEXIT_CRITICAL(nullptr);
+  taskEXIT_CRITICAL(&activityMux);
 
   // Render task cannot call requestUpdateAndWait() or it will cause a deadlock
   assert(!isRenderTask && "Render task cannot call requestUpdateAndWait()");

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -143,10 +143,14 @@ bool BaseTheme::showButtonHints() { return CROSSPOINT_SHOW_BUTTON_HINTS; }
 // *Impl, which only ever runs when hints are enabled.
 void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                                 const char* btn4) const {
+  // showButtonHints() is a build-time switch (CROSSPOINT_SHOW_BUTTON_HINTS); the
+  // constant condition is intentional.
+  // cppcheck-suppress knownConditionTrueFalse
   if (!showButtonHints()) return;
   drawButtonHintsImpl(renderer, btn1, btn2, btn3, btn4);
 }
 void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
+  // cppcheck-suppress knownConditionTrueFalse
   if (!showButtonHints()) return;
   drawSideButtonHintsImpl(renderer, topBtn, bottomBtn);
 }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -132,8 +132,27 @@ void BaseTheme::drawProgressBar(const GfxRenderer& renderer, Rect rect, const si
   renderer.drawCenteredText(UI_10_FONT_ID, rect.y + rect.height + 15, percentText.c_str());
 }
 
+// CROSSPOINT_SHOW_BUTTON_HINTS: build-flag switch (env). Default on. A device with
+// no physical button row (touch + rotary, e.g. M5Paper) builds with =0.
+#ifndef CROSSPOINT_SHOW_BUTTON_HINTS
+#define CROSSPOINT_SHOW_BUTTON_HINTS 1
+#endif
+bool BaseTheme::showButtonHints() { return CROSSPOINT_SHOW_BUTTON_HINTS; }
+
+// Non-virtual gates: one check hides hints across every theme. Themes override the
+// *Impl, which only ever runs when hints are enabled.
 void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                                 const char* btn4) const {
+  if (!showButtonHints()) return;
+  drawButtonHintsImpl(renderer, btn1, btn2, btn3, btn4);
+}
+void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
+  if (!showButtonHints()) return;
+  drawSideButtonHintsImpl(renderer, topBtn, bottomBtn);
+}
+
+void BaseTheme::drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                                    const char* btn4) const {
   const GfxRenderer::Orientation orig_orientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 
@@ -163,7 +182,7 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   renderer.setOrientation(orig_orientation);
 }
 
-void BaseTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
+void BaseTheme::drawSideButtonHintsImpl(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
   const int screenWidth = renderer.getScreenWidth();
   constexpr int buttonWidth = BaseMetrics::values.sideButtonHintsWidth;  // Width on screen (height when rotated)
   constexpr int buttonHeight = 80;                                       // Height on screen (width when rotated)

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -179,9 +179,19 @@ class BaseTheme {
   void drawBatteryRight(const GfxRenderer& renderer, Rect rect,
                         bool showPercentage = true) const;  // Right aligned (UI headers)
   virtual void fillBatteryIcon(const GfxRenderer& renderer, Rect rect, uint16_t percentage) const;
-  virtual void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
-                               const char* btn4) const;
-  virtual void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
+  // Single switch for on-screen button hints, set by the CROSSPOINT_SHOW_BUTTON_HINTS
+  // build flag (env; default on). Devices with no physical button row (touch +
+  // rotary, e.g. M5Paper) set it to 0 in their env.
+  static bool showButtonHints();
+  // Public, NON-virtual gate: returns early when hints are disabled, otherwise
+  // dispatches to the per-theme *Impl below. Themes override the *Impl, never
+  // these — so one switch hides hints across every theme.
+  void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                       const char* btn4) const;
+  void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
+  virtual void drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                                   const char* btn4) const;
+  virtual void drawSideButtonHintsImpl(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
   virtual int getListPageItems(int contentHeight, bool hasSubtitle) const;
   virtual void drawList(const GfxRenderer& renderer, Rect rect, int itemCount, int selectedIndex,
                         const std::function<std::string(int index)>& rowTitle,

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -317,8 +317,8 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   }
 }
 
-void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
-                                const char* btn4) const {
+void LyraTheme::drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                                    const char* btn4) const {
   const GfxRenderer::Orientation orig_orientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 
@@ -356,7 +356,7 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   renderer.setOrientation(orig_orientation);
 }
 
-void LyraTheme::drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
+void LyraTheme::drawSideButtonHintsImpl(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const {
   const int screenWidth = renderer.getScreenWidth();
   constexpr int buttonWidth = LyraMetrics::values.sideButtonHintsWidth;  // Width on screen (height when rotated)
   constexpr int buttonHeight = 78;                                       // Height on screen (width when rotated)

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -84,9 +84,9 @@ class LyraTheme : public BaseTheme {
                 const std::function<std::string(int index)>& rowSubtitle,
                 const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
                 bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr) const override;
-  void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
-                       const char* btn4) const override;
-  void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;
+  void drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                           const char* btn4) const override;
+  void drawSideButtonHintsImpl(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;
   void drawButtonMenu(GfxRenderer& renderer, Rect rect, int buttonCount, int selectedIndex,
                       const std::function<std::string(int index)>& buttonLabel,
                       const std::function<UIIcon(int index)>& rowIcon) const override;

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -381,8 +381,8 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
   drawScrollBar(renderer, rect, itemCount, pageStartIndex, pageItems);
 }
 
-void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
-                                       const char* btn4) const {
+void RoundedRaffTheme::drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                                           const char* btn4) const {
   const GfxRenderer::Orientation origOrientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 

--- a/src/components/themes/roundedraff/RoundedRaffTheme.h
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.h
@@ -92,7 +92,7 @@ class RoundedRaffTheme : public BaseTheme {
                 const std::function<UIIcon(int index)>& rowIcon = nullptr,
                 const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
                 const std::function<bool(int index)>& rowDimmed = nullptr) const override;
-  void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
-                       const char* btn4) const override;
+  void drawButtonHintsImpl(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
+                           const char* btn4) const override;
   bool homeMenuShowsContinueReading() const { return true; }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,6 +305,14 @@ void setupDisplayAndFonts(bool seamless = false) {
 void setup() {
   t1 = millis();
 
+#if defined(FREEINK_DEVICE_M5PAPER) && FREEINK_DEVICE_M5PAPER
+  // M5Paper v1.1 latches its own power through a MOSFET on GPIO2. Drive it HIGH
+  // first thing or the board powers off the instant USB is unplugged. (Board
+  // responsibility, not the SDK — see freeink-sdk platformio.sample.ini.)
+  pinMode(2, OUTPUT);
+  digitalWrite(2, HIGH);
+#endif
+
 #ifdef ENABLE_SERIAL_LOG
   // Earliest possible Serial setup. The 250 ms stall before begin() lets the
   // USB Serial/JTAG peripheral finish power-on and lets the host complete USB
@@ -313,7 +321,11 @@ void setup() {
   // worked without the delay because USB was already enumerated.
   delay(250);
   Serial.begin(115200);
+#if defined(ARDUINO_USB_CDC_ON_BOOT) && ARDUINO_USB_CDC_ON_BOOT
+  // setTxTimeoutMs is an HWCDC (native USB CDC) method. On the classic ESP32
+  // (M5Paper) Serial is UART0/HardwareSerial, which has no such method.
   logSerial.setTxTimeoutMs(1);  // This is a load-bearing 1. Do not modify.
+#endif
 #endif
 
   HalSystem::begin();


### PR DESCRIPTION
Adds support for the m5paper1.1 to crosspoint via the new freeink sdk. This sdk is a complete rewrite of the openx4 sdk designed to allow us to port to more devices with minimal changes to the crosspoint core code. This PR allows you to use the rotary dial on the side of the device for up, down, select, sleep and a tap top left to back out of any screen. It does NOT support full touch interaction across all menus. This is an mvp to prove out the use of the sdk and see how minimal of a system we can get into crosspoint without muddying the codebase. We currently hide the button hints on touch devices and eventually this needs to support full touch for use cases like the keyboard and menus where left and right are also needed. 

This is not a "need this to be merged" kind of thing but I'm opening as a PR for feedback and review as supporting more devices is the next major sprint and this is the model I think we should have moving forward. This sdk is drop in compatible with x3/x4 without any changes on the crosspoint side (minus one nice to have around power management which is documented in the readme). Docs are available at https://freeink.org/docs/overview

- [ ] Add support for orientation aware touch/dial
- [ ] Add support for menu and keyboard touch interaction
- [ ] Test wifi/web server