### PR TITLE
fix: don't justify-stretch a leading no-break space (#2185)

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -808,7 +808,10 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
         int advance =
             renderer.getKerning(fontId, lastCodepoint(reorderedWordsScratch[wordIdx]),
                                 firstCodepoint(reorderedWordsScratch[wordIdx + 1]), reorderedStylesScratch[wordIdx]);
-        if (reorderedWordsScratch[wordIdx] == " " && reorderedContinuesScratch[wordIdx] &&
+        // wordIdx > 0 mirrors the gap accounting above (which skips index 0): a leading
+        // no-break space must not receive justifyExtra, or the line over-stretches by one
+        // gap and the last word is pushed past the right margin (issue #2185).
+        if (wordIdx > 0 && reorderedWordsScratch[wordIdx] == " " && reorderedContinuesScratch[wordIdx] &&
             effectiveAlignment == CssTextAlign::Justify && !isLastLine) {
           advance += reorderedJustifyExtra;
         }
@@ -848,7 +851,8 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
           // Cross-boundary kerning for continuation words
           int advance = renderer.getKerning(fontId, lastCodepoint(lineWords[wordIdx]),
                                             firstCodepoint(lineWords[wordIdx + 1]), lineWordStyles[wordIdx]);
-          if (lineWords[wordIdx] == " " && continuesVec[lastBreakAt + wordIdx] &&
+          // wordIdx > 0: see the LTR branch — a leading no-break space is not a justifiable gap.
+          if (wordIdx > 0 && lineWords[wordIdx] == " " && continuesVec[lastBreakAt + wordIdx] &&
               effectiveAlignment == CssTextAlign::Justify && !isLastLine) {
             advance += justifyExtra;
           }
@@ -882,7 +886,10 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
           int advance = wordWidths[lastBreakAt + wordIdx];
           advance += renderer.getKerning(fontId, lastCodepoint(lineWords[wordIdx]),
                                          firstCodepoint(lineWords[wordIdx + 1]), lineWordStyles[wordIdx]);
-          if (lineWords[wordIdx] == " " && continuesVec[lastBreakAt + wordIdx] &&
+          // wordIdx > 0 mirrors the gap accounting above (which skips index 0): a leading
+          // no-break space must not receive justifyExtra, or the line over-stretches by one
+          // gap and the last word is pushed past the right margin (issue #2185).
+          if (wordIdx > 0 && lineWords[wordIdx] == " " && continuesVec[lastBreakAt + wordIdx] &&
               effectiveAlignment == CssTextAlign::Justify && !isLastLine) {
             advance += justifyExtra;
           }


### PR DESCRIPTION
Fixes #2185.

### Symptom
Justified lines that begin with a superscript verse number run off the right edge — the last word is clipped. Reproduced with the reporter's Bible (e.g. Proverbs 15:3 "are", 15:7 "spread").

### Root cause (not the superscript width)
The superscript glyph is measured and rendered consistently (`getTextAdvanceX` and `drawText` both halve the SUP/SUB advance), so it isn't the cause. The real trigger is the **no-break space** that precedes the verse number. Each verse is authored as:

```
&#xA0;<strong><sup>N</sup></strong>&#x202F;Word
```

The leading `&#xA0;` becomes a continuation `" "` token at **index 0** of the line.

In `ParsedText::extractLine()`, the justify-gap *accounting* counts a continuation `" "` token only when `wordIdx > 0` (a leading space is not an inter-word gap). But the three *positioning* loops (LTR, RTL, BiDi-reorder) added `justifyExtra` to a leading `" "` **unconditionally**. So the line received one more `justifyExtra` than `actualGapCount` budgeted for, and the final word overshot the right margin by exactly `justifyExtra` px.

### Fix
Guard the leading-space `justifyExtra` with `wordIdx > 0` in all three positioning paths, mirroring the accounting loop. The em-space paragraph indent is prepended *into* a word token (not a standalone `" "`), so indented paragraphs are unaffected — only genuine leading no-break-space tokens change.

### Verification
I reproduced the math with a faithful numeric replica of the accounting-vs-positioning logic using the actual token sequence (`nbsp · ³ · narrow-nbsp · The · eyes · of · Jehovah · are`):

```
before fix: gapCount=5 justifyExtra=37 lastWordRight=494 (page=460) -> overflow +34px
after  fix: gapCount=5 justifyExtra=37 lastWordRight=457 (page=460) -> fits (-3px)
```

The +34px overshoot is one `justifyExtra`, matching the clipped last word in both reported screenshots.

> [!NOTE]
> The firmware has no host-side harness for the layout/render engine (renderer + fonts + HAL), so I verified the accounting arithmetic off-device rather than adding a disproportionate test scaffold. **On-device rendering verification is human scope** — flagging for a tester (open the Bible to Proverbs 15 and confirm justified verse lines no longer clip).

Supported by Claude Opus 4.8