### PR TITLE
fix: Restore first-line paragraph indentation

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -261,10 +261,19 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
   }
 }
 
-int ParsedText::resolveFirstLineIndent(const bool isFirstLine) const {
-  if (isFirstLine && blockStyle.textIndentDefined && (blockStyle.textIndent < 0 || !extraParagraphSpacing) &&
-      isNaturalAlign) {
-    return blockStyle.textIndent;
+int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer& renderer, const int fontId) const {
+  if (!isFirstLine || !isNaturalAlign) {
+    return 0;
+  }
+  if (blockStyle.textIndentDefined) {
+    if (blockStyle.textIndent < 0 || !extraParagraphSpacing) {
+      return blockStyle.textIndent;
+    }
+    return 0;
+  }
+  if (!extraParagraphSpacing) {
+    // Fallback: Use EmSpace width for visual indent when CSS text-indent is not defined
+    return renderer.getTextAdvanceX(fontId, "\xe2\x80\x83", EpdFontFamily::REGULAR);
   }
   return 0;
 }
@@ -292,9 +301,6 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
   isNaturalAlign =
       blockStyle.alignment == CssTextAlign::Justify ||
       (blockStyle.isRtl ? blockStyle.alignment == CssTextAlign::Right : blockStyle.alignment == CssTextAlign::Left);
-
-  // Apply fixed transforms before any per-line layout work.
-  applyParagraphIndent();
 
   // Ensure SD card font glyph metrics are loaded before measuring word widths.
   // For flash-based fonts isSdCardFont() returns false and this block is skipped
@@ -356,7 +362,7 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
     return {};
   }
 
-  const int firstLineIndent = resolveFirstLineIndent(true);
+  const int firstLineIndent = resolveFirstLineIndent(true, renderer, fontId);
 
   // Ensure any word that would overflow even as the first entry on a line is split using fallback hyphenation.
   for (size_t i = 0; i < wordWidths.size(); ++i) {
@@ -462,25 +468,11 @@ std::vector<size_t> ParsedText::computeLineBreaks(const GfxRenderer& renderer, c
   return lineBreakIndices;
 }
 
-void ParsedText::applyParagraphIndent() {
-  if (extraParagraphSpacing || words.empty()) {
-    return;
-  }
-
-  if (blockStyle.textIndentDefined) {
-    // CSS text-indent is explicitly set (even if 0) - don't use fallback EmSpace
-    // The actual indent positioning is handled in extractLine()
-  } else if (isNaturalAlign) {
-    // No CSS text-indent defined - use EmSpace fallback for visual indent
-    words.front().insert(0, "\xe2\x80\x83");
-  }
-}
-
 // Builds break indices while opportunistically splitting the word that would overflow the current line.
 std::vector<size_t> ParsedText::computeHyphenatedLineBreaks(const GfxRenderer& renderer, const int fontId,
                                                             const int pageWidth, std::vector<uint16_t>& wordWidths,
                                                             std::vector<bool>& continuesVec) {
-  const int firstLineIndent = resolveFirstLineIndent(true);
+  const int firstLineIndent = resolveFirstLineIndent(true, renderer, fontId);
 
   std::vector<size_t> lineBreakIndices;
   size_t currentIndex = 0;
@@ -643,7 +635,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
 
-  const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0);
+  const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0, renderer, fontId);
 
   // Build line data by moving from the original vectors using index range
   std::vector<std::string> lineWords;

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -30,8 +30,7 @@ class ParsedText {
   std::vector<bool> reorderedFocusSuffixScratch;
   std::vector<uint16_t> visualOrderScratch;
 
-  void applyParagraphIndent();
-  int resolveFirstLineIndent(bool isFirstLine) const;
+  int resolveFirstLineIndent(bool isFirstLine, const GfxRenderer& renderer, int fontId) const;
   std::vector<size_t> computeLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,
                                         std::vector<uint16_t>& wordWidths, std::vector<bool>& continuesVec);
   std::vector<size_t> computeHyphenatedLineBreaks(const GfxRenderer& renderer, int fontId, int pageWidth,


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Should fix #2241
 
* **What changes are included?**


### Problem

Users upgrading from v1.1.0 to v1.3.0 reported that first-line paragraph indentation disappeared when both "Embedded Style" and "Extra Paragraph Spacing" were set to OFF — contrary to documented behavior, which states that disabling extra paragraph spacing should produce first-line indentation instead.

The root cause was a combination of two issues introduced in v1.3.0:

1. `resolveFirstLineIndent()` only returned a non-zero indent when CSS `text-indent` was explicitly defined in the stylesheet. With "Embedded Style" OFF, no CSS `text-indent` existed, so it always returned `0`.
2. The fallback path in `applyParagraphIndent()` tried to compensate by prepending a literal Em Space character (`U+2003`, `\xe2\x80\x83`) directly to the first word string. This caused downstream formatting bugs — the pixel layout pipeline still believed the first-line indent was `0`, so line start coordinates were placed flush with the left margin, and the hidden character interfered with line splitting and alignment.

### Fix

**Removed** `ParsedText::applyParagraphIndent()` entirely — the "hidden character hack" approach is gone.

**Updated** `ParsedText::resolveFirstLineIndent()` to accept `GfxRenderer` and `fontId` parameters so it can measure real pixel widths. It now handles all three cases cleanly:

- **CSS `text-indent` defined** → returns the explicit CSS value (existing behavior preserved).
- **No CSS `text-indent`, `extraParagraphSpacing` OFF** → queries `GfxRenderer::getTextAdvanceX()` for the pixel width of the Em Space glyph in the current font, and returns that as the indent. This feeds directly into the standard layout pipeline's X-coordinate offset.
- **`extraParagraphSpacing` ON, or non-natural alignment** → returns `0` (no indent).

All three `resolveFirstLineIndent` call sites (`computeLineBreaks`, `computeHyphenatedLineBreaks`, `extractLine`) are updated to pass through `renderer` and `fontId`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YEP >**_
