### PR TITLE
fix: use HALF_REFRESH in BMP viewer to prevent ghosting

### DIFF
--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -115,7 +115,7 @@ void BmpViewerActivity::onEnter() {
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
       // Single pass for non-grayscale images
 
-      renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+      renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 
     } else {
       // Handle file parsing error


### PR DESCRIPTION
## Summary

  * **What is the goal of this PR?** Fix display ghosting in the BMP viewer — the file browser menu remains visible
  behind the displayed image.
  * **What changes are included?** Changed the display refresh mode from `FAST_REFRESH` to `HALF_REFRESH` when
  rendering a BMP image in `BmpViewerActivity::onEnter()`.

  ## Additional Context

  Between v1.2.0 and v1.3.0, the refresh mode for the main BMP display path was changed from `FULL_REFRESH` to
  `FAST_REFRESH`. `FAST_REFRESH` is a differential update — the e-ink controller only redraws pixels that differ
  from its previous state. When the viewer opens from the file browser, areas where the new content matches the old
  (especially white regions around the image) retain visible traces of the previous screen.

  `HALF_REFRESH` drives every pixel to its target value without the full black→white→target flash of
  `FULL_REFRESH`. This is already the mode used by the error and exit paths in the same activity.

  - [ ] Open a BMP image from the file browser — no ghosting from the menu
  - [ ] Navigate between images with left/right — no ghosting between images
  - [ ] Verify no full-screen flash (would indicate accidental `FULL_REFRESH`)
  - [ ] Test in all 4 orientations

  ---

  ### AI Usage

  Did you use AI tools to help write this code? _**PARTIALLY**_
