### PR TITLE
fix: Hanging indent causes overlapping words

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -799,7 +799,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     }
 
     for (size_t wordIdx = 0; wordIdx < reorderedWidthsScratch.size(); wordIdx++) {
-      lineXPos.push_back(static_cast<int16_t>(xpos < 0 ? 0 : xpos));
+      lineXPos.push_back(static_cast<int16_t>(xpos));
       xpos += reorderedWidthsScratch[wordIdx];
 
       const bool nextIsContinuation =
@@ -830,7 +830,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     // Standard LTR/RTL positioning loop when no visual reordering is needed
     if (blockStyle.isRtl) {
       // RTL: position words from right to left
-      auto xpos = static_cast<int>(effectivePageWidth);
+      int xpos = effectivePageWidth;
       if (effectiveAlignment == CssTextAlign::Left) {
         // Explicit left alignment in RTL context
         xpos = lineWordWidthSum + totalNaturalGaps;
@@ -841,7 +841,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
       for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
         xpos -= wordWidths[lastBreakAt + wordIdx];
-        lineXPos.push_back(static_cast<int16_t>(xpos < 0 ? 0 : xpos));
+        lineXPos.push_back(static_cast<int16_t>(xpos));
 
         const bool nextIsContinuation = wordIdx + 1 < lineWordCount && continuesVec[lastBreakAt + wordIdx + 1];
         if (nextIsContinuation) {
@@ -867,7 +867,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       }
     } else {
       // LTR: position words from left to right
-      auto xpos = static_cast<int16_t>(firstLineIndent);
+      int xpos = firstLineIndent;
       if (effectiveAlignment == CssTextAlign::Right) {
         xpos = effectivePageWidth - lineWordWidthSum - totalNaturalGaps;
       } else if (effectiveAlignment == CssTextAlign::Center) {
@@ -875,7 +875,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       }
 
       for (size_t wordIdx = 0; wordIdx < lineWordCount; wordIdx++) {
-        lineXPos.push_back(static_cast<int16_t>(xpos < 0 ? 0 : xpos));
+        lineXPos.push_back(static_cast<int16_t>(xpos));
 
         const bool nextIsContinuation = wordIdx + 1 < lineWordCount && continuesVec[lastBreakAt + wordIdx + 1];
         if (nextIsContinuation) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 25;
+constexpr uint8_t SECTION_FILE_VERSION = 26;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +


### PR DESCRIPTION
## Summary

Hanging-indent paragraphs (CSS `text-indent: <negative>`) rendered with overlapping text. Small regression from the RTL refactor in #1700.

**Example**

"The Story of B" uses `p.hanging` for dialogue:

```css
p.hanging {
  margin-left: 2.5em;
  text-indent: -1em;  /* first line sticks out 1em to the left of the rest */
}
```

```html
<p class="hanging">ME: Hello.</p>
<p class="hanging">HIM: Fr. Osborne?</p>
```

Bug: `E:` is drawn on top of `H`, `M:` on top of `F`. The first word's x-position clamps to 0, but the cursor for subsequent words advances from the un-clamped (negative) base — collapsing the gap.

**Root cause**

#1700 consolidated the per-word positioning loops in `extractLine` and added a defensive clamp at each push site:

```cpp
lineXPos.push_back(static_cast<int16_t>(xpos < 0 ? 0 : xpos));
```

For RTL the clamp absorbs real underflow when `xpos -= wordWidth` runs past the left edge. The same clamp got applied to the LTR branch, where the *only* way `xpos` starts negative is `firstLineIndent < 0`, i.e. a legitimate hanging indent.

**Fix**

Drop the clamp at all three push sites (LTR, RTL, BiDi-reorder). Negative `xpos` is a valid relative coordinate that `BlockStyle::leftInset()` already absorbs when the line is positioned on screen.

**Screenshots**

| Before | After |
| -- | -- |
| <img src="https://github.com/user-attachments/files/28842084/The-Story-of-B_ch11_p7_7pct_277469.bmp" width="400" /> | <img src="https://github.com/user-attachments/files/28842119/The-Story-of-B_ch11_p7_7pct_123297.bmp" width="400" /> |

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_
