### PR TITLE
fix(i18n): localize home empty-state strings

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -635,8 +635,8 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
     // No book to continue reading
     const int y =
         bookY + (bookHeight - renderer.getLineHeight(UI_12_FONT_ID) - renderer.getLineHeight(UI_10_FONT_ID)) / 2;
-    renderer.drawCenteredText(UI_12_FONT_ID, y, "No open book");
-    renderer.drawCenteredText(UI_10_FONT_ID, y + renderer.getLineHeight(UI_12_FONT_ID), "Start reading below");
+    renderer.drawCenteredText(UI_12_FONT_ID, y, tr(STR_NO_OPEN_BOOK));
+    renderer.drawCenteredText(UI_10_FONT_ID, y + renderer.getLineHeight(UI_12_FONT_ID), tr(STR_START_READING));
   }
 }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Localize the two hardcoded English strings on the home-screen empty state so they respect the user's language setting.
* **What changes are included?** `BaseTheme::drawRecentBookCover` drew `"No open book"` and `"Start reading below"` as English literals, while the sibling "Continue Reading" label already used `tr()`. This wraps both in the existing `tr(STR_NO_OPEN_BOOK)` / `tr(STR_START_READING)` keys.

## Additional Context

* Both keys already exist in `english.yaml` and are already translated in all 24 locale files, so there are no new strings to translate and no change for English users.
* No meaningful RAM/flash cost — the strings are already flash-resident; this only swaps the literal for the lookup, matching the pattern used two lines above for `STR_CONTINUE_READING`.
* Verification: `bin/clang-format-fix`, `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` (no defects), and `pio run -e default` all pass.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

I reviewed the change and confirmed the keys exist and are translated across all locale files.
