### PR TITLE
fix(epub): render ordered-list item numbers

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,13 +90,17 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 25
+### Version 27
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
-Version 25 includes:
+The on-disk structure is unchanged since version 25; versions 26 and 27 are
+layout-only cache-busting bumps (26: first-line paragraph indentation; 27:
+ordered-list `<li>` items render numeric markers instead of bullets).
+
+Version 27 includes:
 
 - cache-busting fields for paragraph alignment, hyphenation, embedded CSS,
   image rendering mode, and Focus Reading
@@ -113,7 +117,7 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define EXPECTED_VERSION 25
+#define EXPECTED_VERSION 27
 #define MAX_STRING_LENGTH 65535
 #define FOOTNOTE_NUMBER_LEN 32
 #define FOOTNOTE_HREF_LEN 96

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -10,7 +10,7 @@
 #include "parsers/ChapterHtmlSlimParser.h"
 
 namespace {
-constexpr uint8_t SECTION_FILE_VERSION = 26;
+constexpr uint8_t SECTION_FILE_VERSION = 27;
 constexpr uint32_t HEADER_SIZE = sizeof(uint8_t) + sizeof(int) + sizeof(float) + sizeof(bool) + sizeof(uint8_t) +
                                  sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(bool) + sizeof(bool) +
                                  sizeof(uint8_t) + sizeof(bool) + sizeof(uint32_t) + sizeof(uint32_t) +

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -9,6 +9,9 @@
 #include <expat.h>
 
 #include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <iterator>
 #include <new>
 
@@ -295,16 +298,24 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->xpathListItemIndex++;
   }
 
-  // Extract class, style, id, and dir attributes for CSS/RTL processing
+  // Extract class, style, id, and dir attributes for CSS/RTL processing.
+  // start/value drive ordered-list numbering (<ol start>, <li value>); they point
+  // into expat's atts and are only valid for the duration of this callback.
   std::string classAttr;
   std::string styleAttr;
   std::string dirAttr;
+  const char* startAttr = nullptr;
+  const char* valueAttr = nullptr;
   if (atts != nullptr) {
     for (int i = 0; atts[i]; i += 2) {
       if (strcmp(atts[i], "class") == 0) {
         classAttr = atts[i + 1];
       } else if (strcmp(atts[i], "style") == 0) {
         styleAttr = atts[i + 1];
+      } else if (strcmp(atts[i], "start") == 0) {
+        startAttr = atts[i + 1];
+      } else if (strcmp(atts[i], "value") == 0) {
+        valueAttr = atts[i + 1];
       } else if (strcmp(atts[i], "id") == 0) {
         // Defer both anchor recording and TOC page breaks until startNewTextBlock,
         // after the previous block is flushed to pages via makePages().
@@ -363,6 +374,23 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     self->skipUntilDepth = self->depth;
     self->depth += 1;
     return;
+  }
+
+  // Track <ol>/<ul> nesting so each <li> renders the right marker. Placed after the
+  // display:none short-circuit so hidden lists never push; the pop in endElement is
+  // depth-matched, so an unbalanced/skipped list can never pop the wrong entry. These
+  // tags carry no other layout here, so we fall through to the generic depth increment.
+  if (strcmp(name, "ol") == 0 || strcmp(name, "ul") == 0) {
+    ListContext ctx;
+    ctx.depth = self->depth;
+    ctx.ordered = strcmp(name, "ol") == 0;
+    if (ctx.ordered && startAttr != nullptr) {
+      const long start = strtol(startAttr, nullptr, 10);
+      if (start >= 1 && start <= UINT16_MAX) {
+        ctx.nextValue = static_cast<uint16_t>(start);
+      }
+    }
+    self->listStack.push_back(ctx);
   }
 
   // Special handling for tables/cells: flatten into per-cell paragraphs with a prefixed header.
@@ -820,7 +848,25 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+        if (!self->listStack.empty() && self->listStack.back().ordered) {
+          ListContext& list = self->listStack.back();
+          // <li value="N"> restarts numbering from N.
+          if (valueAttr != nullptr) {
+            const long value = strtol(valueAttr, nullptr, 10);
+            if (value >= 1 && value <= UINT16_MAX) {
+              list.nextValue = static_cast<uint16_t>(value);
+            }
+          }
+          char marker[12];
+          snprintf(marker, sizeof(marker), "%u.", static_cast<unsigned>(list.nextValue));
+          self->currentTextBlock->addWord(marker, EpdFontFamily::REGULAR);
+          if (list.nextValue < UINT16_MAX) {
+            list.nextValue++;
+          }
+        } else {
+          // Unordered list, or a stray <li> with no list ancestor: keep the bullet.
+          self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR);
+        }
       }
     }
   } else if (matches(name, UNDERLINE_TAGS, std::size(UNDERLINE_TAGS))) {
@@ -1234,6 +1280,13 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
     self->updateEffectiveInlineStyle();
   }
 
+  // Pop list context when leaving the <ol>/<ul> that opened it. Depth-matched so a
+  // hidden (display:none) list, which never pushed, can never pop the wrong entry.
+  if (!self->listStack.empty() && self->listStack.back().depth == self->depth &&
+      (strcmp(name, "ol") == 0 || strcmp(name, "ul") == 0)) {
+    self->listStack.pop_back();
+  }
+
   // Clear block style when leaving header or block elements
   if (headerOrBlockTag) {
     self->currentCssStyle.reset();
@@ -1264,6 +1317,10 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   blockStyleStack.clear();
   blockStyleStack.reserve(8);
   blockStyleStack.push_back(rootBlockStyle);
+
+  // Reserve for a few levels of <ol>/<ul> nesting to avoid reallocations mid-parse.
+  listStack.clear();
+  listStack.reserve(4);
 
   auto paragraphAlignmentBlockStyle = BlockStyle();
   paragraphAlignmentBlockStyle.textAlignDefined = true;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -80,6 +80,14 @@ class ChapterHtmlSlimParser {
   int tableRowIndex = 0;
   int tableColIndex = 0;
 
+  // List tracking: <ol>/<ul> nesting drives the <li> marker (numeric vs bullet).
+  struct ListContext {
+    int depth = 0;           // depth of the opening <ol>/<ul>, used for matched pop
+    bool ordered = false;    // true for <ol>, false for <ul>
+    uint16_t nextValue = 1;  // next item number for an ordered list
+  };
+  std::vector<ListContext> listStack;
+
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
   std::vector<std::pair<std::string, uint16_t>> anchorData;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make ordered lists (`<ol>`) render numeric markers (`1.` `2.` `3.`) instead of bullets. Fixes #291 — unordered-list bullets already worked; this completes the issue for ordered lists.
* **What changes are included?**
  - Track `<ol>`/`<ul>` nesting on a depth-matched stack in `ChapterHtmlSlimParser` (same pattern as the existing inline-style stack), so each `<li>` knows whether it is ordered and what number it is.
  - Ordered-list items emit `N.` markers; unordered lists and stray `<li>` (no list ancestor) keep the bullet.
  - Honors `<ol start="N">` and `<li value="N">`; nested lists keep independent counters; `display:none` lists never push, and the pop is depth-matched so it can never pop the wrong entry.
  - Bumps `SECTION_FILE_VERSION` 26 → 27 so cached sections re-layout with the new markers, and brings `docs/file-formats.md` back in sync (it had been left at 25 after the v26 bump).
  
Before:
  
<img width="3024" height="4032" alt="before" src="https://github.com/user-attachments/assets/094fc648-53d8-4053-97a2-b676cfa6c30b" />

After:
<img width="3024" height="4032" alt="after" src="https://github.com/user-attachments/assets/38c93718-8465-4013-bb47-600eebb7b457" />


## Additional Context

* **Memory:** the list stack is a small parse-time `std::vector` (reserved for 4 nesting levels) that is freed after layout. Static RAM is unchanged; build RAM/flash usage is effectively flat.
* **Risk / tradeoff:** the cache-version bump triggers a one-time re-layout of all books on first launch after updating — consistent with how prior layout changes (e.g. the v26 first-line-indent fix) shipped.
* **Verification:**
  - `bin/clang-format-fix`, `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` (no defects), and `pio run -e default` all pass.
  - Tested on **X4 hardware** with an EPUB exercising ordered, unordered, `<ol start="5">`, `<li value="9">`, nested `ol > ul > ol`, and a long wrapping item. All render correctly: numbers where expected, bullets preserved for `<ul>`, nested counters independent, the outer counter resumes after a nested list, and a long numbered item still wraps cleanly.

<details>
<summary>Reproduction — body of the test chapter (XHTML)</summary>

```html
<h2>1. Ordered list (expect 1. 2. 3.)</h2>
<ol><li>First</li><li>Second</li><li>Third</li></ol>

<h2>2. Unordered list (expect bullets)</h2>
<ul><li>Alpha</li><li>Beta</li><li>Gamma</li></ul>

<h2>3. ol start="5" (expect 5. 6. 7.)</h2>
<ol start="5"><li>Five</li><li>Six</li><li>Seven</li></ol>

<h2>4. li value="9" mid-list (expect 1. 9. 10.)</h2>
<ol><li>One</li><li value="9">Nine</li><li>Ten</li></ol>

<h2>5. Nested ol &gt; ul &gt; ol</h2>
<ol>
  <li>Outer one
    <ul>
      <li>bullet a</li>
      <li>bullet b
        <ol><li>deep one</li><li>deep two</li></ol>
      </li>
    </ul>
  </li>
  <li>Outer two (counter resumes)</li>
</ol>

<h2>6. Long ordered item (expect number + correct wrapping)</h2>
<ol><li>This list item is intentionally long so that the text must wrap across several lines on the narrow e-ink screen, confirming that the numeric marker does not break line wrapping.</li></ol>
```
</details>

---

### AI Usage

Did you use AI tools to help write this code? **YES**

I reviewed the code and manually tested it on X4 hardware.
