### PR TITLE
fix: enable Shift key for URL keyboard input (#2178)

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -99,7 +99,9 @@ bool KeyboardEntryActivity::handleKeyPress() {
       case SpecialKeyType::Shift:
         delPressCount = 0;
         hintVisible = false;
-        if (urlMode || inputType == InputType::Url) return true;
+        // Shift is meaningless in the URL-snippet panel and the symbol layout, but
+        // must work for the URL letter layout so uppercase letters can be entered (#2178).
+        if (urlMode) return true;
         if (symMode) return true;
         shiftState = (shiftState + 1) % 2;
         return true;
@@ -675,8 +677,8 @@ void KeyboardEntryActivity::render(RenderLock&&) {
     const char* label;
   };
   const BottomKeyInfo bottomKeys[BOTTOM_KEY_COUNT] = {
-      {(symMode || urlMode || inputType == InputType::Url) ? KeyboardKeyType::Disabled : KeyboardKeyType::Shift,
-       (symMode || urlMode || inputType == InputType::Url) ? shiftString[0] : shiftString[shiftState]},
+      {(symMode || urlMode) ? KeyboardKeyType::Disabled : KeyboardKeyType::Shift,
+       (symMode || urlMode) ? shiftString[0] : shiftString[shiftState]},
       {KeyboardKeyType::Mode, urlMode ? "abc" : (symMode ? "abc" : "#@!")},
       {inputType == InputType::Url ? KeyboardKeyType::Mode : KeyboardKeyType::Space,
        inputType == InputType::Url ? "URL" : nullptr},


### PR DESCRIPTION
## Summary

Fixes #2178.

When entering a URL (OPDS server address or KOReader Sync URL), the on-screen keyboard's **Shift key did nothing**, so it was impossible to type uppercase letters — exactly the problem the reporter hit when their OPDS endpoint contained capital letters.

## Root cause

In `KeyboardEntryActivity`, Shift was hard-disabled for `InputType::Url`:

- `handleKeyPress()` returned early for `inputType == InputType::Url`, so `shiftState` never toggled.
- The bottom Shift key was themed `Disabled` for URL input.
- The long-press "secondary char" fallback (`getAlternativeChar()`) is limited to the number row for URL input, so it could not produce uppercase letters on the letter rows either.

The net effect: **no way to enter capital letters in a URL field.**

## Fix

Enable Shift for the URL letter layout, while keeping it disabled where it has no meaning:

- the symbol layout (`symMode`), and
- the URL-snippet panel (`urlMode`, the `https://` / `.com` / `:8080` … shortcuts).

`getSelectedChar()` already selects from `urlLayout`, whose `secondary` entries are the uppercase letters, so once `shiftState` can toggle, uppercase input works with no further changes. The bottom key now renders enabled and shows its `shift` / `SHIFT` state, consistent with the regular text keyboard.

## Behavior after the change

- URL input, normal letter layout: **Shift toggles lower/upper case** (caps-lock style, same as text input).
- URL input, `#@!` symbol layout: Shift stays disabled (unchanged).
- URL input, `URL` snippet panel: Shift stays disabled (unchanged).
- Non-URL `Text` / `Password` input: unchanged.

## Verification

- 🔲 On-device check (flagged for a human tester): in Settings → OPDS Servers / KOReader Sync → enter a URL, press Shift, confirm letters are inserted uppercase and the Shift label toggles `shift` ↔ `SHIFT`; confirm the symbol and URL-snippet sub-modes still show Shift disabled.
- Change is confined to two boolean conditions in `KeyboardEntryActivity.cpp`; no new allocations, no layout/struct changes. clang-format clean (lines ≤120 cols). Full build / format are covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)