### PR TITLE
fix: stream XTC pages with fixed 12 KiB buffer

### DIFF
--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -524,6 +524,27 @@ xtc::XtcError Xtc::loadPageStreaming(uint32_t pageIndex,
   return const_cast<xtc::XtcParser*>(parser.get())->loadPageStreaming(pageIndex, callback, chunkSize);
 }
 
+xtc::XtcError Xtc::beginPageBitmapRead(uint32_t pageIndex, xtc::PageBitmapLayout& layout) const {
+  if (!loaded || !parser) {
+    return xtc::XtcError::FILE_NOT_FOUND;
+  }
+  return const_cast<xtc::XtcParser*>(parser.get())->beginPageBitmapRead(pageIndex, layout);
+}
+
+xtc::XtcError Xtc::readPageBitmapRange(const xtc::PageBitmapLayout& layout, uint32_t relativeOffset, uint8_t* dst,
+                                       size_t len) const {
+  if (!loaded || !parser) {
+    return xtc::XtcError::FILE_NOT_FOUND;
+  }
+  return const_cast<xtc::XtcParser*>(parser.get())->readPageBitmapRange(layout, relativeOffset, dst, len);
+}
+
+void Xtc::endPageBitmapRead() const {
+  if (parser) {
+    const_cast<xtc::XtcParser*>(parser.get())->endPageBitmapRead();
+  }
+}
+
 uint8_t Xtc::calculateProgress(uint32_t currentPage) const {
   if (!loaded || !parser || parser->getPageCount() == 0) {
     return 0;

--- a/lib/Xtc/Xtc.h
+++ b/lib/Xtc/Xtc.h
@@ -94,6 +94,11 @@ class Xtc {
                                   std::function<void(const uint8_t* data, size_t size, size_t offset)> callback,
                                   size_t chunkSize = 1024) const;
 
+  xtc::XtcError beginPageBitmapRead(uint32_t pageIndex, xtc::PageBitmapLayout& layout) const;
+  xtc::XtcError readPageBitmapRange(const xtc::PageBitmapLayout& layout, uint32_t relativeOffset, uint8_t* dst,
+                                    size_t len) const;
+  void endPageBitmapRead() const;
+
   // Progress calculation
   uint8_t calculateProgress(uint32_t currentPage) const;
 

--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -474,8 +474,7 @@ XtcError XtcParser::beginPageBitmapRead(uint32_t pageIndex, PageBitmapLayout& la
   }
 
   if (page.size != 0 && page.size < bitmapSize) {
-    LOG_DBG("XTC", "Page %u table entry smaller than layout: entry=%u expected=%u", pageIndex, page.size,
-            bitmapSize);
+    LOG_DBG("XTC", "Page %u table entry smaller than layout: entry=%u expected=%u", pageIndex, page.size, bitmapSize);
     m_lastError = XtcError::CORRUPTED_HEADER;
     return m_lastError;
   }

--- a/lib/Xtc/Xtc/XtcParser.cpp
+++ b/lib/Xtc/Xtc/XtcParser.cpp
@@ -10,10 +10,33 @@
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 
+#include <algorithm>
 #include <cstring>
+#include <limits>
 
 namespace xtc {
+
+namespace {
+
+bool calculateBitmapSize(uint16_t width, uint16_t height, uint8_t bitDepth, uint32_t& out) {
+  uint64_t size = 0;
+  if (bitDepth == 2) {
+    const uint64_t colBytes = (static_cast<uint64_t>(height) + 7) / 8;
+    size = static_cast<uint64_t>(width) * colBytes * 2;
+  } else {
+    const uint64_t rowBytes = (static_cast<uint64_t>(width) + 7) / 8;
+    size = rowBytes * height;
+  }
+  if (size == 0 || size > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  out = static_cast<uint32_t>(size);
+  return true;
+}
+
+}  // namespace
 
 XtcParser::XtcParser()
     : m_isOpen(false),
@@ -390,142 +413,192 @@ const std::vector<ChapterInfo>& XtcParser::getChapters() {
 
 bool XtcParser::getPageInfo(uint32_t pageIndex, PageInfo& info) { return readPageTableEntry(pageIndex, info); }
 
-size_t XtcParser::loadPage(uint32_t pageIndex, uint8_t* buffer, size_t bufferSize) {
+XtcError XtcParser::beginPageBitmapRead(uint32_t pageIndex, PageBitmapLayout& layout) {
+  memset(&layout, 0, sizeof(layout));
+
   if (!m_isOpen) {
     m_lastError = XtcError::FILE_NOT_FOUND;
-    return 0;
+    return m_lastError;
   }
 
   if (pageIndex >= m_header.pageCount) {
     m_lastError = XtcError::PAGE_OUT_OF_RANGE;
-    return 0;
+    return m_lastError;
   }
 
   PageInfo page;
   if (!readPageTableEntry(pageIndex, page)) {
     m_lastError = XtcError::READ_ERROR;
-    return 0;
+    return m_lastError;
   }
 
   if (!ensureFileOpen()) {
     m_lastError = XtcError::FILE_NOT_FOUND;
-    return 0;
+    return m_lastError;
   }
 
-  // Seek to page data
   if (!m_file.seek64(page.offset)) {
     LOG_DBG("XTC", "Failed to seek to page %u at offset %llu", pageIndex, static_cast<unsigned long long>(page.offset));
     m_lastError = XtcError::READ_ERROR;
-    return 0;
+    return m_lastError;
   }
 
-  // Read page header (XTG for 1-bit, XTH for 2-bit - same structure)
   XtgPageHeader pageHeader;
   size_t headerRead = m_file.read(reinterpret_cast<uint8_t*>(&pageHeader), sizeof(XtgPageHeader));
   if (headerRead != sizeof(XtgPageHeader)) {
     LOG_DBG("XTC", "Failed to read page header for page %u", pageIndex);
     m_lastError = XtcError::READ_ERROR;
-    return 0;
+    return m_lastError;
   }
 
-  // Verify page magic (XTG for 1-bit, XTH for 2-bit)
   const uint32_t expectedMagic = (m_bitDepth == 2) ? XTH_MAGIC : XTG_MAGIC;
   if (pageHeader.magic != expectedMagic) {
     LOG_DBG("XTC", "Invalid page magic for page %u: 0x%08X (expected 0x%08X)", pageIndex, pageHeader.magic,
             expectedMagic);
     m_lastError = XtcError::INVALID_MAGIC;
-    return 0;
+    return m_lastError;
   }
 
-  // Calculate bitmap size based on bit depth
-  // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
-  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes
-  size_t bitmapSize;
-  if (m_bitDepth == 2) {
-    // XTH: two bit planes, each containing (width * height) bits rounded up to bytes
-    bitmapSize = ((static_cast<size_t>(pageHeader.width) * pageHeader.height + 7) / 8) * 2;
-  } else {
-    bitmapSize = ((pageHeader.width + 7) / 8) * pageHeader.height;
+  uint32_t bitmapSize = 0;
+  if (!calculateBitmapSize(pageHeader.width, pageHeader.height, m_bitDepth, bitmapSize)) {
+    LOG_DBG("XTC", "Invalid bitmap dimensions for page %u: %ux%u", pageIndex, pageHeader.width, pageHeader.height);
+    m_lastError = XtcError::CORRUPTED_HEADER;
+    return m_lastError;
   }
 
-  // Check buffer size
-  if (bufferSize < bitmapSize) {
-    LOG_DBG("XTC", "Buffer too small: need %u, have %u", bitmapSize, bufferSize);
+  if (pageHeader.dataSize != 0 && pageHeader.dataSize < bitmapSize) {
+    LOG_DBG("XTC", "Page %u bitmap smaller than layout: header=%u expected=%u", pageIndex, pageHeader.dataSize,
+            bitmapSize);
+    m_lastError = XtcError::CORRUPTED_HEADER;
+    return m_lastError;
+  }
+
+  if (page.size != 0 && page.size < bitmapSize) {
+    LOG_DBG("XTC", "Page %u table entry smaller than layout: entry=%u expected=%u", pageIndex, page.size,
+            bitmapSize);
+    m_lastError = XtcError::CORRUPTED_HEADER;
+    return m_lastError;
+  }
+
+  const uint64_t bitmapOffset = page.offset + sizeof(XtgPageHeader);
+  const uint64_t fileSize = m_file.fileSize64();
+  if (bitmapOffset > fileSize || static_cast<uint64_t>(bitmapSize) > fileSize - bitmapOffset) {
+    LOG_DBG("XTC", "Page %u bitmap exceeds file bounds", pageIndex);
+    m_lastError = XtcError::CORRUPTED_HEADER;
+    return m_lastError;
+  }
+
+  layout.bitmapOffset = bitmapOffset;
+  layout.bitmapSize = bitmapSize;
+  layout.width = pageHeader.width;
+  layout.height = pageHeader.height;
+  layout.bitDepth = m_bitDepth;
+  layout.colorMode = pageHeader.colorMode;
+  layout.compression = pageHeader.compression;
+  layout.pageMagic = pageHeader.magic;
+  layout.headerDataSize = pageHeader.dataSize;
+
+  m_lastError = XtcError::OK;
+  return m_lastError;
+}
+
+XtcError XtcParser::readPageBitmapRange(const PageBitmapLayout& layout, uint32_t relativeOffset, uint8_t* dst,
+                                        size_t len) {
+  if (!m_isOpen) {
+    m_lastError = XtcError::FILE_NOT_FOUND;
+    return m_lastError;
+  }
+  if (!dst && len > 0) {
     m_lastError = XtcError::MEMORY_ERROR;
-    return 0;
+    return m_lastError;
+  }
+  if (static_cast<uint64_t>(relativeOffset) + len > layout.bitmapSize) {
+    LOG_DBG("XTC", "Bitmap range exceeds page: offset=%u len=%u size=%u", relativeOffset, static_cast<unsigned>(len),
+            layout.bitmapSize);
+    m_lastError = XtcError::READ_ERROR;
+    return m_lastError;
+  }
+  if (!ensureFileOpen()) {
+    m_lastError = XtcError::FILE_NOT_FOUND;
+    return m_lastError;
+  }
+  if (!m_file.seek64(layout.bitmapOffset + relativeOffset)) {
+    m_lastError = XtcError::READ_ERROR;
+    return m_lastError;
   }
 
-  // Read bitmap data
-  size_t bytesRead = m_file.read(buffer, bitmapSize);
-  if (bytesRead != bitmapSize) {
-    LOG_DBG("XTC", "Page read error: expected %u, got %u", bitmapSize, bytesRead);
+  const size_t bytesRead = m_file.read(dst, len);
+  if (bytesRead != len) {
+    LOG_DBG("XTC", "Bitmap range read error: expected %u, got %u", static_cast<unsigned>(len),
+            static_cast<unsigned>(bytesRead));
     m_lastError = XtcError::READ_ERROR;
-    return 0;
+    return m_lastError;
   }
 
   m_lastError = XtcError::OK;
-  return bytesRead;
+  return m_lastError;
+}
+
+void XtcParser::endPageBitmapRead() { closeFile(); }
+
+size_t XtcParser::loadPage(uint32_t pageIndex, uint8_t* buffer, size_t bufferSize) {
+  PageBitmapLayout layout;
+  if (beginPageBitmapRead(pageIndex, layout) != XtcError::OK) {
+    endPageBitmapRead();
+    return 0;
+  }
+
+  if (bufferSize < layout.bitmapSize) {
+    LOG_DBG("XTC", "Buffer too small: need %u, have %u", layout.bitmapSize, static_cast<unsigned>(bufferSize));
+    m_lastError = XtcError::MEMORY_ERROR;
+    endPageBitmapRead();
+    return 0;
+  }
+
+  if (readPageBitmapRange(layout, 0, buffer, layout.bitmapSize) != XtcError::OK) {
+    endPageBitmapRead();
+    return 0;
+  }
+
+  endPageBitmapRead();
+  m_lastError = XtcError::OK;
+  return layout.bitmapSize;
 }
 
 XtcError XtcParser::loadPageStreaming(uint32_t pageIndex,
                                       std::function<void(const uint8_t* data, size_t size, size_t offset)> callback,
                                       size_t chunkSize) {
-  if (!m_isOpen) {
-    return XtcError::FILE_NOT_FOUND;
+  if (chunkSize == 0) return XtcError::MEMORY_ERROR;
+
+  PageBitmapLayout layout;
+  XtcError err = beginPageBitmapRead(pageIndex, layout);
+  if (err != XtcError::OK) {
+    endPageBitmapRead();
+    return err;
   }
 
-  if (pageIndex >= m_header.pageCount) {
-    return XtcError::PAGE_OUT_OF_RANGE;
+  auto chunk = makeUniqueNoThrow<uint8_t[]>(chunkSize);
+  if (!chunk) {
+    m_lastError = XtcError::MEMORY_ERROR;
+    endPageBitmapRead();
+    return m_lastError;
   }
-
-  PageInfo page;
-  if (!readPageTableEntry(pageIndex, page)) {
-    return XtcError::READ_ERROR;
-  }
-
-  if (!ensureFileOpen()) {
-    return XtcError::FILE_NOT_FOUND;
-  }
-
-  // Seek to page data
-  if (!m_file.seek64(page.offset)) {
-    return XtcError::READ_ERROR;
-  }
-
-  // Read and skip page header (XTG for 1-bit, XTH for 2-bit)
-  XtgPageHeader pageHeader;
-  size_t headerRead = m_file.read(reinterpret_cast<uint8_t*>(&pageHeader), sizeof(XtgPageHeader));
-  const uint32_t expectedMagic = (m_bitDepth == 2) ? XTH_MAGIC : XTG_MAGIC;
-  if (headerRead != sizeof(XtgPageHeader) || pageHeader.magic != expectedMagic) {
-    return XtcError::READ_ERROR;
-  }
-
-  // Calculate bitmap size based on bit depth
-  // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
-  // XTH (2-bit): Two bit planes, ((width * height + 7) / 8) * 2 bytes
-  size_t bitmapSize;
-  if (m_bitDepth == 2) {
-    bitmapSize = ((static_cast<size_t>(pageHeader.width) * pageHeader.height + 7) / 8) * 2;
-  } else {
-    bitmapSize = ((pageHeader.width + 7) / 8) * pageHeader.height;
-  }
-
-  // Read in chunks
-  std::vector<uint8_t> chunk(chunkSize);
   size_t totalRead = 0;
 
-  while (totalRead < bitmapSize) {
-    size_t toRead = std::min(chunkSize, bitmapSize - totalRead);
-    size_t bytesRead = m_file.read(chunk.data(), toRead);
-
-    if (bytesRead == 0) {
-      return XtcError::READ_ERROR;
+  while (totalRead < layout.bitmapSize) {
+    size_t toRead = std::min(chunkSize, static_cast<size_t>(layout.bitmapSize) - totalRead);
+    err = readPageBitmapRange(layout, totalRead, chunk.get(), toRead);
+    if (err != XtcError::OK) {
+      endPageBitmapRead();
+      return err;
     }
 
-    callback(chunk.data(), bytesRead, totalRead);
-    totalRead += bytesRead;
+    callback(chunk.get(), toRead, totalRead);
+    totalRead += toRead;
   }
 
+  endPageBitmapRead();
+  m_lastError = XtcError::OK;
   return XtcError::OK;
 }
 

--- a/lib/Xtc/Xtc/XtcParser.h
+++ b/lib/Xtc/Xtc/XtcParser.h
@@ -70,6 +70,17 @@ class XtcParser {
                              std::function<void(const uint8_t* data, size_t size, size_t offset)> callback,
                              size_t chunkSize = 1024);
 
+  /**
+   * Open a page bitmap for bounded range reads.
+   *
+   * beginPageBitmapRead validates the page table entry and XTG/XTH page header,
+   * fills layout with the bitmap payload location, and keeps the source file open
+   * for subsequent readPageBitmapRange calls. Call endPageBitmapRead when done.
+   */
+  XtcError beginPageBitmapRead(uint32_t pageIndex, PageBitmapLayout& layout);
+  XtcError readPageBitmapRange(const PageBitmapLayout& layout, uint32_t relativeOffset, uint8_t* dst, size_t len);
+  void endPageBitmapRead();
+
   // Get title/author from metadata
   std::string getTitle() const { return m_title; }
   std::string getAuthor() const { return m_author; }

--- a/lib/Xtc/Xtc/XtcTypes.h
+++ b/lib/Xtc/Xtc/XtcTypes.h
@@ -81,7 +81,7 @@ struct XtgPageHeader {
   //   dataSize = ((width + 7) / 8) * height
   //
   // XTH (2-bit): Two bit planes, column-major (right-to-left), 8 vertical pixels/byte
-  //   dataSize = ((width * height + 7) / 8) * 2
+  //   dataSize = width * ((height + 7) / 8) * 2
   //   First plane: Bit1 for all pixels
   //   Second plane: Bit2 for all pixels
   //   pixelValue = (bit1 << 1) | bit2
@@ -96,6 +96,19 @@ struct PageInfo {
   uint16_t height;   // Page height
   uint8_t bitDepth;  // 1 = XTG (1-bit), 2 = XTH (2-bit grayscale)
   uint8_t padding;   // Alignment padding
+};
+
+struct PageBitmapLayout {
+  uint64_t bitmapOffset;  // Absolute file offset to bitmap bytes, after the XTG/XTH page header
+  uint32_t bitmapSize;    // Bitmap payload bytes
+  uint16_t width;
+  uint16_t height;
+  uint8_t bitDepth;     // 1 = XTG, 2 = XTH
+  uint8_t colorMode;    // From XtgPageHeader
+  uint8_t compression;  // From XtgPageHeader
+  uint8_t padding;
+  uint32_t pageMagic;       // Validated XTG/XTH page magic
+  uint32_t headerDataSize;  // Raw XtgPageHeader::dataSize
 };
 
 struct ChapterInfo {

--- a/src/SilentRestart.h
+++ b/src/SilentRestart.h
@@ -5,4 +5,9 @@
 // heap fragmentation accumulated during a wifi session.
 
 void silentRestart();          // home screen
-void silentRestartToReader();  // currently-open EPUB (APP_STATE.openEpubPath)
+void silentRestartToReader();  // currently-open book (APP_STATE.openEpubPath)
+
+// One-shot heap-defrag retry for reader allocations that failed due to
+// fragmentation. Returns false if the retry was already used in this boot path.
+bool silentRestartToReaderForHeapRecovery();
+void clearReaderHeapRecoveryRestart();

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -282,6 +282,7 @@ bool XtcReaderActivity::renderXtgPageStreamed(const xtc::PageBitmapLayout& layou
     requestHeapRecoveryOrShowMemoryError(XTC_STREAM_CHUNK_LIMIT, largest8BitBlock());
     return false;
   }
+  uint8_t* const chunkData = chunk.data.get();
 
   renderer.clearScreen();
 
@@ -289,7 +290,7 @@ bool XtcReaderActivity::renderXtgPageStreamed(const xtc::PageBitmapLayout& layou
     const uint16_t rows = static_cast<uint16_t>(std::min<int>(chunk.units, layout.height - yStart));
     const size_t bytes = static_cast<size_t>(rows) * rowBytes;
     const uint32_t offset = static_cast<uint32_t>(static_cast<size_t>(yStart) * rowBytes);
-    const xtc::XtcError err = xtc->readPageBitmapRange(layout, offset, chunk.data.get(), bytes);
+    const xtc::XtcError err = xtc->readPageBitmapRange(layout, offset, chunkData, bytes);
     if (err != xtc::XtcError::OK) {
       showPageLoadError(err);
       return false;
@@ -297,7 +298,7 @@ bool XtcReaderActivity::renderXtgPageStreamed(const xtc::PageBitmapLayout& layou
 
     for (uint16_t localY = 0; localY < rows; localY++) {
       const uint16_t y = yStart + localY;
-      const uint8_t* row = chunk.data.get() + static_cast<size_t>(localY) * rowBytes;
+      const uint8_t* row = chunkData + static_cast<size_t>(localY) * rowBytes;
       for (uint16_t x = 0; x < layout.width; x++) {
         const size_t srcByte = x / 8;
         const size_t srcBit = 7 - (x % 8);
@@ -335,6 +336,7 @@ bool XtcReaderActivity::renderXthPageStreamed(const xtc::PageBitmapLayout& layou
     requestHeapRecoveryOrShowMemoryError(XTC_STREAM_CHUNK_LIMIT, largest8BitBlock());
     return false;
   }
+  uint8_t* const chunkData = chunk.data.get();
 
   const uint16_t columnsPerChunk = chunk.units;
   const uint16_t chunkCount = (layout.width + columnsPerChunk - 1) / columnsPerChunk;
@@ -353,19 +355,19 @@ bool XtcReaderActivity::renderXthPageStreamed(const xtc::PageBitmapLayout& layou
       const uint32_t plane1Offset = static_cast<uint32_t>(fileColStart * colBytes);
       const uint32_t plane2Offset = static_cast<uint32_t>(planeStride + fileColStart * colBytes);
 
-      xtc::XtcError err = xtc->readPageBitmapRange(layout, plane1Offset, chunk.data.get(), planeBytes);
+      xtc::XtcError err = xtc->readPageBitmapRange(layout, plane1Offset, chunkData, planeBytes);
       if (err != xtc::XtcError::OK) {
         showPageLoadError(err);
         return false;
       }
-      err = xtc->readPageBitmapRange(layout, plane2Offset, chunk.data.get() + planeBytes, planeBytes);
+      err = xtc->readPageBitmapRange(layout, plane2Offset, chunkData + planeBytes, planeBytes);
       if (err != xtc::XtcError::OK) {
         showPageLoadError(err);
         return false;
       }
 
-      const uint8_t* plane1 = chunk.data.get();
-      const uint8_t* plane2 = chunk.data.get() + planeBytes;
+      const uint8_t* plane1 = chunkData;
+      const uint8_t* plane2 = chunkData + planeBytes;
 
       for (uint16_t y = 0; y < layout.height; y++) {
         const size_t byteInCol = y / 8;

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -11,17 +11,65 @@
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
+#include <Logging.h>
+#include <Memory.h>
+#include <esp_heap_caps.h>
 
 #include <algorithm>
+#include <memory>
 
 #include "CrossPointSettings.h"
 #include "CrossPointState.h"
 #include "MappedInputManager.h"
 #include "ReaderUtils.h"
 #include "RecentBooksStore.h"
+#include "SilentRestart.h"
 #include "XtcReaderChapterSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+
+namespace {
+
+constexpr size_t XTC_STREAM_CHUNK_LIMIT = 12 * 1024;
+
+struct StreamBuffer {
+  std::unique_ptr<uint8_t[]> data;
+  size_t bytes = 0;
+  uint16_t units = 0;
+};
+
+size_t largest8BitBlock() { return heap_caps_get_largest_free_block(MALLOC_CAP_8BIT); }
+
+StreamBuffer allocateStreamBuffer(size_t bytesPerUnit, uint16_t maxUnits, const char* tag) {
+  StreamBuffer out;
+  if (bytesPerUnit == 0 || maxUnits == 0 || bytesPerUnit > XTC_STREAM_CHUNK_LIMIT) {
+    return out;
+  }
+
+  const size_t largest = largest8BitBlock();
+  if (largest < XTC_STREAM_CHUNK_LIMIT) {
+    LOG_ERR(tag, "No 12 KiB contiguous stream buffer: largest=%u", static_cast<unsigned>(largest));
+    return out;
+  }
+
+  auto data = makeUniqueNoThrow<uint8_t[]>(XTC_STREAM_CHUNK_LIMIT);
+  if (!data) {
+    LOG_ERR(tag, "Failed to allocate 12 KiB stream buffer: largest=%u", static_cast<unsigned>(largest));
+    return out;
+  }
+
+  size_t units = XTC_STREAM_CHUNK_LIMIT / bytesPerUnit;
+  if (units > maxUnits) units = maxUnits;
+
+  out.data = std::move(data);
+  out.bytes = XTC_STREAM_CHUNK_LIMIT;
+  out.units = static_cast<uint16_t>(units);
+  LOG_DBG(tag, "Stream buffer: 12 KiB, %u units, largest=%u", static_cast<unsigned>(out.units),
+          static_cast<unsigned>(largest));
+  return out;
+}
+
+}  // namespace
 
 void XtcReaderActivity::onEnter() {
   Activity::onEnter();
@@ -47,6 +95,7 @@ void XtcReaderActivity::onEnter() {
 void XtcReaderActivity::onExit() {
   Activity::onExit();
 
+  clearReaderHeapRecoveryRestart();
   APP_STATE.readerActivityLoadCount = 0;
   APP_STATE.saveToFile();
   xtc.reset();
@@ -123,14 +172,17 @@ void XtcReaderActivity::render(RenderLock&&) {
   // Bounds check
   if (currentPage >= xtc->getPageCount()) {
     // Show end of book screen
+    clearReaderHeapRecoveryRestart();
     renderer.clearScreen();
     renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_END_OF_BOOK), true, EpdFontFamily::BOLD);
     renderer.displayBuffer();
     return;
   }
 
-  renderPage();
-  saveProgress();
+  if (renderPage()) {
+    clearReaderHeapRecoveryRestart();
+    saveProgress();
+  }
 }
 
 XtcReaderActivity::StatusBarInfo XtcReaderActivity::getStatusBarInfo() const {
@@ -203,165 +255,59 @@ void XtcReaderActivity::renderStatusBarOverlay(const StatusBarOverlayPosition po
   GUI.drawStatusBar(renderer, progress, pageInfo.currentPage, pageInfo.pageCount, pageInfo.title, paddingBottom);
 }
 
-void XtcReaderActivity::renderPage() {
-  const uint16_t pageWidth = xtc->getPageWidth();
-  const uint16_t pageHeight = xtc->getPageHeight();
-  const uint8_t bitDepth = xtc->getBitDepth();
+bool XtcReaderActivity::requestHeapRecoveryOrShowMemoryError(size_t requestedBytes, size_t largestBlock) {
+  LOG_ERR("XTR", "Insufficient contiguous heap for stream buffer: requested=%u largest=%u",
+          static_cast<unsigned>(requestedBytes), static_cast<unsigned>(largestBlock));
+  saveProgress();
+  if (silentRestartToReaderForHeapRecovery()) {
+    return true;
+  }
+  renderer.clearScreen();
+  renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_MEMORY_ERROR), true, EpdFontFamily::BOLD);
+  renderer.displayBuffer();
+  return false;
+}
 
-  // Calculate buffer size for one page
-  // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
-  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes
-  size_t pageBufferSize;
-  if (bitDepth == 2) {
-    pageBufferSize = ((static_cast<size_t>(pageWidth) * pageHeight + 7) / 8) * 2;
-  } else {
-    pageBufferSize = ((pageWidth + 7) / 8) * pageHeight;
+void XtcReaderActivity::showPageLoadError(xtc::XtcError err) const {
+  LOG_ERR("XTR", "Failed to load page %lu: error=%s", currentPage, xtc::errorToString(err));
+  renderer.clearScreen();
+  renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
+  renderer.displayBuffer();
+}
+
+bool XtcReaderActivity::renderXtgPageStreamed(const xtc::PageBitmapLayout& layout) {
+  const size_t rowBytes = (layout.width + 7) / 8;
+  StreamBuffer chunk = allocateStreamBuffer(rowBytes, layout.height, "XTR");
+  if (!chunk.data) {
+    requestHeapRecoveryOrShowMemoryError(XTC_STREAM_CHUNK_LIMIT, largest8BitBlock());
+    return false;
   }
 
-  // Allocate page buffer
-  uint8_t* pageBuffer = static_cast<uint8_t*>(malloc(pageBufferSize));
-  if (!pageBuffer) {
-    LOG_ERR("XTR", "Failed to allocate page buffer (%lu bytes)", pageBufferSize);
-    renderer.clearScreen();
-    renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_MEMORY_ERROR), true, EpdFontFamily::BOLD);
-    renderer.displayBuffer();
-    return;
-  }
-
-  // Load page data
-  size_t bytesRead = xtc->loadPage(currentPage, pageBuffer, pageBufferSize);
-  if (bytesRead == 0) {
-    LOG_ERR("XTR", "Failed to load page %lu: bufferSize=%lu bitDepth=%u error=%s", currentPage, pageBufferSize,
-            bitDepth, xtc::errorToString(xtc->getLastError()));
-    free(pageBuffer);
-    renderer.clearScreen();
-    renderer.drawCenteredText(UI_12_FONT_ID, 300, tr(STR_PAGE_LOAD_ERROR), true, EpdFontFamily::BOLD);
-    renderer.displayBuffer();
-    return;
-  }
-
-  // Clear screen first
   renderer.clearScreen();
 
-  // Copy page bitmap using GfxRenderer's drawPixel
-  // XTC/XTCH pages are pre-rendered with status bar included, so render full page
-  const uint16_t maxSrcY = pageHeight;
-
-  if (bitDepth == 2) {
-    // XTH 2-bit mode: Two bit planes, column-major order
-    // - Columns scanned right to left (x = width-1 down to 0)
-    // - 8 vertical pixels per byte (MSB = topmost pixel in group)
-    // - First plane: Bit1, Second plane: Bit2
-    // - Pixel value = (bit1 << 1) | bit2
-    // - Grayscale: 0=White, 1=Dark Grey, 2=Light Grey, 3=Black
-
-    const size_t planeSize = (static_cast<size_t>(pageWidth) * pageHeight + 7) / 8;
-    const uint8_t* plane1 = pageBuffer;              // Bit1 plane
-    const uint8_t* plane2 = pageBuffer + planeSize;  // Bit2 plane
-    const size_t colBytes = (pageHeight + 7) / 8;    // Bytes per column (100 for 800 height)
-
-    // Lambda to get pixel value at (x, y)
-    auto getPixelValue = [&](uint16_t x, uint16_t y) -> uint8_t {
-      const size_t colIndex = pageWidth - 1 - x;
-      const size_t byteInCol = y / 8;
-      const size_t bitInByte = 7 - (y % 8);
-      const size_t byteOffset = colIndex * colBytes + byteInCol;
-      const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
-      const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
-      return (bit1 << 1) | bit2;
-    };
-
-    // Optimized grayscale rendering without storeBwBuffer (saves 48KB peak memory)
-    // Flow: BW display → LSB/MSB passes → grayscale display → re-render BW for next frame
-
-    // Count pixel distribution for debugging
-    uint32_t pixelCounts[4] = {0, 0, 0, 0};
-    for (uint16_t y = 0; y < pageHeight; y++) {
-      for (uint16_t x = 0; x < pageWidth; x++) {
-        pixelCounts[getPixelValue(x, y)]++;
-      }
-    }
-    LOG_DBG("XTR", "Pixel distribution: White=%lu, DarkGrey=%lu, LightGrey=%lu, Black=%lu", pixelCounts[0],
-            pixelCounts[1], pixelCounts[2], pixelCounts[3]);
-
-    // Pass 1: BW buffer - draw all non-white pixels as black
-    for (uint16_t y = 0; y < pageHeight; y++) {
-      for (uint16_t x = 0; x < pageWidth; x++) {
-        if (getPixelValue(x, y) >= 1) {
-          renderer.drawPixel(x, y, true);
-        }
-      }
+  for (uint16_t yStart = 0; yStart < layout.height; yStart += chunk.units) {
+    const uint16_t rows = static_cast<uint16_t>(std::min<int>(chunk.units, layout.height - yStart));
+    const size_t bytes = static_cast<size_t>(rows) * rowBytes;
+    const uint32_t offset = static_cast<uint32_t>(static_cast<size_t>(yStart) * rowBytes);
+    const xtc::XtcError err = xtc->readPageBitmapRange(layout, offset, chunk.data.get(), bytes);
+    if (err != xtc::XtcError::OK) {
+      showPageLoadError(err);
+      return false;
     }
 
-    ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
-
-    // Pass 2: LSB buffer - mark DARK gray only (XTH value 1)
-    // In LUT: 0 bit = apply gray effect, 1 bit = untouched
-    renderer.clearScreen(0x00);
-    for (uint16_t y = 0; y < pageHeight; y++) {
-      for (uint16_t x = 0; x < pageWidth; x++) {
-        if (getPixelValue(x, y) == 1) {  // Dark grey only
-          renderer.drawPixel(x, y, false);
-        }
-      }
-    }
-    renderer.copyGrayscaleLsbBuffers();
-
-    // Pass 3: MSB buffer - mark LIGHT AND DARK gray (XTH value 1 or 2)
-    // In LUT: 0 bit = apply gray effect, 1 bit = untouched
-    renderer.clearScreen(0x00);
-    for (uint16_t y = 0; y < pageHeight; y++) {
-      for (uint16_t x = 0; x < pageWidth; x++) {
-        const uint8_t pv = getPixelValue(x, y);
-        if (pv == 1 || pv == 2) {  // Dark grey or Light grey
-          renderer.drawPixel(x, y, false);
-        }
-      }
-    }
-    renderer.copyGrayscaleMsbBuffers();
-
-    // Display grayscale overlay
-    renderer.displayGrayBuffer();
-
-    // Pass 4: Re-render BW to framebuffer (restore for next frame, instead of restoreBwBuffer)
-    renderer.clearScreen();
-    for (uint16_t y = 0; y < pageHeight; y++) {
-      for (uint16_t x = 0; x < pageWidth; x++) {
-        if (getPixelValue(x, y) >= 1) {
-          renderer.drawPixel(x, y, true);
-        }
-      }
-    }
-
-    // Cleanup grayscale buffers with current frame buffer
-    renderer.cleanupGrayscaleWithFrameBuffer();
-
-    free(pageBuffer);
-
-    LOG_DBG("XTR", "Rendered page %lu/%lu (2-bit grayscale)", currentPage + 1, xtc->getPageCount());
-    return;
-  } else {
-    // 1-bit mode: 8 pixels per byte, MSB first
-    const size_t srcRowBytes = (pageWidth + 7) / 8;  // 60 bytes for 480 width
-
-    for (uint16_t srcY = 0; srcY < maxSrcY; srcY++) {
-      const size_t srcRowStart = srcY * srcRowBytes;
-
-      for (uint16_t srcX = 0; srcX < pageWidth; srcX++) {
-        // Read source pixel (MSB first, bit 7 = leftmost pixel)
-        const size_t srcByte = srcRowStart + srcX / 8;
-        const size_t srcBit = 7 - (srcX % 8);
-        const bool isBlack = !((pageBuffer[srcByte] >> srcBit) & 1);  // XTC: 0 = black, 1 = white
-
+    for (uint16_t localY = 0; localY < rows; localY++) {
+      const uint16_t y = yStart + localY;
+      const uint8_t* row = chunk.data.get() + static_cast<size_t>(localY) * rowBytes;
+      for (uint16_t x = 0; x < layout.width; x++) {
+        const size_t srcByte = x / 8;
+        const size_t srcBit = 7 - (x % 8);
+        const bool isBlack = !((row[srcByte] >> srcBit) & 1);  // XTC: 0 = black, 1 = white
         if (isBlack) {
-          renderer.drawPixel(srcX, srcY, true);
+          renderer.drawPixel(x, y, true);
         }
       }
     }
   }
-  // White pixels are already cleared by clearScreen()
-
-  free(pageBuffer);
 
   if (SETTINGS.xtcStatusBarMode == CrossPointSettings::XTC_STATUS_BAR_MODE::XTC_STATUS_BAR_TOP) {
     renderStatusBarOverlay(StatusBarOverlayPosition::Top);
@@ -370,8 +316,134 @@ void XtcReaderActivity::renderPage() {
   }
 
   ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+  LOG_DBG("XTR", "Rendered page %lu/%lu (1-bit streamed, chunk=%u bytes)", currentPage + 1, xtc->getPageCount(),
+          static_cast<unsigned>(chunk.bytes));
+  return true;
+}
 
-  LOG_DBG("XTR", "Rendered page %lu/%lu (%u-bit)", currentPage + 1, xtc->getPageCount(), bitDepth);
+bool XtcReaderActivity::renderXthPageStreamed(const xtc::PageBitmapLayout& layout) {
+  const size_t colBytes = (layout.height + 7) / 8;
+  const size_t planeStride = static_cast<size_t>(layout.width) * colBytes;
+  const size_t bytesPerColumnPair = colBytes * 2;
+  if (planeStride == 0 || bytesPerColumnPair == 0 || planeStride * 2 > layout.bitmapSize) {
+    showPageLoadError(xtc::XtcError::CORRUPTED_HEADER);
+    return false;
+  }
+
+  StreamBuffer chunk = allocateStreamBuffer(bytesPerColumnPair, layout.width, "XTR");
+  if (!chunk.data) {
+    requestHeapRecoveryOrShowMemoryError(XTC_STREAM_CHUNK_LIMIT, largest8BitBlock());
+    return false;
+  }
+
+  const uint16_t columnsPerChunk = chunk.units;
+  const uint16_t chunkCount = (layout.width + columnsPerChunk - 1) / columnsPerChunk;
+  LOG_DBG("XTR", "XTCH streaming: %ux%u colBytes=%u columns/chunk=%u chunk=%u bytes chunks=%u", layout.width,
+          layout.height, static_cast<unsigned>(colBytes), static_cast<unsigned>(columnsPerChunk),
+          static_cast<unsigned>(chunk.bytes), static_cast<unsigned>(chunkCount));
+
+  enum class XthPass : uint8_t { Bw, Lsb, Msb, Restore };
+
+  auto renderPass = [&](XthPass pass, uint32_t pixelCounts[4]) -> bool {
+    for (uint16_t xStart = 0; xStart < layout.width; xStart += columnsPerChunk) {
+      const uint16_t xEnd = static_cast<uint16_t>(std::min<int>(layout.width, xStart + columnsPerChunk));
+      const uint16_t columns = xEnd - xStart;
+      const size_t planeBytes = static_cast<size_t>(columns) * colBytes;
+      const size_t fileColStart = layout.width - xEnd;
+      const uint32_t plane1Offset = static_cast<uint32_t>(fileColStart * colBytes);
+      const uint32_t plane2Offset = static_cast<uint32_t>(planeStride + fileColStart * colBytes);
+
+      xtc::XtcError err = xtc->readPageBitmapRange(layout, plane1Offset, chunk.data.get(), planeBytes);
+      if (err != xtc::XtcError::OK) {
+        showPageLoadError(err);
+        return false;
+      }
+      err = xtc->readPageBitmapRange(layout, plane2Offset, chunk.data.get() + planeBytes, planeBytes);
+      if (err != xtc::XtcError::OK) {
+        showPageLoadError(err);
+        return false;
+      }
+
+      const uint8_t* plane1 = chunk.data.get();
+      const uint8_t* plane2 = chunk.data.get() + planeBytes;
+
+      for (uint16_t y = 0; y < layout.height; y++) {
+        const size_t byteInCol = y / 8;
+        const uint8_t bitInByte = 7 - (y % 8);
+        for (uint16_t x = xStart; x < xEnd; x++) {
+          const size_t fileCol = layout.width - 1 - x;
+          const size_t localCol = fileCol - fileColStart;
+          const size_t byteOffset = localCol * colBytes + byteInCol;
+          const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
+          const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
+          const uint8_t pixelValue = (bit1 << 1) | bit2;
+
+          switch (pass) {
+            case XthPass::Bw:
+              pixelCounts[pixelValue]++;
+              if (pixelValue >= 1) renderer.drawPixel(x, y, true);
+              break;
+            case XthPass::Lsb:
+              if (pixelValue == 1) renderer.drawPixel(x, y, false);
+              break;
+            case XthPass::Msb:
+              if (pixelValue == 1 || pixelValue == 2) renderer.drawPixel(x, y, false);
+              break;
+            case XthPass::Restore:
+              if (pixelValue >= 1) renderer.drawPixel(x, y, true);
+              break;
+          }
+        }
+      }
+    }
+    return true;
+  };
+
+  uint32_t pixelCounts[4] = {0, 0, 0, 0};
+
+  renderer.clearScreen();
+  if (!renderPass(XthPass::Bw, pixelCounts)) return false;
+  LOG_DBG("XTR", "Pixel distribution: White=%lu, DarkGrey=%lu, LightGrey=%lu, Black=%lu", pixelCounts[0],
+          pixelCounts[1], pixelCounts[2], pixelCounts[3]);
+  ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
+
+  renderer.clearScreen(0x00);
+  if (!renderPass(XthPass::Lsb, pixelCounts)) return false;
+  renderer.copyGrayscaleLsbBuffers();
+
+  renderer.clearScreen(0x00);
+  if (!renderPass(XthPass::Msb, pixelCounts)) return false;
+  renderer.copyGrayscaleMsbBuffers();
+
+  renderer.displayGrayBuffer();
+
+  renderer.clearScreen();
+  if (!renderPass(XthPass::Restore, pixelCounts)) return false;
+  renderer.cleanupGrayscaleWithFrameBuffer();
+
+  LOG_DBG("XTR", "Rendered page %lu/%lu (2-bit streamed grayscale)", currentPage + 1, xtc->getPageCount());
+  return true;
+}
+
+bool XtcReaderActivity::renderPage() {
+  xtc::PageBitmapLayout layout;
+  xtc::XtcError err = xtc->beginPageBitmapRead(currentPage, layout);
+  if (err != xtc::XtcError::OK) {
+    xtc->endPageBitmapRead();
+    showPageLoadError(err);
+    return false;
+  }
+  const ScopedCleanup cleanup{[this]() {
+    if (xtc) xtc->endPageBitmapRead();
+  }};
+
+  bool ok = false;
+  if (layout.bitDepth == 2) {
+    ok = renderXthPageStreamed(layout);
+  } else {
+    ok = renderXtgPageStreamed(layout);
+  }
+  return ok;
 }
 
 void XtcReaderActivity::saveProgress() const {

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -27,7 +27,11 @@ class XtcReaderActivity final : public Activity {
     std::string title;
   };
 
-  void renderPage();
+  bool renderPage();
+  bool renderXtgPageStreamed(const xtc::PageBitmapLayout& layout);
+  bool renderXthPageStreamed(const xtc::PageBitmapLayout& layout);
+  bool requestHeapRecoveryOrShowMemoryError(size_t requestedBytes, size_t largestBlock);
+  void showPageLoadError(xtc::XtcError err) const;
   void renderStatusBarOverlay(StatusBarOverlayPosition position) const;
   StatusBarInfo getStatusBarInfo() const;
   void saveProgress() const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,13 +152,9 @@ static bool runSilentRestart(uint32_t target, const char* targetLabel) {
   return true;
 }
 
-void silentRestart() {
-  runSilentRestart(SILENT_REBOOT_TARGET_HOME, "home");
-}
+void silentRestart() { runSilentRestart(SILENT_REBOOT_TARGET_HOME, "home"); }
 
-void silentRestartToReader() {
-  runSilentRestart(SILENT_REBOOT_TARGET_READER, "reader");
-}
+void silentRestartToReader() { runSilentRestart(SILENT_REBOOT_TARGET_READER, "reader"); }
 
 bool silentRestartToReaderForHeapRecovery() {
   if (deepSleepInProgress) return false;  // sleeping supersedes the heap-defrag reboot

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,9 +114,11 @@ unsigned long t2 = 0;
 // Definitions for SilentRestart.h. RTC_NOINIT survives ESP.restart() but not power loss.
 RTC_NOINIT_ATTR uint32_t silentRebootMagic;
 RTC_NOINIT_ATTR uint32_t silentRebootTarget;
+RTC_NOINIT_ATTR uint32_t readerHeapRecoveryMagic;
 constexpr uint32_t SILENT_REBOOT_MAGIC = 0xC1EAB007;
 constexpr uint32_t SILENT_REBOOT_TARGET_HOME = 0;
 constexpr uint32_t SILENT_REBOOT_TARGET_READER = 1;
+constexpr uint32_t READER_HEAP_RECOVERY_MAGIC = 0x5A435458;  // "XTCZ"
 
 // How the device is coming back to life, resolved once at boot. Both resume
 // flows suppress the splash and leave the panel holding its pre-boot frame; a
@@ -135,11 +137,11 @@ enum class BootResume : uint8_t {
 // startDeepSleep() does not return, so a set latch only ends at the wakeup reset.
 static bool deepSleepInProgress = false;
 
-void silentRestart() {
-  if (deepSleepInProgress) return;  // sleeping supersedes the heap-defrag reboot
-  silentRebootTarget = SILENT_REBOOT_TARGET_HOME;
+static bool runSilentRestart(uint32_t target, const char* targetLabel) {
+  if (deepSleepInProgress) return false;  // sleeping supersedes the heap-defrag reboot
+  silentRebootTarget = target;
   silentRebootMagic = SILENT_REBOOT_MAGIC;
-  LOG_DBG("MAIN", "Silent restart (target=home)");
+  LOG_DBG("MAIN", "Silent restart (target=%s)", targetLabel);
   // E-ink retains the previous frame until Home's first paint lands (~2-3s).
   // Without an overlay, users don't see the reboot and fire input through to
   // Home. Select on the default selectorIndex=0 then opens the most-recent
@@ -147,17 +149,28 @@ void silentRestart() {
   GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
   delay(50);
   ESP.restart();
+  return true;
+}
+
+void silentRestart() {
+  runSilentRestart(SILENT_REBOOT_TARGET_HOME, "home");
 }
 
 void silentRestartToReader() {
-  if (deepSleepInProgress) return;  // sleeping supersedes the heap-defrag reboot
-  silentRebootTarget = SILENT_REBOOT_TARGET_READER;
-  silentRebootMagic = SILENT_REBOOT_MAGIC;
-  LOG_DBG("MAIN", "Silent restart (target=reader)");
-  GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
-  delay(50);
-  ESP.restart();
+  runSilentRestart(SILENT_REBOOT_TARGET_READER, "reader");
 }
+
+bool silentRestartToReaderForHeapRecovery() {
+  if (deepSleepInProgress) return false;  // sleeping supersedes the heap-defrag reboot
+  if (readerHeapRecoveryMagic == READER_HEAP_RECOVERY_MAGIC) {
+    LOG_ERR("MAIN", "Reader heap recovery restart already attempted");
+    return false;
+  }
+  readerHeapRecoveryMagic = READER_HEAP_RECOVERY_MAGIC;
+  return runSilentRestart(SILENT_REBOOT_TARGET_READER, "reader, heap recovery");
+}
+
+void clearReaderHeapRecoveryRestart() { readerHeapRecoveryMagic = 0; }
 
 // Verify power button press duration on wake-up from deep sleep
 // Pre-condition: isWakeupByPowerButton() == true
@@ -325,6 +338,9 @@ void setup() {
       (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_READER) ? silentRebootTarget : 0;
   silentRebootMagic = 0;
   silentRebootTarget = 0;
+  if (!isSilentReboot || snapshotTarget != SILENT_REBOOT_TARGET_READER) {
+    readerHeapRecoveryMagic = 0;
+  }
 
   gpio.begin();
   powerManager.begin();


### PR DESCRIPTION
## Summary
- add parser-level bitmap range reads for XTC/XTCH pages
- stream XTC/XTCH page rendering through one fixed 12 KiB staging buffer instead of full-page bitmap allocations
- trigger the existing silent restart flow once when a contiguous 12 KiB 8-bit heap block is unavailable, then show memory error on repeated failure
- share silent restart helper logic so reader heap recovery matches the WiFi restart mechanism

## Testing
- pio run
- pio run -t upload --upload-port /dev/cu.usbmodem2101