### PR TITLE
fix(reader): return to book menu from sub-screens; close QR on Back only (#2317)

### DIFF
--- a/src/activities/ActivityResult.h
+++ b/src/activities/ActivityResult.h
@@ -21,6 +21,9 @@ struct MenuResult {
   int action = -1;
   uint8_t orientation = 0;
   uint8_t pageTurnOption = 0;
+  // Menu row that was highlighted when the menu closed, so the reader can
+  // re-open the menu on the same row after a sub-screen is cancelled (#2317).
+  int selectedIndex = 0;
 };
 
 struct ChapterResult {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -573,9 +573,14 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
         std::string fullText = section->getTextFromSectionFile();
         if (!fullText.empty()) {
-          // QR has no confirm action; closing it with Back returns to the menu (#2317).
+          // QR closes with Back, which reports a cancelled result; reopen the menu then,
+          // consistent with the other sub-screens (#2317).
           startActivityForResult(std::make_unique<QrDisplayActivity>(renderer, mappedInput, fullText),
-                                 [this, menuIndex](const ActivityResult& result) { openReaderMenu(menuIndex); });
+                                 [this, menuIndex](const ActivityResult& result) {
+                                   if (result.isCancelled) {
+                                     openReaderMenu(menuIndex);
+                                   }
+                                 });
           break;
         }
       }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -263,26 +263,7 @@ void EpubReaderActivity::loop() {
     if (ignoreNextConfirmRelease) {
       ignoreNextConfirmRelease = false;
     } else {
-      const int currentPage = section ? section->currentPage + 1 : 0;
-      const int totalPages = section ? section->pageCount : 0;
-      float bookProgress = 0.0f;
-      if (epub->getBookSize() > 0 && section && section->pageCount > 0) {
-        const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
-        bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
-      }
-      const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
-      startActivityForResult(std::make_unique<EpubReaderMenuActivity>(
-                                 renderer, mappedInput, epub->getTitle(), currentPage, totalPages, bookProgressPercent,
-                                 SETTINGS.orientation, !currentPageFootnotes.empty()),
-                             [this](const ActivityResult& result) {
-                               // Always apply orientation change even if the menu was cancelled
-                               const auto& menu = std::get<MenuResult>(result.data);
-                               applyOrientation(menu.orientation);
-                               toggleAutoPageTurn(menu.pageTurnOption);
-                               if (!result.isCancelled) {
-                                 onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action));
-                               }
-                             });
+      openReaderMenu();
     }
   }
 
@@ -490,8 +471,34 @@ void EpubReaderActivity::jumpToPercent(int percent) {
   }
 }
 
-void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action) {
-  auto progressChangeResultHandler = [this](const ActivityResult& result) {
+void EpubReaderActivity::openReaderMenu(const int initialSelectedIndex) {
+  const int currentPage = section ? section->currentPage + 1 : 0;
+  const int totalPages = section ? section->pageCount : 0;
+  float bookProgress = 0.0f;
+  if (epub->getBookSize() > 0 && section && section->pageCount > 0) {
+    const float chapterProgress = static_cast<float>(section->currentPage) / static_cast<float>(section->pageCount);
+    bookProgress = epub->calculateProgress(currentSpineIndex, chapterProgress) * 100.0f;
+  }
+  const int bookProgressPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
+  startActivityForResult(std::make_unique<EpubReaderMenuActivity>(renderer, mappedInput, epub->getTitle(), currentPage,
+                                                                  totalPages, bookProgressPercent, SETTINGS.orientation,
+                                                                  !currentPageFootnotes.empty(), initialSelectedIndex),
+                         [this](const ActivityResult& result) {
+                           // Always apply orientation change even if the menu was cancelled
+                           const auto& menu = std::get<MenuResult>(result.data);
+                           applyOrientation(menu.orientation);
+                           toggleAutoPageTurn(menu.pageTurnOption);
+                           if (!result.isCancelled) {
+                             onReaderMenuConfirm(static_cast<EpubReaderMenuActivity::MenuAction>(menu.action),
+                                                 menu.selectedIndex);
+                           }
+                         });
+}
+
+void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action, const int menuIndex) {
+  // Sub-screens opened from the menu return to the menu (not the reader) when
+  // cancelled with Back, re-selecting the row they were launched from (#2317).
+  auto progressChangeResultHandler = [this, menuIndex](const ActivityResult& result) {
     if (!result.isCancelled) {
       const auto& sync = std::get<ProgressChangeResult>(result.data);
       if (currentSpineIndex != sync.spineIndex || (section && section->currentPage != sync.page)) {
@@ -500,6 +507,8 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         nextPageNumber = sync.page;
         section.reset();
       }
+    } else {
+      openReaderMenu(menuIndex);
     }
   };
 
@@ -509,7 +518,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       const std::string path = epub->getPath();
       startActivityForResult(
           std::make_unique<EpubReaderChapterSelectionActivity>(renderer, mappedInput, epub, path, spineIdx),
-          [this](const ActivityResult& result) {
+          [this, menuIndex](const ActivityResult& result) {
             if (!result.isCancelled) {
               const auto& chapterResult = std::get<ChapterResult>(result.data);
               RenderLock lock(*this);
@@ -523,18 +532,22 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
               nextPageNumber = 0;
 
               section.reset();
+            } else {
+              openReaderMenu(menuIndex);
             }
           });
       break;
     }
     case EpubReaderMenuActivity::MenuAction::FOOTNOTES: {
       startActivityForResult(std::make_unique<EpubReaderFootnotesActivity>(renderer, mappedInput, currentPageFootnotes),
-                             [this](const ActivityResult& result) {
+                             [this, menuIndex](const ActivityResult& result) {
                                if (!result.isCancelled) {
                                  const auto& footnoteResult = std::get<FootnoteResult>(result.data);
                                  navigateToHref(footnoteResult.href, true);
+                                 requestUpdate();
+                               } else {
+                                 openReaderMenu(menuIndex);
                                }
-                               requestUpdate();
                              });
       break;
     }
@@ -547,9 +560,11 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       const int initialPercent = clampPercent(static_cast<int>(bookProgress + 0.5f));
       startActivityForResult(
           std::make_unique<EpubReaderPercentSelectionActivity>(renderer, mappedInput, initialPercent),
-          [this](const ActivityResult& result) {
+          [this, menuIndex](const ActivityResult& result) {
             if (!result.isCancelled) {
               jumpToPercent(std::get<PercentResult>(result.data).percent);
+            } else {
+              openReaderMenu(menuIndex);
             }
           });
       break;
@@ -558,13 +573,14 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       if (section && section->currentPage >= 0 && section->currentPage < section->pageCount) {
         std::string fullText = section->getTextFromSectionFile();
         if (!fullText.empty()) {
+          // QR has no confirm action; closing it with Back returns to the menu (#2317).
           startActivityForResult(std::make_unique<QrDisplayActivity>(renderer, mappedInput, fullText),
-                                 [this](const ActivityResult& result) {});
+                                 [this, menuIndex](const ActivityResult& result) { openReaderMenu(menuIndex); });
           break;
         }
       }
-      // If no text or page loading failed, just close menu
-      requestUpdate();
+      // If no text or page loading failed, re-open the menu instead of dropping to the reader.
+      openReaderMenu(menuIndex);
       break;
     }
     case EpubReaderMenuActivity::MenuAction::GO_HOME: {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -59,7 +59,10 @@ class EpubReaderActivity final : public Activity {
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);
-  void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action);
+  // Open the reader menu, optionally re-selecting a given row. Used both for the
+  // initial open and to re-open the menu after a sub-screen is cancelled (#2317).
+  void openReaderMenu(int initialSelectedIndex = 0);
+  void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action, int menuIndex);
   // Returns true if sync acted (launched, or surfaced a save error); false if it was a no-op
   // because no KOReader credentials are stored.
   bool launchKOReaderSync();

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -10,9 +10,12 @@
 EpubReaderMenuActivity::EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
                                                const std::string& title, const int currentPage, const int totalPages,
                                                const int bookProgressPercent, const uint8_t currentOrientation,
-                                               const bool hasFootnotes)
+                                               const bool hasFootnotes, const int initialSelectedIndex)
     : Activity("EpubReaderMenu", renderer, mappedInput),
       menuItems(buildMenuItems(hasFootnotes)),
+      selectedIndex(initialSelectedIndex >= 0 && initialSelectedIndex < static_cast<int>(menuItems.size())
+                        ? initialSelectedIndex
+                        : 0),
       title(title),
       pendingOrientation(currentOrientation),
       currentPage(currentPage),
@@ -72,13 +75,13 @@ void EpubReaderMenuActivity::loop() {
       return;
     }
 
-    setResult(MenuResult{static_cast<int>(selectedAction), pendingOrientation, selectedPageTurnOption});
+    setResult(MenuResult{static_cast<int>(selectedAction), pendingOrientation, selectedPageTurnOption, selectedIndex});
     finish();
     return;
   } else if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     ActivityResult result;
     result.isCancelled = true;
-    result.data = MenuResult{-1, pendingOrientation, selectedPageTurnOption};
+    result.data = MenuResult{-1, pendingOrientation, selectedPageTurnOption, selectedIndex};
     setResult(std::move(result));
     finish();
     return;

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -27,7 +27,8 @@ class EpubReaderMenuActivity final : public Activity {
 
   explicit EpubReaderMenuActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const std::string& title,
                                   const int currentPage, const int totalPages, const int bookProgressPercent,
-                                  const uint8_t currentOrientation, const bool hasFootnotes);
+                                  const uint8_t currentOrientation, const bool hasFootnotes,
+                                  const int initialSelectedIndex = 0);
 
   void onEnter() override;
   void onExit() override;

--- a/src/activities/reader/QrDisplayActivity.cpp
+++ b/src/activities/reader/QrDisplayActivity.cpp
@@ -16,8 +16,9 @@ void QrDisplayActivity::onEnter() {
 void QrDisplayActivity::onExit() { Activity::onExit(); }
 
 void QrDisplayActivity::loop() {
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
-      mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+  // Only Back closes the QR page; the on-screen hint advertises Back alone, so
+  // Confirm must not double as a second back button (#2317).
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     finish();
     return;
   }

--- a/src/activities/reader/QrDisplayActivity.cpp
+++ b/src/activities/reader/QrDisplayActivity.cpp
@@ -19,6 +19,11 @@ void QrDisplayActivity::loop() {
   // Only Back closes the QR page; the on-screen hint advertises Back alone, so
   // Confirm must not double as a second back button (#2317).
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
+    // Report a cancelled result so the caller re-opens the reader menu, matching
+    // how the other menu sub-screens signal a Back dismissal (#2317).
+    ActivityResult result;
+    result.isCancelled = true;
+    setResult(std::move(result));
     finish();
     return;
   }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Fixes #2317. Opening the reader menu, picking a sub-screen (Select Chapter, Go to %, Show Page as QR, Footnotes, or Bookmarks), then pressing Back took you to the reading page instead of back to the menu. This makes Back return to the menu. It also fixes the second half of that issue: the QR page closed on both Back and Confirm, so Confirm acted as an unlabeled second back button.

* **What changes are included?**

The menu opens with `startActivityForResult`. When you pick an item, the menu finishes and pops itself before the reader's handler launches the sub-screen, so the stack ends up as `[Reader] -> [SubScreen]` with the menu already gone, and Back lands on the reader.

This keeps the menu reader-owned and unaware of the book (no epub/section passed into it). The menu-open logic moves into `openReaderMenu()`, and the reader re-opens the menu when a sub-screen is cancelled with Back, landing on the row it was launched from. Confirm actions still return to the reader. `MenuResult` now carries the highlighted row so the menu reopens in place.

For the QR page, the Confirm condition is removed so only Back closes it, matching the on-screen hint.

The same Back behavior now applies to Footnotes and Bookmarks as well, not just the three items named in the issue, so every menu sub-screen behaves the same way.

## Additional Context

Builds clean with `pio run` (no warnings or errors) and flashed to an Xteink X3. Verified that Back from each sub-screen returns to the menu on the same row, Back from the menu returns to the reader, the confirm paths (jump to %, pick chapter, open bookmark) still return to the reader, and the QR page closes on Back only.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_