### PR TITLE
fix: use STR_SELECT instead of STR_OPEN in bookmark button hint

### DIFF
--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -217,7 +217,7 @@ void EpubReaderBookmarksActivity::render(RenderLock&&) {
 
   const auto backLabel = confirmingDelete >= DELETE_MODE_DISPLAY ? tr(STR_CANCEL) : tr(STR_BACK);
   const auto confirmLabel =
-      bookmarks.size() > 0 ? (confirmingDelete >= DELETE_MODE_DISPLAY ? tr(STR_DELETE) : tr(STR_OPEN)) : "";
+      bookmarks.size() > 0 ? (confirmingDelete >= DELETE_MODE_DISPLAY ? tr(STR_DELETE) : tr(STR_SELECT)) : "";
   const auto labels = mappedInput.mapLabels(backLabel, confirmLabel, tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 


### PR DESCRIPTION
## Summary

Fixes #2355

- The confirm button hint in the bookmarks screen was showing `Open` (`STR_OPEN`)
- Every other list screen in the reader (chapter selection, footnotes, KOReader sync, percent selection) uses `STR_SELECT` for the same button position
- This aligns the bookmarks screen with the established pattern across the reader

## Change

`src/activities/reader/EpubReaderBookmarksActivity.cpp` line 220: `STR_OPEN` → `STR_SELECT`
