### PR TITLE
fix(reader): rotate button hint text 180° in inverted orientation (#2364)

### DIFF
--- a/lib/EpdFont/EpdFont.h
+++ b/lib/EpdFont/EpdFont.h
@@ -2,13 +2,13 @@
 #include "EpdFontData.h"
 
 class EpdFont {
-  void getTextBounds(const char* string, int startX, int startY, int* minX, int* minY, int* maxX, int* maxY) const;
-
  public:
   const EpdFontData* data;
   explicit EpdFont(const EpdFontData* data) : data(data) {}
   ~EpdFont() = default;
   void getTextDimensions(const char* string, int* w, int* h) const;
+  // Baseline-relative ink bounding box for \p string laid out from (startX, startY).
+  void getTextBounds(const char* string, int startX, int startY, int* minX, int* minY, int* maxX, int* maxY) const;
 
   const EpdGlyph* getGlyph(uint32_t cp) const;
 

--- a/lib/EpdFont/EpdFontFamily.cpp
+++ b/lib/EpdFont/EpdFontFamily.cpp
@@ -22,6 +22,11 @@ void EpdFontFamily::getTextDimensions(const char* string, int* w, int* h, const 
   getFont(style)->getTextDimensions(string, w, h);
 }
 
+void EpdFontFamily::getTextBounds(const char* string, const int startX, const int startY, int* minX, int* minY,
+                                  int* maxX, int* maxY, const Style style) const {
+  getFont(style)->getTextBounds(string, startX, startY, minX, minY, maxX, maxY);
+}
+
 const EpdFontData* EpdFontFamily::getData(const Style style) const { return getFont(style)->data; }
 
 const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style) const {

--- a/lib/EpdFont/EpdFontFamily.h
+++ b/lib/EpdFont/EpdFontFamily.h
@@ -23,6 +23,9 @@ class EpdFontFamily {
       : regular(regular), bold(bold), italic(italic), boldItalic(boldItalic) {}
   ~EpdFontFamily() = default;
   void getTextDimensions(const char* string, int* w, int* h, Style style = REGULAR) const;
+  // Baseline-relative ink bounding box for \p string laid out from (startX, startY).
+  void getTextBounds(const char* string, int startX, int startY, int* minX, int* minY, int* maxX, int* maxY,
+                     Style style = REGULAR) const;
   const EpdFontData* getData(Style style = REGULAR) const;
   const EpdGlyph* getGlyph(uint32_t cp, Style style = REGULAR) const;
   int8_t getKerning(uint32_t leftCp, uint32_t rightCp, Style style = REGULAR) const;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1681,6 +1681,32 @@ void GfxRenderer::drawTextRotated180(const int fontId, const int x, const int y,
   }
 }
 
+void GfxRenderer::drawTextRotated180VCentered(const int fontId, const int x, const int boxTop, const int boxHeight,
+                                              const char* text, const bool black, const EpdFontFamily::Style style,
+                                              const BidiUtils::BidiBaseDir baseDir) const {
+  if (text == nullptr || *text == '\0') {
+    return;
+  }
+
+  const auto fontIt = fontMap.find(fontId);
+  if (fontIt == fontMap.end()) {
+    LOG_ERR("GFX", "Font %d not found", fontId);
+    return;
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+
+  // Find the top y that vertically centres the text's real ink box in [boxTop, boxTop+boxHeight).
+  // Ink spans screen rows [baseline - maxY, baseline - minY] with baseline = y + ascender, so
+  // ink centre = y + ascender - (minY + maxY) / 2. Solve for y given the desired centre.
+  int minX = 0, minY = 0, maxX = 0, maxY = 0;
+  fontIt->second.getTextBounds(renderedText, 0, 0, &minX, &minY, &maxX, &maxY, style);
+  const int y = boxTop + boxHeight / 2 - getFontAscenderSize(fontId) + (minY + maxY) / 2;
+
+  drawTextRotated180(fontId, x, y, text, black, style, baseDir);
+}
+
 uint8_t* GfxRenderer::getFrameBuffer() const { return frameBuffer; }
 
 size_t GfxRenderer::getBufferSize() const { return frameBufferSize; }

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1617,20 +1617,25 @@ void GfxRenderer::drawTextRotated180(const int fontId, const int x, const int y,
     return;
   }
 
-  // A 180° rotation reflects every glyph pen about the centre of the text's bounding box,
-  // so the output fills the same box as drawText(fontId, x, y, ...) but upside-down. The
-  // layout pass below mirrors drawText() exactly (kerning, ligatures, combining marks); only
-  // the final pen passed to renderCharImpl is reflected: rotatedPen = 2*centre - normalPen.
-  // The doubled centre uses the inclusive far pixel (width/height - 1): a W-wide box spans
-  // pixels [x, x+W-1], so its centre is x + (W-1)/2 and the reflection lands back in place.
-  // Measure the already-resolved text via the cached font handle to avoid repeating the BiDi
-  // pass and a second fontMap lookup.
-  int textW = 0, textH = 0;
-  font.getTextDimensions(renderedText, &textW, &textH, style);
-  const int cx2 = 2 * x + textW - 1;                  // 2 * box centre X
-  const int cy2 = 2 * y + getTextHeight(fontId) - 1;  // 2 * box centre Y (box height = ascender)
+  // A 180° rotation reflects every glyph pen about the centre of the rendered text, so the
+  // output lands on the same pixels as drawText(fontId, x, y, ...) but upside-down. The layout
+  // pass below mirrors drawText() exactly (kerning, ligatures, combining marks); only the final
+  // pen passed to renderCharImpl is reflected: rotatedPen = 2*centre - normalPen.
+  //
+  // Reflect about the real ink bounding box (getTextBounds), not an ascender-derived box: a
+  // glyph's cap height is smaller than the font ascender, so an ascender-based centre would
+  // leave the flipped text vertically off-centre in the button (#2375 review). getTextBounds
+  // returns extents relative to a baseline at the origin; the rendered baseline sits at
+  // y + ascender. The trailing -1 converts the exclusive far edge to the inclusive far pixel so
+  // the reflection lands back in place. Reusing the already-resolved text and cached font handle
+  // also avoids a second BiDi pass / fontMap lookup.
+  int minX = 0, minY = 0, maxX = 0, maxY = 0;
+  font.getTextBounds(renderedText, 0, 0, &minX, &minY, &maxX, &maxY, style);
+  const int ascender = getFontAscenderSize(fontId);
+  const int cx2 = 2 * x + minX + maxX - 1;               // 2 * ink centre X
+  const int cy2 = 2 * (y + ascender) - minY - maxY - 1;  // 2 * ink centre Y
 
-  const int yPos = y + getFontAscenderSize(fontId);
+  const int yPos = y + ascender;
   int lastBaseX = x;
   int lastBaseLeft = 0;
   int lastBaseWidth = 0;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -134,7 +134,7 @@ static inline void rotateCoordinates(const GfxRenderer::Orientation orientation,
   }
 }
 
-enum class TextRotation { None, Rotated90CW };
+enum class TextRotation { None, Rotated90CW, Rotated180 };
 
 // Shared glyph rendering logic for normal and rotated text.
 // Coordinate mapping and cursor advance direction are selected at compile time via the template parameter.
@@ -238,6 +238,12 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
     if (!renderer.glyphIntersectsStrip(ob, ib - (width - 1), ob + height - 1, ib)) {
       return;
     }
+  } else if constexpr (rotation == TextRotation::Rotated180) {
+    const int gx1 = cursorX - left;  // rightmost screen X (glyphX = 0)
+    const int gy1 = cursorY + top;   // bottommost screen Y (glyphY = 0)
+    if (!renderer.glyphIntersectsStrip(gx1 - (width - 1), gy1 - (height - 1), gx1, gy1)) {
+      return;
+    }
   } else {
     const int gx0 = cursorX + left;
     const int gy0 = cursorY - top;
@@ -255,6 +261,9 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
     if constexpr (rotation == TextRotation::Rotated90CW) {
       outerBase = cursorX + fontData->ascender - top;  // screenX = outerBase + glyphY
       innerBase = cursorY - left;                      // screenY = innerBase - glyphX
+    } else if constexpr (rotation == TextRotation::Rotated180) {
+      outerBase = cursorY + top;   // screenY = outerBase - glyphY
+      innerBase = cursorX - left;  // screenX = innerBase - glyphX
     } else {
       outerBase = cursorY - top;   // screenY = outerBase + glyphY
       innerBase = cursorX + left;  // screenX = innerBase + glyphX
@@ -263,15 +272,17 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
     if (is2Bit) {
       int pixelPosition = 0;
       for (int glyphY = 0; glyphY < height; glyphY++) {
-        const int outerCoord = outerBase + glyphY;
         for (int glyphX = 0; glyphX < width; glyphX++, pixelPosition++) {
           int screenX, screenY;
           if constexpr (rotation == TextRotation::Rotated90CW) {
-            screenX = outerCoord;
+            screenX = outerBase + glyphY;
             screenY = innerBase - glyphX;
+          } else if constexpr (rotation == TextRotation::Rotated180) {
+            screenX = innerBase - glyphX;
+            screenY = outerBase - glyphY;
           } else {
             screenX = innerBase + glyphX;
-            screenY = outerCoord;
+            screenY = outerBase + glyphY;
           }
 
           const uint8_t byte = bitmap[pixelPosition >> 2];
@@ -298,15 +309,17 @@ static void renderCharImpl(const GfxRenderer& renderer, GfxRenderer::RenderMode 
     } else {
       int pixelPosition = 0;
       for (int glyphY = 0; glyphY < height; glyphY++) {
-        const int outerCoord = outerBase + glyphY;
         for (int glyphX = 0; glyphX < width; glyphX++, pixelPosition++) {
           int screenX, screenY;
           if constexpr (rotation == TextRotation::Rotated90CW) {
-            screenX = outerCoord;
+            screenX = outerBase + glyphY;
             screenY = innerBase - glyphX;
+          } else if constexpr (rotation == TextRotation::Rotated180) {
+            screenX = innerBase - glyphX;
+            screenY = outerBase - glyphY;
           } else {
             screenX = innerBase + glyphX;
-            screenY = outerCoord;
+            screenY = outerBase + glyphY;
           }
 
           const uint8_t byte = bitmap[pixelPosition >> 3];
@@ -1576,6 +1589,89 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
     prevAdvanceFP = glyph ? glyph->advanceX : 0;  // 12.4 fixed-point
 
     renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, x, lastBaseY, black, style);
+    prevCp = cp;
+  }
+}
+
+void GfxRenderer::drawTextRotated180(const int fontId, const int x, const int y, const char* text, const bool black,
+                                     const EpdFontFamily::Style style, const BidiUtils::BidiBaseDir baseDir) const {
+  // Cannot draw a NULL / empty string
+  if (text == nullptr || *text == '\0') {
+    return;
+  }
+
+  const auto fontIt = fontMap.find(fontId);
+  if (fontIt == fontMap.end()) {
+    LOG_ERR("GFX", "Font %d not found", fontId);
+    return;
+  }
+  const auto& font = fontIt->second;
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+
+  // Respect font-cache scan mode like drawText(): record the text for prewarming and skip
+  // rendering during the scan pass.
+  if (fontCacheManager_ && fontCacheManager_->isScanning()) {
+    fontCacheManager_->recordText(renderedText, fontId, style);
+    return;
+  }
+
+  // A 180° rotation reflects every glyph pen about the centre of the text's bounding box,
+  // so the output fills the same box as drawText(fontId, x, y, ...) but upside-down. The
+  // layout pass below mirrors drawText() exactly (kerning, ligatures, combining marks); only
+  // the final pen passed to renderCharImpl is reflected: rotatedPen = 2*centre - normalPen.
+  // The doubled centre uses the inclusive far pixel (width/height - 1): a W-wide box spans
+  // pixels [x, x+W-1], so its centre is x + (W-1)/2 and the reflection lands back in place.
+  // Measure the already-resolved text via the cached font handle to avoid repeating the BiDi
+  // pass and a second fontMap lookup.
+  int textW = 0, textH = 0;
+  font.getTextDimensions(renderedText, &textW, &textH, style);
+  const int cx2 = 2 * x + textW - 1;                  // 2 * box centre X
+  const int cy2 = 2 * y + getTextHeight(fontId) - 1;  // 2 * box centre Y (box height = ascender)
+
+  const int yPos = y + getFontAscenderSize(fontId);
+  int lastBaseX = x;
+  int lastBaseLeft = 0;
+  int lastBaseWidth = 0;
+  int lastBaseTop = 0;
+  int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
+
+  const char* textCursor = renderedText;
+  uint32_t cp;
+  uint32_t prevCp = 0;
+  while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor)))) {
+    // Skip Hebrew Niqqud (vowel marks)
+    if (cp >= 0x0591 && cp <= 0x05C7) {
+      continue;
+    }
+
+    if (utf8IsCombiningMark(cp)) {
+      const EpdGlyph* combiningGlyph = font.getGlyph(cp, style);
+      if (!combiningGlyph) continue;
+      const int raiseBy = combiningMark::raiseAboveBase(combiningGlyph->top, combiningGlyph->height, lastBaseTop);
+      const int combiningX = combiningMark::centerOver(lastBaseX, lastBaseLeft, lastBaseWidth, combiningGlyph->left,
+                                                       combiningGlyph->width);
+      renderCharImpl<TextRotation::Rotated180>(*this, renderMode, font, cp, cx2 - combiningX, cy2 - (yPos - raiseBy),
+                                               black, style);
+      continue;
+    }
+
+    cp = font.applyLigatures(cp, textCursor, style);
+
+    if (prevCp != 0) {
+      const auto kernFP = font.getKerning(prevCp, cp, style);  // 4.4 fixed-point kern
+      lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);       // snap 12.4 fixed-point to nearest pixel
+    }
+
+    const EpdGlyph* glyph = font.getGlyph(cp, style);
+
+    lastBaseLeft = glyph ? glyph->left : 0;
+    lastBaseWidth = glyph ? glyph->width : 0;
+    lastBaseTop = glyph ? glyph->top : 0;
+    prevAdvanceFP = glyph ? glyph->advanceX : 0;  // 12.4 fixed-point
+
+    renderCharImpl<TextRotation::Rotated180>(*this, renderMode, font, cp, cx2 - lastBaseX, cy2 - yPos, black, style);
     prevCp = cp;
   }
 }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -213,6 +213,11 @@ class GfxRenderer {
   // Helper for drawing rotated text (90 degrees clockwise, for side buttons)
   void drawTextRotated90CW(int fontId, int x, int y, const char* text, bool black = true,
                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  // Helper for drawing 180-degree rotated text. Fills the same bounding box as drawText(),
+  // flipped upside-down. Used for bottom button hints in inverted orientation.
+  void drawTextRotated180(int fontId, int x, int y, const char* text, bool black = true,
+                          EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                          BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
   int getTextHeight(int fontId) const;
 
   // Grayscale functions

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -218,6 +218,14 @@ class GfxRenderer {
   void drawTextRotated180(int fontId, int x, int y, const char* text, bool black = true,
                           EpdFontFamily::Style style = EpdFontFamily::REGULAR,
                           BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  // Draws 180-degree rotated text horizontally at \p x and vertically centred (by its real ink
+  // box) within [boxTop, boxTop + boxHeight). Used for bottom button hints when the device is
+  // held inverted: forcing Portrait plus the physical 180 flip means mirroring the upright
+  // position would reproduce its small vertical offset, so the inverted text must be centred
+  // in the box directly.
+  void drawTextRotated180VCentered(int fontId, int x, int boxTop, int boxHeight, const char* text, bool black = true,
+                                   EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                                   BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
   int getTextHeight(int fontId) const;
 
   // Grayscale functions

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -163,11 +163,12 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
       renderer.drawRect(x, pageHeight - buttonY, buttonWidth, buttonHeight);
       const int textWidth = renderer.getTextWidth(UI_10_FONT_ID, labels[i]);
       const int textX = x + (buttonWidth - 1 - textWidth) / 2;
-      const int textY = pageHeight - buttonY + textYOffset;
       if (flipHintText) {
-        renderer.drawTextRotated180(UI_10_FONT_ID, textX, textY, labels[i]);
+        // Centre in the box directly: the physical 180 flip means mirroring the upright
+        // position would surface its small vertical offset (#2375 review).
+        renderer.drawTextRotated180VCentered(UI_10_FONT_ID, textX, pageHeight - buttonY, buttonHeight, labels[i]);
       } else {
-        renderer.drawText(UI_10_FONT_ID, textX, textY, labels[i]);
+        renderer.drawText(UI_10_FONT_ID, textX, pageHeight - buttonY + textYOffset, labels[i]);
       }
     }
   }

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -137,6 +137,13 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   const GfxRenderer::Orientation orig_orientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 
+  // Forcing Portrait positions the hints at the physical buttons regardless of the active
+  // orientation (see #362). The inverted case still needs its glyphs flipped 180° so the
+  // labels read the right way up for someone holding the device inverted (#2364). The two
+  // landscape modes are left upright: a 90° flip would change the text's footprint and force
+  // taller hint buttons, whereas 180° keeps the exact same button box.
+  const bool flipHintText = orig_orientation == GfxRenderer::Orientation::PortraitInverted;
+
   const int pageHeight = renderer.getScreenHeight();
   constexpr int buttonWidth = 106;
   constexpr int buttonHeight = BaseMetrics::values.buttonHintsHeight;
@@ -156,7 +163,12 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
       renderer.drawRect(x, pageHeight - buttonY, buttonWidth, buttonHeight);
       const int textWidth = renderer.getTextWidth(UI_10_FONT_ID, labels[i]);
       const int textX = x + (buttonWidth - 1 - textWidth) / 2;
-      renderer.drawText(UI_10_FONT_ID, textX, pageHeight - buttonY + textYOffset, labels[i]);
+      const int textY = pageHeight - buttonY + textYOffset;
+      if (flipHintText) {
+        renderer.drawTextRotated180(UI_10_FONT_ID, textX, textY, labels[i]);
+      } else {
+        renderer.drawText(UI_10_FONT_ID, textX, textY, labels[i]);
+      }
     }
   }
 

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -322,6 +322,10 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   const GfxRenderer::Orientation orig_orientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 
+  // Forced Portrait keeps the hints at the physical buttons (#362); the inverted case still
+  // needs its glyphs flipped 180° to read correctly when the device is held inverted (#2364).
+  const bool flipHintText = orig_orientation == GfxRenderer::Orientation::PortraitInverted;
+
   const int pageHeight = renderer.getScreenHeight();
   constexpr int buttonWidth = 80;
   constexpr int smallButtonHeight = 15;
@@ -343,7 +347,12 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
                                false, true);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, labels[i]);
       const int textX = x + (buttonWidth - 1 - textWidth) / 2;
-      renderer.drawText(SMALL_FONT_ID, textX, pageHeight - buttonY + textYOffset, labels[i]);
+      const int textY = pageHeight - buttonY + textYOffset;
+      if (flipHintText) {
+        renderer.drawTextRotated180(SMALL_FONT_ID, textX, textY, labels[i]);
+      } else {
+        renderer.drawText(SMALL_FONT_ID, textX, textY, labels[i]);
+      }
     } else {
       // Draw the filled background and border for a SMALL-sized button
       renderer.fillRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, cornerRadius,

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -347,11 +347,12 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
                                false, true);
       const int textWidth = renderer.getTextWidth(SMALL_FONT_ID, labels[i]);
       const int textX = x + (buttonWidth - 1 - textWidth) / 2;
-      const int textY = pageHeight - buttonY + textYOffset;
       if (flipHintText) {
-        renderer.drawTextRotated180(SMALL_FONT_ID, textX, textY, labels[i]);
+        // Centre in the box directly: the physical 180 flip means mirroring the upright
+        // position would surface its small vertical offset (#2375 review).
+        renderer.drawTextRotated180VCentered(SMALL_FONT_ID, textX, pageHeight - buttonY, buttonHeight, labels[i]);
       } else {
-        renderer.drawText(SMALL_FONT_ID, textX, textY, labels[i]);
+        renderer.drawText(SMALL_FONT_ID, textX, pageHeight - buttonY + textYOffset, labels[i]);
       }
     } else {
       // Draw the filled background and border for a SMALL-sized button

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -386,6 +386,17 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const GfxRenderer::Orientation origOrientation = renderer.getOrientation();
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
 
+  // Forced Portrait keeps the hints at the physical buttons (#362); the inverted case still
+  // needs its glyphs flipped 180° to read correctly when the device is held inverted (#2364).
+  const bool flipHintText = origOrientation == GfxRenderer::Orientation::PortraitInverted;
+  const auto drawHint = [&renderer, flipHintText](int x, int y, const char* text) {
+    if (flipHintText) {
+      renderer.drawTextRotated180(kGuideFontId, x, y, text, true, EpdFontFamily::REGULAR);
+    } else {
+      renderer.drawText(kGuideFontId, x, y, text, true, EpdFontFamily::REGULAR);
+    }
+  };
+
   const int pageWidth = renderer.getScreenWidth();
   const int pageHeight = renderer.getScreenHeight();
   const int sidePadding = 20;
@@ -420,14 +431,14 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int downX = rightGroupX + groupWidth - innerEdgePadding - downWidth;
 
   if (!backDisabled) {
-    renderer.drawText(kGuideFontId, backX, textY, backLabel.c_str(), true, EpdFontFamily::REGULAR);
+    drawHint(backX, textY, backLabel.c_str());
   }
-  renderer.drawText(kGuideFontId, selectX, textY, selectText.c_str(), true, EpdFontFamily::REGULAR);
+  drawHint(selectX, textY, selectText.c_str());
 
   renderer.drawRoundedRect(rightGroupX, hintY, groupWidth, hintHeight, 2, kBottomRadius, true);
 
-  renderer.drawText(kGuideFontId, upX, textY, upText.c_str(), true, EpdFontFamily::REGULAR);
-  renderer.drawText(kGuideFontId, downX, textY, downText.c_str(), true, EpdFontFamily::REGULAR);
+  drawHint(upX, textY, upText.c_str());
+  drawHint(downX, textY, downText.c_str());
 
   renderer.setOrientation(origOrientation);
 }

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -389,13 +389,6 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   // Forced Portrait keeps the hints at the physical buttons (#362); the inverted case still
   // needs its glyphs flipped 180° to read correctly when the device is held inverted (#2364).
   const bool flipHintText = origOrientation == GfxRenderer::Orientation::PortraitInverted;
-  const auto drawHint = [&renderer, flipHintText](int x, int y, const char* text) {
-    if (flipHintText) {
-      renderer.drawTextRotated180(kGuideFontId, x, y, text, true, EpdFontFamily::REGULAR);
-    } else {
-      renderer.drawText(kGuideFontId, x, y, text, true, EpdFontFamily::REGULAR);
-    }
-  };
 
   const int pageWidth = renderer.getScreenWidth();
   const int pageHeight = renderer.getScreenHeight();
@@ -406,6 +399,16 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int groupWidth = (pageWidth - sidePadding * 2 - groupGap) / 2;
   const int hintY = pageHeight - hintHeight - bottomMargin;
   const int textY = hintY + (hintHeight - renderer.getLineHeight(kGuideFontId)) / 2;
+
+  const auto drawHint = [&renderer, flipHintText, hintY, hintHeight](int x, int y, const char* text) {
+    if (flipHintText) {
+      // Centre in the box directly: the physical 180 flip means mirroring the upright
+      // position would surface its small vertical offset (#2375 review).
+      renderer.drawTextRotated180VCentered(kGuideFontId, x, hintY, hintHeight, text, true, EpdFontFamily::REGULAR);
+    } else {
+      renderer.drawText(kGuideFontId, x, y, text, true, EpdFontFamily::REGULAR);
+    }
+  };
 
   const bool backDisabled = (btn1 == nullptr || btn1[0] == '\0');
   const int leftGroupX = sidePadding;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes #2364. With Reading Orientation set to Inverted, the bottom button hints land at the right buttons with the right labels, but the text renders upright instead of flipped to match the rest of the screen, so the labels read upside down when the device is held inverted.
* **What changes are included?**
  * New `GfxRenderer::drawTextRotated180`, plus a `TextRotation::Rotated180` branch in `renderCharImpl`. It reuses `drawText`'s layout pass (kerning, ligatures, combining marks, BiDi) and reflects each glyph pen about the centre of the text's ink box, so it fills the same box as `drawText` but upside down.
  * New `GfxRenderer::drawTextRotated180VCentered`, which vertically centres the rotated text in a given box by its real ink extents.
  * Exposed `getTextBounds` on `EpdFont`/`EpdFontFamily` (previously a private helper behind `getTextDimensions`) so the centring can read the ink box.
  * `BaseTheme`, `LyraTheme`, and `RoundedRaffTheme` draw the bottom hints with the centred helper when the orientation is `PortraitInverted`, keeping the forced-Portrait placement from #362.

## Additional Context

* This is the leftover part of #362. That fix forces the renderer to Portrait while drawing the hints so they sit at the physical buttons, which is also why the labels never got rotated for the active orientation.
* The two landscape modes are left upright on purpose. A 90° flip swaps the text's width and height and would force taller hint buttons; a 180° flip keeps the exact same button box, so the inverted case stays self-contained.
* The inverted text is centred in the box directly rather than mirrored from the upright position. The hints are drawn forced-Portrait and the panel is physically rotated 180° when held inverted, so the small vertical offset the upright text has (it sits a few px high, which reads as fine normally) would otherwise appear the opposite way once flipped.
* Scope is limited to the bottom hints. The portrait path is unchanged, and only the reader and its menu run in the inverted orientation, so settings and home hints are unaffected.
* Tested on an X3: in Inverted orientation the hint labels (Back, Select, Up, Down) read the right way up and centred in the boxes. Builds clean on the default env; clang-format clean.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
