### PR TITLE
fix: automatically connect to wifi for clock sync

### DIFF
--- a/src/activities/settings/ClockSyncActivity.cpp
+++ b/src/activities/settings/ClockSyncActivity.cpp
@@ -10,6 +10,8 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "SilentRestart.h"
+#include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -17,14 +19,46 @@ void ClockSyncActivity::onEnter() {
   Activity::onEnter();
   state = SYNCING;
   syncedTime[0] = '\0';
+
+  if (WiFi.status() == WL_CONNECTED) {
+    requestUpdate();
+    return;
+  }
+
+  shouldTearDownWifiOnExit = true;
+  launchWifiSelection();
+}
+
+void ClockSyncActivity::onExit() {
+  Activity::onExit();
+
+  if (shouldTearDownWifiOnExit && WiFi.getMode() != WIFI_MODE_NULL) {
+    WiFi.disconnect(false);
+    delay(30);
+    silentRestart();
+  }
+}
+
+void ClockSyncActivity::launchWifiSelection() {
+  LOG_INF("CLK", "Manual sync requested without WiFi, launching WiFi selection");
+  startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
+                         [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
+}
+
+void ClockSyncActivity::onWifiSelectionComplete(const bool connected) {
+  if (!connected) {
+    LOG_INF("CLK", "WiFi selection cancelled before manual clock sync");
+    finish();
+    return;
+  }
+
+  state = SYNCING;
   requestUpdate();
 }
 
-void ClockSyncActivity::onExit() { Activity::onExit(); }
-
 void ClockSyncActivity::runSync() {
   if (WiFi.status() != WL_CONNECTED) {
-    LOG_INF("CLK", "Manual sync requested but WiFi is not connected");
+    LOG_INF("CLK", "Manual sync requested but WiFi is not connected after selection");
     state = NO_WIFI;
     requestUpdate();
     return;
@@ -59,8 +93,7 @@ void ClockSyncActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back) ||
-      mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
     finish();
   }
 }
@@ -100,7 +133,7 @@ void ClockSyncActivity::render(RenderLock&&) {
   }
 
   if (state != SYNCING) {
-    const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_OK_BUTTON), "", "");
+    const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
   }
 

--- a/src/activities/settings/ClockSyncActivity.h
+++ b/src/activities/settings/ClockSyncActivity.h
@@ -3,7 +3,8 @@
 #include "activities/Activity.h"
 
 // Manual NTP resync action. Runs a forced sync (bypassing the once-per-device debounce),
-// reports success/failure, then waits for Back. Requires WiFi to already be connected.
+// reports success/failure, then waits for Back. If WiFi is not connected yet, it reuses the
+// normal WiFi selection flow first.
 class ClockSyncActivity final : public Activity {
  public:
   explicit ClockSyncActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
@@ -19,6 +20,9 @@ class ClockSyncActivity final : public Activity {
   enum State { SYNCING, SUCCESS, NO_WIFI, FAILED };
   State state = SYNCING;
   char syncedTime[16] = {0};
+  bool shouldTearDownWifiOnExit = false;
 
   void runSync();
+  void launchWifiSelection();
+  void onWifiSelectionComplete(bool connected);
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
  * Make manual clock sync work even when the device is not already connected to Wi-Fi, so the user can start the sync flow directly from settings instead of being blocked by connection state.
* **What changes are included?**
  * `ClockSyncActivity` now launches the normal Wi-Fi selection flow before syncing when the device is offline.
  * After Wi-Fi selection succeeds, clock sync resumes automatically and performs the existing forced NTP sync.
  * If clock sync had to bring Wi-Fi up, the activity disconnects and uses the existing silent restart cleanup path to avoid leaving the device in a fragmented post-Wi-Fi heap state.
  * The completion UI now only advertises Back, matching the updated input handling.

## Additional Context

* Existing behavior is unchanged when Wi-Fi is already connected: the activity syncs immediately.
* Cancelling Wi-Fi selection exits the clock sync flow.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
