### PR TITLE
fix: prevent out-of-memory crash when opening directories with many files

### DIFF
--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -2,6 +2,7 @@
 
 #include <FS.h>  // need to be included before SdFat.h for compatibility with FS.h's File class
 #include <Logging.h>
+#include <Memory.h>
 #include <SDCardManager.h>
 
 #include <cassert>
@@ -81,9 +82,21 @@ HalFile::~HalFile() = default;
 HalFile::HalFile(HalFile&&) = default;
 HalFile& HalFile::operator=(HalFile&&) = default;
 
+// A throwing new aborts() on OOM under -fno-exceptions (CLAUDE.md rule 9),
+// so allocate Impl with nothrow new and degrade to an empty HalFile. Thus
+// callers can detect the failure by checking the file instead of crashing.
+HalFile HalFile::fromFsFile(FsFile&& fsFile, const char* what) {
+  auto impl = makeUniqueNoThrow<Impl>(std::move(fsFile));
+  if (!impl) {
+    LOG_ERR("HAL_FS", "OOM: HalFile::Impl for %s", what);
+    return HalFile();
+  }
+  return HalFile(std::move(impl));
+}
+
 HalFile HalStorage::open(const char* path, const oflag_t oflag) {
   StorageLock lock;  // ensure thread safety for the duration of this function
-  return HalFile(std::make_unique<HalFile::Impl>(SDCard.open(path, oflag)));
+  return HalFile::fromFsFile(SDCard.open(path, oflag), path);
 }
 
 bool HalStorage::mkdir(const char* path, const bool pFlag) { HAL_STORAGE_WRAPPED_CALL(mkdir, path, pFlag); }
@@ -101,8 +114,8 @@ bool HalStorage::openFileForRead(const char* moduleName, const char* path, HalFi
   StorageLock lock;  // ensure thread safety for the duration of this function
   FsFile fsFile;
   bool ok = SDCard.openFileForRead(moduleName, path, fsFile);
-  file = HalFile(std::make_unique<HalFile::Impl>(std::move(fsFile)));
-  return ok;
+  file = HalFile::fromFsFile(std::move(fsFile), path);
+  return ok && file;
 }
 
 bool HalStorage::openFileForRead(const char* moduleName, const std::string& path, HalFile& file) {
@@ -117,8 +130,8 @@ bool HalStorage::openFileForWrite(const char* moduleName, const char* path, HalF
   StorageLock lock;  // ensure thread safety for the duration of this function
   FsFile fsFile;
   bool ok = SDCard.openFileForWrite(moduleName, path, fsFile);
-  file = HalFile(std::make_unique<HalFile::Impl>(std::move(fsFile)));
-  return ok;
+  file = HalFile::fromFsFile(std::move(fsFile), path);
+  return ok && file;
 }
 
 bool HalStorage::openFileForWrite(const char* moduleName, const std::string& path, HalFile& file) {
@@ -166,7 +179,7 @@ bool HalFile::close() { HAL_FILE_WRAPPED_CALL(close, ); }
 HalFile HalFile::openNextFile() {
   HalStorage::StorageLock lock;
   assert(impl != nullptr);
-  return HalFile(std::make_unique<Impl>(impl->file.openNextFile()));
+  return fromFsFile(impl->file.openNextFile(), "openNextFile");
 }
 bool HalFile::isOpen() const { return impl != nullptr && impl->file.isOpen(); }  // already thread-safe, no need to wrap
 HalFile::operator bool() const { return isOpen(); }

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 class HalFile;
+class FsFile;
 
 class HalStorage {
  public:
@@ -63,6 +64,11 @@ class HalFile : public Print {
   class Impl;
   std::unique_ptr<Impl> impl;
   explicit HalFile(std::unique_ptr<Impl> impl);
+
+  // Wrap an FsFile in a HalFile, allocating Impl with nothrow new. Returns an
+  // empty HalFile (operator bool == false) on OOM, after logging; `what` labels
+  // the failed allocation. Callers must already hold StorageLock.
+  static HalFile fromFsFile(FsFile&& fsFile, const char* what);
 
  public:
   HalFile();

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -18,10 +18,19 @@
 namespace {
 constexpr unsigned long GO_HOME_MS = 1000;
 constexpr size_t NAME_BUFFER_SIZE = 500;
+// Pre-size the list to avoid the early geometric-growth reallocation churn that
+// fragments the heap (CLAUDE.md rule 7). Dirs larger than this still work, they
+// just grow from here.
+constexpr size_t FILE_LIST_RESERVE = 256;
+// Hard memory floor: stop collecting entries once free heap drops below this.
+// A directory with thousands of files would otherwise exhaust RAM and crash.
+// Instead we truncate and leave headroom for rendering.
+constexpr uint32_t FILE_LIST_MIN_FREE_HEAP = 24 * 1024;
 }  // namespace
 
 void FileBrowserActivity::loadFiles() {
   files.clear();
+  files.reserve(FILE_LIST_RESERVE);
 
   auto root = Storage.open(basepath.c_str());
   if (!root || !root.isDirectory()) {
@@ -37,6 +46,14 @@ void FileBrowserActivity::loadFiles() {
   }
 
   for (auto file = root.openNextFile(); file; file = root.openNextFile()) {
+    // Stop before the heap is exhausted: a dir with thousands of entries would
+    // otherwise abort() during vector/string growth.
+    if (ESP.getFreeHeap() < FILE_LIST_MIN_FREE_HEAP) {
+      LOG_ERR("FileBrowser", "Low heap (%u B free), truncating list at %u entries",
+              static_cast<unsigned>(ESP.getFreeHeap()), static_cast<unsigned>(files.size()));
+      break;
+    }
+
     file.getName(fileNameBuffer.get(), NAME_BUFFER_SIZE);
     if ((!SETTINGS.showHiddenFiles && fileNameBuffer[0] == '.') ||
         strcmp(fileNameBuffer.get(), "System Volume Information") == 0) {


### PR DESCRIPTION
## Summary

I noticed that x3 crashes when opening directories with many files due to exhausting the heap memory, so I created this patch to avoid crashing by truncating the list of files. This is just a reasonable immediate fix for the crash, not a complete / permanent solution to the problem.

## Additional Context

Please see the commit message for the full context and also potential follow-up work to either increase the truncation limit or eliminate it entirely, for convenience I'm pasting it here:

```
fix: prevent crash when opening dirs with many files

Opening a directory with thousands of files crashes the device with an
abort() panic (PC resolves to __cxxabiv1::__terminate) because large
dirs exhaust the heap in FileBrowserActivity::loadFiles() which builds
an unreserved std::vector<std::string> until the "next" alloc fails.

The decoded stack trace for the OOM is:
  operator new(unsigned int) -> std::bad_alloc()
    -> __cxa_allocate_exception() -> __terminate() -> abort()
  make_unique<HalFile::Impl>(FsFile&&)   HalStorage.cpp:64
  HalFile::openNextFile()                HalStorage.cpp:169
  FileBrowserActivity::loadFiles()       FileBrowserActivity.cpp:39
  FileBrowserActivity::loop()            FileBrowserActivity.cpp:270
  ActivityManager::loop()                ActivityManager.cpp:66
  loop()                                 main.cpp:583

So the HalStorage open paths allocate HalFile::Impl via std::make_unique
which is a bare new. With -fno-exceptions, failed new raises a bad_alloc
which routes to __terminate -> abort() instead of returning null.

The above is a violation of the resource protocol rule 9 (see CLAUDE.md)
and it also violates rule 7 because it doesn't reserve the vector size
and causes reallocation churn.

The fix has 3 steps:

  1. HalStorage: allocate with makeUniqueNoThrow in the open paths and
     degrade gracefully (empty HalFile/false) on OOM instead of crashing.

  2. FileBrowserActivity: reserve the list to cut reallocation churn.

  3. FileBrowserActivity: stop adding entries once the free heap drops
     below a safety floor, logging the truncation. This bounds RAM use
     so the throwing vector can no longer abort.

The heap limit at point 3 is set to a conservative estimate of 24 kb,
based on my observed system usage with a minimum free remaining heap
dip to ~16 kb with an ~17kb largest continuous available block. It's
enough to hold / truncate to 1300 items in memory without crashing.

Obviously further work can be done on this: the std string vec can be
optimized to be more space efficient, or, even better, an implementation
which avoids keeping all filenames in heap memory can replace the naive
string vec, since we never show all files at the same time.

Verified on X3: large directories now open with the file list truncated
and a logged warning instead of crashing and rebooting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Signed-off-by: Adrian Ratiu <adrian.ratiu@collabora.com>
```

## AI Usage

Did you use AI tools to help write this code? **PARTIALLY**

This PR was written with the help of Claude Code, but was **not** vibe-coded. I'm not a fan of vibe-coding. I used AI to better understand the codebase myself (asked it a lot of questions), review both my code and the code generated by AI, used it especially to detect bugs and corner-cases and suggest fixes, however I very carefully reviewed & edited each code/comment lines, the commit messages and so on, until I was satisfied with the result.