### PR TITLE
feat: footnote returns to original position on deep sleep to avoid losing reading position

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -527,6 +527,8 @@ On the **Xteink X3**, the gyroscope can be used to turn pages by tilting the dev
 
 When reading an EPUB that contains footnotes, you can navigate to the footnote text by selecting the footnote reference in the book. From the footnote, you can return to your original reading position.
 
+If the device goes to sleep or you close the book while viewing a footnote, the book reopens to your original reading position, not the footnote.
+
 ### System Navigation
 
 * **Return to Home:** Press the **Back** button to close the book and return to the **[Home](#31-home-screen)** screen.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -177,6 +177,14 @@ void EpubReaderActivity::onExit() {
 
   APP_STATE.readerActivityLoadCount = 0;
   APP_STATE.saveToFile();
+
+  // Leaving mid-footnote loses the in-RAM return stack on deep sleep; persist the
+  // pre-footnote position so the book reopens at the link origin, not the footnote.
+  if (footnoteDepth > 0 && epub) {
+    const SavedPosition& origin = savedPositions[0];
+    saveProgress(origin.spineIndex, origin.pageNumber, 0);
+  }
+
   section.reset();
   if (pendingReadFolderMove && epub) {
     const std::string srcPath = epub->getPath();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Possible fix for #2381

* **What changes are included?**
  If the reader leaves the book while still viewing a footnote, we silently return them to their pre-footnote reading position. This way the true reading position isn't lost, and they can jump back into the footnote again if they wish.

  The current behavior keeps the footnote return point only in RAM, so leaving the reader (most commonly via deep sleep) loses it and the user resumes stranded on the footnote, possibly far from where they navigated from.

## Additional Context
The simpler of two ideas I had for alleviating some of the pain mentioned in #2381. The fix lives in `onExit()`, so deep sleep is the main case but it also covers the other ways out of the reader while a footnote is open (long-press to the file browser, or the reader menu). It restores the original position from before the first footnote jump.

---

### AI Usage

Did you use AI tools to help write this code? _**< YES >**_