### PR TITLE
chore: Replace product link with affiliate tracking link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ CrossPoint is open-source e-reader firmware - community-built, fully hackable, f
 
 ![CrossPoint Reader running on Xteink device](./docs/images/cover.jpg)
 
+> If you're planning to buy an Xteink device, consider purchasing an **X3/X4 Developer Edition** through https://crosspointreader.com. CrossPoint receives a small share of each sale, helping fund development costs.
+
 ## What can CrossPoint do?
 
 - **Reader engine**: EPUB 2/3 rendering with embedded-style option, image handling, hyphenation, kerning, chapter navigation, footnotes, bookmarks, go-to-percent, auto page turn, orientation control, focus reading, KOReader progress sync and more. 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CrossPoint is open-source e-reader firmware - community-built, fully hackable, free forever. It's maintained by a growing community of developers and readers who believe your device should do what you want - not what a manufacturer decided for you.
 
-**Now running on:** ESP32C3-based Xteink [X4](https://go.sjv.io/2RV5N7) and [X3](https://go.sjv.io/m4oEmM).
+**Now running on:** ESP32C3-based Xteink [X4](https://www.xteink.com/products/xteink-x4) and [X3](https://www.xteink.com/products/xteink-x3).
 
 ![CrossPoint Reader running on Xteink device](./docs/images/cover.jpg)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 CrossPoint is open-source e-reader firmware - community-built, fully hackable, free forever. It's maintained by a growing community of developers and readers who believe your device should do what you want - not what a manufacturer decided for you.
 
-**Now running on:** ESP32C3-based Xteink [X4](https://www.xteink.com/products/xteink-x4) and [X3](https://www.xteink.com/products/xteink-x3).
+**Now running on:** ESP32C3-based Xteink [X4](https://go.sjv.io/2RV5N7) and [X3](https://go.sjv.io/m4oEmM).
 
 ![CrossPoint Reader running on Xteink device](./docs/images/cover.jpg)
 


### PR DESCRIPTION
## Summary

Update product link to affiliate URL
Replace direct Xteink product link with affiliate tracking link (go.sjv.io) in README.md.