### PR TITLE
fix: correct font size selection

### DIFF
--- a/lib/EpdFont/SdCardFontRegistry.cpp
+++ b/lib/EpdFont/SdCardFontRegistry.cpp
@@ -19,6 +19,26 @@ const SdCardFontFileInfo* SdCardFontFamilyInfo::findClosestReaderSize(const uint
                                                                       const uint8_t style) const {
   if (files.empty()) return nullptr;
 
+  // Collect sizes matching the requested style, sorted ascending.
+  std::vector<uint8_t> sizes;
+  for (const auto& f : files) {
+    if (f.style != style) continue;
+    sizes.push_back(f.pointSize);
+  }
+  if (sizes.empty()) return nullptr;
+  std::sort(sizes.begin(), sizes.end());
+
+  // When the family provides at least 4 sizes, use ordinal (index-based)
+  // selection so custom-built font sets (e.g. 10/12/14/16) map SMALL to
+  // the smallest file, not to a hardcoded 12pt target.
+  if (sizes.size() >= 4) {
+    uint8_t idx = fontSizeEnum;
+    if (idx >= sizes.size()) idx = sizes.size() - 1;
+    return findFile(sizes[idx], style);
+  }
+
+  // Fewer sizes than enum slots (e.g. CJK packs with only 2-3 sizes):
+  // fall back to closest-match against the built-in reader targets.
   uint8_t target = 14;
   switch (fontSizeEnum) {
     case 0:


### PR DESCRIPTION
## Summary: Fix #2407

The bug was introduced in commit 22f357506 which replaced ordinal (index-based) font size selection with a closest-to-hardcoded-target approach. The hardcoded targets {12, 14, 16, 18} match the default Font Builder sizes, but when a user builds fonts at custom sizes (10/12/14/16), "Small" targets 12pt and picks the wrong file.

The fix uses ordinal selection when the family has ≥4 sizes (covering all enum slots), and falls back to closest-match only for families with fewer files (like CJK packs that ship 2-3 sizes).

---

## Testing
Compiled Bookerly with 
```bash
python3 fontconvert_sdcard.py --intervals latin-ext,punctuation,reading,symbols --sizes 8,10,12,14 --regular /home/urit/Desktop/fonts/Bookerly/Bookerly-Regular.ttf --bold /home/urit/Desktop/fonts/Bookerly/Bookerly-Bold.ttf  --name Bookerly --italic /home/urit/Desktop/fonts/Bookerly/Bookerly-RegularItalic.ttf --bolditalic /home/urit/Desktop/fonts/Bookerly/Bookerly-BoldItalic.ttf --output-dir Bookerly/
```

Current master: 
![The-Colour-of-Magic_ch7_p6_5pct_27930.bmp](https://github.com/user-attachments/files/29288363/The-Colour-of-Magic_ch7_p6_5pct_27930.bmp)

With the fix:
![The-Colour-of-Magic_ch7_p3_5pct_18338.bmp](https://github.com/user-attachments/files/29288368/The-Colour-of-Magic_ch7_p3_5pct_18338.bmp)


### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
