### PR TITLE
fix(reader): stabilize X3 EPUB grayscale page turns

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1065,6 +1065,21 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     // HALF ghost-cleanup path, which drives every pixel to its target
     // regardless of residue.
     pagesUntilFullRefresh = 1;
+  } else if (needsAnyGrayscale) {
+    if (pagesUntilFullRefresh <= 1) {
+      // Cleanup turns still need the stronger HALF pass, but on X3 the
+      // grayscale overlay behaves better if we immediately run the OEM settle
+      // step before writing the gray planes.
+      renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+      renderer.preconditionGrayscale();
+      pagesUntilFullRefresh = SETTINGS.getRefreshFrequency();
+    } else {
+      // Use the grayscale-aware base waveform so the first visible pass is
+      // closer to the final anti-aliased result instead of flashing overly
+      // dark text first and softening a moment later.
+      renderer.displayGrayscaleBase(HalDisplay::FAST_REFRESH);
+      pagesUntilFullRefresh--;
+    }
   } else {
     ReaderUtils::displayWithRefreshCycle(renderer, pagesUntilFullRefresh);
   }


### PR DESCRIPTION
## Summary
- use the grayscale-aware base pass for ordinary X3 EPUB grayscale turns
- run grayscale preconditioning immediately after periodic HALF refresh cleanup turns

## Problem
On X3 EPUB page turns with text anti-aliasing enabled, the new page can appear too dark first and then become slightly lighter when the grayscale overlay completes.

## Root cause
`src/activities/reader/EpubReaderActivity.cpp` still uses the normal reader refresh cycle for text-only grayscale EPUB turns, even though `displayGrayscaleBase(...)` and `preconditionGrayscale(...)` already exist lower in the display stack.

## Change
Wire those existing display primitives into the EPUB reader path:
- cleanup turns: `HALF_REFRESH` then `preconditionGrayscale()`
- ordinary grayscale turns: `displayGrayscaleBase(HalDisplay::FAST_REFRESH)`

This keeps the change narrow to the reader logic because CrossPoint `master` already has the HAL / renderer support.

## Validation
### Checked locally
- `git diff --check` ✅
- `pio run -e default` is currently blocked in this checkout by a pre-existing PlatformIO/sdk layout problem: `open-x4-sdk/libs/hardware/BatteryMonitor` is missing, so Library Manager aborts before compile starts

### Hardware verification requested
On an X3 with EPUB text anti-aliasing enabled:
1. open a text-heavy EPUB
2. turn to a fresh page
3. verify the first visible frame is closer to the final anti-aliased result instead of flashing too dark and then softening a moment later
4. verify periodic cleanup turns still clear ghosting correctly
