### PR TITLE
perf: use one-shot inflate for whole-file ZIP reads

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -410,7 +410,10 @@ uint8_t* ZipFile::readFileToMemory(const char* filename, size_t* size, const boo
     ctx.readBuf = fileReadBuffer;
     ctx.readBufSize = 1024;
 
-    if (!ctx.reader.init(true)) {
+    // One-shot mode: the entire output is decompressed into `data` in a single read()
+    // call, so back-references resolve against the contiguous output buffer and the 32KB
+    // streaming ring buffer (malloc + memset per call) is unnecessary. See InflateReader.
+    if (!ctx.reader.init(false)) {
       LOG_ERR("ZIP", "Failed to init inflate reader");
       free(fileReadBuffer);
       free(data);


### PR DESCRIPTION
## Summary
* **Goal:** Cut peak RAM during EPUB content reads on the no-PSRAM ESP32-C3.
* **Changes:** `ZipFile::readFileToMemory` now inits the inflater in one-shot mode (`init(false)`) for the DEFLATED branch — the whole entry is decompressed into a single contiguous buffer in one `read()`, so back-references resolve against that buffer and the 32KB streaming ring buffer is unnecessary. `readFileToStream` keeps `init(true)` (needs the window for cross-chunk back-refs).

## Additional Context
Removes a 32KB malloc + 32KB memset on every OPF/container/XHTML read. Pure peak-RAM/fragmentation relief; behaviour unchanged.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
