### PR TITLE
perf: always binary-search idref lookups in content.opf

### DIFF
--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -137,8 +137,10 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
       LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
     }
 
-    // Sort item index for binary search if we have enough items
-    if (self->itemIndex.size() >= LARGE_SPINE_THRESHOLD) {
+    // Sort the (unconditionally-built) item index so every idref lookup uses binary
+    // search. Without this, small/medium manifests fell back to an O(spine × manifest)
+    // linear rescan of .items.bin per itemref (up to ~200ms/item at large scale).
+    if (!self->itemIndex.empty()) {
       std::sort(self->itemIndex.begin(), self->itemIndex.end(), [](const ItemIndexEntry& a, const ItemIndexEntry& b) {
         return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
       });
@@ -284,9 +286,8 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
               ++it;
             }
           } else {
-            // Slow path: linear scan (for small manifests, keeps original behavior)
-            // TODO: This lookup is slow as need to scan through all items each time.
-            //       It can take up to 200ms per item when getting to 1500 items.
+            // Fallback linear scan, only reached when the index is empty (no manifest
+            // items). The fast binary-search path above is used for all real manifests.
             self->tempItemStore.seek(0);
             std::string itemId;
             while (self->tempItemStore.available()) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -32,7 +32,7 @@ class ContentOpfParser final : public Print {
   HalFile tempItemStore;
   std::string coverItemId;
 
-  // Index for fast idref→href lookup (used only for large EPUBs)
+  // Index for fast idref→href lookup (binary search over .items.bin)
   struct ItemIndexEntry {
     uint32_t idHash;      // FNV-1a hash of itemId
     uint16_t idLen;       // length for collision reduction
@@ -40,8 +40,6 @@ class ContentOpfParser final : public Print {
   };
   std::deque<ItemIndexEntry> itemIndex;
   bool useItemIndex = false;
-
-  static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a hash function
   static uint32_t fnvHash(const std::string& s) {


### PR DESCRIPTION
## Summary
* **Goal:** Speed up the first (cold) open of a book, especially with large manifests.
* **Changes:** The FNV item index is already built unconditionally, but the sort + binary-search path was gated behind a 400-item threshold, so small/medium books fell back to an O(spine × manifest) linear rescan of `.items.bin` per itemref. Always sort + use the index; keep the linear branch only as an empty-index fallback. Removes the now-unused `LARGE_SPINE_THRESHOLD`.

## Additional Context
The in-code TODO measured ~200ms/item at 1500 items. Zero extra RAM (index already existed).

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
