### PR TITLE
perf: drop per-image delay(50) on chapter build, retry getDimensions

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -496,14 +496,22 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
               extractSuccess = self->epub->readItemContentsToStream(resolvedPath, cachedImageFile, 4096);
               cachedImageFile.flush();
               cachedImageFile.close();
-              delay(50);  // Give SD card time to sync
             }
 
             if (extractSuccess) {
-              // Get image dimensions
+              // Get image dimensions, retrying to absorb SD-card sync latency on slow
+              // cards. Replaces a blanket delay(50) that cost ~50ms on every image, and
+              // closes the silent-drop bug where a single getDimensions failure was fatal.
               ImageDimensions dims = {0, 0};
               ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(cachedImagePath);
-              if (decoder && decoder->getDimensions(cachedImagePath, dims)) {
+              bool gotDimensions = false;
+              for (int attempt = 0; attempt < 3 && !gotDimensions; attempt++) {
+                if (attempt > 0) {
+                  delay(50);  // Give a slow SD card time to finish syncing before retrying
+                }
+                gotDimensions = decoder && decoder->getDimensions(cachedImagePath, dims);
+              }
+              if (gotDimensions) {
                 LOG_DBG("EHP", "Image dimensions: %dx%d", dims.width, dims.height);
 
                 int displayWidth = 0;


### PR DESCRIPTION
## Summary
* **Goal:** Speed up building chapters and covers that contain images.
* **Changes:** Each `<img>` extraction slept 50ms unconditionally "to let the SD card sync". Replace with a bounded retry (up to 3× with a 50ms backoff) around `getDimensions`, so the cost is paid only when a slow card actually needs it.

## Additional Context
Saves ~50ms × image count per chapter/cover build. Also fixes a latent bug: a single `getDimensions` failure previously dropped the image permanently with no retry.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
