### PR TITLE
perf: reserve CSS rule map before loading from cache

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -801,6 +801,9 @@ bool CssParser::loadFromCache() {
     return false;
   }
 
+  // Size the bucket array up front to avoid incremental rehashes while loading rules.
+  rulesBySelector_.reserve(ruleCount);
+
   auto hasRemainingBytes = [&file](const size_t neededBytes) -> bool {
     return static_cast<size_t>(file.available()) >= neededBytes;
   };


### PR DESCRIPTION
## Summary
* **Goal:** Reduce transient heap churn during book open.
* **Changes:** `reserve()` the rule `unordered_map` to the known rule count (read from the cache header) before the load loop.

## Additional Context
Removes incremental bucket-array rehashes; lowers transient peak/fragmentation. No behaviour change.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
