### PR TITLE
perf: cache section LUT offset to speed up page loads

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -127,6 +127,9 @@ bool Section::loadSectionFile(const int fontId, const float lineCompression, con
   }
 
   serialization::readPod(file, pageCount);
+  // lutOffset is written immediately after pageCount in the header; cache it here so
+  // loadPageFromSectionFile can skip the per-load header seek + read.
+  serialization::readPod(file, lutOffset);
   // Explicit close() required: member variable persists beyond function scope
   file.close();
   LOG_DBG("SCT", "Deserialization succeeded: %d pages", pageCount);
@@ -303,6 +306,8 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   serialization::writePod(file, anchorMapOffset);
   serialization::writePod(file, paragraphLutOffset);
   serialization::writePod(file, liLutFileOffset);
+  // Cache the LUT offset so subsequent page loads skip the header seek + read.
+  this->lutOffset = lutOffset;
   // Explicit close() required: member variable persists beyond function scope
   file.close();
   if (cssParser) {
@@ -316,9 +321,13 @@ std::unique_ptr<Page> Section::loadPageFromSectionFile() {
     return nullptr;
   }
 
-  file.seek(HEADER_SIZE - sizeof(uint32_t) * 4);
-  uint32_t lutOffset;
-  serialization::readPod(file, lutOffset);
+  // Use the LUT offset cached by loadSectionFile/createSectionFile; fall back to
+  // reading it from the header if this Section was not populated through those paths.
+  uint32_t lutOffset = this->lutOffset;
+  if (lutOffset == 0) {
+    file.seek(HEADER_SIZE - sizeof(uint32_t) * 4);
+    serialization::readPod(file, lutOffset);
+  }
   file.seek(lutOffset + sizeof(uint32_t) * currentPage);
   uint32_t pagePos;
   serialization::readPod(file, pagePos);

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -15,6 +15,9 @@ class Section {
   GfxRenderer& renderer;
   std::string filePath;
   HalFile file;
+  // Byte offset of the page-offset LUT within the section file, cached from the header
+  // so each page load skips a header seek + read. 0 means not yet loaded.
+  uint32_t lutOffset = 0;
 
   void writeSectionFileHeader(int fontId, float lineCompression, bool extraParagraphSpacing, uint8_t paragraphAlignment,
                               uint16_t viewportWidth, uint16_t viewportHeight, bool hyphenationEnabled,


### PR DESCRIPTION
## Summary
* **Goal:** Remove redundant per-page-load header I/O.
* **Changes:** `loadPageFromSectionFile` re-seeked the header and re-read the invariant page-LUT offset on every page load, though the `Section` lives for the whole chapter. Cache `lutOffset` when the file is loaded or built (it sits immediately after `pageCount` in the header) and use it directly, with a header-read fallback.

## Additional Context
Removes a seek + small read per page load. Fallback preserves exact prior behaviour if a Section wasn't populated through the load/build paths.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
