### PR TITLE
perf: disable expat parse-context retention (XML_CONTEXT_BYTES=0)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,8 @@ build_flags =
   -DDESTRUCTOR_CLOSES_FILE=1
 # https://libexpat.github.io/doc/api/latest/#XML_GE
   -DXML_GE=0
-  -DXML_CONTEXT_BYTES=1024
+# No code calls XML_GetInputContext, so expat need not retain parse context (~1KB/parser).
+  -DXML_CONTEXT_BYTES=0
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1


### PR DESCRIPTION
## Summary
* **Goal:** Free ~1KB per live expat parser.
* **Changes:** `platformio.ini`: `XML_CONTEXT_BYTES` 1024 → 0.

## Additional Context
No code calls `XML_GetInputContext`, so expat does not need to retain already-parsed input context; `XML_GE` is already 0. **Reviewer focus:** the XML parse path (OPF / NCX / nav) — verified on-device that all three parse correctly after the change.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
