### PR TITLE
perf: release CSS rule map after warm open

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -396,6 +396,11 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
         Storage.removeDir((cachePath + "/sections").c_str());
       }
     }
+    // Release the resolved CSS rule map: it is only needed transiently while building
+    // section caches, and createSectionFile reloads it from cache on demand. Holding it
+    // resident pins tens of KB for the whole reading session (more on warm resume into
+    // an already-cached chapter, where createSectionFile never runs to clear it).
+    cssParser->clear();
     LOG_DBG("EBP", "Loaded ePub: %s", filepath.c_str());
     return true;
   }


### PR DESCRIPTION
## Summary
* **Goal:** Reclaim session RAM held by the CSS rule map.
* **Changes:** On a cache-hit open, `loadFromCache` populates the full rule map purely to validate the cache, then leaves it resident for the whole session. Clear it after the fast path; `createSectionFile` reloads CSS from cache on demand when it builds a section.

## Additional Context
On a warm resume directly into an already-built chapter, `createSectionFile` never runs, so the map (tens of KB, up to ~200KB at MAX_RULES) otherwise stays pinned with no reader. **Reviewer focus:** styling correctness — verified on-device that CSS still applies.

### AI Usage
Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
