### PR TITLE
perf: reuse one open ZipFile across a chapter build

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -4,6 +4,7 @@
 #include <HalStorage.h>
 #include <JpegToBmpConverter.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <PngToBmpConverter.h>
 #include <Utf8.h>
 #include <ZipFile.h>
@@ -751,6 +752,33 @@ bool Epub::generateThumbBmp(int height) const {
   return false;
 }
 
+Epub::Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {
+  // create a cache key based on the filepath
+  cachePath = cacheDir + "/epub_" + std::to_string(std::hash<std::string>{}(this->filepath));
+}
+
+Epub::~Epub() = default;
+
+Epub::ZipSession::ZipSession(const Epub& epub) : epub_(epub) {
+  if (epub_.sessionZip) {
+    return;  // a session is already active; reuse it (nesting is a no-op)
+  }
+  auto zip = makeUniqueNoThrow<ZipFile>(epub_.filepath);
+  if (zip && zip->open()) {
+    epub_.sessionZip = std::move(zip);
+    owns_ = true;
+  }
+  // On allocation/open failure sessionZip stays null and readItem* fall back to
+  // transient ZipFiles — correctness is preserved, just without the batch reuse.
+}
+
+Epub::ZipSession::~ZipSession() {
+  if (owns_) {
+    epub_.sessionZip->close();
+    epub_.sessionZip.reset();
+  }
+}
+
 uint8_t* Epub::readItemContentsToBytes(const std::string& itemHref, size_t* size, const bool trailingNullByte) const {
   if (itemHref.empty()) {
     LOG_DBG("EBP", "Failed to read item, empty href");
@@ -759,7 +787,8 @@ uint8_t* Epub::readItemContentsToBytes(const std::string& itemHref, size_t* size
 
   const std::string path = FsHelpers::normalisePath(itemHref);
 
-  const auto content = ZipFile(filepath).readFileToMemory(path.c_str(), size, trailingNullByte);
+  const auto content = sessionZip ? sessionZip->readFileToMemory(path.c_str(), size, trailingNullByte)
+                                  : ZipFile(filepath).readFileToMemory(path.c_str(), size, trailingNullByte);
   if (!content) {
     LOG_DBG("EBP", "Failed to read item %s", path.c_str());
     return nullptr;
@@ -775,12 +804,14 @@ bool Epub::readItemContentsToStream(const std::string& itemHref, Print& out, con
   }
 
   const std::string path = FsHelpers::normalisePath(itemHref);
-  return ZipFile(filepath).readFileToStream(path.c_str(), out, chunkSize);
+  return sessionZip ? sessionZip->readFileToStream(path.c_str(), out, chunkSize)
+                    : ZipFile(filepath).readFileToStream(path.c_str(), out, chunkSize);
 }
 
 bool Epub::getItemSize(const std::string& itemHref, size_t* size) const {
   const std::string path = FsHelpers::normalisePath(itemHref);
-  return ZipFile(filepath).getInflatedFileSize(path.c_str(), size);
+  return sessionZip ? sessionZip->getInflatedFileSize(path.c_str(), size)
+                    : ZipFile(filepath).getInflatedFileSize(path.c_str(), size);
 }
 
 int Epub::getSpineItemsCount() const {

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -29,6 +29,10 @@ class Epub {
   std::unique_ptr<CssParser> cssParser;
   // CSS files
   std::vector<std::string> cssFiles;
+  // When set (via ZipSession), readItem*/getItemSize reuse this single open ZipFile
+  // instead of constructing a transient one per call. Mutable so the const read methods
+  // can use it.
+  mutable std::unique_ptr<ZipFile> sessionZip;
 
   bool findContentOpfFile(std::string* contentOpfFile) const;
   bool parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata, bool writeSpineEntries = true);
@@ -38,11 +42,28 @@ class Epub {
   void parseCssFiles() const;
 
  public:
-  explicit Epub(std::string filepath, const std::string& cacheDir) : filepath(std::move(filepath)) {
-    // create a cache key based on the filepath
-    cachePath = cacheDir + "/epub_" + std::to_string(std::hash<std::string>{}(this->filepath));
-  }
-  ~Epub() = default;
+  // Defined out of line (with the destructor) because the unique_ptr<ZipFile> member
+  // requires a complete ZipFile type, which is only available in the .cpp.
+  explicit Epub(std::string filepath, const std::string& cacheDir);
+  ~Epub();
+
+  // RAII helper: keeps one ZipFile open for its lifetime so a batch of readItem*/
+  // getItemSize calls (e.g. a chapter's HTML plus all its images in createSectionFile)
+  // shares a single SD open + central-directory cursor instead of reopening and
+  // re-scanning the ZIP per read. Nesting is a no-op — only the outermost session owns
+  // the handle. If the open fails, reads transparently fall back to transient ZipFiles.
+  class ZipSession {
+   public:
+    explicit ZipSession(const Epub& epub);
+    ~ZipSession();
+    ZipSession(const ZipSession&) = delete;
+    ZipSession& operator=(const ZipSession&) = delete;
+
+   private:
+    const Epub& epub_;
+    bool owns_ = false;
+  };
+
   std::string& getBasePath() { return contentBasePath; }
   bool load(bool buildIfMissing = true, bool skipLoadingCss = false);
   bool clearCache() const;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -157,6 +157,11 @@ bool Section::createSectionFile(const int fontId, const float lineCompression, c
   const auto localPath = epub->getSpineItem(spineIndex).href;
   const auto tmpHtmlPath = epub->getCachePath() + "/.tmp_" + std::to_string(spineIndex) + ".html";
 
+  // Keep one ZipFile open for the whole build so the chapter HTML read and every
+  // per-image extraction share a single SD open + central-directory cursor instead of
+  // reopening and re-scanning the ZIP for each.
+  const Epub::ZipSession zipSession(*epub);
+
   // Create cache directory if it doesn't exist
   {
     const auto sectionsDir = epub->getCachePath() + "/sections";


### PR DESCRIPTION
## Summary

* **Goal:** Stop re-opening and re-scanning the EPUB ZIP for every read during a chapter build.
* **Changes:** New RAII `Epub::ZipSession` keeps a single `ZipFile` open for its lifetime; while active, `readItem*`/`getItemSize` reuse it instead of constructing a transient per call. `Section::createSectionFile` opens one session covering the chapter HTML read and every `<img>` extraction.

## Additional Context

A chapter with N images previously did N+1 SD opens, each re-running the EOCD scan + a central-directory scan; ZipFile's own central-dir cursor never survived a call. With the session, `zipDetails` (EOCD) is scanned once and the cursor persists across reads. Nesting is a no-op, and an open failure transparently falls back to transient ZipFiles, so behaviour is unchanged. Peak open file handles are unchanged (the zip handle was already open transiently during each read). The `Epub` ctor/dtor move out of line because the `unique_ptr<ZipFile>` member needs a complete type. **Reviewer focus:** the mutable `sessionZip` lifetime + the ctor/dtor move.

---

### AI Usage

Did you use AI tools to help write this code? **YES** — written with Claude Code, human-reviewed, passes clang-format + cppcheck + build, and flash-tested on an X4.
