### PR TITLE
fix: keep status bar indicators stable when toggling bookmarks

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -803,13 +803,6 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     renderer.fillRect(barMarginLeft, progressBarY, barWidth, barHeight, true);
   }
 
-  // Draw Bookmark
-  if (showStatusBarTextLane && isPageBookmarked) {
-    const int bookmarkY = textY + 5;
-    drawBookmarkStatusIcon(renderer, leftClusterX, bookmarkY);
-    leftClusterWidth += bookmarkStatusIconWidth + bookmarkStatusIconGap;
-  }
-
   // Draw Battery
   const bool showBatteryPercentage =
       SETTINGS.hideBatteryPercentage == CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_NEVER;
@@ -846,6 +839,15 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
       }
       renderer.drawText(SMALL_FONT_ID, clockX, textY, timeBuf);
     }
+  }
+
+  // Draw Bookmark
+  if (showStatusBarTextLane && isPageBookmarked) {
+    const int bookmarkGap = leftClusterWidth > 0 ? bookmarkStatusIconGap : 0;
+    const int bookmarkX = leftClusterX + leftClusterWidth + bookmarkGap;
+    const int bookmarkY = textY + 5;
+    drawBookmarkStatusIcon(renderer, bookmarkX, bookmarkY);
+    leftClusterWidth += bookmarkStatusIconWidth + bookmarkGap;
   }
 
   // Draw Title


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
  * Keep the reader status bar’s battery and left-side clock visually stable when a bookmark is toggled on the current page.
* **What changes are included?**
  * Moves the bookmark status icon layout after the battery and clock layout in `BaseTheme::drawStatusBar`.
  * Places the bookmark icon to the right of the battery, or to the right of both battery and left-positioned X3 clock when that clock is enabled.
  * Preserves the existing right-side clock behavior.

## Additional Context

* This is a layout-only change; it does not change bookmark storage, status bar settings, or battery/clock rendering logic.
* Practical behavior: the conditional bookmark icon is now the item that appears/disappears at the end of the left cluster, instead of pushing stable indicators around.

<img width="427" height="640" alt="Disorientation_ch7_p1_1pct_32939 Medium" src="https://github.com/user-attachments/assets/49f66088-d43e-4c97-8cb0-05c49885ec27" />
<img width="427" height="640" alt="Disorientation_ch7_p1_1pct_242877 Medium" src="https://github.com/user-attachments/assets/a3d34f23-1351-45b9-ab36-88e94d388d49" />
<img width="427" height="640" alt="Disorientation_ch7_p1_1pct_279405 Medium" src="https://github.com/user-attachments/assets/cd28e8d7-2412-4b35-89d3-7f80267c4f41" />
<img width="427" height="640" alt="Disorientation_ch7_p1_1pct_309007 Medium" src="https://github.com/user-attachments/assets/d8d8369c-ed60-4374-95c3-e1bdd84e7b00" />

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
