### PR TITLE
feat: add Footnotes option to long-press Menu

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -146,6 +146,7 @@ class CrossPointSettings {
     LP_MENU_KOSYNC = 0,
     LP_MENU_DISABLED = 1,
     LP_MENU_BOOKMARK = 2,
+    LP_MENU_FOOTNOTES = 3,
     LONG_PRESS_MENU_FUNCTION_COUNT
   };
 

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -173,8 +173,8 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
                            StrId::STR_LONG_PRESS_BEHAVIOR_ORIENTATION},
                           "longPressButtonBehavior", StrId::STR_CAT_CONTROLS),
         SettingInfo::Enum(StrId::STR_LONG_PRESS_MENU, &CrossPointSettings::longPressMenuFunction,
-                          {StrId::STR_KOSYNC, StrId::STR_DISABLED, StrId::STR_BOOKMARK_OPTION}, "longPressMenuFunction",
-                          StrId::STR_CAT_CONTROLS),
+                          {StrId::STR_KOSYNC, StrId::STR_DISABLED, StrId::STR_BOOKMARK_OPTION, StrId::STR_FOOTNOTES},
+                          "longPressMenuFunction", StrId::STR_CAT_CONTROLS),
         SettingInfo::Enum(
             StrId::STR_SHORT_PWR_BTN, &CrossPointSettings::shortPwrBtn,
             {StrId::STR_IGNORE, StrId::STR_SLEEP, StrId::STR_PAGE_TURN, StrId::STR_FORCE_REFRESH, StrId::STR_FOOTNOTES},

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -351,6 +351,19 @@ void EpubReaderActivity::loop() {
           }
         }
         break;
+      case CrossPointSettings::LP_MENU_FOOTNOTES:
+        // Hold ~0.4s jumps to the current page's footnote(s) (or returns from one). ignoreNext-
+        // ConfirmRelease latches this to fire once per hold (it stays set until the button is
+        // released), otherwise loop() would re-toggle every iteration while the button is held.
+        // When the page has no footnotes, fall through so the normal Confirm-release still opens
+        // the reader menu.
+        if (mappedInput.getHeldTime() >= ReaderUtils::BOOKMARK_HOLD_MS && !ignoreNextConfirmRelease &&
+            (footnoteDepth > 0 || !currentPageFootnotes.empty())) {
+          ignoreNextConfirmRelease = true;  // one-shot latch + suppress menu open on release
+          openOrToggleFootnotes();
+          return;
+        }
+        break;
       case CrossPointSettings::LP_MENU_DISABLED:
       default:
         break;
@@ -380,23 +393,7 @@ void EpubReaderActivity::loop() {
   if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::FOOTNOTES &&
       mappedInput.wasReleased(MappedInputManager::Button::Power) &&
       !mappedInput.wasReleased(MappedInputManager::Button::Down)) {
-    if (footnoteDepth > 0) {
-      restoreSavedPosition();
-    } else {
-      if (currentPageFootnotes.size() == 1) {
-        navigateToHref(currentPageFootnotes[0].href, true);
-      } else if (currentPageFootnotes.size() > 1) {
-        startActivityForResult(
-            std::make_unique<EpubReaderFootnotesActivity>(renderer, mappedInput, currentPageFootnotes),
-            [this](const ActivityResult& result) {
-              if (!result.isCancelled) {
-                const auto& footnoteResult = std::get<FootnoteResult>(result.data);
-                navigateToHref(footnoteResult.href, true);
-              }
-              requestUpdate();
-            });
-      }
-    }
+    openOrToggleFootnotes();
     return;
   }
 
@@ -529,6 +526,23 @@ void EpubReaderActivity::jumpToPercent(int percent) {
     nextPageNumber = 0;
     pendingPercentJump = true;
     section.reset();
+  }
+}
+
+void EpubReaderActivity::openOrToggleFootnotes() {
+  if (footnoteDepth > 0) {
+    restoreSavedPosition();
+  } else if (currentPageFootnotes.size() == 1) {
+    navigateToHref(currentPageFootnotes[0].href, true);
+  } else if (currentPageFootnotes.size() > 1) {
+    startActivityForResult(std::make_unique<EpubReaderFootnotesActivity>(renderer, mappedInput, currentPageFootnotes),
+                           [this](const ActivityResult& result) {
+                             if (!result.isCancelled) {
+                               const auto& footnoteResult = std::get<FootnoteResult>(result.data);
+                               navigateToHref(footnoteResult.href, true);
+                             }
+                             requestUpdate();
+                           });
   }
 }
 

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -64,6 +64,9 @@ class EpubReaderActivity final : public Activity {
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);
   void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action);
+  // Jump to the current page's footnote(s), or return from a footnote if already viewing one.
+  // Single footnote navigates directly; multiple opens the footnote picker; none is a no-op.
+  void openOrToggleFootnotes();
   // Returns true if sync acted (launched, or surfaced a save error); false if it was a no-op
   // because no KOReader credentials are stored.
   bool launchKOReaderSync();

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -14,9 +14,10 @@ void EpubReaderFootnotesActivity::onEnter() {
   selectedIndex = 0;
   // If we were opened while a select button is still held (the long-press Menu footnotes shortcut
   // pushes this picker before the user lets go of Confirm), ignore that button's first release so
-  // it doesn't immediately select footnote 0.
-  ignoreFirstSelectRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm) ||
-                             mappedInput.isPressed(MappedInputManager::Button::Power);
+  // it doesn't immediately select footnote 0. Track each button separately so releasing one does
+  // not clear the other's latch.
+  ignoreConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
+  ignorePowerRelease = mappedInput.isPressed(MappedInputManager::Button::Power);
   requestUpdate();
 }
 
@@ -31,12 +32,17 @@ void EpubReaderFootnotesActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
-      mappedInput.wasReleased(MappedInputManager::Button::Power)) {
-    if (ignoreFirstSelectRelease) {
-      // This is the release of the button that was still held when the picker opened; consume it
-      // so the list stays open instead of auto-selecting the first footnote.
-      ignoreFirstSelectRelease = false;
+  const bool confirmReleased = mappedInput.wasReleased(MappedInputManager::Button::Confirm);
+  const bool powerReleased = mappedInput.wasReleased(MappedInputManager::Button::Power);
+  if (confirmReleased || powerReleased) {
+    // Swallow the opening release of a button that was still held when the picker opened, clearing
+    // only that button's latch so the list stays open instead of auto-selecting the first footnote.
+    if (confirmReleased && ignoreConfirmRelease) {
+      ignoreConfirmRelease = false;
+      return;
+    }
+    if (powerReleased && ignorePowerRelease) {
+      ignorePowerRelease = false;
       return;
     }
     if (selectedIndex >= 0 && selectedIndex < static_cast<int>(footnotes.size())) {

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -12,6 +12,11 @@
 void EpubReaderFootnotesActivity::onEnter() {
   Activity::onEnter();
   selectedIndex = 0;
+  // If we were opened while a select button is still held (the long-press Menu footnotes shortcut
+  // pushes this picker before the user lets go of Confirm), ignore that button's first release so
+  // it doesn't immediately select footnote 0.
+  ignoreFirstSelectRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm) ||
+                             mappedInput.isPressed(MappedInputManager::Button::Power);
   requestUpdate();
 }
 
@@ -28,6 +33,12 @@ void EpubReaderFootnotesActivity::loop() {
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
       mappedInput.wasReleased(MappedInputManager::Button::Power)) {
+    if (ignoreFirstSelectRelease) {
+      // This is the release of the button that was still held when the picker opened; consume it
+      // so the list stays open instead of auto-selecting the first footnote.
+      ignoreFirstSelectRelease = false;
+      return;
+    }
     if (selectedIndex >= 0 && selectedIndex < static_cast<int>(footnotes.size())) {
       setResult(FootnoteResult{footnotes[selectedIndex].href});
       finish();

--- a/src/activities/reader/EpubReaderFootnotesActivity.h
+++ b/src/activities/reader/EpubReaderFootnotesActivity.h
@@ -24,8 +24,10 @@ class EpubReaderFootnotesActivity final : public Activity {
   const std::vector<FootnoteEntry>& footnotes;
   int selectedIndex = 0;
   int scrollOffset = 0;
-  // Set when the picker is opened while a select button is still held (e.g. the long-press Menu
-  // footnotes shortcut). Swallows that button's first release so it does not auto-select index 0.
-  bool ignoreFirstSelectRelease = false;
+  // Set per button when the picker is opened while that select button is still held (e.g. the
+  // long-press Menu footnotes shortcut). Swallows that button's first release so it does not
+  // auto-select index 0. Tracked separately so releasing one button never clears the other's latch.
+  bool ignoreConfirmRelease = false;
+  bool ignorePowerRelease = false;
   ButtonNavigator buttonNavigator;
 };

--- a/src/activities/reader/EpubReaderFootnotesActivity.h
+++ b/src/activities/reader/EpubReaderFootnotesActivity.h
@@ -24,5 +24,8 @@ class EpubReaderFootnotesActivity final : public Activity {
   const std::vector<FootnoteEntry>& footnotes;
   int selectedIndex = 0;
   int scrollOffset = 0;
+  // Set when the picker is opened while a select button is still held (e.g. the long-press Menu
+  // footnotes shortcut). Swallows that button's first release so it does not auto-select index 0.
+  bool ignoreFirstSelectRelease = false;
   ButtonNavigator buttonNavigator;
 };


### PR DESCRIPTION
## What

Adds a **Footnotes** choice to the **Controls → Long-press Menu** setting (alongside KOSync / Disabled / Bookmark).

When enabled, holding the **Menu (Confirm)** button in the EPUB reader jumps to the current page's footnote(s):

- **One footnote** on the page → navigates directly to it
- **Multiple footnotes** → opens the footnote picker
- **Already viewing a footnote** → returns to the previous position
- **No footnotes on the page** → falls through, so the normal short-press menu still opens

## Why

Footnote navigation already exists (reader menu + short-power-button shortcut), but there was no way to bind it to the long-press Menu button. This makes jumping to footnotes a one-press gesture for users who read footnote-heavy books.

## Implementation notes

- Reuses the existing footnote-navigation logic, extracted into `openOrToggleFootnotes()` and shared with the short-power-button footnote shortcut (no behaviour change there).
- Reuses the existing `STR_FOOTNOTES` string — **no new i18n keys**, works in all languages immediately.
- New enum value `LP_MENU_FOOTNOTES` is appended at the end, so stored setting indices stay stable (per the comment on `LONG_PRESS_MENU_FUNCTION`).
- `ignoreNextConfirmRelease` doubles as a one-shot latch so the action fires once per hold instead of re-toggling every `loop()` iteration while the button is held.
- No new heap allocations; RAM usage unchanged, ~3 KB flash.

## Testing

Built and flashed to **Xteink X4** hardware. Verified:

- [x] Single footnote → direct jump, fires once (no oscillation)
- [x] Multiple footnotes → picker opens cleanly
- [x] Return-from-footnote on a second hold
- [x] Page without footnotes → hold opens the normal menu
- [x] Short-press Menu still opens the reader menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)