### PR TITLE
feat: add server shortcut to OPDS picker

### DIFF
--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -59,6 +59,13 @@ void OpdsServerListActivity::loop() {
 
 void OpdsServerListActivity::handleSelection() {
   const auto serverCount = static_cast<int>(OPDS_STORE.getCount());
+  auto resultHandler = [this](const ActivityResult&) {
+    OPDS_STORE.loadFromFile();
+    selectedIndex = 0;
+  };
+  auto openServerEditor = [this, resultHandler](int serverIndex) {
+    startActivityForResult(std::make_unique<OpdsSettingsActivity>(renderer, mappedInput, serverIndex), resultHandler);
+  };
 
   if (pickerMode) {
     // Picker mode: selecting a server navigates to the OPDS browser; selecting the virtual item opens add-server.
@@ -68,26 +75,16 @@ void OpdsServerListActivity::handleSelection() {
         activityManager.replaceActivity(std::make_unique<OpdsBookBrowserActivity>(renderer, mappedInput, *server));
       }
     } else {
-      auto resultHandler = [this](const ActivityResult&) {
-        OPDS_STORE.loadFromFile();
-        selectedIndex = 0;
-      };
-      startActivityForResult(std::make_unique<OpdsSettingsActivity>(renderer, mappedInput, -1), resultHandler);
+      openServerEditor(-1);
     }
     return;
   }
 
   // Settings mode: open editor for selected server, or create a new one
-  auto resultHandler = [this](const ActivityResult&) {
-    // Reload server list when returning from editor
-    OPDS_STORE.loadFromFile();
-    selectedIndex = 0;
-  };
-
   if (selectedIndex < serverCount) {
-    startActivityForResult(std::make_unique<OpdsSettingsActivity>(renderer, mappedInput, selectedIndex), resultHandler);
+    openServerEditor(selectedIndex);
   } else {
-    startActivityForResult(std::make_unique<OpdsSettingsActivity>(renderer, mappedInput, -1), resultHandler);
+    openServerEditor(-1);
   }
 }
 

--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -13,11 +13,8 @@
 
 int OpdsServerListActivity::getItemCount() const {
   int count = static_cast<int>(OPDS_STORE.getCount());
-  // In settings mode, append a virtual "Add Server" item; in picker mode, only show real servers
-  if (!pickerMode) {
-    count++;
-  }
-  return count;
+  // Append a virtual "Add Server" item to both the settings list and the OPDS browser picker.
+  return count + 1;
 }
 
 void OpdsServerListActivity::onEnter() {
@@ -64,12 +61,18 @@ void OpdsServerListActivity::handleSelection() {
   const auto serverCount = static_cast<int>(OPDS_STORE.getCount());
 
   if (pickerMode) {
-    // Picker mode: selecting a server navigates to the OPDS browser
+    // Picker mode: selecting a server navigates to the OPDS browser; selecting the virtual item opens add-server.
     if (selectedIndex < serverCount) {
       const auto* server = OPDS_STORE.getServer(static_cast<size_t>(selectedIndex));
       if (server) {
         activityManager.replaceActivity(std::make_unique<OpdsBookBrowserActivity>(renderer, mappedInput, *server));
       }
+    } else {
+      auto resultHandler = [this](const ActivityResult&) {
+        OPDS_STORE.loadFromFile();
+        selectedIndex = 0;
+      };
+      startActivityForResult(std::make_unique<OpdsSettingsActivity>(renderer, mappedInput, -1), resultHandler);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- include the existing Add Server row in the OPDS browser picker
- route that picker row to the existing new-server settings flow
- keep existing server selection routing to the OPDS browser unchanged

Fixes #2493.

## Testing
- ./bin/clang-format-fix -g
- git diff --check
- cppcheck on src/activities/settings/OpdsServerListActivity.cpp passed before cleaning local PlatformIO artifacts; it only reported generated I18nKeys.h was absent outside the build-generation step

I also attempted the recommended PlatformIO checks with PlatformIO and clang-format installed in an isolated SSD dependency environment. The full pio run/check path could not complete locally because the external volume generated thousands of AppleDouble ._* files while unpacking the ESP32 Arduino toolchain archives, causing PlatformIO package extraction/install noise before compilation.