### PR TITLE
feat(network): add device serial number to web UI

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -376,7 +376,7 @@ void CrossPointWebServer::handleStatus() const {
   if (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA, snBuf, 256) == ESP_OK) {
     valid = snBuf[0] != '\0' && snBuf[0] != (char)0xFF;
     for (int i = 0; i < 32 && snBuf[i] != '\0'; i++) {
-      if (!std::isprint(snBuf[i])) {
+      if (!std::isprint(static_cast<unsigned char>(snBuf[i]))) {
         valid = false;
         break;
       }

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -6,9 +6,12 @@
 #include <HalStorage.h>
 #include <Logging.h>
 #include <WiFi.h>
+#include <esp_efuse.h>
+#include <esp_efuse_table.h>
 #include <esp_task_wdt.h>
 
 #include <algorithm>
+#include <cctype>
 
 #include "CrossPointSettings.h"
 #include "FontInstaller.h"
@@ -368,9 +371,27 @@ void CrossPointWebServer::handleStatus() const {
   doc["uptime"] = millis() / 1000;
   doc["device"] = gpio.deviceIsX3() ? "X3" : "X4";
 
-  String json;
-  serializeJson(doc, json);
-  server->send(200, "application/json", json);
+  char snBuf[33] = {0};
+  bool valid = false;
+  if (esp_efuse_read_field_blob(ESP_EFUSE_USER_DATA, snBuf, 256) == ESP_OK) {
+    valid = snBuf[0] != '\0' && snBuf[0] != (char)0xFF;
+    for (int i = 0; i < 32 && snBuf[i] != '\0'; i++) {
+      if (!std::isprint(snBuf[i])) {
+        valid = false;
+        break;
+      }
+    }
+  }
+
+  if (valid) {
+    doc["serial"] = snBuf;
+  } else {
+    doc["serial"] = "Not found";
+  }
+
+  String response;
+  serializeJson(doc, response);
+  server->send(200, "application/json", response);
 }
 
 void CrossPointWebServer::scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const {

--- a/src/network/html/HomePage.html
+++ b/src/network/html/HomePage.html
@@ -110,6 +110,10 @@
     <div class="card">
       <h2>Device Status</h2>
       <div class="info-row">
+        <span class="label">Serial #</span>
+        <span class="value" id="serial"></span>
+      </div>
+      <div class="info-row">
         <span class="label">Version</span>
         <span class="value" id="version"></span>
       </div>
@@ -141,6 +145,7 @@
         }
         const data = await response.json();
         document.getElementById('version').textContent = data.version || 'N/A';
+        document.getElementById('serial').textContent = data.serial;
         document.getElementById('ip-address').textContent = data.ip || 'N/A';
         document.getElementById('free-heap').textContent = data.freeHeap
           ? data.freeHeap.toLocaleString() + ' bytes'


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
 
  *  Shows the serial number in the web server

* **What changes are included?**

  *  Shows the serial number in the web server

## Additional Context

* I needed this because xteink sent me the wrong cable w/ my X3, and needed my SN to send a replacement. I had already SD flashed Crosspoint, and for some reason couldn't figure out how to flash the stock firmware back. I figure this would be useful for anyone else dealing with customer service.
* I did try to have the number shown in the settings menu. However, the default style truncates menu item values wider than half the width of the screen, so it wasn't useful. Would be nice to have that but this is still the bare minimum to make the Serial # available (and prob most easy to copy paste).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_


---

<img width="1950" height="1166" alt="image" src="https://github.com/user-attachments/assets/9469c1c1-fe78-456b-a8b9-7d915ab289e1" />

