### PR TITLE
fix: footnote navigation on page border and footnote anchor drift when hyphenation enabled

### DIFF
--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -277,6 +277,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordContinues.push_back(continues);
     wordNoSpaceBefore.push_back(noSpaceBefore);
     wordIsFocusSuffix.push_back(isFocusSuffix);
+    wordIsHyphenRemainder.push_back(false);
   };
 
   bool effectiveAttachToPrevious = attachToPrevious;
@@ -348,6 +349,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
     wordContinues.reserve(newCapacity);
     wordNoSpaceBefore.reserve(newCapacity);
     wordIsFocusSuffix.reserve(newCapacity);
+    wordIsHyphenRemainder.reserve(newCapacity);
   }
 
   // Lambda helper to process and push individual sub-segments of the string
@@ -360,6 +362,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
       wordContinues.push_back(attach);
       wordNoSpaceBefore.push_back(noSpaceBefore);
       wordIsFocusSuffix.push_back(false);
+      wordIsHyphenRemainder.push_back(false);
     } else {
       size_t charCount = 0;
       const unsigned char* countPtr = reinterpret_cast<const unsigned char*>(segment.data());
@@ -382,6 +385,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordIsFocusSuffix.push_back(false);
+        wordIsHyphenRemainder.push_back(false);
       } else {
         countPtr = reinterpret_cast<const unsigned char*>(segment.data());
         for (size_t i = 0; i < targetBoldChars; ++i) {
@@ -395,6 +399,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(attach);
         wordNoSpaceBefore.push_back(noSpaceBefore);
         wordIsFocusSuffix.push_back(false);
+        wordIsHyphenRemainder.push_back(false);
 
         // Regular suffix - marked so extractLine can merge it back into single TextBlock entry
         words.emplace_back(segment.substr(splitByteOffset));
@@ -402,6 +407,7 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
         wordContinues.push_back(true);
         wordNoSpaceBefore.push_back(false);
         wordIsFocusSuffix.push_back(true);
+        wordIsHyphenRemainder.push_back(false);
       }
     }
   };
@@ -463,10 +469,21 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
   }
   return 0;
 }
+
+size_t ParsedText::originalWordCount() const {
+  size_t count = 0;
+  for (size_t i = 0; i < words.size(); ++i) {
+    if (!wordIsHyphenRemainder[i] && !wordIsFocusSuffix[i]) {
+      ++count;
+    }
+  }
+  return count;
+}
+
 // Consumes data to minimize memory usage
-void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
-                                       const bool includeLastLine) {
+void ParsedText::layoutAndExtractLines(
+    const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
+    const std::function<void(std::shared_ptr<TextBlock>, ExtractedLineMeta)>& processLine, const bool includeLastLine) {
   if (words.empty()) {
     return;
   }
@@ -531,6 +548,7 @@ void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fo
     wordContinues.erase(wordContinues.begin(), wordContinues.begin() + consumed);
     wordNoSpaceBefore.erase(wordNoSpaceBefore.begin(), wordNoSpaceBefore.begin() + consumed);
     wordIsFocusSuffix.erase(wordIsFocusSuffix.begin(), wordIsFocusSuffix.begin() + consumed);
+    wordIsHyphenRemainder.erase(wordIsHyphenRemainder.begin(), wordIsHyphenRemainder.begin() + consumed);
   }
 }
 
@@ -792,6 +810,8 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
   wordStyles.insert(wordStyles.begin() + wordIndex + 1, style);
   // The hyphen remainder is not a focus suffix - it starts fresh on the next line.
   wordIsFocusSuffix.insert(wordIsFocusSuffix.begin() + wordIndex + 1, false);
+  // The remainder is a layout-time split of an original word, not an original word itself.
+  wordIsHyphenRemainder.insert(wordIsHyphenRemainder.begin() + wordIndex + 1, true);
 
   // Continuation flag handling after splitting a word into prefix + remainder.
   //
@@ -826,11 +846,19 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                              const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, ExtractedLineMeta)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
   const size_t lineWordCount = lineBreak - lastBreakAt;
+
+  // originalWordCount is order-independent, so it is computed from the source arrays before any RTL reordering.
+  size_t originalWordCount = 0;
+  for (size_t i = 0; i < lineWordCount; ++i) {
+    if (!wordIsHyphenRemainder[lastBreakAt + i] && !wordIsFocusSuffix[lastBreakAt + i]) {
+      ++originalWordCount;
+    }
+  }
 
   const int firstLineIndent = resolveFirstLineIndent(breakIndex == 0, renderer, fontId);
 
@@ -1141,7 +1169,7 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
       LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
       return;
     }
-    processLine(std::move(block));
+    processLine(std::move(block), ExtractedLineMeta{originalWordCount});
     return;
   }
 
@@ -1191,5 +1219,5 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
     LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
     return;
   }
-  processLine(std::move(block));
+  processLine(std::move(block), ExtractedLineMeta{originalWordCount});
 }

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -12,12 +12,20 @@
 
 class GfxRenderer;
 
+// Transient metadata produced by ParsedText::extractLine alongside each laid-out line (TextBlock)
+struct ExtractedLineMeta {
+  // Number of line's original words, excluding layout-time hyphenation remainders and focus-reading suffixes
+  size_t originalWordCount = 0;
+  explicit ExtractedLineMeta(const size_t originalWordCount) : originalWordCount(originalWordCount) {}
+};
+
 class ParsedText {
   std::vector<std::string> words;
   std::vector<EpdFontFamily::Style> wordStyles;
-  std::vector<bool> wordContinues;      // true = word attaches to previous with no break
-  std::vector<bool> wordNoSpaceBefore;  // true = may break before token, but no synthetic space when joined
-  std::vector<bool> wordIsFocusSuffix;  // true = token is the regular tail of a focus bold-prefix split
+  std::vector<bool> wordContinues;          // true = word attaches to previous with no break
+  std::vector<bool> wordNoSpaceBefore;      // true = may break before token, but no synthetic space when joined
+  std::vector<bool> wordIsFocusSuffix;      // true = token is the regular tail of a focus bold-prefix split
+  std::vector<bool> wordIsHyphenRemainder;  // true = token is a layout-time hyphenation remainder, not an original word
   BlockStyle blockStyle;
   bool extraParagraphSpacing;
   bool hyphenationEnabled;
@@ -44,8 +52,8 @@ class ParsedText {
   void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                    const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>)>& processLine, const GfxRenderer& renderer,
-                   int fontId);
+                   const std::function<void(std::shared_ptr<TextBlock>, ExtractedLineMeta)>& processLine,
+                   const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
  public:
@@ -63,8 +71,10 @@ class ParsedText {
   void setBlockStyle(const BlockStyle& blockStyle) { this->blockStyle = blockStyle; }
   BlockStyle& getBlockStyle() { return blockStyle; }
   size_t size() const { return words.size(); }
+  // Number of original words, excluding layout-time hyphenation remainders and focus-reading suffixes
+  size_t originalWordCount() const;
   bool isEmpty() const { return words.empty(); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>)>& processLine,
+                             const std::function<void(std::shared_ptr<TextBlock>, ExtractedLineMeta)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -194,9 +194,22 @@ void ChapterHtmlSlimParser::flushPendingAnchor() {
     }
   }
 
-  // Record deferred anchor after previous block is flushed (and any TOC page break)
-  anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
+  // Anchor belongs to the *next* content yet to be laid out, so we cannot be sure if it
+  // lands on current page or on the next one. So we do not place the anchor instantly but
+  // rather "arm" it to be fired in future when the anchored content is finally placed
+  armedAnchorIds.push_back(std::move(pendingAnchorId));
   pendingAnchorId.clear();
+}
+
+// Stamp every armed anchor with the page whose content just landed. Called from each content
+// placement site (text line, image, horizontal rule) after any page break has been applied,
+// so completedPageCount already reflects the correct target page.
+void ChapterHtmlSlimParser::recordArmedAnchors() {
+  if (armedAnchorIds.empty()) return;
+  for (auto& id : armedAnchorIds) {
+    anchorData.push_back({std::move(id), static_cast<uint16_t>(completedPageCount)});
+  }
+  armedAnchorIds.clear();
 }
 
 // flush the contents of partWordBuffer to currentTextBlock
@@ -319,10 +332,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   currentPage->elements.push_back(pageRule);
   currentPageNextY = static_cast<int16_t>(currentPageNextY + ruleThickness + bottomSpacing);
 
-  if (!pendingAnchorId.empty()) {
-    anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
-    pendingAnchorId.clear();
-  }
+  recordArmedAnchors();
 }
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
@@ -368,8 +378,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
           // never trigger startNewTextBlock, so fn1 gets silently overwritten. That leaves
           // fn1 missing from the anchor map -> getPageForAnchor returns nullopt -> reader
           // lands at page 0 (section start) instead of the footnote.
+          // Such an id sits inline in the current block, so the current page is its best-effort target.
           if (!self->pendingAnchorId.empty()) {
-            self->flushPendingAnchor();
+            self->anchorData.push_back(
+                {std::move(self->pendingAnchorId), static_cast<uint16_t>(self->completedPageCount)});
           }
           self->pendingAnchorId = idValue;
         }
@@ -658,6 +670,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                   self->startNewTextBlock(parentBlockStyle);
                 }
 
+                // Apply page breaks before TOC-boundary anchors (if any)
+                self->flushPendingAnchor();
+
                 // Apply vertical margins from the container to the image.
                 // Top margin lives on the empty text block (deposited via vertical merge
                 // in startNewTextBlock). Bottom margin was stripped by withoutBottom() for
@@ -711,6 +726,9 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 }
                 self->currentPage->elements.push_back(pageImage);
                 self->currentPageNextY += displayHeight + imageMarginBottom;
+
+                // An id resolves to the page the image actually landed on, after the fit/break decision above.
+                self->recordArmedAnchors();
 
                 // The image consumed the empty block's accumulated vertical spacing.
                 // Reset the block so the Vertical merge in startNewTextBlock doesn't
@@ -1389,9 +1407,10 @@ bool ChapterHtmlSlimParser::finishParse() {
   if (currentTextBlock) {
     makePages();
     if (!pendingAnchorId.empty()) {
-      anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
+      armedAnchorIds.push_back(std::move(pendingAnchorId));
       pendingAnchorId.clear();
     }
+    recordArmedAnchors();
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex);
     completedPageCount++;
     currentPage.reset();
@@ -1432,6 +1451,10 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const
     currentPage.reset(new Page());
     currentPageNextY = 0;
   }
+
+  // The first line of the anchored block just landed on this page (top margins already
+  // advanced currentPageNextY and any overflow break above bumped completedPageCount).
+  recordArmedAnchors();
 
   // Track cumulative ORIGINAL words to assign footnotes to the page containing their anchor.
   // Counting original words (not laid-out words) keeps the index aligned with the footnote

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1153,7 +1153,10 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
                                         : self->viewportWidth;
     self->currentTextBlock->layoutAndExtractLines(
         self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock) { self->addLineToPage(textBlock); }, false);
+        [self](const std::shared_ptr<TextBlock>& textBlock, const ExtractedLineMeta lineMeta) {
+          self->addLineToPage(textBlock, lineMeta);
+        },
+        false);
   }
 }
 
@@ -1226,8 +1229,8 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       entry.number[sizeof(entry.number) - 1] = '\0';
       strncpy(entry.href, self->currentFootnote.href, sizeof(entry.href) - 1);
       entry.href[sizeof(entry.href) - 1] = '\0';
-      int wordIndex =
-          self->wordsExtractedInBlock + (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->size()) : 0);
+      int wordIndex = self->wordsExtractedInBlock +
+                      (self->currentTextBlock ? static_cast<int>(self->currentTextBlock->originalWordCount()) : 0);
       self->pendingFootnotes.push_back({wordIndex, entry});
     }
     self->insideFootnoteLink = false;
@@ -1415,7 +1418,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   return finishParse();
 }
 
-void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
+void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const ExtractedLineMeta lineMeta) {
   const int lineHeight = renderer.getLineHeight(fontId) * lineCompression;
 
   if (!currentPage) {
@@ -1430,8 +1433,10 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line) {
     currentPageNextY = 0;
   }
 
-  // Track cumulative words to assign footnotes to the page containing their anchor
-  wordsExtractedInBlock += line->wordCount();
+  // Track cumulative ORIGINAL words to assign footnotes to the page containing their anchor.
+  // Counting original words (not laid-out words) keeps the index aligned with the footnote
+  // word index captured at parse time, even when hyphenation splits words across lines.
+  wordsExtractedInBlock += static_cast<int>(lineMeta.originalWordCount);
   auto footnoteIt = pendingFootnotes.begin();
   while (footnoteIt != pendingFootnotes.end() && footnoteIt->first <= wordsExtractedInBlock) {
     currentPage->addFootnote(footnoteIt->second.number, footnoteIt->second.href);
@@ -1474,7 +1479,9 @@ void ChapterHtmlSlimParser::makePages() {
 
   currentTextBlock->layoutAndExtractLines(
       renderer, fontId, effectiveWidth,
-      [this](const std::shared_ptr<TextBlock>& textBlock) { addLineToPage(textBlock); });
+      [this](const std::shared_ptr<TextBlock>& textBlock, const ExtractedLineMeta lineMeta) {
+        addLineToPage(textBlock, lineMeta);
+      });
 
   // Fallback: transfer any remaining pending footnotes to current page.
   // Normally addLineToPage handles this via word-index tracking, but this catches

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -171,7 +171,7 @@ class ChapterHtmlSlimParser {
   bool finishParse();  // flush the trailing page and tear down; returns true
   void abortParse();   // tear down without flushing (error / abandon)
 
-  void addLineToPage(std::shared_ptr<TextBlock> line);
+  void addLineToPage(std::shared_ptr<TextBlock> line, ExtractedLineMeta lineMeta);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 
   // Byte progress of the in-flight parse, used to estimate a still-building section's total page

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -84,8 +84,9 @@ class ChapterHtmlSlimParser {
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
   std::vector<std::pair<std::string, uint16_t>> anchorData;
-  std::string pendingAnchorId;          // deferred until after previous text block is flushed
-  std::vector<std::string> tocAnchors;  // the list of anchors that are TOC chapter boundaries
+  std::string pendingAnchorId;              // parsed id, not yet tied to a block boundary
+  std::vector<std::string> armedAnchorIds;  // ids awaiting the real page their content lands on
+  std::vector<std::string> tocAnchors;      // the list of anchors that are TOC chapter boundaries
   uint16_t xpathParagraphIndex = 0;
   uint16_t xpathListItemIndex = 0;
 
@@ -110,6 +111,7 @@ class ChapterHtmlSlimParser {
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
   void flushPendingAnchor();
+  void recordArmedAnchors();
   void flushPartWordBuffer();
   void makePages();
   static EpdFontFamily::Style fontStyleForTextDecoration(CssTextDecoration decoration);


### PR DESCRIPTION
## Summary

Fix two footnote bugs:
1. with hyphenation enabled footnotes on long paragraphs can break because anchors offset (which is measured in words) drift as it is measured in hyphenated, split words, but target anchor's offset is mesaured in original, not hyphenated words
2. when note text starts from a fresh page anchor still targets previous page

### Demo for bug 1: footnote 3 works fine while footnote 4 is not available in context menu

https://github.com/user-attachments/assets/aee1a765-df48-4afe-8eac-f61b34d4422b

### Demo for bug 2: footnote 1 tooks one full page, so footnote 2 target is exactly on page border, footnote 2 target misses

https://github.com/user-attachments/assets/b99985fc-7709-40c7-99ae-86ee4eecead3

## Additional Context

I was considering adding originalWordCount to TextBlock class, but TextBlock is serializing to cache and originalWordCount is not needed after initial line processing. So there would be 2 bytes extra cache size for each line. Not much, but unnecessary. So there was added a transient info class for it.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
