### PR TITLE
fix: use nothrow allocs and memcpy for RISC-V alignment

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -39,7 +39,12 @@ std::unique_ptr<PageLine> PageLine::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto tb = TextBlock::deserialize(file);
-  return std::unique_ptr<PageLine>(new PageLine(std::move(tb), xPos, yPos));
+  auto* line = new (std::nothrow) PageLine(std::move(tb), xPos, yPos);
+  if (!line) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageLine");
+    return nullptr;
+  }
+  return std::unique_ptr<PageLine>(line);
 }
 
 void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -62,7 +67,12 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  auto* image = new (std::nothrow) PageImage(std::move(ib), xPos, yPos);
+  if (!image) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageImage");
+    return nullptr;
+  }
+  return std::unique_ptr<PageImage>(image);
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -144,7 +154,11 @@ bool Page::serialize(HalFile& file) const {
 }
 
 std::unique_ptr<Page> Page::deserialize(HalFile& file) {
-  auto page = std::unique_ptr<Page>(new Page());
+  auto page = std::unique_ptr<Page>(new (std::nothrow) Page());
+  if (!page) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate Page");
+    return nullptr;
+  }
 
   uint16_t count;
   serialization::readPod(file, count);
@@ -155,9 +169,15 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
 
     if (tag == TAG_PageLine) {
       auto pl = PageLine::deserialize(file);
+      if (!pl) {
+        return nullptr;
+      }
       page->elements.push_back(std::move(pl));
     } else if (tag == TAG_PageImage) {
       auto pi = PageImage::deserialize(file);
+      if (!pi) {
+        return nullptr;
+      }
       page->elements.push_back(std::move(pi));
     } else if (tag == TAG_PageHorizontalRule) {
       auto rule = PageHorizontalRule::deserialize(file);

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -43,7 +43,13 @@ struct PngContext {
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
 // avoiding the need for global file state.
 void* pngOpenWithHandle(const char* filename, int32_t* size) {
-  HalFile* f = new HalFile();
+  // Raw nothrow allocation: ownership passes to the PNGdec C API, which hands
+  // the handle back to pngCloseWithHandle for delete.
+  HalFile* f = new (std::nothrow) HalFile();
+  if (!f) {
+    LOG_ERR("PNG", "OOM: HalFile alloc failed");
+    return nullptr;
+  }
   if (!Storage.openFileForRead("PNG", std::string(filename), *f)) {
     delete f;
     return nullptr;

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -7,6 +7,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <new>
 
 #include "BitmapHelpers.h"
 
@@ -625,13 +626,21 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
 
   if (oneBit) {
-    atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
+    atkinson1BitDitherer = new (std::nothrow) Atkinson1BitDitherer(outWidth);
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth);
+      atkinsonDitherer = new (std::nothrow) AtkinsonDitherer(outWidth);
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth);
+      fsDitherer = new (std::nothrow) FloydSteinbergDitherer(outWidth);
     }
+  }
+  if ((oneBit && !atkinson1BitDitherer) ||
+      (!oneBit && !USE_8BIT_OUTPUT && ((USE_ATKINSON && !atkinsonDitherer) || (USE_FLOYD_STEINBERG && !fsDitherer)))) {
+    LOG_ERR("PNG", "Failed to allocate ditherer");
+    free(rowBuffer);
+    free(ctx.currentRow);
+    free(ctx.previousRow);
+    return false;
   }
 
   // Scaling accumulators
@@ -641,8 +650,20 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   uint32_t nextOutY_srcStart = 0;
 
   if (needsScaling) {
-    rowAccum = new uint32_t[outWidth]();
-    rowCount = new uint16_t[outWidth]();
+    rowAccum = new (std::nothrow) uint32_t[outWidth]();
+    rowCount = new (std::nothrow) uint16_t[outWidth]();
+    if (!rowAccum || !rowCount) {
+      LOG_ERR("PNG", "Failed to allocate scaling accumulators");
+      delete[] rowAccum;
+      delete[] rowCount;
+      delete atkinsonDitherer;
+      delete fsDitherer;
+      delete atkinson1BitDitherer;
+      free(rowBuffer);
+      free(ctx.currentRow);
+      free(ctx.previousRow);
+      return false;
+    }
     nextOutY_srcStart = scaleY_fp;
   }
 

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 
 #include <algorithm>
+#include <cstring>
 
 struct ZipInflateCtx {
   InflateReader reader;  // Must be first — callback casts uzlib_uncomp* to ZipInflateCtx*
@@ -245,7 +246,10 @@ bool ZipFile::loadZipDetails() {
   int foundOffset = -1;
   for (int i = scanRange - 22; i >= 0; i--) {
     constexpr uint32_t signature = 0x06054b50;
-    if (*reinterpret_cast<uint32_t*>(&buffer[i]) == signature) {
+    // RISC-V faults on unaligned multi-byte loads; &buffer[i] has no alignment guarantee
+    uint32_t candidate;
+    memcpy(&candidate, &buffer[i], sizeof(candidate));
+    if (candidate == signature) {
       foundOffset = i;
       break;
     }
@@ -261,8 +265,12 @@ bool ZipFile::loadZipDetails() {
   // Relative positions within EOCD:
   // Offset 10: Total number of entries (2 bytes)
   // Offset 16: Offset of start of central directory with respect to the starting disk number (4 bytes)
-  zipDetails.totalEntries = *reinterpret_cast<uint16_t*>(&buffer[foundOffset + 10]);
-  zipDetails.centralDirOffset = *reinterpret_cast<uint32_t*>(&buffer[foundOffset + 16]);
+  uint16_t totalEntries;
+  uint32_t centralDirOffset;
+  memcpy(&totalEntries, &buffer[foundOffset + 10], sizeof(totalEntries));
+  memcpy(&centralDirOffset, &buffer[foundOffset + 16], sizeof(centralDirOffset));
+  zipDetails.totalEntries = totalEntries;
+  zipDetails.centralDirOffset = centralDirOffset;
   zipDetails.isSet = true;
 
   free(buffer);

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -845,7 +845,12 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
-    section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+    section = makeUniqueNoThrow<Section>(epub, currentSpineIndex, renderer);
+    if (!section) {
+      LOG_ERR("ERS", "OOM: Section alloc failed");
+      showPendingSyncSaveError();
+      return;
+    }
 
     if (!section->loadSectionFile(SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
                                   SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth,


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix five crash-level bugs where bare `new` or unaligned pointer casts would abort or fault the device on the ESP32-C3.
* **What changes are included?**

### Unaligned reads in ZipFile (RISC-V fault on every EPUB open)

`lib/ZipFile/ZipFile.cpp` — `loadZipDetails` used three `*reinterpret_cast<uintN_t*>(&buf[i])` reads on a `malloc`'d `uint8_t*` buffer. The buffer has no alignment guarantee; unaligned multi-byte loads fault on ESP32-C3 RISC-V (documented in your CLAUDE.md §RISC-V Alignment). This code runs on every EPUB open. Replace with `memcpy` into typed locals.

### Bare `new` without nothrow guard

With `-fno-exceptions`, bare `new` on OOM calls `abort()` rather than returning `nullptr` (CLAUDE.md Rule 9). Four sites fixed:

- `lib/Epub/Epub/Page.cpp` — `PageLine`, `PageImage`, `Page` deserializers used bare `new`. Convert to `new (std::nothrow)` + null-check, consistent with the existing `PageHorizontalRule` pattern in the same file. Null-check propagation added in `Page::deserialize` loop.
- `lib/Epub/Epub/converters/PngToFramebufferConverter.cpp` — `HalFile` alloc in the PNG open callback. Ownership passes to PNGdec C API, so `new (std::nothrow)` used directly.
- `lib/PngToBmpConverter/PngToBmpConverter.cpp` — ditherer objects and scaling accumulators (`uint32_t[]`, `uint16_t[]`). Convert to `new (std::nothrow)` with OOM error paths.
- `src/activities/reader/EpubReaderActivity.cpp:848` — `Section` alloc; convert to `makeUniqueNoThrow<Section>` with null-check before `loadSectionFile`.

## Additional Context

All changes follow the constraints in your CLAUDE.md (Rule 9, §RISC-V Alignment). Verified with `pio run` (0 errors, 0 warnings) and `pio check --fail-on-defect high` (no defects). Formatted with clang-format-21.

No hardware testing was performed — human verification on device is recommended before merging.

This is part of a series of 3 focused fix PRs. See also:
- #2518 — OTA version parse and WiFi power save
- #2519 — Settings persistence, reserve(), minor

---

### AI Usage

Did you use AI tools to help write this code? **YES**

These fixes were identified by Claude Fable 5 (Anthropic) via static analysis and manual review. All changes were verified against your project's own CLAUDE.md Resource Protocol. We flag this transparently in case AI-originated contributions require additional scrutiny.