### PR TITLE
fix: guard sscanf return and restore wifi-ps in OtaUpdater

### DIFF
--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -71,14 +71,19 @@ bool OtaUpdater::isUpdateNewer() const {
     return false;
   }
 
-  int currentMajor, currentMinor, currentPatch;
-  int latestMajor, latestMinor, latestPatch;
+  int currentMajor = 0, currentMinor = 0, currentPatch = 0;
+  int latestMajor = 0, latestMinor = 0, latestPatch = 0;
 
   const auto currentVersion = CROSSPOINT_VERSION;
 
   // semantic version check (only match on 3 segments)
-  sscanf(latestVersion.c_str(), "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch);
-  sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch);
+  if (sscanf(latestVersion.c_str(), "%d.%d.%d", &latestMajor, &latestMinor, &latestPatch) != 3 ||
+      sscanf(currentVersion, "%d.%d.%d", &currentMajor, &currentMinor, &currentPatch) != 3) {
+    // Unparseable version string — comparing garbage could trigger a spurious
+    // install or suppress a real update, so treat as not newer.
+    LOG_DBG("OTA", "Version parse failed: latest=%s current=%s", latestVersion.c_str(), currentVersion);
+    return false;
+  }
 
   /*
    * Compare major versions.
@@ -143,6 +148,9 @@ OtaUpdater::OtaUpdaterError OtaUpdater::installUpdate(ProgressCallback onProgres
   esp_err = esp_https_ota_begin(&ota_config, &ota_handle);
   if (esp_err != ESP_OK) {
     LOG_DBG("OTA", "HTTP OTA Begin Failed: %s", esp_err_to_name(esp_err));
+    // Restore power saving — otherwise the radio stays in max-power mode for
+    // the rest of the session after a failed begin.
+    esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
     return INTERNAL_UPDATE_ERROR;
   }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix two bugs in OTA update handling: an sscanf-based version comparison that reads uninitialised stack values, and a WiFi power-save mode that is left at WIFI_PS_NONE on an early-exit error path.
* **What changes are included?**

### OTA version comparison reads uninitialised stack (OtaUpdater.cpp)

`isUpdateNewer()` declared six version-component `int` locals without initialiser values. The code then called `sscanf` on both version strings and compared the locals without checking whether `sscanf` succeeded. A malformed manifest URL or a dev build without a semver tag (e.g. `"dev"`) would leave all six values undefined; on RISC-V the comparison would use whatever bytes happened to be on the stack, potentially reporting a phantom "newer" version or suppressing a real update.

Fix: zero-initialise all six locals; guard both `sscanf` calls with a `!= 3` check that logs and returns `false` immediately on parse failure.

### WiFi power-save not restored on OTA begin failure (OtaUpdater.cpp)

`installUpdate()` disables modem sleep (`WIFI_PS_NONE`) for the duration of the OTA HTTP download, then re-enables it (`WIFI_PS_MIN_MODEM`) at the end. The function had a single early-exit path — `esp_https_ota_begin` failure — that returned `INTERNAL_UPDATE_ERROR` without restoring modem sleep, leaving the radio in high-power mode for the rest of the session.

Fix: add `esp_wifi_set_ps(WIFI_PS_MIN_MODEM)` before the early return.

## Additional Context

Changes verified with `pio run` (0 errors, 0 warnings) and `pio check --fail-on-defect high` (no defects). Formatted with clang-format-21.

No hardware testing was performed — human verification on device is recommended before merging.

This is part of a series of 3 focused fix PRs. See also:
- #2517 — nothrow allocations + RISC-V unaligned reads
- #2519 — Settings persistence, reserve(), minor

---

### AI Usage

Did you use AI tools to help write this code? **YES**

These fixes were identified by Claude Fable 5 (Anthropic) via static analysis and manual review. All changes were verified against the project's own CLAUDE.md Resource Protocol. We flag this transparently in case AI-originated contributions require additional scrutiny.