### PR TITLE
feat: cjk UI font fallback

### DIFF
--- a/docs/sd-card-fonts.md
+++ b/docs/sd-card-fonts.md
@@ -52,6 +52,52 @@ There are three ways to install fonts:
 
 3. Insert the SD card and power on your CrossPoint reader
 
+## CJK in the User Interface
+
+The built-in UI fonts are Latin-only, so by default the interface (book titles
+in the library, file names in the browser, list rows, headers) shows
+replacement boxes for Chinese/Japanese/Korean text even when book *content*
+renders correctly with a selected SD-card font.
+
+To avoid shipping a large CJK glyph set in flash, CrossPoint instead reuses the
+SD-card font you already selected: when a UI string contains a CJK character
+the built-in font cannot draw, that whole string is rendered with your selected
+SD-card font instead.
+
+The fallback is **size-matched**. The built-in UI fonts render at 8 pt
+(small/author lines), 10 pt (list rows) and 12 pt (book-cover titles, headers),
+so CrossPoint loads your SD family at those sizes too and maps each UI font to
+its same-size SD font. CJK book names therefore appear at the same size as the
+Latin text around them. For this to work the family must contain `.cpfont`
+files at sizes **8, 10 and 12** (in addition to the reader sizes 12–18); any UI
+size missing from the family simply keeps showing boxes for CJK at that size.
+
+When converting your own font, include the UI sizes:
+
+    python3 lib/EpdFont/scripts/fontconvert_sdcard.py \
+      MyCJKFont-Regular.otf \
+      --intervals cjk \
+      --sizes 8,10,12,14,16,18 \
+      --style regular \
+      --name MyCJKFont \
+      --output-dir ./MyCJKFont/
+
+What this means in practice:
+
+- Select a CJK-capable SD font under **Settings > Reader > Font Family**
+  (see [Installing Fonts](#installing-fonts) and the `cjk` / `hangul` presets
+  under [Converting Custom Fonts](#converting-custom-fonts)). That single
+  selection drives both book content *and* size-matched CJK fallback in the UI.
+- Pure-Latin UI strings keep the crisp built-in font; only strings that
+  actually contain CJK are routed to the SD font.
+- The fallback is per *string*, not per glyph: a mixed title such as
+  `三体 Vol.1` renders entirely in the SD font (including the Latin part). If
+  that SD font is a `Mono` family, the Latin portion will appear half/full
+  width.
+- If no SD font is selected (a built-in reading font is active), there is no
+  CJK fallback and the UI again shows boxes for CJK — pick a CJK SD font to
+  restore it.
+
 ## Available Pre-Built Fonts
 
 The current list of pre-built fonts is maintained in the

--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -191,11 +191,18 @@ const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
 
 bool EpdFont::hasCodepoint(const uint32_t cp) const {
   const int count = data->intervalCount;
-  if (count <= 0) return false;
+  if (count > 0) {
+    const EpdUnicodeInterval* intervals = data->intervals;
+    const auto* end = intervals + count;
+    const auto it = std::upper_bound(
+        intervals, end, cp, [](uint32_t value, const EpdUnicodeInterval& interval) { return value < interval.first; });
+    if (it != intervals && cp <= (it - 1)->last) return true;
+  }
 
-  const EpdUnicodeInterval* intervals = data->intervals;
-  const auto* end = intervals + count;
-  const auto it = std::upper_bound(
-      intervals, end, cp, [](uint32_t value, const EpdUnicodeInterval& interval) { return value < interval.first; });
-  return it != intervals && cp <= (it - 1)->last;
+  // Interval table miss. SD card fonts only keep the current page's glyphs in
+  // their interval table — ask their full RAM-resident coverage index instead.
+  if (data->coverageHandler) {
+    return data->coverageHandler(data->glyphMissCtx, cp);
+  }
+  return false;
 }

--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -188,3 +188,14 @@ const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
   }
   return nullptr;
 }
+
+bool EpdFont::hasCodepoint(const uint32_t cp) const {
+  const int count = data->intervalCount;
+  if (count <= 0) return false;
+
+  const EpdUnicodeInterval* intervals = data->intervals;
+  const auto* end = intervals + count;
+  const auto it = std::upper_bound(
+      intervals, end, cp, [](uint32_t value, const EpdUnicodeInterval& interval) { return value < interval.first; });
+  return it != intervals && cp <= (it - 1)->last;
+}

--- a/lib/EpdFont/EpdFont.h
+++ b/lib/EpdFont/EpdFont.h
@@ -12,6 +12,13 @@ class EpdFont {
 
   const EpdGlyph* getGlyph(uint32_t cp) const;
 
+  /// Returns true if this font's interval table covers `cp`. Unlike getGlyph(),
+  /// it does NOT consult the on-demand miss handler or fall back to the
+  /// replacement glyph — it reports only what this font can render directly.
+  /// Used by the CJK UI font fallback to decide whether a string needs to be
+  /// routed to another font.
+  bool hasCodepoint(uint32_t cp) const;
+
   /// Returns the kerning adjustment (4.4 fixed-point in pixels) between two codepoints.
   /// Returns 0 if no kerning data exists for the pair.
   int8_t getKerning(uint32_t leftCp, uint32_t rightCp) const;

--- a/lib/EpdFont/EpdFont.h
+++ b/lib/EpdFont/EpdFont.h
@@ -12,11 +12,12 @@ class EpdFont {
 
   const EpdGlyph* getGlyph(uint32_t cp) const;
 
-  /// Returns true if this font's interval table covers `cp`. Unlike getGlyph(),
-  /// it does NOT consult the on-demand miss handler or fall back to the
-  /// replacement glyph — it reports only what this font can render directly.
-  /// Used by the CJK UI font fallback to decide whether a string needs to be
-  /// routed to another font.
+  /// Returns true if this font covers `cp`: either via its in-RAM interval
+  /// table or, for SD card fonts, via the coverageHandler that consults the
+  /// full RAM-resident coverage index. Unlike getGlyph(), it never performs
+  /// storage I/O and never falls back to the replacement glyph — it reports
+  /// only what this font can render. Used by the CJK UI font fallback to
+  /// decide whether a string needs to be routed to another font.
   bool hasCodepoint(uint32_t cp) const;
 
   /// Returns the kerning adjustment (4.4 fixed-point in pixels) between two codepoints.

--- a/lib/EpdFont/EpdFontData.h
+++ b/lib/EpdFont/EpdFontData.h
@@ -206,4 +206,11 @@ typedef struct {
   /// Context pointer for glyphMissHandler (typically SdCardFont*).  Also used by
   /// GfxRenderer::getGlyphBitmap() to retrieve overflow bitmaps via SdCardFont.
   void* glyphMissCtx;
+
+  /// Full-coverage query for fonts whose interval table only reflects what is
+  /// currently in RAM (SD card fonts: stub/mini data cover at most one page of
+  /// glyphs).  Called by hasCodepoint() when the interval table misses; must
+  /// answer from RAM-resident data without storage I/O.  Shares glyphMissCtx.
+  /// nullptr for fonts whose interval table is already complete (built-ins).
+  bool (*coverageHandler)(void* ctx, uint32_t codepoint);
 } EpdFontData;

--- a/lib/EpdFont/EpdFontFamily.cpp
+++ b/lib/EpdFont/EpdFontFamily.cpp
@@ -28,6 +28,10 @@ const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style) co
   return getFont(style)->getGlyph(cp);
 }
 
+bool EpdFontFamily::hasCodepoint(const uint32_t cp, const Style style) const {
+  return getFont(style)->hasCodepoint(cp);
+}
+
 int8_t EpdFontFamily::getKerning(const uint32_t leftCp, const uint32_t rightCp, const Style style) const {
   return getFont(style)->getKerning(leftCp, rightCp);
 }

--- a/lib/EpdFont/EpdFontFamily.h
+++ b/lib/EpdFont/EpdFontFamily.h
@@ -26,6 +26,9 @@ class EpdFontFamily {
   void getTextDimensions(const char* string, int* w, int* h, Style style = REGULAR) const;
   const EpdFontData* getData(Style style = REGULAR) const;
   const EpdGlyph* getGlyph(uint32_t cp, Style style = REGULAR) const;
+  /// Returns true if the resolved style's font can render `cp` directly
+  /// (interval coverage only — see EpdFont::hasCodepoint).
+  bool hasCodepoint(uint32_t cp, Style style = REGULAR) const;
   int8_t getKerning(uint32_t leftCp, uint32_t rightCp, Style style = REGULAR) const;
   uint32_t applyLigatures(uint32_t cp, const char*& text, Style style = REGULAR) const;
   static constexpr bool hasTextDecoration(const Style style) {

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -402,6 +402,14 @@ void SdCardFont::applyGlyphMissCallback(uint8_t styleIdx) {
   auto& s = styles_[styleIdx];
   s.stubData.glyphMissHandler = &SdCardFont::onGlyphMiss;
   s.stubData.glyphMissCtx = &overflowCtx_[styleIdx];
+  s.stubData.coverageHandler = &SdCardFont::onCoverageQuery;
+}
+
+bool SdCardFont::onCoverageQuery(void* ctx, const uint32_t codepoint) {
+  const auto* octx = static_cast<OverflowContext*>(ctx);
+  const PerStyle& s = octx->self->styles_[octx->styleIdx];
+  if (!s.fullIntervals && !s.bmpIntervals) return false;  // coverage index freed/never loaded
+  return octx->self->findGlobalGlyphIndex(s, codepoint) >= 0;
 }
 
 // --- Compute per-style file offsets from a base data offset ---
@@ -972,6 +980,7 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   }
   s.miniData.glyphMissHandler = &SdCardFont::onGlyphMiss;
   s.miniData.glyphMissCtx = &overflowCtx_[styleIdx];
+  s.miniData.coverageHandler = &SdCardFont::onCoverageQuery;
 
   s.epdFont.data = &s.miniData;
 

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -265,4 +265,8 @@ class SdCardFont {
 
   // Static callback for EpdFontData::glyphMissHandler (per-style via OverflowContext)
   static const EpdGlyph* onGlyphMiss(void* ctx, uint32_t codepoint);
+
+  // Static callback for EpdFontData::coverageHandler: answers hasCodepoint()
+  // from the RAM-resident full interval table, without SD I/O.
+  static bool onCoverageQuery(void* ctx, uint32_t codepoint);
 };

--- a/lib/EpdFont/SdCardFontManager.cpp
+++ b/lib/EpdFont/SdCardFontManager.cpp
@@ -28,6 +28,37 @@ int SdCardFontManager::computeFontId(uint32_t contentHash, const char* familyNam
   return id != 0 ? id : 1;  // 0 is reserved as "not found" sentinel
 }
 
+int SdCardFontManager::loadFile(const SdCardFontFileInfo& file, const char* familyName, GfxRenderer& renderer) {
+  auto* font = new (std::nothrow) SdCardFont();
+  if (!font) {
+    LOG_ERR("SDMGR", "Failed to allocate SdCardFont for %s", file.path.c_str());
+    return 0;
+  }
+
+  if (!font->load(file.path.c_str())) {
+    LOG_ERR("SDMGR", "Failed to load %s", file.path.c_str());
+    delete font;
+    return 0;
+  }
+
+  int fontId = computeFontId(font->contentHash(), familyName, file.pointSize);
+  // Guard against collision with built-in font IDs (astronomically unlikely
+  // with FNV-1a hashes, but provides a safety net)
+  if (renderer.getFontMap().count(fontId) != 0) {
+    LOG_ERR("SDMGR", "Font ID %d collides with existing font, skipping %s", fontId, file.path.c_str());
+    delete font;
+    return 0;
+  }
+  renderer.registerSdCardFont(fontId, font);
+  loaded_.push_back({font, fontId, file.pointSize});
+
+  LOG_DBG("SDMGR", "Loaded %s size=%u id=%d styles=%u", file.path.c_str(), file.pointSize, fontId, font->styleCount());
+
+  EpdFontFamily fontFamily(font->getEpdFont(0), font->getEpdFont(1), font->getEpdFont(2), font->getEpdFont(3));
+  renderer.insertFont(fontId, fontFamily);
+  return fontId;
+}
+
 bool SdCardFontManager::loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t fontSizeEnum) {
   // Unload any previously loaded family first
   if (!loadedFamilyName_.empty()) {
@@ -43,41 +74,32 @@ bool SdCardFontManager::loadFamily(const SdCardFontFamilyInfo& family, GfxRender
     return false;
   }
 
-  auto* font = new (std::nothrow) SdCardFont();
-  if (!font) {
-    LOG_ERR("SDMGR", "Failed to allocate SdCardFont for %s", selected->path.c_str());
+  if (loadFile(*selected, family.name.c_str(), renderer) == 0) {
     return false;
   }
-
-  if (!font->load(selected->path.c_str())) {
-    LOG_ERR("SDMGR", "Failed to load %s", selected->path.c_str());
-    delete font;
-    return false;
-  }
-
-  int fontId = computeFontId(font->contentHash(), family.name.c_str(), selected->pointSize);
-  // Guard against collision with built-in font IDs (astronomically unlikely
-  // with FNV-1a hashes, but provides a safety net)
-  if (renderer.getFontMap().count(fontId) != 0) {
-    LOG_ERR("SDMGR", "Font ID %d collides with existing font, skipping %s", fontId, selected->path.c_str());
-    delete font;
-    return false;
-  }
-  renderer.registerSdCardFont(fontId, font);
-  loaded_.push_back({font, fontId, selected->pointSize});
-
-  LOG_DBG("SDMGR", "Loaded %s size=%u id=%d styles=%u (sizeEnum=%u)", selected->path.c_str(), selected->pointSize,
-          fontId, font->styleCount(), fontSizeEnum);
-
-  EpdFontFamily fontFamily(font->getEpdFont(0), font->getEpdFont(1), font->getEpdFont(2), font->getEpdFont(3));
-  renderer.insertFont(fontId, fontFamily);
 
   loadedFamilyName_ = family.name;
   loadedPointSize_ = selected->pointSize;
   return true;
 }
 
+int SdCardFontManager::loadFamilyExtraSize(const SdCardFontFamilyInfo& family, GfxRenderer& renderer,
+                                           uint8_t pointSize) {
+  const SdCardFontFileInfo* file = family.findFile(pointSize);
+  if (!file) return 0;  // family has no .cpfont at this exact size
+
+  // Reuse an already-loaded font of the same size (e.g. when a reader size
+  // happens to match a UI size) instead of double-loading the file.
+  for (const auto& lf : loaded_) {
+    if (lf.size == pointSize) return lf.fontId;
+  }
+
+  return loadFile(*file, family.name.c_str(), renderer);
+}
+
 void SdCardFontManager::unloadAll(GfxRenderer& renderer) {
+  // Drop UI CJK fallbacks before the SD fonts they point at are freed.
+  renderer.clearFallbackFonts();
   renderer.clearSdCardFonts();
   for (auto& lf : loaded_) {
     renderer.removeFont(lf.fontId);

--- a/lib/EpdFont/SdCardFontManager.h
+++ b/lib/EpdFont/SdCardFontManager.h
@@ -7,6 +7,7 @@
 class GfxRenderer;
 class SdCardFont;
 struct SdCardFontFamilyInfo;
+struct SdCardFontFileInfo;
 
 class SdCardFontManager {
  public:
@@ -21,6 +22,13 @@ class SdCardFontManager {
   // interval + kern/ligature tables to one size's worth of memory.
   // Returns true on success.
   bool loadFamily(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t fontSizeEnum);
+
+  // Additively load the .cpfont of `family` at the exact physical `pointSize`
+  // (used for size-matched CJK UI fallback alongside the reader-size font).
+  // Does not unload anything. If a font of that size is already loaded its id
+  // is reused. Returns the font id, or 0 if the family has no file at that size
+  // or loading failed.
+  int loadFamilyExtraSize(const SdCardFontFamilyInfo& family, GfxRenderer& renderer, uint8_t pointSize);
 
   // Unload everything, unregister from renderer.
   void unloadAll(GfxRenderer& renderer);
@@ -43,6 +51,10 @@ class SdCardFontManager {
     uint8_t size;
   };
   static int computeFontId(uint32_t contentHash, const char* familyName, uint8_t pointSize);
+
+  // Load+register a single .cpfont file and append it to loaded_.
+  // Returns the font id, or 0 on failure (allocation, read, or id collision).
+  int loadFile(const SdCardFontFileInfo& file, const char* familyName, GfxRenderer& renderer);
 
   std::string loadedFamilyName_;
   uint8_t loadedPointSize_ = 0;

--- a/lib/EpdFont/SdCardFontRegistry.cpp
+++ b/lib/EpdFont/SdCardFontRegistry.cpp
@@ -28,6 +28,17 @@ const SdCardFontFileInfo* SdCardFontFamilyInfo::findClosestReaderSize(const uint
   if (sizes.empty()) return nullptr;
   std::sort(sizes.begin(), sizes.end());
 
+  // If the family provides the standard reader sizes, map the enum straight to
+  // them. This keeps body text correct even when the family also ships smaller
+  // UI-fallback sizes (e.g. 8/10 for CJK book titles) that would otherwise
+  // shift the ordinal mapping below and make reading too small.
+  static constexpr uint8_t kReaderTargets[] = {12, 14, 16, 18};
+  const auto hasSizeForStyle = [&](uint8_t s) { return std::find(sizes.begin(), sizes.end(), s) != sizes.end(); };
+  if (hasSizeForStyle(12) && hasSizeForStyle(14) && hasSizeForStyle(16) && hasSizeForStyle(18)) {
+    const uint8_t idx = fontSizeEnum < 4 ? fontSizeEnum : 3;
+    return findFile(kReaderTargets[idx], style);
+  }
+
   // When the family provides at least 4 sizes, use ordinal (index-based)
   // selection so custom-built font sets (e.g. 10/12/14/16) map SMALL to
   // the smallest file, not to a hardcoded 12pt target.

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -179,6 +179,36 @@ void GfxRenderer::insertFont(const int fontId, EpdFontFamily font) {
   }
 }
 
+int GfxRenderer::resolveTextFontId(const int fontId, const char* text, const EpdFontFamily::Style style) const {
+  if (fallbackFontMap_.empty() || text == nullptr || *text == '\0') {
+    return fontId;
+  }
+  const auto fbIt = fallbackFontMap_.find(fontId);
+  if (fbIt == fallbackFontMap_.end()) {
+    return fontId;  // no fallback registered for this font
+  }
+  const int fallbackFontId = fbIt->second;
+  const auto fontIt = fontMap.find(fontId);
+  const auto fallbackIt = fontMap.find(fallbackFontId);
+  if (fontIt == fontMap.end() || fallbackIt == fontMap.end()) {
+    return fontId;  // unknown primary or fallback not loaded — let the caller handle it
+  }
+  const EpdFontFamily& primary = fontIt->second;
+  const EpdFontFamily& fallback = fallbackIt->second;
+  const char* cursor = text;
+  uint32_t cp;
+  while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&cursor)))) {
+    // Only redirect for CJK the primary font cannot draw but the fallback can.
+    // Latin/symbol strings the built-in UI fonts already cover are left
+    // untouched, and a partial-coverage fallback (e.g. kana-only) is not worth
+    // dragging the whole string into for glyphs it would also miss.
+    if (utf8IsCjkCodepoint(cp) && !primary.hasCodepoint(cp, style) && fallback.hasCodepoint(cp, style)) {
+      return fallbackFontId;
+    }
+  }
+  return fontId;
+}
+
 // Translate logical (x,y) coordinates to physical panel coordinates based on current orientation
 // This should always be inlined for better performance
 static inline void rotateCoordinates(const GfxRenderer::Orientation orientation, const int x, const int y, int* phyX,
@@ -499,9 +529,12 @@ int GfxRenderer::getTextWidth(const int fontId, const char* text, const EpdFontF
     return 0;
   }
 
-  const auto fontIt = fontMap.find(fontId);
+  // Measure with the same font drawText would render with (see resolveTextFontId)
+  // so wrapping, truncation and centering of CJK strings stay consistent.
+  const int resolvedFontId = resolveTextFontId(fontId, text, style);
+  const auto fontIt = fontMap.find(resolvedFontId);
   if (fontIt == fontMap.end()) {
-    LOG_ERR("GFX", "Font %d not found", fontId);
+    LOG_ERR("GFX", "Font %d not found", resolvedFontId);
     return 0;
   }
 
@@ -526,10 +559,14 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     return;
   }
 
+  // Route CJK-bearing strings to the fallback font when the requested font
+  // lacks the glyphs (e.g. Chinese book titles drawn with a Latin UI font).
+  const int resolvedFontId = resolveTextFontId(fontId, text, style);
+
   std::string visual;
   const char* renderedText = resolveVisualText(text, visual, baseDir);
 
-  const int yPos = y + getFontAscenderSize(fontId);
+  const int yPos = y + getFontAscenderSize(resolvedFontId);
   int lastBaseX = x;
   int lastBaseLeft = 0;
   int lastBaseWidth = 0;
@@ -537,13 +574,13 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
-    fontCacheManager_->recordText(renderedText, fontId, style);
+    fontCacheManager_->recordText(renderedText, resolvedFontId, style);
     return;
   }
 
-  const auto fontIt = fontMap.find(fontId);
+  const auto fontIt = fontMap.find(resolvedFontId);
   if (fontIt == fontMap.end()) {
-    LOG_ERR("GFX", "Font %d not found", fontId);
+    LOG_ERR("GFX", "Font %d not found", resolvedFontId);
     return;
   }
   const auto& font = fontIt->second;
@@ -1828,6 +1865,8 @@ int GfxRenderer::getKerning(const int fontId, const uint32_t leftCp, const uint3
 }
 
 int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFamily::Style style) const {
+  // Match the font drawText would use for CJK-bearing strings (see resolveTextFontId).
+  const int resolvedFontId = resolveTextFontId(fontId, text, style);
   // Measure the exact codepoint stream drawText renders: bidi-reordered and
   // Arabic-shaped (contextual presentation forms, Lam-Alef collapse).
   // Measuring the raw logical text counts the Alef a ligature absorbs and
@@ -1840,14 +1879,14 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
   // Advance table fast-path for SD card fonts during layout.
   // No kerning/ligature lookup — consistent with previous metadataOnly behavior
   // where kern/lig data was not loaded.
-  auto sdIt = sdCardFonts_.find(fontId);
+  auto sdIt = sdCardFonts_.find(resolvedFontId);
   if (sdIt != sdCardFonts_.end() && sdIt->second->hasAdvanceTable()) {
     int32_t widthFP = 0;
     const bool isSupSub = (style & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0;
     const uint8_t styleIdx = resolveSdCardStyle(*sdIt->second, style);
-    const auto fontIt = fontMap.find(fontId);
+    const auto fontIt = fontMap.find(resolvedFontId);
     if (fontIt == fontMap.end()) {
-      LOG_ERR("GFX", "Font %d not found", fontId);
+      LOG_ERR("GFX", "Font %d not found", resolvedFontId);
       return 0;
     }
     const auto& font = fontIt->second;
@@ -1866,9 +1905,9 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
     return fp4::toPixel(widthFP);
   }
 
-  const auto fontIt = fontMap.find(fontId);
+  const auto fontIt = fontMap.find(resolvedFontId);
   if (fontIt == fontMap.end()) {
-    LOG_ERR("GFX", "Font %d not found", fontId);
+    LOG_ERR("GFX", "Font %d not found", resolvedFontId);
     return 0;
   }
 
@@ -1941,9 +1980,11 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
     return;
   }
 
-  const auto fontIt = fontMap.find(fontId);
+  // Route CJK-bearing strings to the fallback font (see resolveTextFontId).
+  const int resolvedFontId = resolveTextFontId(fontId, text, style);
+  const auto fontIt = fontMap.find(resolvedFontId);
   if (fontIt == fontMap.end()) {
-    LOG_ERR("GFX", "Font %d not found", fontId);
+    LOG_ERR("GFX", "Font %d not found", resolvedFontId);
     return;
   }
 

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -74,6 +74,20 @@ class GfxRenderer {
   mutable int _stripRows = 0;
   mutable bool _stripActive = false;
 
+  // CJK UI font fallback map: primary (built-in, Latin-only) UI font id -> a
+  // size-matched SD-card font id that carries CJK glyphs. When a string drawn
+  // or measured with a mapped primary font contains a CJK codepoint the primary
+  // cannot render, the whole string is routed to the mapped fallback so it
+  // appears at the same point size as the surrounding UI text. Populated by the
+  // app-level SD font setup when an SD family is loaded. See resolveTextFontId().
+  std::map<int, int> fallbackFontMap_;
+
+  // If `text` contains a CJK codepoint that `fontId` cannot render and `fontId`
+  // has a registered fallback, returns the fallback id; otherwise returns
+  // fontId unchanged. The whole string is routed as a unit so each draw/measure
+  // call stays single-font (consistent bit depth, metrics, wrapping).
+  int resolveTextFontId(int fontId, const char* text, EpdFontFamily::Style style) const;
+
   void renderChar(const EpdFontFamily& fontFamily, uint32_t cp, int* x, int* y, bool pixelState,
                   EpdFontFamily::Style style) const;
   void freeBwBufferChunks();
@@ -117,6 +131,10 @@ class GfxRenderer {
   void clearSdCardFonts() { sdCardFonts_.clear(); }
   const std::map<int, SdCardFont*>& getSdCardFonts() const { return sdCardFonts_; }
   bool isSdCardFont(int fontId) const { return sdCardFonts_.count(fontId) > 0; }
+  // Register/clear size-matched CJK UI fallbacks (see fallbackFontMap_).
+  // setFallbackFont maps a primary UI font id to an SD font id of the same size.
+  void setFallbackFont(int primaryFontId, int fallbackFontId) { fallbackFontMap_[primaryFontId] = fallbackFontId; }
+  void clearFallbackFonts() { fallbackFontMap_.clear(); }
   // Ensure SD card font glyph data is loaded for the given text. Called from layout code
   // (which holds a const GfxRenderer&) before measuring word widths. Safe to call on non-SD fonts (no-op).
   // styleMask: bitmask of styles to prepare (bit 0=regular, 1=bold, 2=italic, 3=bold-italic).

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -44,6 +44,29 @@ inline bool utf8IsCjkBreakable(const uint32_t cp) {
          || (cp >= 0x2A700 && cp <= 0x2B73F);  // CJK Extension C
 }
 
+// Returns true for any codepoint in a CJK script block (Han, Kana, Hangul, Bopomofo,
+// radicals, and CJK punctuation/compatibility/enclosed forms). Used for fallback font
+// selection — deliberately broader than utf8IsCjkBreakable, whose ranges are tuned to
+// implicit line-break opportunities and must not grow without rethinking layout.
+inline bool utf8IsCjkCodepoint(const uint32_t cp) {
+  return (cp >= 0x1100 && cp <= 0x11FF)        // Hangul Jamo
+         || (cp >= 0x2E80 && cp <= 0x2FDF)     // CJK Radicals Supplement, Kangxi Radicals
+         || (cp >= 0x3000 && cp <= 0x33FF)     // CJK punctuation, Kana, Bopomofo, Hangul Compat
+                                               // Jamo, Kanbun, strokes, enclosed + compat forms
+         || (cp >= 0x3400 && cp <= 0x4DBF)     // CJK Extension A
+         || (cp >= 0x4E00 && cp <= 0x9FFF)     // CJK Unified Ideographs
+         || (cp >= 0xA960 && cp <= 0xA97F)     // Hangul Jamo Extended-A
+         || (cp >= 0xAC00 && cp <= 0xD7FF)     // Hangul Syllables, Hangul Jamo Extended-B
+         || (cp >= 0xF900 && cp <= 0xFAFF)     // CJK Compatibility Ideographs
+         || (cp >= 0xFE10 && cp <= 0xFE1F)     // Vertical Forms
+         || (cp >= 0xFE30 && cp <= 0xFE4F)     // CJK Compatibility Forms
+         || (cp >= 0xFF01 && cp <= 0xFF60)     // Fullwidth Latin / Punctuation
+         || (cp >= 0xFF65 && cp <= 0xFFEF)     // Halfwidth Katakana / Hangul
+         || (cp >= 0x20000 && cp <= 0x2EBEF)   // CJK Extensions B-F
+         || (cp >= 0x2F800 && cp <= 0x2FA1F)   // CJK Compatibility Ideographs Supplement
+         || (cp >= 0x30000 && cp <= 0x323AF);  // CJK Extensions G-H
+}
+
 // Returns true for Unicode combining diacritical marks that should not advance the cursor.
 inline bool utf8IsCombiningMark(const uint32_t cp) {
   return (cp >= 0x0300 && cp <= 0x036F)      // Combining Diacritical Marks

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -4,6 +4,7 @@
 #include <Logging.h>
 
 #include "CrossPointSettings.h"
+#include "fontIds.h"
 
 namespace {
 
@@ -12,6 +13,19 @@ static uint8_t fontSizeEnumFromSettings() {
   if (e >= CrossPointSettings::FONT_SIZE_COUNT) e = 1;  // default to MEDIUM
   return e;
 }
+
+// Built-in UI fonts and their physical point sizes (at 150 DPI, matching the
+// SD-font converter). Each is paired with a same-size SD fallback so CJK UI
+// text matches the surrounding Latin. See SdCardFontSystem::setupUiFallbacks.
+struct UiFontSize {
+  int fontId;
+  uint8_t pointSize;
+};
+constexpr UiFontSize kUiFontSizes[] = {
+    {SMALL_FONT_ID, 8},
+    {UI_10_FONT_ID, 10},
+    {UI_12_FONT_ID, 12},
+};
 
 }  // namespace
 
@@ -30,6 +44,7 @@ void SdCardFontSystem::begin(GfxRenderer& renderer) {
     const auto* family = registry_.findFamily(SETTINGS.sdFontFamilyName);
     if (family) {
       if (manager_.loadFamily(*family, renderer, fontSizeEnumFromSettings())) {
+        setupUiFallbacks(renderer);
         LOG_DBG("SDFS", "Loaded SD card font family: %s", SETTINGS.sdFontFamilyName);
       } else {
         LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", SETTINGS.sdFontFamilyName);
@@ -95,6 +110,7 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
   const auto* family = registry_.findFamily(wantedFamily);
   if (family) {
     if (manager_.loadFamily(*family, renderer, sizeEnum)) {
+      setupUiFallbacks(renderer);
       LOG_DBG("SDFS", "Loaded SD font family: %s", wantedFamily);
     } else {
       LOG_ERR("SDFS", "Failed to load SD font family: %s (clearing)", wantedFamily);
@@ -105,6 +121,42 @@ void SdCardFontSystem::ensureLoaded(GfxRenderer& renderer) {
     LOG_DBG("SDFS", "SD font family not found: %s (clearing)", wantedFamily);
     SETTINGS.sdFontFamilyName[0] = '\0';
     SETTINGS.saveToFile();
+  }
+}
+
+void SdCardFontSystem::setupUiFallbacks(GfxRenderer& renderer) {
+  const std::string& familyName = manager_.currentFamilyName();
+  if (familyName.empty()) return;  // no SD family loaded — nothing to fall back to
+
+  const auto* family = registry_.findFamily(familyName);
+  if (!family) return;
+
+  // Probe the already-loaded reader-size font before paying for the UI sizes:
+  // resolveTextFontId only redirects on CJK codepoints, so a Latin-only family
+  // can never act as a fallback and its UI sizes would be dead weight in RAM.
+  const auto readerIt = renderer.getFontMap().find(manager_.getFontId(familyName));
+  if (readerIt == renderer.getFontMap().end()) return;
+  // One representative codepoint per script: Han, Hiragana, Katakana, Hangul.
+  static constexpr uint32_t kCjkProbes[] = {0x4E00, 0x3042, 0x30A2, 0xAC00};
+  bool hasCjk = false;
+  for (const uint32_t cp : kCjkProbes) {
+    if (readerIt->second.hasCodepoint(cp)) {
+      hasCjk = true;
+      break;
+    }
+  }
+  if (!hasCjk) {
+    LOG_DBG("SDFS", "%s has no CJK coverage - skipping UI fallback sizes", familyName.c_str());
+    return;
+  }
+
+  for (const auto& ui : kUiFontSizes) {
+    const int sdFontId = manager_.loadFamilyExtraSize(*family, renderer, ui.pointSize);
+    if (sdFontId != 0) {
+      renderer.setFallbackFont(ui.fontId, sdFontId);
+    } else {
+      LOG_DBG("SDFS", "No %u pt SD glyphs for UI fallback in %s", ui.pointSize, familyName.c_str());
+    }
   }
 }
 

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -46,6 +46,13 @@ class SdCardFontSystem {
   }
 
  private:
+  // Load the active SD family at the built-in UI point sizes and register each
+  // as a size-matched CJK fallback for the corresponding UI font, so CJK book
+  // titles/list rows render at the same size as the surrounding Latin UI text.
+  // No-op when no SD family is loaded. Safe to call repeatedly (sizes already
+  // loaded are reused).
+  void setupUiFallbacks(GfxRenderer& renderer);
+
   SdCardFontRegistry registry_;
   SdCardFontManager manager_;
   std::atomic<bool> registryDirty_{false};


### PR DESCRIPTION
# CJK fallback for UI text (size-matched, string-level)

## Summary

Loading a CJK-capable SD-card font already lets CrossPoint show CJK **book
content** correctly — but it did nothing for CJK in the **UI**: book titles in
the library, file names in the browser, list rows, and headers still showed
replacement boxes, because those are always drawn with the built-in Latin-only
flash fonts, independent of whatever SD font is loaded for the book text. This
PR closes that gap: any UI string containing a CJK codepoint is now
automatically routed to the user's already-selected SD-card font, at the same
point size as the surrounding Latin UI text. It also fixes a reader-size
regression that a naive implementation would otherwise introduce for CJK font
packs that ship small UI-only sizes.

## Background

CrossPoint already supports SD-card fonts with extended Unicode coverage, and
loading one is sufficient on its own to render CJK **book content** — the
reader's text-layout path already uses the loaded SD font family directly. The
renderer picks one physical point size per family (closest to the user's
reader-size setting: 12/14/16/18pt) and loads only that file to keep resident
memory down.

**UI chrome is a separate code path** and was unaffected by any of this: it
always draws with the built-in flash fonts (`SMALL_FONT_ID` @ 8pt,
`UI_10_FONT_ID` @ 10pt, `UI_12_FONT_ID` @ 12pt), which have no CJK glyphs at
all — regardless of which SD font, if any, is loaded for the book. So before
this PR, a user could select a CJK SD font, read CJK book content fine, and
still see boxes for a CJK book *title* on the library screen.

## What changed

### 1. String-level fallback routing (`GfxRenderer`)

- Added `fallbackFontMap_` (`std::map<int,int>`): primary UI font id ->
  size-matched fallback font id.
- Added `resolveTextFontId(fontId, text, style)`: walks the codepoints of
  `text`; if any is CJK (`utf8IsCjkBreakable`) and the primary font's active
  style can't render it (`EpdFontFamily::hasCodepoint`), returns the
  registered fallback id, else returns `fontId` unchanged.
- Wired into every text entry point that needs consistent metrics:
  `getTextWidth`, `drawText`, `getTextAdvanceX`, `drawTextRotated90CW`. Each
  resolves once up front and uses the resolved id for lookup, ascender calc,
  and advance-table fast path — so a string is never split across two fonts
  mid-render.
- Public API: `setFallbackFont(primaryId, fallbackId)` /
  `clearFallbackFonts()`.

Routing is **per string, not per glyph** — a mixed title like `三体 Vol.1`
renders entirely in the fallback font (including the Latin portion). This is
called out in the docs since a `Mono` fallback family will render the Latin
part at half/full width.

### 2. Interval-only glyph check (`EpdFont` / `EpdFontFamily`)

- Added `EpdFont::hasCodepoint(cp)`: binary search over the font's interval
  table. Unlike `getGlyph()`, it does **not** consult the on-demand SD miss
  handler or fall back to the replacement glyph — it answers "can this font's
  own table draw this codepoint" so the fallback decision doesn't trigger a
  disk load just to check.
- Added `EpdFontFamily::hasCodepoint(cp, style)` forwarding to the
  style-resolved `EpdFont`.

### 3. Size-matched fallback loading (`SdCardFontManager`, `SdCardFontSystem`)

- Refactored `SdCardFontManager::loadFamily` to share a new private
  `loadFile(file, familyName, renderer)` helper (alloc, disk load, id
  compute/collision check, register, insert) instead of inlining it.
- Added `loadFamilyExtraSize(family, renderer, pointSize)`: additively loads
  the family's `.cpfont` at an exact physical size (used for UI sizes 8/10/12)
  without touching the already-loaded reader-size font. Reuses an existing
  loaded size instead of double-loading if one already matches. Returns 0 if
  the family has no file at that size.
- `unloadAll` now calls `renderer.clearFallbackFonts()` before freeing the SD
  fonts the map points to, so no dangling fallback ids survive a family
  switch.
- `SdCardFontSystem::setupUiFallbacks(renderer)`: for each built-in UI size
  (8/10/12pt), calls `loadFamilyExtraSize` on the active family and, if a file
  exists, registers it via `renderer.setFallbackFont(uiFontId, sdFontId)`.
  Called after `loadFamily` succeeds in both `begin()` and `ensureLoaded()`.
  No-op (and logged at DBG) for any size the family doesn't ship.

### 4. Reader-size selection fix (`SdCardFontRegistry::findClosestReaderSize`)

Families that add 8/10pt UI-fallback files alongside the four reader sizes
(12/14/16/18) would otherwise shift the existing ordinal (index-based)
mapping used for custom font packs — e.g. a family with files at
`8,10,12,14,16,18` has 6 sizes, so `MEDIUM` (enum 1) would index to the
*second* size (10pt) instead of 14pt, making body text too small.

Fix: when a family provides all four standard reader sizes (12/14/16/18) for
the requested style, map the enum straight to `{12,14,16,18}` regardless of
how many extra sizes exist. Ordinal selection is now only used as a fallback
for families that *don't* have the full standard set (genuinely custom-built
packs like 10/12/14/16), and closest-match-by-delta remains the last resort
for packs with fewer than 4 sizes.

## Files touched

| File | Change |
|---|---|
| `lib/EpdFont/EpdFont.{h,cpp}` | `hasCodepoint()` interval-only lookup |
| `lib/EpdFont/EpdFontFamily.{h,cpp}` | `hasCodepoint()` forwarding |
| `lib/EpdFont/SdCardFontManager.{h,cpp}` | `loadFile()` extraction, `loadFamilyExtraSize()`, fallback-map clear on unload |
| `lib/EpdFont/SdCardFontRegistry.cpp` | `findClosestReaderSize` standard-4-sizes fast path |
| `lib/GfxRenderer/GfxRenderer.{h,cpp}` | `fallbackFontMap_`, `resolveTextFontId()`, wiring into draw/measure paths |
| `src/SdCardFontSystem.{h,cpp}` | `setupUiFallbacks()`, called from `begin()`/`ensureLoaded()` |
| `docs/sd-card-fonts.md` | New "CJK in the User Interface" section |

## Memory impact

Additive only when a CJK SD family is active and ships UI sizes: up to 3
extra small `.cpfont` files resident (8/10/12pt), on top of the one
reader-size file already loaded. No change for users without an SD font
selected, or whose family lacks 8/10/12pt files (those sizes silently keep
showing boxes, as before this change).

## Test plan

- [x] Install a CJK family with reader sizes only (no 8/10/12) — verify UI
      still shows boxes for CJK (no crash, no regression) and body text sizes
      correctly.
- [x] Install a CJK family with 8/10/12/12/14/16/18 (per `docs/sd-card-fonts.md`
      conversion example) — verify library titles, file browser rows, and
      headers render CJK at the right size, and reader body text at
      SMALL/MEDIUM/LARGE/EXTRA_LARGE still maps to 12/14/16/18pt.
  Note: the WIP `NotoSansMonoCJKhk-Regular.otf` in `lib/EpdFont/scripts/` is a
  local conversion source, not part of this PR's shipped changes.
- [x] Switch SD font family while a CJK title is on screen — confirm no stale
      fallback font id (freed SD font) is referenced (`clearFallbackFonts()`
      ordering in `unloadAll`).
- [x] Mixed Latin+CJK title (e.g. `三体 Vol.1`) — confirm whole string renders
      in the fallback font, not split per-glyph.
- [x] No SD font selected — confirm UI CJK still shows boxes (fallback map
      empty, no behavior change).

## Out of scope

- CJK glyph coverage in the built-in flash fonts themselves (this stays a
  pure SD-fallback feature to avoid flash-size growth).
- Per-glyph (as opposed to per-string) fallback routing.
- Automatic UI-size font conversion for existing pre-built font packs in the
  `crosspoint-fonts` repo (tracked separately; packs need re-conversion with
  `--sizes 8,10,12,14,16,18` to benefit).
