### PR TITLE
perf: light-sleep idle + refresh downclock — ~3.2x active reading time (X3-measured)

### DIFF
--- a/docs/power-benchmark.md
+++ b/docs/power-benchmark.md
@@ -74,6 +74,7 @@ off, no RAM/RTC retention), so this breakdown is where the responsiveness wins h
 |----|----------|-------------|------------------|--------------------|----------------------|
 | S1 | Idle static (slim) | | 9.68 | | slim, cable out, 2026-07-02 — awake on a reading page, NOT the sleep screen |
 | S1b | Idle static + Opp 1 light-sleep | | 3.45 | | slim, cable out, 2026-07-02 — 50 ms timer-paced light sleep; ~2.8× vs S1; stable after persistent latch-hold fix (runs: 3.38/3.45/3.47) |
+| S1c | Idle static + USB-poll throttle | | 2.78 | | slim, cable out, 2026-07-02 — BQ27220 USB-detect poll 50 ms → 1 s; tilt off; 3.5× vs S1 |
 | S2 | Deep sleep | | 0.0128 | | 12.77 µA — idling at the sleep-screen (latch off, image is bistable); slim, cable out, 2026-07-02 |
 | S3 | Turn, fast | | | 100.75 | slim, cable out, 2026-07-02 — window included the (since-removed) 160 MHz tail |
 | S3b | Turn, fast + Opp 1 + tail fix | ~1.5 | | ~38 | slim, cable out, 2026-07-02 — press→sawtooth window 39.74 mC incl. idle edges; tail eliminated (render consumes the response window, light sleep engages on lock release) |

--- a/docs/power-benchmark.md
+++ b/docs/power-benchmark.md
@@ -73,18 +73,21 @@ off, no RAM/RTC retention), so this breakdown is where the responsiveness wins h
 | ID | Scenario | Duration (s) | Avg current (mA) | Charge (mC = mA·s) | Notes / build / date |
 |----|----------|-------------|------------------|--------------------|----------------------|
 | S1 | Idle static (slim) | | 9.68 | | slim, cable out, 2026-07-02 — awake on a reading page, NOT the sleep screen |
-| S1b | Idle static + Opp 1 light-sleep | | 3.38–3.47 | | slim, cable out, 2026-07-02 — 50 ms timer-paced light sleep; ~2.8× vs S1; stable after persistent latch-hold fix |
+| S1b | Idle static + Opp 1 light-sleep | | 3.45 | | slim, cable out, 2026-07-02 — 50 ms timer-paced light sleep; ~2.8× vs S1; stable after persistent latch-hold fix (runs: 3.38/3.45/3.47) |
 | S2 | Deep sleep | | 0.0128 | | 12.77 µA — idling at the sleep-screen (latch off, image is bistable); slim, cable out, 2026-07-02 |
-| S3 | Turn, fast | | | 100.75 | slim, cable out, 2026-07-02 |
+| S3 | Turn, fast | | | 100.75 | slim, cable out, 2026-07-02 — window included the (since-removed) 160 MHz tail |
+| S3b | Turn, fast + Opp 1 + tail fix | ~1.5 | | ~38 | slim, cable out, 2026-07-02 — press→sawtooth window 39.74 mC incl. idle edges; tail eliminated (render consumes the response window, light sleep engages on lock release) |
 | S4 | Turn, full | | | | |
 | S5 | Refresh only | | | | |
 | S6 | 160 MHz tail | ~2 | 21.22 | ~42 | slim + Opp 1 build, cable out, 2026-07-02 — post-turn window before the 3 s idle threshold |
 | S7 | Chapter index (cold) | | | | |
 | S8 | Cold boot | | | | |
 | S9 | Wake (Quick Resume) | | | | |
-| S10 | Wake (sleep-screen) | | | 262.32 | slim, cable out, 2026-07-02 |
+| S10 | Wake (sleep-screen) | | | 262.32 | slim, cable out, 2026-07-02 — window included the (since-removed) post-paint tail |
+| S10b | Wake (sleep-screen) + Opp 1 + tail | | | 215 | slim, cable out, 2026-07-02 — drop vs S10 ≈ the eliminated post-paint tail |
 | S11 | Sleep (Quick Resume) | | | | |
 | S12 | Sleep (sleep-screen) | | | 143.81 | slim, cable out, 2026-07-02 |
+| S12b | Sleep (sleep-screen) + Opp 1 + tail | | | 142.66 | slim, cable out, 2026-07-02 — unchanged, as expected (path never idles) |
 
 Superseded captures (default build, USB attached — power path contaminated by charger):
 S1 9.79 mA · S2 22.5 µA · S3 90.63 mA·s · S10 241.80 mA·s · S12 154.51 mA·s.

--- a/docs/power-benchmark.md
+++ b/docs/power-benchmark.md
@@ -90,6 +90,19 @@ off, no RAM/RTC retention), so this breakdown is where the responsiveness wins h
 | S12 | Sleep (sleep-screen) | | | 143.81 | slim, cable out, 2026-07-02 |
 | S12b | Sleep (sleep-screen) + Opp 1 + tail | | | 142.66 | slim, cable out, 2026-07-02 — unchanged, as expected (path never idles) |
 
+**S1c floor decomposition (2026-07-02, zoomed trace):** true floor 2.00 mA; wake slices
+8 mA × 4.0 ms every 50 ms (≈0.5 mA); regulator burst spikes ~15–20 mA every ~5.6 ms
+(PFM light-load delivery); **SD card idle ≈ 0.4 mA** (eject A/B mid-capture). Remaining
+~1 mA: MCU light sleep + flash standby (~0.2), DS3231/gauge/IMU/e-ink standby (~0.4),
+regulator + charger quiescent (rest) — not firmware-addressable.
+
+**Wake-slice decomposition (2026-07-02, duplicate-ADC probe: +0.18 mA, slice 4.0→5.6 ms):**
+one button-ADC pair (Arduino `analogRead` ×2 at 10 MHz) ≈ 1.6 ms ≈ 0.18 mA of the
+0.5 mA slice cost; the remaining ~2.4 ms is light-sleep entry/exit + loop overhead.
+Ceiling for a raw one-shot ADC optimization: ~0.15 mA (needs an open-x4-sdk
+InputManager change) — deferred in favor of Opportunity 2 (refresh busy-wait,
+~10 mC/turn).
+
 Superseded captures (default build, USB attached — power path contaminated by charger):
 S1 9.79 mA · S2 22.5 µA · S3 90.63 mA·s · S10 241.80 mA·s · S12 154.51 mA·s.
 

--- a/docs/power-benchmark.md
+++ b/docs/power-benchmark.md
@@ -1,0 +1,175 @@
+# Power Benchmark & Battery-Life Model (Xteink X3)
+
+Purpose: a **repeatable** way to measure per-action energy on the X3 with the Nordic
+Power Profiler Kit II (PPK2), and a **model** that turns those measurements into a
+battery-life estimate for real usage profiles. Scoped to the **X3** (only device with
+usable current instrumentation; X4 has no fuel gauge). See
+[docs/file-formats.md](file-formats.md) for cache versioning that affects indexing runs.
+
+> All current values in this doc that are **not** yet backed by a PPK2 capture are
+> marked _(est.)_. They are datasheet-grade priors to be **replaced with measured
+> numbers**. Do not cite an _(est.)_ value as fact.
+
+---
+
+## 1. Measurement conditions (fix these every run)
+
+Battery life is a ratio of currents, so absolute rig calibration matters less than
+**holding every variable constant between runs**. Lock all of the following:
+
+| Variable | Fixed value | Why |
+|---|---|---|
+| Instrument | PPK2, **Source Meter mode** | supplies + measures; battery disconnected |
+| Supply voltage | **3.70 V** (also sweep 3.5 / 4.0 for sensitivity) | LiPo mid-point |
+| Tap point | battery terminals, upstream of charger + GPIO13 latch | latch behaves normally → real deep-sleep floor |
+| Firmware build | **`slim`** or **`gh_release`** | `default` pins the clock awake (USB-CDC) and hides light-sleep |
+| Serial cable | **unplugged for idle/sleep runs**; data-only (VBUS-cut) otherwise | enumerated USB keeps the C3 awake |
+| Test EPUB | one fixed book, committed hash noted below | layout/indexing must match |
+| Render settings | fixed font family+size, line spacing, paragraph spacing, margins | any change invalidates the section cache |
+| Orientation | fixed (note which) | changes viewport → re-layout |
+| Cache state | **warm** (pre-generated) unless the scenario is "cold index" | isolates the variable under test |
+| Start SOC / temperature | note both; keep within a narrow band | current drifts with both |
+
+Reference test book / settings for this benchmark: _TODO: fill in (filename, hash, font,
+size, spacing, margins, orientation)._
+
+Event segmentation: prefer a **GPIO marker → PPK2 logic pin** (high at event start, low
+at end) for µs-aligned, non-perturbing boundaries. If no free test point, fall back to
+**serial `millis()` timestamps** correlated to the trace (~tens-of-ms skew). Never use
+serial prints as markers on idle/sleep runs.
+
+---
+
+## 2. Scenario suite
+
+For each: capture **duration**, **average current**, **total charge** (integrate), and
+**peak**. Energy = charge × supply voltage. Run each ≥3× and record mean/stddev.
+
+| # | Scenario | What to trigger | Primary metric | Notes |
+|---|---|---|---|---|
+| S1 | **Idle, static page** | park on a page 60 s | avg mA | THE dominant term; run in `slim`, cable out |
+| S2 | **Deep sleep floor** | lock, wait after latch-off | avg µA | steady-state at the sleep screen; validates tap point (should be ~µA) |
+| S3 | **Page turn, fast refresh** | one turn | charge/turn, duration | most frequent active event |
+| S4 | **Page turn, full refresh** | one turn forcing full refresh | charge/turn, duration | heavier panel drive |
+| S5 | **E-ink refresh isolated** | refresh with no re-layout | charge, duration | panel-only floor |
+| S6 | **Post-turn 160 MHz tail** | idle window right after a turn | duration @ high clock | 3 s @ ~160 MHz before downclock |
+| S7 | **Chapter index (cold)** | open uncached chapter | charge, duration | CPU+SD; speed **and** power candidate |
+| S8 | **Cold boot → home ready** | power on from off | charge, duration | one-time for daily reader |
+| S9 | **Wake from sleep (Quick Resume)** | unlock, `sleepScreen=QUICK_RESUME` | charge, duration | boot work + half refresh |
+| S10 | **Wake from sleep (sleep-screen)** | unlock, cover/moon sleep mode | charge, duration | boot + full refresh |
+| S11 | **Go to sleep (Quick Resume)** | lock | charge | 48 KB framebuffer → SD |
+| S12 | **Go to sleep (sleep-screen)** | lock | charge | renders cover + full refresh |
+| S13 | (opt) **WiFi download / OTA** | fetch a book | charge, duration | only if in scope |
+
+**Boot/wake sub-markers (S7–S10):** put GPIO markers at each phase — SD mount → settings/
+state load → font setup → reader re-open/render → first paint — to find which phase
+dominates. Wake is a **full cold boot** (`HalPowerManager.cpp:79-94`: MCU fully powered
+off, no RAM/RTC retention), so this breakdown is where the responsiveness wins hide.
+
+---
+
+## 3. Results table (fill from PPK2)
+
+| ID | Scenario | Duration (s) | Avg current (mA) | Charge (mC = mA·s) | Notes / build / date |
+|----|----------|-------------|------------------|--------------------|----------------------|
+| S1 | Idle static (slim) | | 9.68 | | slim, cable out, 2026-07-02 — awake on a reading page, NOT the sleep screen |
+| S1b | Idle static + Opp 1 light-sleep | | 3.38–3.47 | | slim, cable out, 2026-07-02 — 50 ms timer-paced light sleep; ~2.8× vs S1; stable after persistent latch-hold fix |
+| S2 | Deep sleep | | 0.0128 | | 12.77 µA — idling at the sleep-screen (latch off, image is bistable); slim, cable out, 2026-07-02 |
+| S3 | Turn, fast | | | 100.75 | slim, cable out, 2026-07-02 |
+| S4 | Turn, full | | | | |
+| S5 | Refresh only | | | | |
+| S6 | 160 MHz tail | ~2 | 21.22 | ~42 | slim + Opp 1 build, cable out, 2026-07-02 — post-turn window before the 3 s idle threshold |
+| S7 | Chapter index (cold) | | | | |
+| S8 | Cold boot | | | | |
+| S9 | Wake (Quick Resume) | | | | |
+| S10 | Wake (sleep-screen) | | | 262.32 | slim, cable out, 2026-07-02 |
+| S11 | Sleep (Quick Resume) | | | | |
+| S12 | Sleep (sleep-screen) | | | 143.81 | slim, cable out, 2026-07-02 |
+
+Superseded captures (default build, USB attached — power path contaminated by charger):
+S1 9.79 mA · S2 22.5 µA · S3 90.63 mA·s · S10 241.80 mA·s · S12 154.51 mA·s.
+
+**Current priors** _(est., replace with measured)_: idle static ≈ 8 mA; idle w/ light-sleep
+(Opp 1 target) ≈ 0.5 mA; deep sleep ≈ 0.03 mA; fast turn ≈ 55 mA × 1.5 s; 160 MHz tail
+≈ 20 mA × 3 s; wake (Quick Resume) ≈ 150–200 mA·s; wake (sleep-screen) ≈ 280 mA·s;
+sleep (Quick Resume) ≈ 30 mA·s; sleep (sleep-screen) ≈ 110 mA·s.
+
+---
+
+## 4. Battery-life model
+
+Symbols: `D` = dwell seconds/page, `t_r`/`I_r` = refresh time/current, `t_t`/`I_t` =
+160 MHz-tail time/current, `I_idle` = static-page idle current, `I_ds` = deep-sleep
+current, `E_wake`/`E_sleep` = charge per wake/sleep transition (mA·s), `C` = battery
+capacity (mAh, **unknown for X3 — parameterize**).
+
+**Per-page charge (mA·s):**
+
+```
+E_page = I_r·t_r  +  I_t·t_t  +  I_idle·(D − t_r − t_t)
+```
+
+**Continuous reader — session average current (mA):**
+
+```
+avg = E_page / D
+```
+
+**Commuter — locks every N pages:**
+
+```
+E_cycle = N·E_page + E_wake + E_sleep
+avg     = E_cycle / (N·D)
+```
+
+**Daily energy (mA·h)** for `H` reading hours + `(24−H)` standby hours:
+
+```
+E_day = avg·H + I_ds·(24 − H)
+```
+
+**Battery life:** `days_per_charge = C / E_day`  •  `active_hours_per_charge = C / avg`
+
+### Worked example (priors, C left symbolic)
+
+Continuous reader, `D = 30 s`, priors above:
+
+- `E_page = 55·1.5 + 20·3 + 8·(30−1.5−3) = 82.5 + 60 + 204 = 346.5 mA·s`
+- `avg = 346.5 / 30 ≈ 11.6 mA` → shares: idle **59%**, tail 17%, refresh 24%.
+- With Opp 1 (`I_idle` 8→0.5): `E_page ≈ 82.5 + 60 + 12.75 = 155 mA·s` → `avg ≈ 5.2 mA`
+  (and lower once the tail is also slept). **≈ 2–3× active reading time.**
+
+Commuter, `N = 5`, `D = 30 s`, Quick Resume (`E_wake≈165`, `E_sleep≈30`):
+
+- `E_cycle = 5·346.5 + 165 + 30 = 1927.5 mA·s` over 150 s → `avg ≈ 12.9 mA`
+  (≈ **+11%** vs. continuous; sleep-screen mode ≈ +22%).
+- Idle is still the biggest slice even here.
+
+### Light-sleep vs deep-sleep break-even (per lock of gap `G`)
+
+Deep-sleeping a lock is only worth it when the standby saving beats the wake cost:
+
+```
+G* = E_wake / (I_idle_lightsleep − I_ds)
+```
+
+- **Today** (`I_idle` 8 mA): `G* ≈ 165 / (8 − 0.03) ≈ 20 s` → locks shorter than ~20 s
+  _lose_ energy vs. staying awake (and resume slower).
+- **After Opp 1** (`I_idle` 0.5 mA): `G* ≈ 165 / (0.5 − 0.03) ≈ 350 s ≈ 6 min` → short
+  locks should stay in **light sleep** (instant resume, less energy); reserve **deep
+  sleep** for long "put it away" gaps.
+
+---
+
+## 5. How to read the results
+
+1. **Idle static (S1) is ~60% of a reading session** and sets the break-even above — it is
+   the single most important number. Measure it first, in `slim`, cable out.
+2. **Long-duration × high-current** actions (S7 chapter index, S4 full refresh, S8/S9 boot/
+   wake) are **double wins**: optimizing them cuts energy _and_ improves responsiveness.
+3. **Wake = cold boot**, so its cost scales with how often the user locks. Negligible for a
+   once-a-day continuous reader; second-largest cost for a commuter locking every few pages.
+4. Compare builds A/B on the **same rig, same conditions** — relative deltas are trustworthy
+   even if absolute mA carries rig error.
+
+Related planning notes live in the power-optimization effort (light-sleep Opportunities 1 & 2).

--- a/docs/power-benchmark.md
+++ b/docs/power-benchmark.md
@@ -78,6 +78,7 @@ off, no RAM/RTC retention), so this breakdown is where the responsiveness wins h
 | S2 | Deep sleep | | 0.0128 | | 12.77 µA — idling at the sleep-screen (latch off, image is bistable); slim, cable out, 2026-07-02 |
 | S3 | Turn, fast | | | 100.75 | slim, cable out, 2026-07-02 — window included the (since-removed) 160 MHz tail |
 | S3b | Turn, fast + Opp 1 + tail fix | ~1.5 | | ~38 | slim, cable out, 2026-07-02 — press→sawtooth window 39.74 mC incl. idle edges; tail eliminated (render consumes the response window, light sleep engages on lock release) |
+| S3c | Turn, fast + Opp 2 (BUSY-wait downclock) | ~1.5 | | 28.98 | slim, cable out, 2026-07-02 — CPU at 10 MHz during the refresh BUSY wait via EInkDisplay busy-wait hooks |
 | S4 | Turn, full | | | | |
 | S5 | Refresh only | | | | |
 | S6 | 160 MHz tail | ~2 | 21.22 | ~42 | slim + Opp 1 build, cable out, 2026-07-02 — post-turn window before the 3 s idle threshold |

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -75,6 +75,10 @@ void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen
 
 void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
 
+void HalDisplay::setBusyWaitHooks(void (*beginHook)(), void (*endHook)()) {
+  einkDisplay.setBusyWaitHooks(beginHook, endHook);
+}
+
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
 void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer) {

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -44,6 +44,9 @@ class HalDisplay {
   // Power management
   void deepSleep();
 
+  // Install hooks fired around long e-ink BUSY waits (see EInkDisplay::setBusyWaitHooks)
+  void setBusyWaitHooks(void (*beginHook)(), void (*endHook)());
+
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -204,6 +204,14 @@ void HalGPIO::begin() {
 
 void HalGPIO::update() {
   inputMgr.update();
+  // Throttle the X3's I2C-based USB detection; see USB_POLL_X3_MS. First call
+  // (usbLastPollMs == 0) always polls so boot state is correct.
+  const unsigned long now = millis();
+  if (deviceIsX3() && usbLastPollMs != 0 && now - usbLastPollMs < USB_POLL_X3_MS) {
+    usbStateChanged = false;
+    return;
+  }
+  usbLastPollMs = now;
   const bool connected = isUsbConnected();
   usbStateChanged = (connected != lastUsbConnected);
   lastUsbConnected = connected;

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -45,6 +45,14 @@ class HalGPIO {
 
   bool lastUsbConnected = false;
   bool usbStateChanged = false;
+  unsigned long usbLastPollMs = 0;
+
+  // X3 USB detection is a BQ27220 I2C read (~0.3-1 ms of awake CPU per call);
+  // polled every loop it costs a few percent of the light-sleep idle floor for
+  // nothing. At >=1 s intervals the energy cost is unmeasurable (~µC/s), so 1 s
+  // is chosen for prompt plug/unplug UX (battery icon, light-sleep USB guard /
+  // CDC recovery). X4 detection is a single digitalRead and stays per-loop.
+  static constexpr unsigned long USB_POLL_X3_MS = 1000;
 
  public:
   enum class DeviceType : uint8_t { X4, X3 };

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -83,6 +83,10 @@ class HalGPIO {
   // Check if USB is connected
   bool isUsbConnected() const;
 
+  // USB state as sampled by the last update() call.
+  // Prefer this in per-loop polling: isUsbConnected() performs a fresh I2C read on X3.
+  bool isUsbConnectedCached() const { return lastUsbConnected; }
+
   // Returns true once per edge (plug or unplug) since the last update()
   bool wasUsbStateChanged() const;
 

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -145,6 +145,30 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
   return true;
 }
 
+void HalPowerManager::onEinkBusyWaitBegin() {
+  if (normalFreq <= 0) {
+    return;
+  }
+  // Same exclusions as setPowerSaving()/lightSleep(): a low clock breaks an
+  // active WiFi association and an enumerated USB-CDC link.
+  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
+    return;
+  }
+  if (setCpuFrequencyMhz(LOW_POWER_FREQ)) {
+    busyWaitLowClock = true;
+  }
+}
+
+void HalPowerManager::onEinkBusyWaitEnd() {
+  if (!busyWaitLowClock) {
+    return;
+  }
+  busyWaitLowClock = false;
+  if (!setCpuFrequencyMhz(normalFreq)) {
+    LOG_ERR("PWR", "Failed to restore CPU frequency after busy wait");
+  }
+}
+
 uint16_t HalPowerManager::getBatteryPercentage() const {
   if (_batteryUseI2C) {
     const unsigned long now = millis();

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -2,6 +2,7 @@
 
 #include <Logging.h>
 #include <WiFi.h>
+#include <driver/gpio.h>
 #include <esp_sleep.h>
 
 #include <cassert>
@@ -9,6 +10,10 @@
 #include "HalGPIO.h"
 
 HalPowerManager powerManager;  // Singleton instance
+
+// GPIO13 is the flash SPIWP pad (unused in this board's DIO flash mode), rewired to the
+// battery-latch MOSFET gate: high keeps the battery connected, low powers the device off.
+static constexpr gpio_num_t GPIO_BATTERY_LATCH = GPIO_NUM_13;
 
 void HalPowerManager::begin() {
   if (gpio.deviceIsX3()) {
@@ -76,14 +81,13 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
 #endif
 
   // Pre-sleep routines from the original firmware
-  // GPIO13 is connected to battery latch MOSFET, we need to make sure it's low during sleep
-  // Note that this means the MCU will be completely powered off during sleep, including RTC
-  constexpr gpio_num_t GPIO_SPIWP = GPIO_NUM_13;
-  gpio_set_direction(GPIO_SPIWP, GPIO_MODE_OUTPUT);
-  gpio_set_level(GPIO_SPIWP, 0);
+  // The battery latch must go low during sleep: the MCU is completely powered off, including RTC
+  gpio_hold_dis(GPIO_BATTERY_LATCH);  // lightSleep() holds the pad high; release so we can drive it low
+  gpio_set_direction(GPIO_BATTERY_LATCH, GPIO_MODE_OUTPUT);
+  gpio_set_level(GPIO_BATTERY_LATCH, 0);
   esp_sleep_config_gpio_isolate();
   gpio_deep_sleep_hold_en();
-  gpio_hold_en(GPIO_SPIWP);
+  gpio_hold_en(GPIO_BATTERY_LATCH);
   pinMode(InputManager::POWER_BUTTON_PIN, INPUT_PULLUP);
   // Arm the wakeup trigger *after* the button is released
   // Note: this is only useful for waking up on USB power. On battery, the MCU will be completely powered off, so the
@@ -92,6 +96,53 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   esp_deep_sleep_enable_gpio_wakeup(1ULL << InputManager::POWER_BUTTON_PIN, ESP_GPIO_WAKEUP_GPIO_LOW);
   // Enter Deep Sleep
   esp_deep_sleep_start();
+}
+
+bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
+  // A performance Lock means a render (or similar) task is mid-flight; light sleep
+  // freezes the whole chip, so it would stall that task.
+  // Note: like setPowerSaving(), read without the mutex — a stale value only delays
+  // sleeping by one 50 ms slice.
+  if (currentLockMode != None) {
+    return false;
+  }
+  // Light sleep drops a WiFi association and kills an enumerated USB-CDC link.
+  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
+    return false;
+  }
+
+  // Timer wake only. It keeps the button/tilt poll cadence identical to the delay()
+  // it replaces: the front/side buttons are ADC resistor-ladder inputs whose pressed
+  // levels sit mid-rail, invisible to a digital GPIO wake, so they must be polled.
+  // The power button (a true GPIO) is deliberately NOT armed as a wake source: a
+  // level wake on it can misread around sleep transitions and inject phantom
+  // presses, and the timer poll catches it within one slice anyway.
+  esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(LIGHT_SLEEP_SLICE_MS) * 1000ULL);
+
+  // The IDF flash-leakage workaround (CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND) pulls the
+  // DIO-unused SPIWP pad low on light-sleep entry — on this board that releases the battery
+  // latch and hard-powers-off the device. Drive the latch high and pad-hold it (hold latches
+  // the pad state and overrides both the sleep-time pull and any pad re-muxing on the wake
+  // path). The hold is left enabled permanently while running — the wake path may restore
+  // flash-pad muxing, so even a brief release between slices can drop the latch. It is
+  // released only in startDeepSleep(), which must drive the latch low to power off.
+  // Level is set BEFORE direction so the pad never glitches low on the way to output mode.
+  gpio_set_level(GPIO_BATTERY_LATCH, 1);
+  gpio_set_direction(GPIO_BATTERY_LATCH, GPIO_MODE_OUTPUT);
+  gpio_hold_en(GPIO_BATTERY_LATCH);
+
+  const esp_err_t err = esp_light_sleep_start();
+
+  // Disarm immediately: an armed timer wake persists across sleep calls and would
+  // carry over into startDeepSleep(), waking the device on USB power after 50 ms.
+  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+
+  if (err != ESP_OK) {
+    // e.g. ESP_ERR_SLEEP_REJECT — we did not actually sleep
+    LOG_DBG("PWR", "Light sleep rejected: %d", static_cast<int>(err));
+    return false;
+  }
+  return true;
 }
 
 uint16_t HalPowerManager::getBatteryPercentage() const {

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -31,6 +31,7 @@ class HalPowerManager {
   static constexpr int LOW_POWER_FREQ = 10;                    // MHz
   static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms
   static constexpr unsigned long BATTERY_POLL_MS = 1500;       // ms
+  static constexpr unsigned long LIGHT_SLEEP_SLICE_MS = 50;    // ms
 
   void begin();
 
@@ -40,6 +41,13 @@ class HalPowerManager {
   // Setup wake up GPIO and enter deep sleep
   // Should be called inside main loop() to handle the currentLockMode
   void startDeepSleep(HalGPIO& gpio) const;
+
+  // Light-sleep the CPU for LIGHT_SLEEP_SLICE_MS (timer wake; buttons are polled on
+  // wake at the same cadence as the delay() this replaces). Returns false WITHOUT
+  // sleeping when unsafe: a performance Lock is held (render in flight), WiFi is
+  // active, or USB is connected (light sleep kills the CDC link). The caller must
+  // fall back to delay() in that case.
+  bool lightSleep(const HalGPIO& gpio) const;
 
   // Get battery percentage (range 0-100)
   uint16_t getBatteryPercentage() const;

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -26,6 +26,7 @@ class HalPowerManager {
   enum LockMode { None, NormalSpeed };
   LockMode currentLockMode = None;
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
+  bool busyWaitLowClock = false;          // Set/cleared only by the render task (see onEinkBusyWait*)
 
  public:
   static constexpr int LOW_POWER_FREQ = 10;  // MHz
@@ -54,6 +55,15 @@ class HalPowerManager {
   // active, or USB is connected (light sleep kills the CDC link). The caller must
   // fall back to delay() in that case.
   bool lightSleep(const HalGPIO& gpio) const;
+
+  // E-ink BUSY-wait hooks (installed on EInkDisplay via HalDisplay): during a
+  // refresh the render task only polls the BUSY pin for 0.3-2 s, so drop the CPU
+  // clock for the wait and restore it after. Deliberately raw setCpuFrequencyMhz,
+  // NOT setPowerSaving(): the render task holds a Lock (mode != None) which blocks
+  // setPowerSaving, and isLowPower must stay false so input-driven
+  // setPowerSaving(false) calls stay no-ops during the wait.
+  void onEinkBusyWaitBegin();
+  void onEinkBusyWaitEnd();
 
   // Get battery percentage (range 0-100)
   uint16_t getBatteryPercentage() const;

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -28,10 +28,16 @@ class HalPowerManager {
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
 
  public:
-  static constexpr int LOW_POWER_FREQ = 10;                    // MHz
-  static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms
-  static constexpr unsigned long BATTERY_POLL_MS = 1500;       // ms
-  static constexpr unsigned long LIGHT_SLEEP_SLICE_MS = 50;    // ms
+  static constexpr int LOW_POWER_FREQ = 10;  // MHz
+
+  // Two-stage idle backoff. Renders re-raise the clock via Lock regardless, so the
+  // full-speed window only needs to cover rapid consecutive input (avoids clock
+  // thrash); polling stays at 100 Hz until light sleep takes over the cadence.
+  static constexpr unsigned long IDLE_DOWNCLOCK_MS = 500;     // full speed -> LOW_POWER_FREQ
+  static constexpr unsigned long IDLE_LIGHT_SLEEP_MS = 1000;  // 100 Hz polling -> light sleep
+
+  static constexpr unsigned long BATTERY_POLL_MS = 1500;     // ms
+  static constexpr unsigned long LIGHT_SLEEP_SLICE_MS = 50;  // ms
 
   void begin();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -597,15 +597,20 @@ void loop() {
     powerManager.setPowerSaving(false);  // Make sure we're at full performance when skipLoopDelay is requested
     yield();                             // Give FreeRTOS a chance to run tasks, but return immediately
   } else {
-    if (millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
-      // If we've been inactive for a while, drop the CPU clock and light-sleep
-      // between input polls instead of busy-delaying (same poll cadence)
-      powerManager.setPowerSaving(true);  // Lower CPU frequency after extended inactivity
+    const unsigned long idleMs = millis() - lastActivityTime;
+    if (idleMs >= HalPowerManager::IDLE_LIGHT_SLEEP_MS) {
+      // Idle: light-sleep between input polls instead of busy-delaying (same poll cadence)
+      powerManager.setPowerSaving(true);
       if (!powerManager.lightSleep(gpio)) {
         delay(HalPowerManager::LIGHT_SLEEP_SLICE_MS);
       }
     } else {
-      // Short delay to prevent tight loop while still being responsive
+      // Response window after recent input: keep 100 Hz polling for snappy interaction,
+      // but downclock once rapid-input bursts have settled — renders re-raise the clock
+      // via HalPowerManager::Lock, so full speed only serves loop bookkeeping here
+      if (idleMs >= HalPowerManager::IDLE_DOWNCLOCK_MS) {
+        powerManager.setPowerSaving(true);
+      }
       delay(10);
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,6 +331,10 @@ void setup() {
   halTiltSensor.begin();
   halClock.begin();
 
+  // Downclock the CPU while the render task busy-waits on an e-ink refresh
+  // (0.3-2 s of pure pin polling); the hooks no-op when WiFi/USB is active
+  display.setBusyWaitHooks([] { powerManager.onEinkBusyWaitBegin(); }, [] { powerManager.onEinkBusyWaitEnd(); });
+
   LOG_INF("MAIN", "Hardware detect: %s", gpio.deviceIsX3() ? "X3" : "X4");
 
   // SD Card Initialization

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -598,9 +598,12 @@ void loop() {
     yield();                             // Give FreeRTOS a chance to run tasks, but return immediately
   } else {
     if (millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
-      // If we've been inactive for a while, increase the delay to save power
+      // If we've been inactive for a while, drop the CPU clock and light-sleep
+      // between input polls instead of busy-delaying (same poll cadence)
       powerManager.setPowerSaving(true);  // Lower CPU frequency after extended inactivity
-      delay(50);
+      if (!powerManager.lightSleep(gpio)) {
+        delay(HalPowerManager::LIGHT_SLEEP_SLICE_MS);
+      }
     } else {
       // Short delay to prevent tight loop while still being responsive
       delay(10);


### PR DESCRIPTION
## Summary

Reduces active-reading power draw ~3.2x, measured end-to-end on an X3 with a Nordic PPK2 at the battery terminals (slim build, cable out, fixed book/settings). Three independent changes:

1. **Light-sleep between input polls when idle** (the big one): after 1 s of inactivity the main loop replaces its busy `delay(50)` with 50 ms timer-paced `esp_light_sleep_start()` slices. Poll cadence and input latency are unchanged — the CPU sleeps between polls instead of spinning at 10 MHz. Guards: never sleeps while a `HalPowerManager::Lock` is held (render in flight), WiFi is up, or USB is connected (light sleep kills the CDC link).
2. **Two-stage idle backoff**: downclock at 500 ms, light sleep at 1 s, replacing the flat 3 s full-speed window. Renders re-raise the clock via `Lock` the moment they start, so the full-speed tail only ever served loop bookkeeping. (The 3 s value in #852 was a placeholder; responsiveness verified on device against stock.)
3. **Refresh BUSY-wait downclock**: drops the CPU to 10 MHz while `pollBusy()` polls the BUSY pin (0.3–2 s per refresh), via new optional hooks in the SDK — **depends on crosspoint-reader/community-sdk#21**. Plus a 1 Hz throttle on the X3's I2C-based USB detection (was polled every loop).

## Measured results (PPK2, X3)

| Metric | Before | After |
|---|---|---|
| Idle on a static page | 9.68 mA | **2.78 mA** |
| Fast page turn (incl. post-turn behavior) | ~100 mC | **28.98 mC** |
| Post-turn 160 MHz tail | 21.2 mA x 3 s | eliminated |
| Session average @ 30 s/page | ~11.6 mA | **~3.6 mA (~3.2x reading time)** |
| Deep sleep | 12.8 µA | unchanged |

Full measurement conditions, scenario suite, and battery-life model: `docs/power-benchmark.md` (added in this PR).

## Hardware hazard worth knowing about

First light-sleep attempt hard-powered-off the device: **GPIO13 is the flash SPIWP pad (unused in DIO mode), rewired to the battery-latch MOSFET gate** — and the prebuilt IDF libs ship `CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND=y`, which pulls unused flash pads low on every light-sleep entry, releasing the latch. The fix drives GPIO13 high with a persistent pad hold, released only in `startDeepSleep()`. Any future light-sleep code must preserve this (documented in `HalPowerManager::lightSleep`).

## Notes for review

- Buttons are ADC resistor-ladder inputs (mid-rail when pressed), invisible to digital GPIO wake — hence timer-paced polling rather than GPIO wake. The 50 ms cadence matches the previous idle `delay(50)` exactly.
- #801's original light-sleep rejection (wake overhead, no ADC wake source) is addressed by measurement: 2.78 mA *includes* all wake overhead.
- Draft until community-sdk#21 merges: the submodule pointer currently references the fork commit, so CI cannot fetch it. Once merged I'll re-bump to the upstream SHA and mark ready.
- Verified on device: stability soaks, all refresh modes + grayscale, power-off/wake, auto-sleep, responsiveness A/B against master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)