### PR TITLE
fix: FontDecompressor OOM aborts on the render path (-fno-exceptions makes vector resize fatal)

### DIFF
--- a/lib/EpdFont/FontDecompressor.cpp
+++ b/lib/EpdFont/FontDecompressor.cpp
@@ -33,12 +33,24 @@ void FontDecompressor::freePageBuffer() {
 }
 
 void FontDecompressor::freeHotGroup() {
-  hotGroup.clear();
-  hotGroup.shrink_to_fit();
+  free(hotGroup);
+  hotGroup = nullptr;
+  hotGroupCapacity = 0;
   hotGroupFont = nullptr;
   hotGroupIndex = UINT16_MAX;
-  hotGlyphBuf.clear();
-  hotGlyphBuf.shrink_to_fit();
+  free(hotGlyphBuf);
+  hotGlyphBuf = nullptr;
+  hotGlyphBufCapacity = 0;
+}
+
+bool FontDecompressor::ensureCapacity(uint8_t*& buf, uint32_t& capacity, uint32_t needed) {
+  if (capacity >= needed) return true;
+  // Grow-only, free-then-malloc: every caller fully rewrites the buffer after a grow, so the
+  // old contents are dead -- freeing first gives the allocator its best shot on a tight heap.
+  free(buf);
+  buf = static_cast<uint8_t*>(malloc(needed));  // owned by FontDecompressor, freed in freeHotGroup()
+  capacity = buf ? needed : 0;
+  return buf != nullptr;
 }
 
 uint16_t FontDecompressor::getGroupIndex(const EpdFontData* fontData, uint32_t glyphIndex) {
@@ -170,24 +182,20 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
   }
 
   // Check if hot group already has this group decompressed — if not, decompress it
-  if (!(!hotGroup.empty() && hotGroupFont == fontData && hotGroupIndex == groupIndex)) {
+  if (!(hotGroup != nullptr && hotGroupFont == fontData && hotGroupIndex == groupIndex)) {
     stats.cacheMisses++;
     const EpdFontGroup& group = fontData->groups[groupIndex];
 
-    hotGroup.resize(group.uncompressedSize);
-    if (hotGroup.empty()) {
+    // ensureCapacity may free the buffer, so the cached-group identity dies with it either way.
+    hotGroupFont = nullptr;
+    hotGroupIndex = UINT16_MAX;
+    if (!ensureCapacity(hotGroup, hotGroupCapacity, group.uncompressedSize)) {
       LOG_ERR("FDC", "Failed to allocate %u bytes for hot group %u", group.uncompressedSize, groupIndex);
-      hotGroupFont = nullptr;
-      hotGroupIndex = UINT16_MAX;
       stats.getBitmapTimeUs += micros() - tStart;
       return nullptr;
     }
 
-    if (!decompressGroup(fontData, groupIndex, hotGroup.data(), group.uncompressedSize)) {
-      hotGroup.clear();
-      hotGroup.shrink_to_fit();
-      hotGroupFont = nullptr;
-      hotGroupIndex = UINT16_MAX;
+    if (!decompressGroup(fontData, groupIndex, hotGroup, group.uncompressedSize)) {
       stats.getBitmapTimeUs += micros() - tStart;
       return nullptr;
     }
@@ -200,18 +208,16 @@ const uint8_t* FontDecompressor::getBitmap(const EpdFontData* fontData, const Ep
   }
 
   // Compact just the requested glyph from byte-aligned data into scratch buffer
-  if (glyph->dataLength > hotGlyphBuf.size()) {
-    hotGlyphBuf.resize(glyph->dataLength);
-  }
-  if (hotGlyphBuf.empty()) {
+  if (!ensureCapacity(hotGlyphBuf, hotGlyphBufCapacity, glyph->dataLength)) {
+    LOG_ERR("FDC", "Failed to allocate %u bytes for glyph scratch", (unsigned)glyph->dataLength);
     stats.getBitmapTimeUs += micros() - tStart;
     return nullptr;
   }
 
   uint32_t alignedOff = getAlignedOffset(fontData, groupIndex, glyphIndex);
-  compactSingleGlyph(&hotGroup[alignedOff], hotGlyphBuf.data(), glyph->width, glyph->height);
+  compactSingleGlyph(&hotGroup[alignedOff], hotGlyphBuf, glyph->width, glyph->height);
   stats.getBitmapTimeUs += micros() - tStart;
-  return hotGlyphBuf.data();
+  return hotGlyphBuf;
 }
 
 // --- Prewarm: pre-decompress glyph bitmaps for a page of text ---

--- a/lib/EpdFont/FontDecompressor.h
+++ b/lib/EpdFont/FontDecompressor.h
@@ -2,8 +2,6 @@
 
 #include <InflateReader.h>
 
-#include <vector>
-
 #include "EpdFontData.h"
 
 class FontDecompressor {
@@ -67,13 +65,22 @@ class FontDecompressor {
 
   // Hot group: last decompressed group (byte-aligned) for non-prewarmed fallback path.
   // Kept in byte-aligned format; individual glyphs are compacted on demand into hotGlyphBuf.
+  // Nothrow high-water malloc buffers, NOT std::vector: getBitmap() runs on the render path,
+  // and under -fno-exceptions a vector resize that hits OOM abort()s the firmware instead of
+  // failing (field crash: hotGroup.resize() -> std::bad_alloc -> abort with ~11 KB free).
+  // ensureCapacity() returns false on OOM so the caller can skip the glyph gracefully.
   const EpdFontData* hotGroupFont = nullptr;
   uint16_t hotGroupIndex = UINT16_MAX;
-  std::vector<uint8_t> hotGroup;
+  uint8_t* hotGroup = nullptr;  // owned; freed in freeHotGroup()/dtor
+  uint32_t hotGroupCapacity = 0;
 
   // Scratch buffer for compacting a single glyph from the hot group.
-  // Valid until the next getBitmap() call.
-  std::vector<uint8_t> hotGlyphBuf;
+  // Valid until the next getBitmap() call. Same ownership/OOM contract as hotGroup.
+  uint8_t* hotGlyphBuf = nullptr;
+  uint32_t hotGlyphBufCapacity = 0;
+
+  // Grow (never shrink) an owned buffer to at least `needed` bytes; false on OOM, buffer freed.
+  static bool ensureCapacity(uint8_t*& buf, uint32_t& capacity, uint32_t needed);
 
   void freePageBuffer();
   void freeHotGroup();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a class of OOM `abort()` crashes on the render path. `FontDecompressor::hotGroup` / `hotGlyphBuf` were `std::vector<uint8_t>` resized inside `getBitmap()` — the render path. Under `-fno-exceptions`, a resize that hits OOM throws `std::bad_alloc` with no handler → `std::terminate()` → `abort()`. The existing `if (hotGroup.empty())` "graceful failure" checks were unreachable: the abort happens inside `resize()` before they run.

* **What changes are included?** Both buffers converted to grow-only nothrow `malloc` buffers behind a shared `ensureCapacity()` helper (free-then-malloc, since callers fully rewrite the buffer after a grow — no point holding both blocks on a tight heap). On OOM, `getBitmap()` returns `nullptr`; both `renderCharImpl` call sites in GfxRenderer already skip the glyph on a null bitmap, so the worst case is a page with a missing glyph instead of a reboot. This matches the heap-discipline skill's rule ("Bare `new`/`new[]` is never correct here") — the vector just hid the `new`. The `malloc`-based `tempBuf` in `prewarmCache()` twenty lines away already does this correctly; this brings the hot-group path in line with it. One detail: the cached-group identity (`hotGroupFont`/`hotGroupIndex`) is now invalidated *before* the grow, so a failed allocation can't leave a stale "group N loaded" marker pointing at a freed buffer.

## Additional Context

### Field crash (X4, 2026-07-02)

Reading with the BLE page-turner branch (#2418) resident, heap ~11 KB free after prewarm degraded gracefully. Symbolized stack from the on-device crash report:

```
abort() ← __terminate ← operator new
       ← std::__new_allocator<uint8_t>::allocate
       ← renderCharImpl (GfxRenderer.cpp:249 → getGlyphBitmap → FontDecompressor::getBitmap)
       ← GfxRenderer::drawText ← TextBlock::render ← EpubReaderActivity::renderContents
```

Last logs before the abort:
```
[FDC] Failed to allocate temp buffer (8480 bytes) for group 0   ← prewarm failing cleanly
[FDC] Prewarm: 55 glyphs in 0 bytes from 3 groups (3 missed)    ← forces hot-group fallback
→ abort() in hotGroup.resize()
```

Reproducible with a glyph-heavy EPUB ("Fundamentals of Data Engineering", many font groups + multiple styles per page) on any build where something else (NimBLE, WiFi) holds ~60 KB. Happy to share the crash report + book.

### Verification

Tested on X4 hardware: verified the same book renders through low-heap episodes (glyphs degrade, no abort). No behavior change when memory is fine.

### Related

- #2527 is the broader heap-resilience PR for BLE + reader coexistence; this PR fixes the same `-fno-exceptions` abort class inside the render path and is independent of it, but both are needed for the full story.

---

### AI Usage

Did you use AI tools to help write this code? **< YES >**

The code changes in this PR were written with AI assistance. Hardware testing and crash reproduction on the X4 were done manually by the author.
