### PR TITLE
fix: follow spec for zxing qr code generation

### DIFF
--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -410,7 +410,8 @@ void CrossPointWebServerActivity::renderServerRunning() const {
     startY += height10 + metrics.verticalSpacing * 2;
 
     // Show QR code for Wifi
-    const std::string wifiConfig = std::string("WIFI:S:") + connectedSSID + ";;";
+    // follows spec at https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11
+    const std::string wifiConfig = std::string("WIFI:T:nopass;S:") + connectedSSID + ";;";
     const Rect qrBoundsWifi(metrics.contentSidePadding, startY, QR_CODE_WIDTH, QR_CODE_HEIGHT);
     QrUtils::drawQrCode(renderer, qrBoundsWifi, wifiConfig);
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Follows spec for QR code generation for the Wi-Fi QR code. I was reading the docs around the QR code for this, and I noticed the spec defines the nopass param. Additionally, if we ever migrate to a password protected hotspot, this allows for an search and replace (`nopass` -> `WPA`, etc)

I also think there is value in the hotspot not being open, I find it a bit worrisome that the hotspot is not secured with a password (even if it's hardcoded and known, still better imo than an open network giving anyone access to all files on the SD card. I will do a follow-up PR for discussion on that)

* **What changes are included?**
Alters the generation string for the QR code

## Additional Context

Specification can be found here: https://github.com/zxing/zxing/wiki/Barcode-Contents#wi-fi-network-config-android-ios-11


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**no**_
