### PR TITLE
feat: implement captive portal redirects for auto-loading the management page on hotspot mode

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -353,6 +353,15 @@ void CrossPointWebServer::handleJszip() const {
 }
 
 void CrossPointWebServer::handleNotFound() const {
+  // in AP mode, redirect all unmatched URLs to "/" — this handles captive portal detection probes
+  // (e.g. /generate_204, /hotspot-detect.html, /connecttest.txt) so the OS auto-opens the browser
+  // see https://en.wikipedia.org/wiki/Captive_portal#Detection
+  if (apMode) {
+    server->sendHeader("Location", "/", true);
+    server->send(302, "text/plain", "");
+    return;
+  }
+
   String message = "404 Not Found\n\n";
   message += "URI: " + server->uri() + "\n";
   server->send(404, "text/plain", message);

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -353,10 +353,10 @@ void CrossPointWebServer::handleJszip() const {
 }
 
 void CrossPointWebServer::handleNotFound() const {
-  // in AP mode, redirect all unmatched URLs to "/" — this handles captive portal detection probes
-  // (e.g. /generate_204, /hotspot-detect.html, /connecttest.txt) so the OS auto-opens the browser
+  // in AP mode, redirect unmatched browser/captive-portal requests to "/" so the OS auto-opens the browser
+  // API requests (/api/*) still return 404 so XHR errors surface correctly
   // see https://en.wikipedia.org/wiki/Captive_portal#Detection
-  if (apMode) {
+  if (apMode && !server->uri().startsWith("/api/")) {
     server->sendHeader("Location", "/", true);
     server->send(302, "text/plain", "");
     return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** I had a bit of trouble of the network working on my android device, so I implemented a redirect for non API routes to allow for devices to automatically connect to the homepage once on the network

Without it, connecting to `CrossPoint-Reader` gives you a WiFi connection but nothing happens, you'd have to open a browser and manually type `192.168.4.1` or `crosspoint.local` or scan another qr code.

With the redir changes, the phone detects an unexpected response on its captive portal probe, recognizes it as a sign-in network, and auto-pops the browser straight to the CrossPoint home page without an additional step.

The main beneficiary is a non-technical user who just wants to drop an EPUB on the device. they scan the QR code on the e-ink screen to connect, their phone opens the page automatically, they upload the file, done.

* **What changes are included?** Handle captive endpoints for major device categories so that the management webpage automatically loads via instead of issuing a 404

<img width="1012" height="694" alt="image" src="https://github.com/user-attachments/assets/b1efde2e-77b1-49a8-a945-843f004b1a68" />


## Additional Context

Docs for captive portal detection methods: https://en.wikipedia.org/wiki/Captive_portal#Detection

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**no**_
