### PR TITLE
fix: prevent font manager OOM abort with many SD fonts installed

### DIFF
--- a/lib/EpdFont/SdCardFontRegistry.h
+++ b/lib/EpdFont/SdCardFontRegistry.h
@@ -49,6 +49,10 @@ class SdCardFontRegistry {
   int getFamilyIndex(const std::string& name) const;
   int getFamilyCount() const { return static_cast<int>(families_.size()); }
 
+  // Release all discovered family metadata, freeing its heap. Call discover()
+  // again to repopulate. Used to reclaim memory before heavy network work.
+  void clear() { std::vector<SdCardFontFamilyInfo>().swap(families_); }
+
  private:
   std::vector<SdCardFontFamilyInfo> families_;  // sorted alphabetically
 

--- a/src/SdCardFontSystem.h
+++ b/src/SdCardFontSystem.h
@@ -45,6 +45,16 @@ class SdCardFontSystem {
     }
   }
 
+  /// Free the active SD font and the discovered registry before a memory-heavy
+  /// network operation (e.g. the font manager). Both are restored on demand
+  /// afterwards: the registry via discover()/refreshIfDirty(), the active font
+  /// via ensureLoaded().
+  void releaseForNetwork(GfxRenderer& renderer) {
+    manager_.unloadAll(renderer);
+    registry_.clear();
+    registryDirty_.store(true, std::memory_order_release);
+  }
+
  private:
   SdCardFontRegistry registry_;
   SdCardFontManager manager_;

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -24,6 +24,11 @@ FontDownloadActivity::FontDownloadActivity(GfxRenderer& renderer, MappedInputMan
 
 void FontDownloadActivity::onEnter() {
   Activity::onEnter();
+  // Free the active reader font and the SD font registry before the network +
+  // manifest work. With an SD font active and many families installed, both stay
+  // resident and, together with the parsed manifest, exhaust the heap and abort
+  // during parse on low-heap devices. Restored in onExit()/on reboot.
+  sdFontSystem.releaseForNetwork(renderer);
   WiFi.mode(WIFI_STA);
   startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
@@ -37,6 +42,10 @@ void FontDownloadActivity::onExit() {
     delay(30);
     silentRestart();
   }
+
+  // Reached only when WiFi selection was cancelled (no reboot above): restore the
+  // reader font and registry that releaseForNetwork() freed in onEnter().
+  sdFontSystem.ensureLoaded(renderer);
 }
 
 void FontDownloadActivity::onWifiSelectionComplete(const bool success) {
@@ -90,57 +99,71 @@ bool FontDownloadActivity::fetchAndParseManifest() {
     return false;
   }
 
-  JsonDocument doc;
-  DeserializationError err = deserializeJson(doc, manifestFile);
-  manifestFile.close();
-  Storage.remove(MANIFEST_TMP);
+  // The parsed manifest and the installed-font registry are each large when many
+  // families are installed. Keep the JsonDocument in its own scope and defer
+  // loading the registry until after it is freed (second pass below), so the two
+  // are never resident at once. That coexistence aborts during parse on low-heap
+  // devices with many SD fonts installed (bare new is fatal with -fno-exceptions).
+  {
+    JsonDocument doc;
+    DeserializationError err = deserializeJson(doc, manifestFile);
+    manifestFile.close();
+    Storage.remove(MANIFEST_TMP);
 
-  if (err) {
-    LOG_ERR("FONT", "Manifest parse error: %s", err.c_str());
-    errorMessage_ = "Invalid font manifest";
-    return false;
-  }
-
-  int version = doc["version"] | 0;
-  if (version != FONTS_MANIFEST_VERSION) {
-    LOG_ERR("FONT", "Unsupported manifest version: %d", version);
-    errorMessage_ = "Unsupported manifest version";
-    return false;
-  }
-
-  baseUrl_ = doc["baseUrl"] | "";
-  families_.clear();
-  fontInstaller_.refreshRegistry();
-
-  JsonArray familiesArr = doc["families"].as<JsonArray>();
-  families_.reserve(familiesArr.size());
-
-  for (JsonObject fObj : familiesArr) {
-    ManifestFamily family;
-    family.name = fObj["name"] | "";
-    family.description = fObj["description"] | "";
-
-    for (JsonVariant s : fObj["styles"].as<JsonArray>()) {
-      family.styles.push_back(s.as<std::string>());
+    if (err) {
+      LOG_ERR("FONT", "Manifest parse error: %s", err.c_str());
+      errorMessage_ = "Invalid font manifest";
+      return false;
     }
 
-    family.totalSize = 0;
-    for (JsonObject fileObj : fObj["files"].as<JsonArray>()) {
-      ManifestFile file;
-      file.name = fileObj["name"] | "";
-      file.size = fileObj["size"] | 0;
+    int version = doc["version"] | 0;
+    if (version != FONTS_MANIFEST_VERSION) {
+      LOG_ERR("FONT", "Unsupported manifest version: %d", version);
+      errorMessage_ = "Unsupported manifest version";
+      return false;
+    }
 
-      if (!fileObj["crc32"].is<uint32_t>()) {
-        LOG_ERR("FONT", "Malformed manifest file entry: missing or invalid crc32 for %s", file.name.c_str());
-        errorMessage_ = "Invalid font manifest";
-        return false;
+    baseUrl_ = doc["baseUrl"] | "";
+    families_.clear();
+
+    JsonArray familiesArr = doc["families"].as<JsonArray>();
+    families_.reserve(familiesArr.size());
+
+    for (JsonObject fObj : familiesArr) {
+      ManifestFamily family;
+      family.name = fObj["name"] | "";
+      family.description = fObj["description"] | "";
+
+      for (JsonVariant s : fObj["styles"].as<JsonArray>()) {
+        family.styles.push_back(s.as<std::string>());
       }
-      file.crc32 = fileObj["crc32"].as<uint32_t>();
 
-      family.totalSize += file.size;
-      family.files.push_back(std::move(file));
+      family.totalSize = 0;
+      for (JsonObject fileObj : fObj["files"].as<JsonArray>()) {
+        ManifestFile file;
+        file.name = fileObj["name"] | "";
+        file.size = fileObj["size"] | 0;
+
+        if (!fileObj["crc32"].is<uint32_t>()) {
+          LOG_ERR("FONT", "Malformed manifest file entry: missing or invalid crc32 for %s", file.name.c_str());
+          errorMessage_ = "Invalid font manifest";
+          return false;
+        }
+        file.crc32 = fileObj["crc32"].as<uint32_t>();
+
+        family.totalSize += file.size;
+        family.files.push_back(std::move(file));
+      }
+
+      families_.push_back(std::move(family));
     }
+  }  // JsonDocument freed here, before the registry is loaded below.
 
+  // Second pass: load the installed-font registry and resolve installed/update
+  // state now that the manifest JsonDocument has been released, keeping peak heap
+  // usage down on devices with many SD fonts installed.
+  fontInstaller_.refreshRegistry();
+  for (auto& family : families_) {
     family.installed = fontInstaller_.isFamilyInstalled(family.name.c_str());
 
     // Detect updates by comparing manifest file sizes with files on disk.
@@ -164,8 +187,6 @@ bool FontDownloadActivity::fetchAndParseManifest() {
         }
       }
     }
-
-    families_.push_back(std::move(family));
   }
 
   LOG_DBG("FONT", "Manifest loaded: %zu families", families_.size());


### PR DESCRIPTION
## Summary

Opening **Settings > Fonts > Manage Fonts** can `abort()` during font-manifest parsing on low-heap devices that have an **SD reader font active** and **many font families installed**. This fixes it by freeing the active font and the font registry before the network/parse work, and by not holding the parsed manifest and the registry in memory at the same time.

**Verified on hardware (X3)** — see the A/B below.

## Root cause

At the parse peak, four large things were resident in RAM simultaneously:

1. the discovered SD-font **registry** (populated in `SdCardFontSystem::begin()` at boot and never released),
2. the **active reader font** (`onEnter()` freed nothing),
3. the parsed manifest **`JsonDocument`** (~40 KB for the ~29 KB `fonts.json`), and
4. the growing **`families_`** list.

With `-fno-exceptions`, the failing allocation doesn't return `nullptr` — it throws `bad_alloc`, which goes to `__terminate` → `abort()` (the hazard in `CLAUDE.md` rule #9).

Symbolicated crash (unfixed, `riscv32-esp-elf-addr2line`):

```
__terminate ← std::bad_alloc ← __cxa_allocate_exception
  ← std::vector<ManifestFile>::_M_realloc_append(ManifestFile&&)
  ← FontDownloadActivity::fetchAndParseManifest  (onWifiSelectionComplete)
```

The reproduction needs the heap already squeezed low (~48 KB free), which happens in normal use after reading with an SD font selected — not on a fresh boot.

## Changes

- **`SdCardFontRegistry::clear()`** — release discovered family metadata (repopulated by `discover()`).
- **`SdCardFontSystem::releaseForNetwork()`** — unload the active font (`manager_.unloadAll`) and clear the registry before heavy network work; both restore on demand.
- **`FontDownloadActivity::onEnter()`** calls `releaseForNetwork()`; **`onExit()`** restores via `ensureLoaded()` when WiFi selection is cancelled (the WiFi-connected path already reboots via `silentRestart()`).
- **`fetchAndParseManifest()`** now parses in **two passes**: build `families_` from the JSON, free the `JsonDocument`, then re-discover the registry for installed/update detection — so the JSON and the registry are never resident together.

No behavior change to the resulting font list; this only lowers peak heap during load.

## Testing

Built `env:default`, flashed to an X3 with an SD reader font active (NotoSansExtended, XLarge) and 24 SD font families (192 `.cpfont` files) installed, heap squeezed by reading a book first. Same steps each time → Settings > Fonts > Manage Fonts:

| Build | Result |
|---|---|
| `develop` (unfixed) | ❌ `abort()` — `bad_alloc` in `vector<ManifestFile>` append |
| two-pass parse only | ❌ `abort()` — `bad_alloc` in a `std::string` (registry is resident from boot, so reordering alone didn't help) |
| **this PR** (`releaseForNetwork` + two-pass) | ✅ Font Browser loads, no abort |

(For on-device reproduction the manifest was served from an HTTP mirror, since the ESP32‑C3 stalls on the GitHub‑HTTPS manifest redirect before reaching the parse — a separate transport issue, not part of this change.)

## Related

This is the upstream counterpart of the same crash reported on the CrossInk fork: [uxjulia/CrossInk#344](https://github.com/uxjulia/CrossInk/issues/344) ("Crash abort 1.4.0 RC in manage fonts"). The mechanism is identical (`bad_alloc` → `__terminate` during font-manifest parse under low heap). CrossInk already had a `releaseForNetwork()` helper that frees the registry, so its fix was smaller (call it in `onEnter()` + the two-pass parse); this repository had no font/registry release path, so this PR adds `SdCardFontRegistry::clear()` and `SdCardFontSystem::releaseForNetwork()` before applying the same approach. The CrossInk fix was verified on an X3; this upstream fix was verified on the same device against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
