### PR TITLE
feat: HTTP serve static with Cache-Control and ETag headers

### DIFF
--- a/scripts/build_html.py
+++ b/scripts/build_html.py
@@ -61,8 +61,9 @@ for root, _, files in os.walk(SRC_DIR):
                 processed = content
 
             # Compress with gzip (compresslevel 9 is maximum compression)
+            # mtime=0 keeps the output reproducible across builds
             # IMPORTANT: we don't use brotli because Firefox doesn't support brotli with insecured context (only supported on HTTPS)
-            compressed = gzip.compress(processed.encode('utf-8'), compresslevel=9)
+            compressed = gzip.compress(processed.encode('utf-8'), compresslevel=9, mtime=0)
 
             # Create valid C identifier from filename
             # Use appropriate suffix based on file type

--- a/scripts/build_html.py
+++ b/scripts/build_html.py
@@ -1,6 +1,7 @@
 import os
 import re
 import gzip
+import hashlib
 
 SRC_DIR = "src"
 
@@ -86,6 +87,13 @@ for root, _, files in os.walk(SRC_DIR):
                 h.write(f"}};\n\n")
                 h.write(f"constexpr size_t {base_name}CompressedSize = {len(compressed)};\n")
                 h.write(f"constexpr size_t {base_name}OriginalSize = {len(processed)};\n")
+
+                # ETag derived from the compressed payload. The content is
+                # immutable at runtime (baked into flash at build time), so a
+                # strong ETag keyed on the bytes is safe and stable. Browsers
+                # echo it back as If-None-Match, enabling 304 responses.
+                etag = hashlib.sha256(compressed).hexdigest()[:16]
+                h.write(f'constexpr const char* {base_name}ETag = "\\"{etag}\\"";\n')
 
             print(f"Generated: {header_path}")
             print(f"  Original: {len(content)} bytes")

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -182,8 +182,10 @@ void CrossPointWebServer::begin() {
   LOG_DBG("WEB", "[MEM] Free heap after route setup: %d bytes", ESP.getFreeHeap());
 
   // Collect WebDAV headers and register handler
-  const char* davHeaders[] = {"Depth", "Destination", "Overwrite", "If", "Lock-Token", "Timeout"};
-  server->collectHeaders(davHeaders, 6);
+  // If-None-Match is collected so the static-page handlers can answer conditional GETs with 304
+  const char* collectedHeaders[] = {"Depth",      "Destination", "Overwrite",    "If",
+                                    "Lock-Token", "Timeout",     "If-None-Match"};
+  server->collectHeaders(collectedHeaders, 7);
   server->addHandler(new WebDAVHandler());  // Note: WebDAVHandler will be deleted by WebServer when server is stopped
   LOG_DBG("WEB", "WebDAV handler initialized");
 
@@ -336,19 +338,32 @@ CrossPointWebServer::WsUploadStatus CrossPointWebServer::getWsUploadStatus() con
   return status;
 }
 
-static void sendHtmlContent(WebServer* server, const char* data, size_t len) {
+static void sendStaticContent(WebServer* server, const char* data, size_t len, const char* etag,
+                              const char* contentType) {
+  // Content is baked into flash at build time, so the ETag is stable for the
+  // lifetime of a firmware image. Honor If-None-Match with a 304 so browsers
+  // reuse their cache instead of re-downloading on every navigation.
+  if (server->header("If-None-Match") == etag) {
+    server->sendHeader("ETag", etag);
+    server->sendHeader("Cache-Control", "no-cache");
+    server->send(304);
+    return;
+  }
   server->sendHeader("Content-Encoding", "gzip");
-  server->send_P(200, "text/html", data, len);
+  server->sendHeader("ETag", etag);
+  // no-cache: the browser may cache, but must revalidate (conditional GET)
+  // before reuse — this is what unlocks 304 responses.
+  server->sendHeader("Cache-Control", "no-cache");
+  server->send_P(200, contentType, data, len);
 }
 
 void CrossPointWebServer::handleRoot() const {
-  sendHtmlContent(server.get(), HomePageHtml, sizeof(HomePageHtml));
+  sendStaticContent(server.get(), HomePageHtml, sizeof(HomePageHtml), HomePageHtmlETag, "text/html");
   LOG_DBG("WEB", "Served root page");
 }
 
 void CrossPointWebServer::handleJszip() const {
-  server->sendHeader("Content-Encoding", "gzip");
-  server->send_P(200, "application/javascript", jszip_minJs, jszip_minJsCompressedSize);
+  sendStaticContent(server.get(), jszip_minJs, jszip_minJsCompressedSize, jszip_minJsETag, "application/javascript");
   LOG_DBG("WEB", "Served jszip.min.js");
 }
 
@@ -455,7 +470,7 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
 bool CrossPointWebServer::isEpubFile(const String& filename) const { return FsHelpers::hasEpubExtension(filename); }
 
 void CrossPointWebServer::handleFileList() const {
-  sendHtmlContent(server.get(), FilesPageHtml, sizeof(FilesPageHtml));
+  sendStaticContent(server.get(), FilesPageHtml, sizeof(FilesPageHtml), FilesPageHtmlETag, "text/html");
 }
 
 void CrossPointWebServer::handleFileListData() const {
@@ -1119,7 +1134,7 @@ void CrossPointWebServer::handleDelete() const {
 }
 
 void CrossPointWebServer::handleSettingsPage() const {
-  sendHtmlContent(server.get(), SettingsPageHtml, sizeof(SettingsPageHtml));
+  sendStaticContent(server.get(), SettingsPageHtml, sizeof(SettingsPageHtml), SettingsPageHtmlETag, "text/html");
   LOG_DBG("WEB", "Served settings page");
 }
 
@@ -1732,7 +1747,7 @@ void CrossPointWebServer::onWebSocketEvent(uint8_t num, WStype_t type, uint8_t* 
 // --- Font management handlers ---
 
 void CrossPointWebServer::handleFontsPage() const {
-  sendHtmlContent(server.get(), FontsPageHtml, sizeof(FontsPageHtml));
+  sendStaticContent(server.get(), FontsPageHtml, sizeof(FontsPageHtml), FontsPageHtmlETag, "text/html");
   LOG_DBG("WEB", "Served fonts page");
 }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

The WebUI is currently a static web page, relying on JS and refreshing to display new data. But since these static resources are not served with Cache-Control header, the browser is not willing to cache them but requesting them each time, making performance impact.

This PR set `Cache-Control` and `ETag` headers, asking browser to request with the `ETag` later so server side can return `304 Not Modified` instead of full file.

* **What changes are included?**

Apart from server, `scripts/build_html.py` is also changed to compute sha256 of file content and generate consts like `HomePageHtmlETag`.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).

`if (server->header("If-None-Match") == etag)` might add a string compare cost, but since only [:16] of sha256 is taken as `ETag` that's probably fine.

---

### AI Usage

Claude Code + Claude Sonnet 5
