### PR TITLE
Solution (#1029): CSS styled element is not centered (When Paragraph Alignment is s

### DIFF
--- a/path/to/CssParser.cpp
+++ b/path/to/CssParser.cpp
@@ -1,0 +1,34 @@
+#include "CssParser.h"
+#include "CssStyle.h"
+
+namespace Epub {
+
+CssParser::CssParser() {}
+
+CssParser::~CssParser() {}
+
+void CssParser::parse(const std::string& css) {
+    // Split the CSS into individual rules
+    size_t pos = 0;
+    while ((pos = css.find('}')) != std::string::npos) {
+        std::string rule = css.substr(0, pos);
+        css.erase(0, pos + 1);
+
+        // Parse the selector and style
+        size_t selectorEnd = rule.find('{');
+        std::string selector = rule.substr(0, selectorEnd);
+        std::string style = rule.substr(selectorEnd + 1);
+
+        // Handle the "Justify" alignment
+        if (style.find("text-align: justify") != std::string::npos) {
+            // Apply the centering style
+            style += " text-align: center";
+        }
+
+        // Create a new CssStyle object and add it to the list
+        CssStyle* styleObj = new CssStyle(selector, style);
+        m_styles.push_back(styleObj);
+    }
+}
+
+}  // namespace Epub

--- a/path/to/CssStyle.cpp
+++ b/path/to/CssStyle.cpp
@@ -1,0 +1,18 @@
+#include "CssStyle.h"
+
+namespace Epub {
+
+CssStyle::CssStyle(const std::string& selector, const std::string& style)
+    : m_selector(selector), m_style(style) {}
+
+CssStyle::~CssStyle() {}
+
+std::string CssStyle::getSelector() const {
+    return m_selector;
+}
+
+std::string CssStyle::getStyle() const {
+    return m_style;
+}
+
+}  // namespace Epub

--- a/path/to/CssStyle.h
+++ b/path/to/CssStyle.h
@@ -1,0 +1,23 @@
+#ifndef CSS_STYLE_H
+#define CSS_STYLE_H
+
+#include <string>
+
+namespace Epub {
+
+class CssStyle {
+public:
+    CssStyle(const std::string& selector, const std::string& style);
+    ~CssStyle();
+
+    std::string getSelector() const;
+    std::string getStyle() const;
+
+private:
+    std::string m_selector;
+    std::string m_style;
+};
+
+}  // namespace Epub
+
+#endif  // CSS_STYLE_H

--- a/path/to/Epub.cpp
+++ b/path/to/Epub.cpp
@@ -1,0 +1,15 @@
+#include "Epub.h"
+#include "CssParser.h"
+
+namespace Epub {
+
+Epub::Epub() {}
+
+Epub::~Epub() {}
+
+void Epub::parse(const std::string& css) {
+    CssParser parser;
+    parser.parse(css);
+}
+
+}  // namespace Epub

--- a/path/to/Epub.h
+++ b/path/to/Epub.h
@@ -1,0 +1,22 @@
+#ifndef EPUB_H
+#define EPUB_H
+
+#include <string>
+#include <vector>
+
+namespace Epub {
+
+class Epub {
+public:
+    Epub();
+    ~Epub();
+
+    void parse(const std::string& css);
+
+private:
+    std::vector<CssStyle*> m_styles;
+};
+
+}  // namespace Epub
+
+#endif  // EPUB_H

--- a/path/to/main.cpp
+++ b/path/to/main.cpp
@@ -1,0 +1,8 @@
+#include "Epub.h"
+
+int main() {
+    std::string css = ".orn {text-indent: 0; text-align: center; margin: 1em 0 1em 0}";
+    Epub epub;
+    epub.parse(css);
+    return 0;
+}


### PR DESCRIPTION
This pull request modifies the `CssParser` class to handle the "Justify" alignment in CSS styles. The change is implemented in the `parse` method of the `CssParser` class, where the code checks for the presence of "text-align: justify" and appends "text-align: center" to the style if found.

To test this change, create a sample CSS string with a paragraph alignment set to "Justify" and verify that the text elements are properly centered. You can use the following code as a test case:

```cpp:path/to/test.cpp
#include "Epub.h"

int main() {
    std::string css = ".orn {text-indent: 0; text-align: justify; margin: 1em 0 1em 0}";
    Epub epub;
    epub.parse(css);
    return 0;
}
```

Run the test code and verify that the text elements are centered. If the change is successful, the text elements should be properly centered.