### PR TITLE
Use selected SD font as glyph fallback for user-content titles

### DIFF
--- a/docs/korean-title-fallback.md
+++ b/docs/korean-title-fallback.md
@@ -1,0 +1,46 @@
+# Korean title fallback
+
+This patch keeps the built-in UI fonts as the primary fonts, and uses the
+currently selected SD-card reader `.cpfont` only for user-content titles and
+file names that contain codepoints missing from the UI font.
+
+## Traced rendering paths
+
+- Home recent title: `HomeActivity::render()` passes the latest book title to
+  `BaseTheme::drawHeader()` when `homeContinueReadingInMenu` is active, and to
+  `drawRecentBookCover()` for cover tiles.
+- Recent books list: `RecentBooksActivity::render()` passes `RecentBook::title`
+  and `RecentBook::author` to `drawList()`.
+- File browser list: `FileBrowserActivity::render()` passes `getFileName()` to
+  `drawList()`. The extension value remains normal UI text.
+- Width and truncation: theme code now uses
+  `GfxRenderer::getContentTextWidth()`, `truncatedContentText()`, and
+  `wrappedContentText()` only when a row/header/cover string is marked as user
+  content.
+
+## Fallback rule
+
+For each codepoint:
+
+1. Use the built-in UI font when it contains a real glyph.
+2. Otherwise use the selected SD-card reader font when it is loaded and contains
+   the glyph.
+3. Otherwise keep the existing replacement-glyph behavior.
+
+The renderer uses the same rule for measurement and drawing. `EpdFont::hasGlyph`
+and `SdCardFont::hasGlyph` intentionally test real coverage and do not treat
+U+FFFD replacement fallback as a match.
+
+## Manual test matrix
+
+- English title: `The Hobbit` should use UI glyphs only.
+- Korean title: `한글 제목` should use SD `.cpfont` glyphs for Hangul.
+- Mixed title: `English 한글 123` should use UI glyphs for Latin/digits and SD
+  glyphs for Hangul.
+- No SD font selected: affected screens must still open and show the existing
+  replacement-glyph behavior for missing UI glyphs.
+- Missing or corrupt `.cpfont`: `SdCardFontSystem::ensureLoaded()` must fail
+  closed and leave the UI rendering path usable.
+
+No flashing, unlock/re-lock, partition change, or OTA install is part of this
+test procedure.

--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -4,6 +4,29 @@
 
 #include <algorithm>
 
+namespace {
+const EpdGlyph* findGlyphExact(const EpdFontData* data, const uint32_t cp) {
+  const int count = data->intervalCount;
+  if (count == 0) return nullptr;
+
+  const EpdUnicodeInterval* intervals = data->intervals;
+  const auto* end = intervals + count;
+
+  // upper_bound: range lookup. Finds the first interval with first > cp, so the
+  // interval just before it is the last one with first <= cp.
+  const auto it = std::upper_bound(
+      intervals, end, cp, [](uint32_t value, const EpdUnicodeInterval& interval) { return value < interval.first; });
+
+  if (it != intervals) {
+    const auto& interval = *(it - 1);
+    if (cp <= interval.last) {
+      return &data->glyph[interval.offset + (cp - interval.first)];
+    }
+  }
+  return nullptr;
+}
+}  // namespace
+
 void EpdFont::getTextBounds(const char* string, const int startX, const int startY, int* minX, int* minY, int* maxX,
                             int* maxY) const {
   *minX = startX;
@@ -154,27 +177,10 @@ uint32_t EpdFont::applyLigatures(uint32_t cp, const char*& text) const {
   return cp;
 }
 
+bool EpdFont::hasGlyph(const uint32_t cp) const { return findGlyphExact(data, cp) != nullptr; }
+
 const EpdGlyph* EpdFont::getGlyph(const uint32_t cp) const {
-  const int count = data->intervalCount;
-  if (count == 0 && !data->glyphMissHandler) return nullptr;
-
-  if (count > 0) {
-    const EpdUnicodeInterval* intervals = data->intervals;
-    const auto* end = intervals + count;
-
-    // upper_bound: range lookup. Finds the first interval with first > cp, so the
-    // interval just before it is the last one with first <= cp. That's the only
-    // candidate that could contain cp. Then we verify cp <= candidate.last.
-    const auto it = std::upper_bound(
-        intervals, end, cp, [](uint32_t value, const EpdUnicodeInterval& interval) { return value < interval.first; });
-
-    if (it != intervals) {
-      const auto& interval = *(it - 1);
-      if (cp <= interval.last) {
-        return &data->glyph[interval.offset + (cp - interval.first)];
-      }
-    }
-  }
+  if (const EpdGlyph* glyph = findGlyphExact(data, cp)) return glyph;
 
   // Codepoint not in interval table — try on-demand loading (SD card fonts).
   if (data->glyphMissHandler) {

--- a/lib/EpdFont/EpdFont.h
+++ b/lib/EpdFont/EpdFont.h
@@ -10,6 +10,10 @@ class EpdFont {
   ~EpdFont() = default;
   void getTextDimensions(const char* string, int* w, int* h) const;
 
+  /// Returns true only when this font has a real glyph for \p cp.
+  /// Unlike getGlyph(), this does not fall back to U+FFFD.
+  bool hasGlyph(uint32_t cp) const;
+
   const EpdGlyph* getGlyph(uint32_t cp) const;
 
   /// Returns the kerning adjustment (4.4 fixed-point in pixels) between two codepoints.

--- a/lib/EpdFont/EpdFontFamily.cpp
+++ b/lib/EpdFont/EpdFontFamily.cpp
@@ -24,6 +24,8 @@ void EpdFontFamily::getTextDimensions(const char* string, int* w, int* h, const 
 
 const EpdFontData* EpdFontFamily::getData(const Style style) const { return getFont(style)->data; }
 
+bool EpdFontFamily::hasGlyph(const uint32_t cp, const Style style) const { return getFont(style)->hasGlyph(cp); }
+
 const EpdGlyph* EpdFontFamily::getGlyph(const uint32_t cp, const Style style) const {
   return getFont(style)->getGlyph(cp);
 }

--- a/lib/EpdFont/EpdFontFamily.h
+++ b/lib/EpdFont/EpdFontFamily.h
@@ -25,6 +25,7 @@ class EpdFontFamily {
   ~EpdFontFamily() = default;
   void getTextDimensions(const char* string, int* w, int* h, Style style = REGULAR) const;
   const EpdFontData* getData(Style style = REGULAR) const;
+  bool hasGlyph(uint32_t cp, Style style = REGULAR) const;
   const EpdGlyph* getGlyph(uint32_t cp, Style style = REGULAR) const;
   int8_t getKerning(uint32_t leftCp, uint32_t rightCp, Style style = REGULAR) const;
   uint32_t applyLigatures(uint32_t cp, const char*& text, Style style = REGULAR) const;

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -1089,6 +1089,13 @@ uint16_t SdCardFont::getAdvance(uint32_t codepoint, uint8_t style) const {
   return 0;
 }
 
+bool SdCardFont::hasGlyph(const uint32_t codepoint, uint8_t style) const {
+  if (!loaded_) return false;
+  style = resolveStyle(style);
+  if (style >= MAX_STYLES || !styles_[style].present) return false;
+  return findGlobalGlyphIndex(styles_[style], codepoint) >= 0;
+}
+
 // Given a sorted array of unique codepoints, resolve glyph indices per style,
 // batch-read advanceX from SD, and merge into the persistent advance table.
 // Caller owns the codepoints buffer.

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -55,6 +55,10 @@ class SdCardFont {
   // Returns the 12.4 fixed-point advance, or 0 if not found.
   uint16_t getAdvance(uint32_t codepoint, uint8_t style) const;
 
+  // Returns true only when the loaded .cpfont contains a real glyph for the codepoint.
+  // This uses the resident interval table and does not read bitmap data from SD.
+  bool hasGlyph(uint32_t codepoint, uint8_t style = 0) const;
+
   // Returns true if advance table is populated for at least one style.
   bool hasAdvanceTable() const;
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -8,17 +8,25 @@
 #include <Utf8.h>
 
 #include <algorithm>
+#include <cstring>
 
 #include "FontCacheManager.h"
 
 namespace {
 
-/**
- * Resolves the requested style to the best available style in the given SD card font.
- * Falls back gracefully when the font lacks the requested variant.
- */
 uint8_t resolveSdCardStyle(const SdCardFont& font, const EpdFontFamily::Style style) {
   return font.resolveStyle(static_cast<uint8_t>(style));
+}
+
+uint8_t styleMaskFor(const EpdFontFamily::Style style) {
+  return static_cast<uint8_t>(1u << (static_cast<uint8_t>(style) & 0x03));
+}
+
+bool isHebrewNiqqud(const uint32_t cp) { return cp >= 0x0591 && cp <= 0x05C7; }
+
+int32_t glyphAdvance(const EpdFontFamily& font, const uint32_t cp, const EpdFontFamily::Style style) {
+  const EpdGlyph* glyph = font.getGlyph(cp, style);
+  return glyph ? glyph->advanceX : 0;
 }
 }  // namespace
 
@@ -465,6 +473,246 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
       renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, lastBaseX, yPos, black, style);
     }
     prevCp = cp;
+  }
+}
+
+bool GfxRenderer::contentTextNeedsFallback(const int primaryFontId, const int fallbackFontId, const char* text,
+                                           const EpdFontFamily::Style style,
+                                           const BidiUtils::BidiBaseDir baseDir) const {
+  if (text == nullptr || *text == '\0' || fallbackFontId == 0 || fallbackFontId == primaryFontId) {
+    return false;
+  }
+
+  const auto primaryIt = fontMap.find(primaryFontId);
+  const auto fallbackIt = fontMap.find(fallbackFontId);
+  const auto sdIt = sdCardFonts_.find(fallbackFontId);
+  if (primaryIt == fontMap.end() || fallbackIt == fontMap.end() || sdIt == sdCardFonts_.end() || !sdIt->second) {
+    return false;
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+
+  const char* textCursor = renderedText;
+  while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor))) {
+    if (isHebrewNiqqud(cp)) continue;
+    if (primaryIt->second.hasGlyph(cp, style)) continue;
+    if (sdIt->second->hasGlyph(cp, static_cast<uint8_t>(style))) return true;
+  }
+  return false;
+}
+
+void GfxRenderer::prepareContentTextFallback(const int primaryFontId, const int fallbackFontId, const char* text,
+                                             const EpdFontFamily::Style style,
+                                             const BidiUtils::BidiBaseDir baseDir, const bool prewarmBitmaps) const {
+  if (text == nullptr || *text == '\0' || fallbackFontId == 0 || fallbackFontId == primaryFontId) {
+    return;
+  }
+
+  const auto primaryIt = fontMap.find(primaryFontId);
+  const auto fallbackIt = fontMap.find(fallbackFontId);
+  const auto sdIt = sdCardFonts_.find(fallbackFontId);
+  if (primaryIt == fontMap.end() || fallbackIt == fontMap.end() || sdIt == sdCardFonts_.end() || !sdIt->second) {
+    return;
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+  std::string fallbackText;
+  fallbackText.reserve(strlen(renderedText));
+
+  const char* textCursor = renderedText;
+  while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor))) {
+    if (isHebrewNiqqud(cp)) continue;
+    if (primaryIt->second.hasGlyph(cp, style)) continue;
+    if (!sdIt->second->hasGlyph(cp, static_cast<uint8_t>(style))) continue;
+    utf8AppendCodepoint(cp, fallbackText);
+  }
+
+  if (fallbackText.empty()) return;
+
+  const uint8_t styleMask = styleMaskFor(style);
+  ensureSdCardFontReady(fallbackFontId, fallbackText.c_str(), styleMask);
+  if (prewarmBitmaps && fontCacheManager_ && !fontCacheManager_->isScanning()) {
+    fontCacheManager_->prewarmCache(fallbackFontId, fallbackText.c_str(), styleMask);
+  }
+}
+
+int GfxRenderer::getContentTextWidth(const int primaryFontId, const int fallbackFontId, const char* text,
+                                     const EpdFontFamily::Style style,
+                                     const BidiUtils::BidiBaseDir baseDir) const {
+  if (text == nullptr || *text == '\0') {
+    return 0;
+  }
+  if (!contentTextNeedsFallback(primaryFontId, fallbackFontId, text, style, baseDir)) {
+    return getTextWidth(primaryFontId, text, style, baseDir);
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+  prepareContentTextFallback(primaryFontId, fallbackFontId, renderedText, style, BidiUtils::BidiBaseDir::LTR, false);
+
+  const auto primaryIt = fontMap.find(primaryFontId);
+  const auto fallbackIt = fontMap.find(fallbackFontId);
+  const auto sdIt = sdCardFonts_.find(fallbackFontId);
+  if (primaryIt == fontMap.end() || fallbackIt == fontMap.end() || sdIt == sdCardFonts_.end() || !sdIt->second) {
+    return getTextWidth(primaryFontId, renderedText, style, BidiUtils::BidiBaseDir::LTR);
+  }
+
+  const auto& primaryFont = primaryIt->second;
+  const auto& fallbackFont = fallbackIt->second;
+  const auto* fallbackSdFont = sdIt->second;
+  const uint8_t fallbackStyle = fallbackSdFont->resolveStyle(static_cast<uint8_t>(style));
+
+  int widthPx = 0;
+  int32_t prevAdvanceFP = 0;
+  uint32_t prevCp = 0;
+  int prevFontId = 0;
+
+  const char* textCursor = renderedText;
+  while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor))) {
+    if (isHebrewNiqqud(cp) || utf8IsCombiningMark(cp)) {
+      continue;
+    }
+
+    const EpdFontFamily* font = &primaryFont;
+    int fontId = primaryFontId;
+    bool useFallback = false;
+
+    if (primaryFont.hasGlyph(cp, style)) {
+      const char* ligatureCursor = textCursor;
+      const uint32_t ligatureCp = primaryFont.applyLigatures(cp, ligatureCursor, style);
+      if (ligatureCp != cp && primaryFont.hasGlyph(ligatureCp, style)) {
+        cp = ligatureCp;
+        textCursor = ligatureCursor;
+      }
+    } else if (fallbackSdFont->hasGlyph(cp, static_cast<uint8_t>(style))) {
+      font = &fallbackFont;
+      fontId = fallbackFontId;
+      useFallback = true;
+    }
+
+    if (prevCp != 0) {
+      const int kernFP = (prevFontId == fontId && !useFallback) ? font->getKerning(prevCp, cp, style) : 0;
+      widthPx += fp4::toPixel(prevAdvanceFP + kernFP);
+    }
+
+    if (useFallback) {
+      prevAdvanceFP = fallbackSdFont->getAdvance(cp, fallbackStyle);
+      if (prevAdvanceFP == 0) prevAdvanceFP = glyphAdvance(fallbackFont, cp, style);
+    } else {
+      prevAdvanceFP = glyphAdvance(primaryFont, cp, style);
+    }
+    if ((style & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0) {
+      prevAdvanceFP = (prevAdvanceFP + 1) / 2;
+    }
+    prevCp = cp;
+    prevFontId = fontId;
+  }
+
+  widthPx += fp4::toPixel(prevAdvanceFP);
+  return widthPx;
+}
+
+void GfxRenderer::drawCenteredContentText(const int primaryFontId, const int fallbackFontId, const int y,
+                                          const char* text, const bool black, const EpdFontFamily::Style style,
+                                          const BidiUtils::BidiBaseDir baseDir) const {
+  const int x = (getScreenWidth() - getContentTextWidth(primaryFontId, fallbackFontId, text, style, baseDir)) / 2;
+  drawContentText(primaryFontId, fallbackFontId, x, y, text, black, style, baseDir);
+}
+
+void GfxRenderer::drawContentText(const int primaryFontId, const int fallbackFontId, const int x, const int y,
+                                  const char* text, const bool black, const EpdFontFamily::Style style,
+                                  const BidiUtils::BidiBaseDir baseDir) const {
+  if (text == nullptr || *text == '\0') {
+    return;
+  }
+  if (!contentTextNeedsFallback(primaryFontId, fallbackFontId, text, style, baseDir)) {
+    drawText(primaryFontId, x, y, text, black, style, baseDir);
+    return;
+  }
+
+  std::string visual;
+  const char* renderedText = resolveVisualText(text, visual, baseDir);
+
+  if (fontCacheManager_ && fontCacheManager_->isScanning()) {
+    fontCacheManager_->recordText(renderedText, primaryFontId, style);
+    return;
+  }
+
+  const auto primaryIt = fontMap.find(primaryFontId);
+  const auto fallbackIt = fontMap.find(fallbackFontId);
+  const auto sdIt = sdCardFonts_.find(fallbackFontId);
+  if (primaryIt == fontMap.end() || fallbackIt == fontMap.end() || sdIt == sdCardFonts_.end() || !sdIt->second) {
+    drawText(primaryFontId, x, y, renderedText, black, style, BidiUtils::BidiBaseDir::LTR);
+    return;
+  }
+
+  const auto& primaryFont = primaryIt->second;
+  const auto& fallbackFont = fallbackIt->second;
+  const auto* fallbackSdFont = sdIt->second;
+  const int yPos = y + getFontAscenderSize(primaryFontId);
+  int lastBaseX = x;
+  int lastBaseLeft = 0;
+  int lastBaseWidth = 0;
+  int lastBaseTop = 0;
+  int32_t prevAdvanceFP = 0;
+  uint32_t prevCp = 0;
+  int prevFontId = 0;
+
+  const char* textCursor = renderedText;
+  while (uint32_t cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&textCursor))) {
+    if (isHebrewNiqqud(cp)) {
+      continue;
+    }
+
+    const EpdFontFamily* font = &primaryFont;
+    int fontId = primaryFontId;
+    bool useFallback = false;
+
+    if (utf8IsCombiningMark(cp)) {
+      const EpdGlyph* combiningGlyph = font->getGlyph(cp, style);
+      if (!combiningGlyph) continue;
+      const int raiseBy = combiningMark::raiseAboveBase(combiningGlyph->top, combiningGlyph->height, lastBaseTop);
+      const int combiningX = combiningMark::centerOver(lastBaseX, lastBaseLeft, lastBaseWidth, combiningGlyph->left,
+                                                       combiningGlyph->width);
+      renderCharImpl<TextRotation::None>(*this, renderMode, *font, cp, combiningX, yPos - raiseBy, black, style);
+      continue;
+    }
+
+    if (primaryFont.hasGlyph(cp, style)) {
+      const char* ligatureCursor = textCursor;
+      const uint32_t ligatureCp = primaryFont.applyLigatures(cp, ligatureCursor, style);
+      if (ligatureCp != cp && primaryFont.hasGlyph(ligatureCp, style)) {
+        cp = ligatureCp;
+        textCursor = ligatureCursor;
+      }
+    } else if (fallbackSdFont->hasGlyph(cp, static_cast<uint8_t>(style))) {
+      font = &fallbackFont;
+      fontId = fallbackFontId;
+      useFallback = true;
+    }
+
+    if (prevCp != 0) {
+      const int kernFP = (prevFontId == fontId && !useFallback) ? font->getKerning(prevCp, cp, style) : 0;
+      lastBaseX += fp4::toPixel(prevAdvanceFP + kernFP);
+    }
+
+    const EpdGlyph* glyph = font->getGlyph(cp, style);
+    lastBaseLeft = glyph ? glyph->left : 0;
+    lastBaseWidth = glyph ? glyph->width : 0;
+    lastBaseTop = glyph ? glyph->top : 0;
+    prevAdvanceFP = glyph ? glyph->advanceX : 0;
+
+    const bool isSupSub = (style & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0;
+    if (isSupSub) {
+      prevAdvanceFP = (prevAdvanceFP + 1) / 2;
+      renderCharScaled(*this, renderMode, *font, cp, lastBaseX, yPos, black, style);
+    } else {
+      renderCharImpl<TextRotation::None>(*this, renderMode, *font, cp, lastBaseX, yPos, black, style);
+    }
+    prevCp = cp;
+    prevFontId = fontId;
   }
 }
 
@@ -1389,6 +1637,25 @@ std::string GfxRenderer::truncatedText(const int fontId, const char* text, const
   return item.empty() ? ellipsis : item + ellipsis;
 }
 
+std::string GfxRenderer::truncatedContentText(const int primaryFontId, const int fallbackFontId, const char* text,
+                                              const int maxWidth, const EpdFontFamily::Style style) const {
+  if (!text || maxWidth <= 0) return "";
+
+  std::string item = text;
+  const char* ellipsis = "\xe2\x80\xa6";
+  int textWidth = getContentTextWidth(primaryFontId, fallbackFontId, item.c_str(), style);
+  if (textWidth <= maxWidth) {
+    return item;
+  }
+
+  while (!item.empty() && getContentTextWidth(primaryFontId, fallbackFontId, (item + ellipsis).c_str(), style) >=
+                              maxWidth) {
+    utf8RemoveLastChar(item);
+  }
+
+  return item.empty() ? ellipsis : item + ellipsis;
+}
+
 std::vector<std::string> GfxRenderer::wrappedText(const int fontId, const char* text, const int maxWidth,
                                                   const int maxLines, const EpdFontFamily::Style style) const {
   std::vector<std::string> lines;
@@ -1441,6 +1708,62 @@ std::vector<std::string> GfxRenderer::wrappedText(const int fontId, const char* 
         // splitting rules (different between languages). Results in an aesthetically
         // pleasing end.
         lines.push_back(truncatedText(fontId, word.c_str(), maxWidth, style));
+        return lines;
+      }
+    }
+  }
+
+  if (!currentLine.empty() && static_cast<int>(lines.size()) < maxLines) {
+    lines.push_back(currentLine);
+  }
+
+  return lines;
+}
+
+std::vector<std::string> GfxRenderer::wrappedContentText(const int primaryFontId, const int fallbackFontId,
+                                                         const char* text, const int maxWidth, const int maxLines,
+                                                         const EpdFontFamily::Style style) const {
+  std::vector<std::string> lines;
+
+  if (!text || maxWidth <= 0 || maxLines <= 0) return lines;
+
+  std::string remaining = text;
+  std::string currentLine;
+
+  while (!remaining.empty()) {
+    if (static_cast<int>(lines.size()) == maxLines - 1) {
+      std::string lastContent = currentLine.empty() ? remaining : currentLine + " " + remaining;
+      lines.push_back(truncatedContentText(primaryFontId, fallbackFontId, lastContent.c_str(), maxWidth, style));
+      return lines;
+    }
+
+    size_t spacePos = remaining.find(' ');
+    std::string word;
+
+    if (spacePos == std::string::npos) {
+      word = remaining;
+      remaining.clear();
+    } else {
+      word = remaining.substr(0, spacePos);
+      remaining.erase(0, spacePos + 1);
+    }
+
+    std::string testLine = currentLine.empty() ? word : currentLine + " " + word;
+
+    if (getContentTextWidth(primaryFontId, fallbackFontId, testLine.c_str(), style) <= maxWidth) {
+      currentLine = testLine;
+    } else {
+      if (!currentLine.empty()) {
+        lines.push_back(currentLine);
+        if (getContentTextWidth(primaryFontId, fallbackFontId, word.c_str(), style) > maxWidth) {
+          lines.push_back(truncatedContentText(primaryFontId, fallbackFontId, word.c_str(), maxWidth, style));
+          currentLine.clear();
+          if (static_cast<int>(lines.size()) >= maxLines) return lines;
+        } else {
+          currentLine = word;
+        }
+      } else {
+        lines.push_back(truncatedContentText(primaryFontId, fallbackFontId, word.c_str(), maxWidth, style));
         return lines;
       }
     }

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -198,6 +198,22 @@ class GfxRenderer {
   void drawText(int fontId, int x, int y, const char* text, bool black = true,
                 EpdFontFamily::Style style = EpdFontFamily::REGULAR,
                 BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  bool contentTextNeedsFallback(int primaryFontId, int fallbackFontId, const char* text,
+                                EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                                BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  void prepareContentTextFallback(int primaryFontId, int fallbackFontId, const char* text,
+                                  EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                                  BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO,
+                                  bool prewarmBitmaps = true) const;
+  int getContentTextWidth(int primaryFontId, int fallbackFontId, const char* text,
+                          EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                          BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  void drawCenteredContentText(int primaryFontId, int fallbackFontId, int y, const char* text, bool black = true,
+                               EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                               BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
+  void drawContentText(int primaryFontId, int fallbackFontId, int x, int y, const char* text, bool black = true,
+                       EpdFontFamily::Style style = EpdFontFamily::REGULAR,
+                       BidiUtils::BidiBaseDir baseDir = BidiUtils::BidiBaseDir::AUTO) const;
   int getSpaceWidth(int fontId, EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// Returns the total inter-word advance: fp4::toPixel(spaceAdvance + kern(leftCp,' ') + kern(' ',rightCp)).
   /// Using a single snap avoids the +/-1 px rounding error that arises when space advance and kern are
@@ -210,11 +226,16 @@ class GfxRenderer {
   int getLineHeight(int fontId) const;
   std::string truncatedText(int fontId, const char* text, int maxWidth,
                             EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  std::string truncatedContentText(int primaryFontId, int fallbackFontId, const char* text, int maxWidth,
+                                   EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// Word-wrap \p text into at most \p maxLines lines, each no wider than
   /// \p maxWidth pixels. Overflowing words and excess lines are UTF-8-safely
   /// truncated with an ellipsis (U+2026).
   std::vector<std::string> wrappedText(int fontId, const char* text, int maxWidth, int maxLines,
                                        EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
+  std::vector<std::string> wrappedContentText(int primaryFontId, int fallbackFontId, const char* text, int maxWidth,
+                                              int maxLines,
+                                              EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
 
   // Helper for drawing rotated text (90 degrees clockwise, for side buttons)
   void drawTextRotated90CW(int fontId, int x, int y, const char* text, bool black = true,

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -10,6 +10,7 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
+#include "SdCardFontSystem.h"
 #include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -65,6 +66,7 @@ void FileBrowserActivity::loadFiles() {
 
 void FileBrowserActivity::onEnter() {
   Activity::onEnter();
+  sdFontSystem.ensureLoaded(renderer);
 
   fileNameBuffer = makeUniqueNoThrow<char[]>(NAME_BUFFER_SIZE);
   if (!fileNameBuffer) {
@@ -370,7 +372,7 @@ void FileBrowserActivity::render(RenderLock&&) {
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, files.size(), selectorIndex,
         [this](int index) { return getFileName(files[index]); }, nullptr,
         [this](int index) { return UITheme::getFileIcon(files[index]); },
-        [this](int index) { return getFileExtension(files[index]); }, false);
+        [this](int index) { return getFileExtension(files[index]); }, false, nullptr, true);
   }
 
   // Full path display

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -17,6 +17,7 @@
 #include "MappedInputManager.h"
 #include "OpdsServerStore.h"
 #include "RecentBooksStore.h"
+#include "SdCardFontSystem.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 
@@ -110,6 +111,7 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
 
 void HomeActivity::onEnter() {
   Activity::onEnter();
+  sdFontSystem.ensureLoaded(renderer);
 
   hasOpdsServers = OPDS_STORE.hasServers();
 
@@ -215,8 +217,10 @@ void HomeActivity::render(RenderLock&&) {
   renderer.clearScreen();
   bool bufferRestored = coverBufferStored && restoreCoverBuffer();
 
+  const bool headerTitleIsRecentBook = metrics.homeContinueReadingInMenu && !recentBooks.empty();
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.homeTopPadding},
-                 metrics.homeContinueReadingInMenu && !recentBooks.empty() ? recentBooks[0].title.c_str() : nullptr);
+                 headerTitleIsRecentBook ? recentBooks[0].title.c_str() : nullptr, nullptr,
+                 headerTitleIsRecentBook);
 
   // Record the tile rect so storeCoverBuffer (called from the theme) knows
   // which sub-region of the framebuffer to snapshot. ~16 KB in Portrait

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -9,6 +9,7 @@
 
 #include "MappedInputManager.h"
 #include "RecentBooksStore.h"
+#include "SdCardFontSystem.h"
 #include "activities/util/ConfirmationActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
@@ -22,6 +23,7 @@ void RecentBooksActivity::loadRecentBooks() { recentBooks = RECENT_BOOKS.getBook
 
 void RecentBooksActivity::onEnter() {
   Activity::onEnter();
+  sdFontSystem.ensureLoaded(renderer);
 
   // Prune entries whose backing files are gone; this is one of two interaction
   // points where the persistent store gets cleaned (the other is addBook).
@@ -140,7 +142,7 @@ void RecentBooksActivity::render(RenderLock&&) {
     GUI.drawList(
         renderer, Rect{0, contentTop, pageWidth, contentHeight}, recentBooks.size(), selectorIndex,
         [this](int index) { return recentBooks[index].title; }, [this](int index) { return recentBooks[index].author; },
-        [this](int index) { return UITheme::getFileIcon(recentBooks[index].path); });
+        [this](int index) { return UITheme::getFileIcon(recentBooks[index].path); }, nullptr, false, nullptr, true);
   }
 
   // Help text

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -260,7 +260,7 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowSubtitle,
                          const std::function<UIIcon(int index)>& rowIcon,
                          const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                         const std::function<bool(int index)>& rowDimmed) const {
+                         const std::function<bool(int index)>& rowDimmed, bool rowTextIsUserContent) const {
   int rowHeight =
       (rowSubtitle != nullptr) ? BaseMetrics::values.listWithSubtitleRowHeight : BaseMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
@@ -300,6 +300,26 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
   // Draw all items
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
+  const int contentFallbackFontId = rowTextIsUserContent ? SETTINGS.getReaderFontId() : 0;
+  if (rowTextIsUserContent) {
+    std::string titleText;
+    std::string subtitleText;
+    titleText.reserve(256);
+    subtitleText.reserve(256);
+    for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
+      titleText += rowTitle(i);
+      titleText += '\n';
+      if (rowSubtitle != nullptr) {
+        subtitleText += rowSubtitle(i);
+        subtitleText += '\n';
+      }
+    }
+    renderer.prepareContentTextFallback(UI_10_FONT_ID, contentFallbackFontId, titleText.c_str());
+    if (rowSubtitle != nullptr) {
+      renderer.prepareContentTextFallback(SMALL_FONT_ID, contentFallbackFontId, subtitleText.c_str());
+    }
+  }
+
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
 
@@ -317,12 +337,22 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
     auto itemName = rowTitle(i);
     auto font = UI_10_FONT_ID;
-    auto item = renderer.truncatedText(font, itemName.c_str(), rowTextWidth);
-    renderer.drawText(font, rect.x + BaseMetrics::values.contentSidePadding, itemY, item.c_str(), i != selectedIndex);
+    auto item = rowTextIsUserContent
+                    ? renderer.truncatedContentText(font, contentFallbackFontId, itemName.c_str(), rowTextWidth)
+                    : renderer.truncatedText(font, itemName.c_str(), rowTextWidth);
+    if (rowTextIsUserContent) {
+      renderer.drawContentText(font, contentFallbackFontId, rect.x + BaseMetrics::values.contentSidePadding, itemY,
+                               item.c_str(), i != selectedIndex);
+    } else {
+      renderer.drawText(font, rect.x + BaseMetrics::values.contentSidePadding, itemY, item.c_str(),
+                        i != selectedIndex);
+    }
 
     // Apply checkerboard dither to create gray text effect for dimmed items
     if (rowDimmed && rowDimmed(i) && i != selectedIndex) {
-      const int titleWidth = renderer.getTextWidth(font, item.c_str());
+      const int titleWidth = rowTextIsUserContent
+                                 ? renderer.getContentTextWidth(font, contentFallbackFontId, item.c_str())
+                                 : renderer.getTextWidth(font, item.c_str());
       const int lineH = renderer.getLineHeight(font);
       const int tx = rect.x + BaseMetrics::values.contentSidePadding;
       for (int py = itemY; py < itemY + lineH; py++)
@@ -333,9 +363,19 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     if (rowSubtitle != nullptr) {
       std::string subtitleText = rowSubtitle(i);
       if (!subtitleText.empty()) {
-        auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
-        renderer.drawText(SMALL_FONT_ID, rect.x + BaseMetrics::values.contentSidePadding, itemY + 22, subtitle.c_str(),
-                          i != selectedIndex);
+        auto subtitle =
+            rowTextIsUserContent
+                ? renderer.truncatedContentText(SMALL_FONT_ID, contentFallbackFontId, subtitleText.c_str(),
+                                                rowTextWidth)
+                : renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
+        if (rowTextIsUserContent) {
+          renderer.drawContentText(SMALL_FONT_ID, contentFallbackFontId,
+                                   rect.x + BaseMetrics::values.contentSidePadding, itemY + 22, subtitle.c_str(),
+                                   i != selectedIndex);
+        } else {
+          renderer.drawText(SMALL_FONT_ID, rect.x + BaseMetrics::values.contentSidePadding, itemY + 22,
+                            subtitle.c_str(), i != selectedIndex);
+        }
       }
     }
 
@@ -351,7 +391,8 @@ void BaseTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
   }
 }
 
-void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle) const {
+void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle,
+                           const bool titleIsUserContent) const {
   // Hide last battery draw
   constexpr int maxBatteryWidth = 80;
   renderer.fillRect(rect.x + rect.width - maxBatteryWidth, rect.y + 5, maxBatteryWidth,
@@ -367,10 +408,22 @@ void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
 
   if (title) {
     int padding = rect.width - batteryX + BaseMetrics::values.batteryWidth;
-    auto truncatedTitle = renderer.truncatedText(UI_12_FONT_ID, title,
-                                                 rect.width - padding * 2 - BaseMetrics::values.contentSidePadding * 2,
-                                                 EpdFontFamily::BOLD);
-    renderer.drawCenteredText(UI_12_FONT_ID, rect.y + 5, truncatedTitle.c_str(), true, EpdFontFamily::BOLD);
+    const int maxTitleWidth = rect.width - padding * 2 - BaseMetrics::values.contentSidePadding * 2;
+    const int contentFallbackFontId = titleIsUserContent ? SETTINGS.getReaderFontId() : 0;
+    if (titleIsUserContent) {
+      renderer.prepareContentTextFallback(UI_12_FONT_ID, contentFallbackFontId, title, EpdFontFamily::BOLD);
+    }
+    auto truncatedTitle =
+        titleIsUserContent
+            ? renderer.truncatedContentText(UI_12_FONT_ID, contentFallbackFontId, title, maxTitleWidth,
+                                            EpdFontFamily::BOLD)
+            : renderer.truncatedText(UI_12_FONT_ID, title, maxTitleWidth, EpdFontFamily::BOLD);
+    if (titleIsUserContent) {
+      renderer.drawCenteredContentText(UI_12_FONT_ID, contentFallbackFontId, rect.y + 5, truncatedTitle.c_str(), true,
+                                       EpdFontFamily::BOLD);
+    } else {
+      renderer.drawCenteredText(UI_12_FONT_ID, rect.y + 5, truncatedTitle.c_str(), true, EpdFontFamily::BOLD);
+    }
   }
 
   if (subtitle) {
@@ -577,12 +630,20 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
   if (hasContinueReading) {
     const std::string& lastBookTitle = recentBooks[0].title;
     const std::string& lastBookAuthor = recentBooks[0].author;
+    const int contentFallbackFontId = SETTINGS.getReaderFontId();
+    renderer.prepareContentTextFallback(UI_12_FONT_ID, contentFallbackFontId, lastBookTitle.c_str(),
+                                        EpdFontFamily::BOLD);
+    if (!lastBookAuthor.empty()) {
+      renderer.prepareContentTextFallback(UI_10_FONT_ID, contentFallbackFontId, lastBookAuthor.c_str());
+    }
 
     // Invert text colors based on selection state:
     // - With cover: selected = white text on black box, unselected = black text on white box
     // - Without cover: selected = white text on black card, unselected = black text on white card
 
-    auto lines = renderer.wrappedText(UI_12_FONT_ID, lastBookTitle.c_str(), bookWidth - 40, 3);
+    auto lines =
+        renderer.wrappedContentText(UI_12_FONT_ID, contentFallbackFontId, lastBookTitle.c_str(), bookWidth - 40, 3,
+                                    EpdFontFamily::BOLD);
 
     // Book title text
     int totalTextHeight = renderer.getLineHeight(UI_12_FONT_ID) * static_cast<int>(lines.size());
@@ -595,7 +656,8 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
 
     const auto truncatedAuthor = lastBookAuthor.empty()
                                      ? std::string{}
-                                     : renderer.truncatedText(UI_10_FONT_ID, lastBookAuthor.c_str(), bookWidth - 40);
+                                     : renderer.truncatedContentText(UI_10_FONT_ID, contentFallbackFontId,
+                                                                     lastBookAuthor.c_str(), bookWidth - 40);
 
     // If cover image was rendered, draw box behind title and author
     if (coverRendered) {
@@ -603,13 +665,15 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
       // Calculate the max text width for the box
       int maxTextWidth = 0;
       for (const auto& line : lines) {
-        const int lineWidth = renderer.getTextWidth(UI_12_FONT_ID, line.c_str());
+        const int lineWidth =
+            renderer.getContentTextWidth(UI_12_FONT_ID, contentFallbackFontId, line.c_str(), EpdFontFamily::BOLD);
         if (lineWidth > maxTextWidth) {
           maxTextWidth = lineWidth;
         }
       }
       if (!truncatedAuthor.empty()) {
-        const int authorWidth = renderer.getTextWidth(UI_10_FONT_ID, truncatedAuthor.c_str());
+        const int authorWidth = renderer.getContentTextWidth(UI_10_FONT_ID, contentFallbackFontId,
+                                                             truncatedAuthor.c_str());
         if (authorWidth > maxTextWidth) {
           maxTextWidth = authorWidth;
         }
@@ -627,13 +691,15 @@ void BaseTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
     }
 
     for (const auto& line : lines) {
-      renderer.drawCenteredText(UI_12_FONT_ID, titleYStart, line.c_str(), !bookSelected);
+      renderer.drawCenteredContentText(UI_12_FONT_ID, contentFallbackFontId, titleYStart, line.c_str(), !bookSelected,
+                                       EpdFontFamily::BOLD);
       titleYStart += renderer.getLineHeight(UI_12_FONT_ID);
     }
 
     if (!truncatedAuthor.empty()) {
       titleYStart += renderer.getLineHeight(UI_10_FONT_ID) / 2;
-      renderer.drawCenteredText(UI_10_FONT_ID, titleYStart, truncatedAuthor.c_str(), !bookSelected);
+      renderer.drawCenteredContentText(UI_10_FONT_ID, contentFallbackFontId, titleYStart, truncatedAuthor.c_str(),
+                                       !bookSelected);
     }
 
     // "Continue Reading" label at the bottom

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -218,9 +218,10 @@ class BaseTheme {
                         const std::function<std::string(int index)>& rowSubtitle = nullptr,
                         const std::function<UIIcon(int index)>& rowIcon = nullptr,
                         const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
-                        const std::function<bool(int index)>& rowDimmed = nullptr) const;
+                        const std::function<bool(int index)>& rowDimmed = nullptr,
+                        bool rowTextIsUserContent = false) const;
   virtual void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
-                          const char* subtitle = nullptr) const;
+                          const char* subtitle = nullptr, bool titleIsUserContent = false) const;
   virtual void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,
                              const char* rightLabel = nullptr) const;
   virtual void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,

--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -87,8 +87,12 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
       int tileX = Lyra3CoversMetrics::values.contentSidePadding + tileWidth * i;
 
       const int maxLineWidth = tileWidth - 2 * hPaddingInSelection;
+      const int contentFallbackFontId = SETTINGS.getReaderFontId();
+      renderer.prepareContentTextFallback(SMALL_FONT_ID, contentFallbackFontId, recentBooks[i].title.c_str());
 
-      auto titleLines = renderer.wrappedText(SMALL_FONT_ID, recentBooks[i].title.c_str(), maxLineWidth, 3);
+      auto titleLines =
+          renderer.wrappedContentText(SMALL_FONT_ID, contentFallbackFontId, recentBooks[i].title.c_str(), maxLineWidth,
+                                      3);
 
       const int titleLineHeight = renderer.getLineHeight(SMALL_FONT_ID);
       const int dynamicBlockHeight = static_cast<int>(titleLines.size()) * titleLineHeight;
@@ -110,7 +114,8 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
 
       int currentY = tileY + Lyra3CoversMetrics::values.homeCoverHeight + hPaddingInSelection + 5;
       for (const auto& line : titleLines) {
-        renderer.drawText(SMALL_FONT_ID, tileX + hPaddingInSelection, currentY, line.c_str(), true);
+        renderer.drawContentText(SMALL_FONT_ID, contentFallbackFontId, tileX + hPaddingInSelection, currentY,
+                                 line.c_str(), true);
         currentY += titleLineHeight;
       }
     }

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -104,7 +104,8 @@ void LyraTheme::fillBatteryIcon(const GfxRenderer& renderer, Rect rect, uint16_t
   }
 }
 
-void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle) const {
+void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle,
+                           const bool titleIsUserContent) const {
   renderer.fillRect(rect.x, rect.y, rect.width, rect.height, false);
 
   const bool showBatteryPercentage =
@@ -115,7 +116,18 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
                    Rect{batteryX, rect.y + 5, LyraMetrics::values.batteryWidth, LyraMetrics::values.batteryHeight},
                    showBatteryPercentage);
 
-  int maxTitleWidth = title != nullptr ? renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD) : 0;
+  const int contentFallbackFontId = titleIsUserContent ? SETTINGS.getReaderFontId() : 0;
+  if (titleIsUserContent && title != nullptr) {
+    renderer.prepareContentTextFallback(UI_12_FONT_ID, contentFallbackFontId, title, EpdFontFamily::BOLD);
+  }
+
+  int maxTitleWidth = 0;
+  if (title != nullptr) {
+    maxTitleWidth = titleIsUserContent
+                        ? renderer.getContentTextWidth(UI_12_FONT_ID, contentFallbackFontId, title,
+                                                       EpdFontFamily::BOLD)
+                        : renderer.getTextWidth(UI_12_FONT_ID, title, EpdFontFamily::BOLD);
+  }
   int maxSubtitleWidth =
       subtitle != nullptr ? renderer.getTextWidth(SMALL_FONT_ID, subtitle, EpdFontFamily::REGULAR) : 0;
 
@@ -138,10 +150,20 @@ void LyraTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
   }
 
   if (title) {
-    auto truncatedTitle = renderer.truncatedText(UI_12_FONT_ID, title, maxTitleWidth, EpdFontFamily::BOLD);
-    renderer.drawText(UI_12_FONT_ID, rect.x + LyraMetrics::values.contentSidePadding,
-                      rect.y + LyraMetrics::values.batteryBarHeight + 3, truncatedTitle.c_str(), true,
-                      EpdFontFamily::BOLD);
+    auto truncatedTitle =
+        titleIsUserContent
+            ? renderer.truncatedContentText(UI_12_FONT_ID, contentFallbackFontId, title, maxTitleWidth,
+                                            EpdFontFamily::BOLD)
+            : renderer.truncatedText(UI_12_FONT_ID, title, maxTitleWidth, EpdFontFamily::BOLD);
+    if (titleIsUserContent) {
+      renderer.drawContentText(UI_12_FONT_ID, contentFallbackFontId, rect.x + LyraMetrics::values.contentSidePadding,
+                               rect.y + LyraMetrics::values.batteryBarHeight + 3, truncatedTitle.c_str(), true,
+                               EpdFontFamily::BOLD);
+    } else {
+      renderer.drawText(UI_12_FONT_ID, rect.x + LyraMetrics::values.contentSidePadding,
+                        rect.y + LyraMetrics::values.batteryBarHeight + 3, truncatedTitle.c_str(), true,
+                        EpdFontFamily::BOLD);
+    }
     renderer.drawLine(rect.x, rect.y + rect.height - 3, rect.x + rect.width - 1, rect.y + rect.height - 3, 3, true);
   }
 
@@ -215,7 +237,7 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
                          const std::function<std::string(int index)>& rowSubtitle,
                          const std::function<UIIcon(int index)>& rowIcon,
                          const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                         const std::function<bool(int index)>& rowDimmed) const {
+                         const std::function<bool(int index)>& rowDimmed, bool rowTextIsUserContent) const {
   int rowHeight =
       (rowSubtitle != nullptr) ? LyraMetrics::values.listWithSubtitleRowHeight : LyraMetrics::values.listRowHeight;
   int pageItems = rect.height / rowHeight;
@@ -255,6 +277,25 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
 
   // Draw all items
   const auto pageStartIndex = selectedIndex / pageItems * pageItems;
+  const int contentFallbackFontId = rowTextIsUserContent ? SETTINGS.getReaderFontId() : 0;
+  if (rowTextIsUserContent) {
+    std::string titleText;
+    std::string subtitleText;
+    titleText.reserve(256);
+    subtitleText.reserve(256);
+    for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
+      titleText += rowTitle(i);
+      titleText += '\n';
+      if (rowSubtitle != nullptr) {
+        subtitleText += rowSubtitle(i);
+        subtitleText += '\n';
+      }
+    }
+    renderer.prepareContentTextFallback(UI_10_FONT_ID, contentFallbackFontId, titleText.c_str());
+    if (rowSubtitle != nullptr) {
+      renderer.prepareContentTextFallback(SMALL_FONT_ID, contentFallbackFontId, subtitleText.c_str());
+    }
+  }
   int iconY = (rowSubtitle != nullptr) ? 16 : 10;
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int itemY = rect.y + (i % pageItems) * rowHeight;
@@ -271,12 +312,21 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     }
 
     auto itemName = rowTitle(i);
-    auto item = renderer.truncatedText(UI_10_FONT_ID, itemName.c_str(), rowTextWidth);
-    renderer.drawText(UI_10_FONT_ID, textX, itemY + 7, item.c_str(), true);
+    auto item = rowTextIsUserContent
+                    ? renderer.truncatedContentText(UI_10_FONT_ID, contentFallbackFontId, itemName.c_str(),
+                                                    rowTextWidth)
+                    : renderer.truncatedText(UI_10_FONT_ID, itemName.c_str(), rowTextWidth);
+    if (rowTextIsUserContent) {
+      renderer.drawContentText(UI_10_FONT_ID, contentFallbackFontId, textX, itemY + 7, item.c_str(), true);
+    } else {
+      renderer.drawText(UI_10_FONT_ID, textX, itemY + 7, item.c_str(), true);
+    }
 
     // Apply checkerboard dither to create gray text effect for dimmed items
     if (rowDimmed && rowDimmed(i) && i != selectedIndex) {
-      const int titleWidth = renderer.getTextWidth(UI_10_FONT_ID, item.c_str());
+      const int titleWidth = rowTextIsUserContent
+                                 ? renderer.getContentTextWidth(UI_10_FONT_ID, contentFallbackFontId, item.c_str())
+                                 : renderer.getTextWidth(UI_10_FONT_ID, item.c_str());
       const int lineH = renderer.getLineHeight(UI_10_FONT_ID);
       for (int py = itemY + 7; py < itemY + 7 + lineH; py++)
         for (int px = textX; px < textX + titleWidth; px++)
@@ -295,8 +345,15 @@ void LyraTheme::drawList(const GfxRenderer& renderer, Rect rect, int itemCount, 
     if (rowSubtitle != nullptr) {
       // Draw subtitle
       std::string subtitleText = rowSubtitle(i);
-      auto subtitle = renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
-      renderer.drawText(SMALL_FONT_ID, textX, itemY + 30, subtitle.c_str(), true);
+      auto subtitle =
+          rowTextIsUserContent
+              ? renderer.truncatedContentText(SMALL_FONT_ID, contentFallbackFontId, subtitleText.c_str(), rowTextWidth)
+              : renderer.truncatedText(SMALL_FONT_ID, subtitleText.c_str(), rowTextWidth);
+      if (rowTextIsUserContent) {
+        renderer.drawContentText(SMALL_FONT_ID, contentFallbackFontId, textX, itemY + 30, subtitle.c_str(), true);
+      } else {
+        renderer.drawText(SMALL_FONT_ID, textX, itemY + 30, subtitle.c_str(), true);
+      }
     }
 
     // Draw value
@@ -479,9 +536,17 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
                                hPaddingInSelection, cornerRadius, false, false, true, true, Color::LightGray);
     }
 
-    auto titleLines = renderer.wrappedText(UI_12_FONT_ID, book.title.c_str(), textWidth, 3, EpdFontFamily::BOLD);
+    const int contentFallbackFontId = SETTINGS.getReaderFontId();
+    renderer.prepareContentTextFallback(UI_12_FONT_ID, contentFallbackFontId, book.title.c_str(),
+                                        EpdFontFamily::BOLD);
+    if (!book.author.empty()) {
+      renderer.prepareContentTextFallback(UI_10_FONT_ID, contentFallbackFontId, book.author.c_str());
+    }
+    auto titleLines =
+        renderer.wrappedContentText(UI_12_FONT_ID, contentFallbackFontId, book.title.c_str(), textWidth, 3,
+                                    EpdFontFamily::BOLD);
 
-    auto author = renderer.truncatedText(UI_10_FONT_ID, book.author.c_str(), textWidth);
+    auto author = renderer.truncatedContentText(UI_10_FONT_ID, contentFallbackFontId, book.author.c_str(), textWidth);
     const int titleLineHeight = renderer.getLineHeight(UI_12_FONT_ID);
     const int titleBlockHeight = titleLineHeight * static_cast<int>(titleLines.size());
     const int authorHeight = book.author.empty() ? 0 : (renderer.getLineHeight(UI_10_FONT_ID) * 3 / 2);
@@ -489,12 +554,13 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
     int titleY = tileY + tileHeight / 2 - totalBlockHeight / 2;
     const int textX = tileX + hPaddingInSelection + coverWidth + LyraMetrics::values.verticalSpacing;
     for (const auto& line : titleLines) {
-      renderer.drawText(UI_12_FONT_ID, textX, titleY, line.c_str(), true, EpdFontFamily::BOLD);
+      renderer.drawContentText(UI_12_FONT_ID, contentFallbackFontId, textX, titleY, line.c_str(), true,
+                               EpdFontFamily::BOLD);
       titleY += titleLineHeight;
     }
     if (!book.author.empty()) {
       titleY += renderer.getLineHeight(UI_10_FONT_ID) / 2;
-      renderer.drawText(UI_10_FONT_ID, textX, titleY, author.c_str(), true);
+      renderer.drawContentText(UI_10_FONT_ID, contentFallbackFontId, textX, titleY, author.c_str(), true);
     }
   } else {
     drawEmptyRecents(renderer, rect);

--- a/src/components/themes/lyra/LyraTheme.h
+++ b/src/components/themes/lyra/LyraTheme.h
@@ -87,7 +87,8 @@ class LyraTheme : public BaseTheme {
  public:
   // Component drawing methods
   void fillBatteryIcon(const GfxRenderer& renderer, Rect rect, uint16_t percentage) const override;
-  void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle) const override;
+  void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title, const char* subtitle,
+                  bool titleIsUserContent = false) const override;
   void drawSubHeader(const GfxRenderer& renderer, Rect rect, const char* label,
                      const char* rightLabel = nullptr) const override;
   void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,
@@ -97,7 +98,8 @@ class LyraTheme : public BaseTheme {
                 const std::function<std::string(int index)>& rowTitle,
                 const std::function<std::string(int index)>& rowSubtitle,
                 const std::function<UIIcon(int index)>& rowIcon, const std::function<std::string(int index)>& rowValue,
-                bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr) const override;
+                bool highlightValue, const std::function<bool(int index)>& rowDimmed = nullptr,
+                bool rowTextIsUserContent = false) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                        const char* btn4) const override;
   void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const override;

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -47,7 +47,7 @@ void drawScrollBar(const GfxRenderer& renderer, Rect rect, int itemCount, int pa
 int coverWidth = 0;
 
 void RoundedRaffTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
-                                  const char* subtitle) const {
+                                  const char* subtitle, const bool titleIsUserContent) const {
   (void)subtitle;
   // Home screen header is custom-rendered in drawRecentBookCover.
   if (title == nullptr) {
@@ -74,8 +74,21 @@ void RoundedRaffTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const 
   }
 
   const int maxTitleWidth = std::max(0, batteryGroupLeftX - 20 - titleX);
-  auto headerTitle = renderer.truncatedText(kTitleFontId, title, maxTitleWidth, EpdFontFamily::BOLD);
-  renderer.drawText(kTitleFontId, titleX, titleY, headerTitle.c_str(), true, EpdFontFamily::BOLD);
+  const int contentFallbackFontId = titleIsUserContent ? SETTINGS.getReaderFontId() : 0;
+  if (titleIsUserContent) {
+    renderer.prepareContentTextFallback(kTitleFontId, contentFallbackFontId, title, EpdFontFamily::BOLD);
+  }
+  auto headerTitle =
+      titleIsUserContent
+          ? renderer.truncatedContentText(kTitleFontId, contentFallbackFontId, title, maxTitleWidth,
+                                          EpdFontFamily::BOLD)
+          : renderer.truncatedText(kTitleFontId, title, maxTitleWidth, EpdFontFamily::BOLD);
+  if (titleIsUserContent) {
+    renderer.drawContentText(kTitleFontId, contentFallbackFontId, titleX, titleY, headerTitle.c_str(), true,
+                             EpdFontFamily::BOLD);
+  } else {
+    renderer.drawText(kTitleFontId, titleX, titleY, headerTitle.c_str(), true, EpdFontFamily::BOLD);
+  }
   drawBatteryRight(renderer,
                    Rect{batteryIconX, rect.y + 14, RoundedRaffMetrics::values.batteryWidth,
                         RoundedRaffMetrics::values.batteryHeight},
@@ -306,7 +319,7 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
                                 const std::function<std::string(int index)>& rowSubtitle,
                                 const std::function<UIIcon(int index)>& rowIcon,
                                 const std::function<std::string(int index)>& rowValue, bool highlightValue,
-                                const std::function<bool(int index)>& rowDimmed) const {
+                                const std::function<bool(int index)>& rowDimmed, bool rowTextIsUserContent) const {
   (void)rowIcon;
   (void)highlightValue;
   (void)rowDimmed;
@@ -326,6 +339,26 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
   const int sidePadding = RoundedRaffMetrics::values.contentSidePadding;
   const int rowX = rect.x + sidePadding;
   const int rowWidth = rect.width - sidePadding * 2;
+  const int contentFallbackFontId = rowTextIsUserContent ? SETTINGS.getReaderFontId() : 0;
+  if (rowTextIsUserContent) {
+    std::string titleText;
+    std::string subtitleText;
+    titleText.reserve(256);
+    subtitleText.reserve(256);
+    for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
+      titleText += rowTitle(i);
+      titleText += '\n';
+      if (hasSubtitle) {
+        subtitleText += rowSubtitle(i);
+        subtitleText += '\n';
+      }
+    }
+    renderer.prepareContentTextFallback(kTitleFontId, contentFallbackFontId, titleText.c_str(),
+                                        EpdFontFamily::BOLD);
+    if (hasSubtitle) {
+      renderer.prepareContentTextFallback(kSubtitleFontId, contentFallbackFontId, subtitleText.c_str());
+    }
+  }
 
   for (int i = pageStartIndex; i < itemCount && i < pageStartIndex + pageItems; i++) {
     const int rowY = rect.y + (i % pageItems) * rowStep;
@@ -353,28 +386,57 @@ void RoundedRaffTheme::drawList(const GfxRenderer& renderer, Rect rect, int item
 
     if (hasSubtitle) {
       const std::string subtitleRaw = rowSubtitle(i);
-      auto title = renderer.truncatedText(kTitleFontId, rowTitle(i).c_str(), textAreaWidth, EpdFontFamily::BOLD);
+      auto title =
+          rowTextIsUserContent
+              ? renderer.truncatedContentText(kTitleFontId, contentFallbackFontId, rowTitle(i).c_str(), textAreaWidth,
+                                              EpdFontFamily::BOLD)
+              : renderer.truncatedText(kTitleFontId, rowTitle(i).c_str(), textAreaWidth, EpdFontFamily::BOLD);
 
       if (subtitleRaw.empty()) {
         // If there is no subtitle/author, center title vertically in the full row.
         const int centeredTitleY = rowY + (rowHeight - titleLineHeight) / 2;
-        renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX, centeredTitleY, title.c_str(), !isSelected,
-                          EpdFontFamily::BOLD);
+        if (rowTextIsUserContent) {
+          renderer.drawContentText(kTitleFontId, contentFallbackFontId, rowX + kInteractiveInsetX, centeredTitleY,
+                                   title.c_str(), !isSelected, EpdFontFamily::BOLD);
+        } else {
+          renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX, centeredTitleY, title.c_str(), !isSelected,
+                            EpdFontFamily::BOLD);
+        }
       } else {
         const int titleY = rowY + subtitleTopPadding;
         const int subtitleY = titleY + titleLineHeight + subtitleInterLineGap;
         auto subtitle =
-            renderer.truncatedText(kSubtitleFontId, subtitleRaw.c_str(), textAreaWidth, EpdFontFamily::REGULAR);
-        renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX, titleY, title.c_str(), !isSelected,
-                          EpdFontFamily::BOLD);
-        renderer.drawText(kSubtitleFontId, rowX + kInteractiveInsetX, subtitleY, subtitle.c_str(), !isSelected,
-                          EpdFontFamily::REGULAR);
+            rowTextIsUserContent
+                ? renderer.truncatedContentText(kSubtitleFontId, contentFallbackFontId, subtitleRaw.c_str(),
+                                                textAreaWidth, EpdFontFamily::REGULAR)
+                : renderer.truncatedText(kSubtitleFontId, subtitleRaw.c_str(), textAreaWidth,
+                                         EpdFontFamily::REGULAR);
+        if (rowTextIsUserContent) {
+          renderer.drawContentText(kTitleFontId, contentFallbackFontId, rowX + kInteractiveInsetX, titleY,
+                                   title.c_str(), !isSelected, EpdFontFamily::BOLD);
+          renderer.drawContentText(kSubtitleFontId, contentFallbackFontId, rowX + kInteractiveInsetX, subtitleY,
+                                   subtitle.c_str(), !isSelected, EpdFontFamily::REGULAR);
+        } else {
+          renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX, titleY, title.c_str(), !isSelected,
+                            EpdFontFamily::BOLD);
+          renderer.drawText(kSubtitleFontId, rowX + kInteractiveInsetX, subtitleY, subtitle.c_str(), !isSelected,
+                            EpdFontFamily::REGULAR);
+        }
       }
     } else {
-      auto title = renderer.truncatedText(kTitleFontId, rowTitle(i).c_str(), textAreaWidth, EpdFontFamily::BOLD);
-      renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX,
-                        rowY + (rowHeight - renderer.getLineHeight(kTitleFontId)) / 2, title.c_str(), !isSelected,
-                        EpdFontFamily::BOLD);
+      auto title =
+          rowTextIsUserContent
+              ? renderer.truncatedContentText(kTitleFontId, contentFallbackFontId, rowTitle(i).c_str(), textAreaWidth,
+                                              EpdFontFamily::BOLD)
+              : renderer.truncatedText(kTitleFontId, rowTitle(i).c_str(), textAreaWidth, EpdFontFamily::BOLD);
+      const int titleY = rowY + (rowHeight - renderer.getLineHeight(kTitleFontId)) / 2;
+      if (rowTextIsUserContent) {
+        renderer.drawContentText(kTitleFontId, contentFallbackFontId, rowX + kInteractiveInsetX, titleY,
+                                 title.c_str(), !isSelected, EpdFontFamily::BOLD);
+      } else {
+        renderer.drawText(kTitleFontId, rowX + kInteractiveInsetX, titleY, title.c_str(), !isSelected,
+                          EpdFontFamily::BOLD);
+      }
     }
   }
 

--- a/src/components/themes/roundedraff/RoundedRaffTheme.h
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.h
@@ -86,7 +86,7 @@ constexpr ThemeMetrics values = {.batteryWidth = 15,
 class RoundedRaffTheme : public BaseTheme {
  public:
   void drawHeader(const GfxRenderer& renderer, Rect rect, const char* title,
-                  const char* subtitle = nullptr) const override;
+                  const char* subtitle = nullptr, bool titleIsUserContent = false) const override;
   void drawTabBar(const GfxRenderer& renderer, Rect rect, const std::vector<TabInfo>& tabs,
                   bool selected) const override;
   void drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std::vector<RecentBook>& recentBooks,
@@ -105,7 +105,8 @@ class RoundedRaffTheme : public BaseTheme {
                 const std::function<std::string(int index)>& rowSubtitle = nullptr,
                 const std::function<UIIcon(int index)>& rowIcon = nullptr,
                 const std::function<std::string(int index)>& rowValue = nullptr, bool highlightValue = false,
-                const std::function<bool(int index)>& rowDimmed = nullptr) const override;
+                const std::function<bool(int index)>& rowDimmed = nullptr,
+                bool rowTextIsUserContent = false) const override;
   void drawButtonHints(GfxRenderer& renderer, const char* btn1, const char* btn2, const char* btn3,
                        const char* btn4) const override;
   bool homeMenuShowsContinueReading() const { return true; }

--- a/test/differential_rounding/DifferentialRoundingTest.cpp
+++ b/test/differential_rounding/DifferentialRoundingTest.cpp
@@ -5,6 +5,7 @@
 
 #include "lib/EpdFont/EpdFont.h"
 #include "lib/EpdFont/EpdFontData.h"
+#include "lib/Utf8/Utf8.h"
 
 // ============================================================================
 // Synthetic test font
@@ -76,10 +77,51 @@ const EpdFontData kTestFontData = {
   .glyphMissHandler  = nullptr,
   .glyphMissCtx      = nullptr,
 };
+
+const EpdGlyph kReplacementGlyphs[] = {
+  // idx  width  height  advanceX  left  top  dataLength  dataOffset
+  /* 0 'A'    */ { 6, 8, 112, 0, 8, 0, 0 },
+  /* 1 U+FFFD */ { 7, 8, 128, 0, 8, 0, 0 },
+};
+
+const EpdUnicodeInterval kReplacementIntervals[] = {
+  { 0x41, 0x41, 0 },                          // 'A' -> glyph[0]
+  { REPLACEMENT_GLYPH, REPLACEMENT_GLYPH, 1 }, // U+FFFD -> glyph[1]
+};
+
+const EpdFontData kReplacementFontData = {
+  .bitmap            = nullptr,
+  .glyph             = kReplacementGlyphs,
+  .intervals         = kReplacementIntervals,
+  .intervalCount     = 2,
+  .advanceY          = 16,
+  .ascender          = 12,
+  .descender         = 0,
+  .is2Bit            = false,
+  .groups            = nullptr,
+  .groupCount        = 0,
+  .glyphToGroup      = nullptr,
+  .kernLeftClasses   = nullptr,
+  .kernRightClasses  = nullptr,
+  .kernMatrix        = nullptr,
+  .kernLeftEntryCount  = 0,
+  .kernRightEntryCount = 0,
+  .kernLeftClassCount  = 0,
+  .kernRightClassCount = 0,
+  .ligaturePairs     = nullptr,
+  .ligaturePairCount = 0,
+  .glyphMissHandler  = nullptr,
+  .glyphMissCtx      = nullptr,
+};
 // clang-format on
 
 EpdFont& testFont() {
   static EpdFont font(&kTestFontData);
+  return font;
+}
+
+EpdFont& replacementFont() {
+  static EpdFont font(&kReplacementFontData);
   return font;
 }
 
@@ -189,6 +231,19 @@ TEST(EpdFont, GlyphLookup) {
   // No U+FFFD in font, so unknown codepoints return nullptr
   EXPECT_EQ(testFont().getGlyph('Z'), nullptr);
   EXPECT_EQ(testFont().getGlyph('b'), nullptr);
+}
+
+TEST(EpdFont, HasGlyphIgnoresReplacementFallback) {
+  ASSERT_NE(replacementFont().getGlyph('A'), nullptr);
+  ASSERT_NE(replacementFont().getGlyph(REPLACEMENT_GLYPH), nullptr);
+
+  EXPECT_TRUE(replacementFont().hasGlyph('A'));
+  EXPECT_TRUE(replacementFont().hasGlyph(REPLACEMENT_GLYPH));
+  EXPECT_FALSE(replacementFont().hasGlyph(0xAC00));  // Hangul syllable "ga".
+  EXPECT_FALSE(replacementFont().hasGlyph(0xD55C));  // Hangul syllable "han".
+
+  EXPECT_EQ(replacementFont().getGlyph(0xAC00), replacementFont().getGlyph(REPLACEMENT_GLYPH));
+  EXPECT_EQ(replacementFont().getGlyph(0xD55C), replacementFont().getGlyph(REPLACEMENT_GLYPH));
 }
 
 // Known-value regression tests.  Expected widths are computed by hand using


### PR DESCRIPTION
## Summary

Fixes missing CJK/Korean glyph rendering for book titles and file names by using the selected SD-card reader font as a glyph fallback only for user-content text.

I'm aware that Korean-specific firmware builds exist, but I'd like to keep using the original upstream CrossPoint firmware and only have user-content titles and file names render correctly when an SD-card font contains the needed glyphs. This keeps the UI and firmware behavior upstream-compatible while fixing missing title glyphs for Korean/CJK users.

## Problem

Reader content can render Korean correctly when an SD `.cpfont` is selected, but Home, Recent Books, and File Browser titles are rendered with built-in UI fonts. Those fonts may not contain Hangul/CJK glyphs, so titles can appear blank or as replacement glyphs.

## Approach

- Keep built-in UI fonts as the primary UI font.
- Add exact glyph coverage checks that do not treat U+FFFD replacement fallback as a real glyph.
- Use the selected SD-card font only for missing glyphs in user-content strings.
- Apply fallback to Home recent titles, Recent Books list title/author, and File Browser names.
- Keep UI labels, settings, menus, and other application text unchanged.
- Use the same fallback rule for measurement, truncation/wrapping, and drawing.

## Validation

- `git diff --check`
- `pio check -e default`
- `pio run -t unit-tests` - 86/86 tests passed
- `pio run -e default` - firmware build succeeded

A local firmware build was produced for validation only. No device flashing, unlock/re-lock, partition changes, or OTA install were performed.
