### PR TITLE
fix: run OTA check and install at boot to give TLS enough heap (#2570)

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -77,6 +77,10 @@ void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
+void HalDisplay::releaseBuffers() { einkDisplay.releaseBuffers(); }
+
+bool HalDisplay::reallocBuffers() { return einkDisplay.reallocBuffers(); }
+
 void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer) {
   einkDisplay.copyGrayscaleBuffers(lsbBuffer, msbBuffer);
 }

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -47,6 +47,13 @@ class HalDisplay {
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 
+  // Hand the framebuffer heap back to the system while the panel keeps
+  // showing its last refresh (e-ink retains the image unpowered). Rendering
+  // is unavailable until reallocBuffers() succeeds again. Used by the
+  // boot-time OTA download, which needs every contiguous block it can get.
+  void releaseBuffers();
+  bool reallocBuffers();
+
   // X3 grayscale preconditioning (OEM "AA-pre-BW(mid)" settle pass), windowed
   // to the gray region in physical panel coordinates (no-arg = full frame).
   // Call after the BW base frame is displayed and before the grayscale planes

--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -9,7 +9,22 @@
 #include "activities/network/WifiSelectionActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
-#include "network/OtaUpdater.h"
+#include "network/OtaBootCheck.h"
+
+void OtaUpdateActivity::consumeBootResult(const OtaBootCheck::Result& result) {
+  {
+    RenderLock lock(*this);
+    if (result.error == OtaUpdater::OK) {
+      updater.adoptManifest(result.version, result.url, result.size);
+      state = updater.isUpdateNewer() ? WAITING_CONFIRMATION : NO_UPDATE;
+    } else if (result.error == OtaUpdater::NO_UPDATE) {
+      state = NO_UPDATE;
+    } else {
+      state = FAILED;
+    }
+  }
+  requestUpdate(true);
+}
 
 void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
   if (!success) {
@@ -18,48 +33,35 @@ void OtaUpdateActivity::onWifiSelectionComplete(const bool success) {
     return;
   }
 
-  LOG_DBG("OTA", "WiFi connected, checking for update");
-
-  {
-    RenderLock lock(*this);
-    state = CHECKING_FOR_UPDATE;
-  }
-  requestUpdateAndWait();
-
-  const auto res = updater.checkForUpdate();
-  if (res != OtaUpdater::OK) {
-    LOG_DBG("OTA", "Update check failed: %d", res);
-    {
-      RenderLock lock(*this);
-      state = FAILED;
-    }
-    return;
-  }
-
-  if (!updater.isUpdateNewer()) {
-    LOG_DBG("OTA", "No new update available");
-    {
-      RenderLock lock(*this);
-      state = NO_UPDATE;
-    }
-    return;
-  }
-
-  {
-    RenderLock lock(*this);
-    state = WAITING_CONFIRMATION;
-  }
+  // The selection saved the credential; the boot stage reconnects with it.
+  OtaBootCheck::requestCheck();
 }
 
 void OtaUpdateActivity::onEnter() {
   Activity::onEnter();
 
-  // Turn on WiFi immediately
-  LOG_DBG("OTA", "Turning on WiFi...");
-  WiFi.mode(WIFI_STA);
+  // Landing here after a boot-time stage: show its outcome.
+  if (const auto* bootResult = OtaBootCheck::takeResult()) {
+    LOG_DBG("OTA", "Consuming boot stage result: error=%d", static_cast<int>(bootResult->error));
+    consumeBootResult(*bootResult);
+    return;
+  }
 
-  // Launch WiFi selection subactivity
-  LOG_DBG("OTA", "Launching WifiSelectionActivity...");
+  // Fresh entry from Settings: hand the check to the next boot, where the TLS
+  // handshake has enough heap. Needs a saved credential to reconnect with.
+  if (OtaBootCheck::canAutoConnect()) {
+    {
+      RenderLock lock(*this);
+      state = CHECKING_FOR_UPDATE;
+    }
+    requestUpdateAndWait();
+    OtaBootCheck::requestCheck();  // does not return
+    return;
+  }
+
+  // No saved network yet: run the selection UI once to capture a credential.
+  LOG_DBG("OTA", "No saved WiFi network, launching WifiSelectionActivity");
+  WiFi.mode(WIFI_STA);
   startActivityForResult(std::make_unique<WifiSelectionActivity>(renderer, mappedInput),
                          [this](const ActivityResult& result) { onWifiSelectionComplete(!result.isCancelled); });
 }
@@ -67,10 +69,9 @@ void OtaUpdateActivity::onEnter() {
 void OtaUpdateActivity::onExit() {
   Activity::onExit();
 
-  // Success path reboots via the SHUTTING_DOWN state's plain ESP.restart()
-  // (loop() above) so the new firmware boots normally. Back-out paths land
-  // here with wifi still active; silent-restart to free the LWIP/mbedTLS
-  // fragmentation, same as the other wifi activities.
+  // Only the credential-capture path turns WiFi on in this activity; the boot
+  // stages tear their connection down themselves. Silent-restart to free the
+  // LWIP/TLS fragmentation, same as the other wifi activities.
   if (WiFi.getMode() != WIFI_MODE_NULL) {
     WiFi.disconnect(false);
     delay(30);
@@ -89,17 +90,6 @@ void OtaUpdateActivity::render(RenderLock&&) {
   const auto height = renderer.getLineHeight(UI_10_FONT_ID);
   const auto top = (pageHeight - height) / 2;
 
-  float updaterProgress = 0;
-  if (state == UPDATE_IN_PROGRESS) {
-    LOG_DBG("OTA", "Update progress: %d / %d", updater.getProcessedSize(), updater.getTotalSize());
-    updaterProgress = static_cast<float>(updater.getProcessedSize()) / static_cast<float>(updater.getTotalSize());
-    // Only update every 2% at the most
-    if (static_cast<int>(updaterProgress * 50) == lastUpdaterPercentage / 2) {
-      return;
-    }
-    lastUpdaterPercentage = static_cast<int>(updaterProgress * 100);
-  }
-
   if (state == CHECKING_FOR_UPDATE) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_CHECKING_UPDATE));
   } else if (state == WAITING_CONFIRMATION) {
@@ -111,22 +101,6 @@ void OtaUpdateActivity::render(RenderLock&&) {
 
     const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-  } else if (state == UPDATE_IN_PROGRESS) {
-    renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_UPDATING));
-
-    int y = top + height + metrics.verticalSpacing;
-    GUI.drawProgressBar(
-        renderer,
-        Rect{metrics.contentSidePadding, y, pageWidth - metrics.contentSidePadding * 2, metrics.progressBarHeight},
-        static_cast<int>(updaterProgress * 100), 100);
-
-    y += metrics.progressBarHeight + metrics.verticalSpacing;
-    // Percent label is drawn by BaseTheme::drawProgressBar; this slot is left intentionally empty
-    // so the bytes line below stays at the same Y it was at when the activity drew its own percent.
-    y += height + metrics.verticalSpacing;
-    renderer.drawCenteredText(
-        UI_10_FONT_ID, y,
-        (std::to_string(updater.getProcessedSize()) + " / " + std::to_string(updater.getTotalSize())).c_str());
   } else if (state == NO_UPDATE) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_NO_UPDATE), true, EpdFontFamily::BOLD);
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
@@ -135,9 +109,6 @@ void OtaUpdateActivity::render(RenderLock&&) {
     renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_UPDATE_FAILED), true, EpdFontFamily::BOLD);
     const auto labels = mappedInput.mapLabels(tr(STR_BACK), "", "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-  } else if (state == FINISHED) {
-    renderer.drawCenteredText(UI_10_FONT_ID, top, tr(STR_UPDATE_COMPLETE), true, EpdFontFamily::BOLD);
-    renderer.drawCenteredText(UI_10_FONT_ID, top + height + metrics.verticalSpacing, tr(STR_POWER_ON_HINT));
   }
 
   renderer.displayBuffer();
@@ -146,42 +117,10 @@ void OtaUpdateActivity::render(RenderLock&&) {
 void OtaUpdateActivity::loop() {
   if (state == WAITING_CONFIRMATION) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
-      LOG_DBG("OTA", "New update available, starting download...");
-      {
-        RenderLock lock(*this);
-        state = UPDATE_IN_PROGRESS;
-      }
-      requestUpdateAndWait();
-      const auto res = updater.installUpdate(
-          [](void* ctx) {
-            // immediate=true notifies the render task directly. The default deferred path only
-            // sets a flag consumed at the end of ActivityManager::loop(), which never runs while
-            // installUpdate() blocks this task.
-            static_cast<OtaUpdateActivity*>(ctx)->requestUpdate(true);
-          },
-          this);
-
-      if (res != OtaUpdater::OK) {
-        LOG_DBG("OTA", "Update failed: %d", res);
-        {
-          RenderLock lock(*this);
-          state = FAILED;
-        }
-        requestUpdate();
-        return;
-      }
-
-      {
-        RenderLock lock(*this);
-        state = FINISHED;
-      }
-      requestUpdateAndWait();
-      // Hold the completion screen briefly so the user sees it, then restart.
-      delay(3000);
-      {
-        RenderLock lock(*this);
-        state = SHUTTING_DOWN;
-      }
+      LOG_DBG("OTA", "Update confirmed, requesting boot-time install");
+      OtaBootCheck::requestInstall(updater.getLatestVersion().c_str(), updater.getOtaUrl().c_str(),
+                                   updater.getOtaSize());  // does not return
+      return;
     }
 
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
@@ -191,21 +130,9 @@ void OtaUpdateActivity::loop() {
     return;
   }
 
-  if (state == FAILED) {
+  if (state == FAILED || state == NO_UPDATE) {
     if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
       finish();
     }
-    return;
-  }
-
-  if (state == NO_UPDATE) {
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
-      finish();
-    }
-    return;
-  }
-
-  if (state == SHUTTING_DOWN) {
-    ESP.restart();
   }
 }

--- a/src/activities/settings/OtaUpdateActivity.h
+++ b/src/activities/settings/OtaUpdateActivity.h
@@ -1,28 +1,26 @@
 #pragma once
 
 #include "activities/Activity.h"
+#include "network/OtaBootCheck.h"
 #include "network/OtaUpdater.h"
 
+// The network work (check + install) runs at boot time via OtaBootCheck, not
+// in this activity — see OtaBootCheck.h. This activity only shows the boot
+// result, collects the user's confirmation, and requests the next boot stage.
 class OtaUpdateActivity : public Activity {
   enum State {
     WIFI_SELECTION,
     CHECKING_FOR_UPDATE,
     WAITING_CONFIRMATION,
-    UPDATE_IN_PROGRESS,
     NO_UPDATE,
     FAILED,
-    FINISHED,
-    SHUTTING_DOWN
   };
 
-  // Can't initialize this to 0 or the first render doesn't happen
-  static constexpr unsigned int UNINITIALIZED_PERCENTAGE = 111;
-
   State state = WIFI_SELECTION;
-  unsigned int lastUpdaterPercentage = UNINITIALIZED_PERCENTAGE;
   OtaUpdater updater;
 
   void onWifiSelectionComplete(bool success);
+  void consumeBootResult(const OtaBootCheck::Result& result);
 
  public:
   explicit OtaUpdateActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
@@ -31,6 +29,6 @@ class OtaUpdateActivity : public Activity {
   void onExit() override;
   void loop() override;
   void render(RenderLock&&) override;
-  bool preventAutoSleep() override { return state == CHECKING_FOR_UPDATE || state == UPDATE_IN_PROGRESS; }
+  bool preventAutoSleep() override { return state == CHECKING_FOR_UPDATE; }
   bool skipLoopDelay() override { return true; }  // Prevent power-saving mode
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,10 +27,12 @@
 #include "SdCardFontSystem.h"
 #include "activities/Activity.h"
 #include "activities/ActivityManager.h"
+#include "activities/settings/OtaUpdateActivity.h"
 #include "activities/settings/SdFirmwareUpdateActivity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "images/LoadingIcon.h"
+#include "network/OtaBootCheck.h"
 #include "util/ButtonNavigator.h"
 #include "util/ScreenshotUtil.h"
 
@@ -325,6 +327,8 @@ void setup() {
       (isSilentReboot && silentRebootTarget <= SILENT_REBOOT_TARGET_READER) ? silentRebootTarget : 0;
   silentRebootMagic = 0;
   silentRebootTarget = 0;
+  // Same read-and-clear rule as the silent-reboot flag above.
+  const OtaBootCheck::Stage otaBootStage = OtaBootCheck::takeStage();
 
   gpio.begin();
   powerManager.begin();
@@ -436,6 +440,12 @@ void setup() {
   } else if (HalSystem::isRebootFromPanic()) {
     // If we rebooted from a panic, go to crash report screen to show the panic info
     activityManager.goToCrashReport();
+  } else if (otaBootStage != OtaBootCheck::Stage::None) {
+    // OTA network work runs here, before the activity stack exists, because a
+    // TLS handshake needs more contiguous heap than survives full UI init
+    // (#2570). A successful install restarts inside runStage.
+    OtaBootCheck::runStage(otaBootStage, renderer);
+    activityManager.replaceActivity(std::make_unique<OtaUpdateActivity>(renderer, mappedInputManager));
   } else if (resume == BootResume::Silent && snapshotTarget == SILENT_REBOOT_TARGET_READER &&
              !APP_STATE.openEpubPath.empty()) {
     activityManager.goToReader(APP_STATE.openEpubPath);

--- a/src/network/OtaBootCheck.cpp
+++ b/src/network/OtaBootCheck.cpp
@@ -88,8 +88,6 @@ void runInstallStage(OtaUpdater& updater, GfxRenderer& renderer) {
   rtcRequest.url[sizeof(rtcRequest.url) - 1] = '\0';
   updater.adoptManifest(rtcRequest.version, rtcRequest.url, rtcRequest.size);
 
-  drawStatus(renderer, tr(STR_UPDATING));
-
   // The panel retains the frame just drawn, so hand the framebuffer heap to
   // the download: the TLS pipeline plus flash writes need every contiguous
   // block available. No progress UI — rendering is offline until the buffers
@@ -97,7 +95,11 @@ void runInstallStage(OtaUpdater& updater, GfxRenderer& renderer) {
   display.releaseBuffers();
   bootResult.error = updater.installUpdate(nullptr, nullptr);
   const bool buffersBack = display.reallocBuffers();
-  if (!buffersBack) {
+  if (buffersBack) {
+    // The renderer caches the framebuffer pointer in begin(); the realloc may
+    // have moved it, so refresh before anything paints again.
+    renderer.begin();
+  } else {
     // Can't render anything; reboot clean. The pending result is lost and the
     // OTA screen will simply offer the update again.
     LOG_ERR("OTA", "Framebuffer realloc failed after install, restarting");
@@ -134,7 +136,7 @@ void runStage(const Stage stage, GfxRenderer& renderer) {
 
   LOG_INF("OTA", "Boot stage %d starting (heap=%u maxAlloc=%u)", static_cast<int>(stage), ESP.getFreeHeap(),
           ESP.getMaxAllocHeap());
-  drawStatus(renderer, tr(STR_CHECKING_UPDATE));
+  drawStatus(renderer, stage == Stage::Check ? tr(STR_CHECKING_UPDATE) : tr(STR_UPDATING));
 
   if (!connectSavedWifi()) {
     bootResult.error = OtaUpdater::HTTP_ERROR;

--- a/src/network/OtaBootCheck.cpp
+++ b/src/network/OtaBootCheck.cpp
@@ -1,0 +1,187 @@
+#include "OtaBootCheck.h"
+
+#include <Arduino.h>
+#include <GfxRenderer.h>
+#include <HalDisplay.h>
+#include <I18n.h>
+#include <Logging.h>
+#include <WiFi.h>
+
+#include <cstring>
+
+#include "SilentRestart.h"
+#include "WifiCredentialStore.h"
+#include "fontIds.h"
+
+namespace {
+
+struct RtcRequest {
+  uint32_t magic;
+  uint8_t stage;
+  char version[32];
+  char url[512];
+  uint32_t size;
+};
+
+constexpr uint32_t OTA_BOOT_MAGIC = 0xC7055074;
+constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 20000;
+
+// Survives ESP.restart() but not power loss; a lost request simply lands the
+// user back on the OTA screen, which re-requests.
+RTC_NOINIT_ATTR RtcRequest rtcRequest;
+
+OtaBootCheck::Result bootResult;
+bool bootResultValid = false;
+
+void drawStatus(GfxRenderer& renderer, const char* text) {
+  renderer.clearScreen();
+  renderer.drawCenteredText(UI_10_FONT_ID, renderer.getScreenHeight() / 2, text);
+  renderer.displayBuffer();
+}
+
+void wifiOff() {
+  WiFi.disconnect(false);
+  delay(30);
+  WiFi.mode(WIFI_OFF);
+}
+
+bool connectSavedWifi() {
+  WIFI_STORE.loadFromFile();
+  const std::string lastSsid = WIFI_STORE.getLastConnectedSsid();
+  const WifiCredential* cred = lastSsid.empty() ? nullptr : WIFI_STORE.findCredential(lastSsid);
+  if (cred == nullptr) {
+    LOG_ERR("OTA", "Boot stage: no saved WiFi credential");
+    return false;
+  }
+
+  LOG_INF("OTA", "Boot stage: connecting to %s (heap=%u maxAlloc=%u)", cred->ssid.c_str(), ESP.getFreeHeap(),
+          ESP.getMaxAllocHeap());
+  WiFi.persistent(false);
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(cred->ssid.c_str(), cred->password.empty() ? nullptr : cred->password.c_str());
+
+  const uint32_t start = millis();
+  while (WiFi.status() != WL_CONNECTED && millis() - start < WIFI_CONNECT_TIMEOUT_MS) {
+    delay(100);
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    LOG_ERR("OTA", "Boot stage: WiFi connect timed out (ssid=%s)", cred->ssid.c_str());
+    return false;
+  }
+  LOG_INF("OTA", "Boot stage: connected, ip=%s rssi=%d", WiFi.localIP().toString().c_str(), WiFi.RSSI());
+  return true;
+}
+
+void runCheckStage(OtaUpdater& updater) {
+  bootResult.error = updater.checkForUpdate();
+  if (bootResult.error != OtaUpdater::OK) return;
+
+  strncpy(bootResult.version, updater.getLatestVersion().c_str(), sizeof(bootResult.version) - 1);
+  strncpy(bootResult.url, updater.getOtaUrl().c_str(), sizeof(bootResult.url) - 1);
+  bootResult.size = static_cast<uint32_t>(updater.getOtaSize());
+}
+
+void runInstallStage(OtaUpdater& updater, GfxRenderer& renderer) {
+  // RTC memory is not trusted blindly: terminate the strings even though
+  // requestInstall wrote them, in case of partial corruption across the reset.
+  rtcRequest.version[sizeof(rtcRequest.version) - 1] = '\0';
+  rtcRequest.url[sizeof(rtcRequest.url) - 1] = '\0';
+  updater.adoptManifest(rtcRequest.version, rtcRequest.url, rtcRequest.size);
+
+  drawStatus(renderer, tr(STR_UPDATING));
+
+  // The panel retains the frame just drawn, so hand the framebuffer heap to
+  // the download: the TLS pipeline plus flash writes need every contiguous
+  // block available. No progress UI — rendering is offline until the buffers
+  // come back below.
+  display.releaseBuffers();
+  bootResult.error = updater.installUpdate(nullptr, nullptr);
+  const bool buffersBack = display.reallocBuffers();
+  if (!buffersBack) {
+    // Can't render anything; reboot clean. The pending result is lost and the
+    // OTA screen will simply offer the update again.
+    LOG_ERR("OTA", "Framebuffer realloc failed after install, restarting");
+    ESP.restart();
+  }
+
+  if (bootResult.error != OtaUpdater::OK) return;
+
+  drawStatus(renderer, tr(STR_UPDATE_COMPLETE));
+  delay(3000);
+  ESP.restart();  // boots the freshly written partition
+}
+
+}  // namespace
+
+namespace OtaBootCheck {
+
+Stage takeStage() {
+  if (rtcRequest.magic != OTA_BOOT_MAGIC) return Stage::None;
+  rtcRequest.magic = 0;  // read-and-clear: a panic in the stage must not loop the boot
+  switch (rtcRequest.stage) {
+    case static_cast<uint8_t>(Stage::Check):
+      return Stage::Check;
+    case static_cast<uint8_t>(Stage::Install):
+      return Stage::Install;
+    default:
+      return Stage::None;
+  }
+}
+
+void runStage(const Stage stage, GfxRenderer& renderer) {
+  bootResult = Result{};
+  bootResultValid = true;
+
+  LOG_INF("OTA", "Boot stage %d starting (heap=%u maxAlloc=%u)", static_cast<int>(stage), ESP.getFreeHeap(),
+          ESP.getMaxAllocHeap());
+  drawStatus(renderer, tr(STR_CHECKING_UPDATE));
+
+  if (!connectSavedWifi()) {
+    bootResult.error = OtaUpdater::HTTP_ERROR;
+    wifiOff();
+    return;
+  }
+
+  OtaUpdater updater;
+  if (stage == Stage::Check) {
+    runCheckStage(updater);
+  } else {
+    runInstallStage(updater, renderer);  // does not return on success
+  }
+
+  wifiOff();
+  LOG_INF("OTA", "Boot stage done: error=%d version=%s", static_cast<int>(bootResult.error), bootResult.version);
+}
+
+const Result* takeResult() {
+  if (!bootResultValid) return nullptr;
+  bootResultValid = false;
+  return &bootResult;
+}
+
+bool canAutoConnect() {
+  WIFI_STORE.loadFromFile();
+  const std::string lastSsid = WIFI_STORE.getLastConnectedSsid();
+  return !lastSsid.empty() && WIFI_STORE.findCredential(lastSsid) != nullptr;
+}
+
+void requestCheck() {
+  memset(&rtcRequest, 0, sizeof(rtcRequest));
+  rtcRequest.stage = static_cast<uint8_t>(Stage::Check);
+  rtcRequest.magic = OTA_BOOT_MAGIC;
+  LOG_INF("OTA", "Restarting into boot-time update check");
+  silentRestart();
+}
+
+void requestInstall(const char* version, const char* url, const size_t size) {
+  memset(&rtcRequest, 0, sizeof(rtcRequest));
+  rtcRequest.stage = static_cast<uint8_t>(Stage::Install);
+  if (version != nullptr) strncpy(rtcRequest.version, version, sizeof(rtcRequest.version) - 1);
+  if (url != nullptr) strncpy(rtcRequest.url, url, sizeof(rtcRequest.url) - 1);
+  rtcRequest.size = static_cast<uint32_t>(size);
+  rtcRequest.magic = OTA_BOOT_MAGIC;
+  LOG_INF("OTA", "Restarting into boot-time install of %s", rtcRequest.version);
+  silentRestart();
+}
+
+}  // namespace OtaBootCheck

--- a/src/network/OtaBootCheck.h
+++ b/src/network/OtaBootCheck.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "OtaUpdater.h"
+
+class GfxRenderer;
+
+// Boot-time OTA stages. A TLS handshake needs tens of KB of heap at its
+// peak; once the activity stack and WiFi UI are up only ~40KB remain and
+// update checks fail with timeouts or allocation errors (#2570). The OTA
+// activity therefore records a request in RTC memory and silent-restarts;
+// setup() runs the network work right after display init while >100KB is
+// still free, then routes back into the activity with the result.
+namespace OtaBootCheck {
+
+enum class Stage : uint8_t { None = 0, Check, Install };
+
+// One-shot outcome of a boot stage, consumed by OtaUpdateActivity.
+struct Result {
+  OtaUpdater::OtaUpdaterError error = OtaUpdater::HTTP_ERROR;
+  char version[32] = {};
+  char url[512] = {};
+  uint32_t size = 0;
+};
+
+// Reads and clears the RTC request flag. Call exactly once per boot, before
+// anything that could panic — a stale flag must not loop the boot.
+Stage takeStage();
+
+// Runs the requested stage: connects to the last saved WiFi network and either
+// checks for an update or downloads and installs the one recorded by
+// requestInstall(). Draws its own minimal status UI via the renderer. A
+// successful install restarts into the new firmware and does not return.
+void runStage(Stage stage, GfxRenderer& renderer);
+
+// One-shot boot result for OtaUpdateActivity; nullptr when none is pending.
+const Result* takeResult();
+
+// True when a saved credential exists for the boot stage to connect with.
+bool canAutoConnect();
+
+// Record the request in RTC memory and silent-restart. These do not return.
+void requestCheck();
+void requestInstall(const char* version, const char* url, size_t size);
+
+}  // namespace OtaBootCheck

--- a/src/network/OtaUpdater.h
+++ b/src/network/OtaUpdater.h
@@ -29,6 +29,18 @@ class OtaUpdater {
 
   size_t getTotalSize() const { return totalSize; }
 
+  const std::string& getOtaUrl() const { return otaUrl; }
+
+  // Restores a manifest captured by an earlier checkForUpdate() — used to hand
+  // the result of a boot-time check across the reboot into installUpdate().
+  void adoptManifest(const std::string& version, const std::string& url, const size_t size) {
+    latestVersion = version;
+    otaUrl = url;
+    otaSize = size;
+    totalSize = size;
+    updateAvailable = true;
+  }
+
   OtaUpdater() = default;
   bool isUpdateNewer() const;
   const std::string& getLatestVersion() const;


### PR DESCRIPTION
Addresses #2570 (and the broader "Update failed" class of OTA reports).

## TL;DR

OTA failures are a heap problem: a TLS handshake needs tens of KB of free heap at its peak, but inside the settings UI with WiFi up only ~40 KB remain. This PR moves the OTA check and install to a boot-time stage that runs right after display init with >100 KB free, and lends the framebuffer to the download while the e-ink panel retains the "Updating…" screen.

## Background

I debugged this extensively in the CrossInk fork (uxjulia/CrossInk#312) on an X4 that had never completed an OTA, with serial logs and packet captures. The measured mechanics, which apply to any TLS engine:

- During a handshake, free heap bottoms out near ~1 KB: record buffers plus certificate processing plus crypto scratch, while received TLS records pile up in RAM because the crypto runs for hundreds of ms in software. Once the heap floor is hit, lwIP can't allocate RX pbufs, the handshake stalls into a timeout — or an allocation fails outright. Which symptom you get depends on where exactly the memory runs out, which is why reports are so inconsistent across devices and networks.
- During the firmware download the same backpressure applies continuously: with ~8 KB free the transfer trickles at ~3 KB/s and eventually times out; with the framebuffer's KBs freed it runs at ~90 KB/s.

With the boot-time stage plus framebuffer lending, that device completed its first ever end-to-end OTA (check → confirm → 5.5 MB download → install → reboot). The fork's fix has additional mbedTLS-specific parts (certificate-chain memory, GitHub API asset endpoint); those don't apply here since this repo's HTTP path runs over wolfSSL with `setInsecure()`, so this PR ports only the engine-agnostic architecture.

## Changes

- **`src/network/OtaBootCheck`** (new): records the requested stage (check/install) in RTC memory, silent-restarts (existing mechanism), reconnects to the last saved WiFi network headlessly, and runs the updater with a minimal status UI. Read-and-clear flag semantics so a panic can't boot-loop.
- **`OtaUpdateActivity`**: no longer performs network work — consumes the boot result, collects confirmation, requests the install stage. The WiFi selection UI only runs when no saved credential exists yet.
- **`HalDisplay::releaseBuffers()/reallocBuffers()`**: passthroughs to the existing FreeInk SDK API; the install stage hands the framebuffer heap to the download and the panel retains the drawn frame.
- UX: one brief silent reboot before the check result appears, and the install shows a static "Updating…" screen instead of a live progress bar (rendering is offline while its memory is lent out).

## Testing

- `pio run -e default` builds clean.
- The architecture is verified end-to-end on X4 hardware in the CrossInk fork (same activity/boot structure); I don't have a stock-Crosspoint test setup, so testers with affected devices — especially the unlocker-tool flow from #2570 — would be very welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
