### PR TITLE
fix: ESP32-C3 WiFi connection consistently timed out at 15/30s

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -295,19 +295,83 @@ void WifiSelectionActivity::attemptConnection() {
 
   WiFi.persistent(false);  // Credentials are managed by WifiCredentialStore; suppress SDK NVS auto-connect
   WiFi.mode(WIFI_STA);
-  WiFi.disconnect(true, true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
-  delay(100);
 
-  // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
-  String mac = WiFi.macAddress();
-  mac.replace(":", "");
-  String hostname = "CrossPoint-Reader-" + mac;
-  WiFi.setHostname(hostname.c_str());
+  disableModemPowerSave();
+  applyDisplayHostname();
+  disableAutoReconnect();
 
+  wl_status_t beginResult;
   if (selectedRequiresPassword && !enteredPassword.empty()) {
-    WiFi.begin(selectedSSID.c_str(), enteredPassword.c_str());
+    beginResult = WiFi.begin(selectedSSID.c_str(), enteredPassword.c_str());
   } else {
-    WiFi.begin(selectedSSID.c_str());
+    beginResult = WiFi.begin(selectedSSID.c_str());
+  }
+
+  if (beginResult != WL_DISCONNECTED) {
+    LOG_ERR("WIFI", "WiFi.begin() returned %d (expected %d=WL_DISCONNECTED) for ssid=%s", beginResult, WL_DISCONNECTED,
+            selectedSSID.c_str());
+    connectionError = tr(STR_ERROR_GENERAL_FAILURE);
+    state = WifiSelectionState::CONNECTION_FAILED;
+    requestUpdate();
+    return;
+  }
+
+  LOG_DBG("WIFI", "WiFi.begin() initiated async connection for ssid=%s", selectedSSID.c_str());
+  LOG_DBG("WIFI", "attemptConnection: ssid=%s requiresPwd=%d hostname=%s", selectedSSID.c_str(),
+          selectedRequiresPassword, WiFi.getHostname());
+}
+
+void WifiSelectionActivity::disableModemPowerSave() { WiFi.setSleep(WIFI_PS_NONE); }
+
+void WifiSelectionActivity::applyDisplayHostname() {
+  // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
+  uint8_t mac[6];
+  WiFi.macAddress(mac);
+  char macStr[13];
+  snprintf(macStr, sizeof(macStr), "%02x%02x%02x%02x%02x%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+  String hostname = "CrossPoint-Reader-" + String(macStr);
+  WiFi.setHostname(hostname.c_str());
+}
+
+void WifiSelectionActivity::disableAutoReconnect() { WiFi.setAutoReconnect(false); }
+
+void WifiSelectionActivity::logConnectionDiagnostics() {
+  const wl_status_t status = WiFi.status();
+  static unsigned long lastStatusLog = 0;
+  const unsigned long elapsed = millis() - connectionStartTime;
+  if (elapsed - lastStatusLog >= 2000) {
+    lastStatusLog = elapsed;
+    const char* statusName = "unknown";
+    switch (status) {
+      case WL_IDLE_STATUS:
+        statusName = "WL_IDLE_STATUS(0)";
+        break;
+      case WL_NO_SSID_AVAIL:
+        statusName = "WL_NO_SSID_AVAIL(1)";
+        break;
+      case WL_SCAN_COMPLETED:
+        statusName = "WL_SCAN_COMPLETED(2)";
+        break;
+      case WL_CONNECTED:
+        statusName = "WL_CONNECTED(3)";
+        break;
+      case WL_CONNECT_FAILED:
+        statusName = "WL_CONNECT_FAILED(4)";
+        break;
+      case WL_CONNECTION_LOST:
+        statusName = "WL_CONNECTION_LOST(5)";
+        break;
+      case WL_DISCONNECTED:
+        statusName = "WL_DISCONNECTED(6)";
+        break;
+      case WL_STOPPED:
+        statusName = "WL_STOPPED(254)";
+        break;
+      case WL_NO_SHIELD:
+        statusName = "WL_NO_SHIELD(255)";
+        break;
+    }
+    LOG_DBG("WIFI", "conn status=%s elapsed=%lums ssid=%s", statusName, elapsed, selectedSSID.c_str());
   }
 }
 
@@ -317,6 +381,7 @@ void WifiSelectionActivity::checkConnectionStatus() {
   }
 
   const wl_status_t status = WiFi.status();
+  logConnectionDiagnostics();
 
   if (status == WL_CONNECTED) {
     // Successfully connected
@@ -376,6 +441,7 @@ void WifiSelectionActivity::checkConnectionStatus() {
   // Check for timeout
   const unsigned long timeoutMs = autoConnecting ? AUTO_CONNECTION_TIMEOUT_MS : CONNECTION_TIMEOUT_MS;
   if (millis() - connectionStartTime > timeoutMs) {
+    LOG_DBG("WIFI", "TIMEOUT after %lums — final WiFi.status()=%d", millis() - connectionStartTime, WiFi.status());
     WiFi.disconnect();
     connectionError = tr(STR_ERROR_CONNECTION_TIMEOUT);
     if (autoConnecting) {

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -108,6 +108,10 @@ class WifiSelectionActivity final : public Activity {
   void handleAutoConnectFailure();
   void showNetworkListFromAutoConnect();
   bool hasAttemptedAutoSsid(const std::string& ssid) const;
+  void disableModemPowerSave();
+  void applyDisplayHostname();
+  void disableAutoReconnect();
+  void logConnectionDiagnostics();
   std::string getSignalStrengthIndicator(int32_t rssi) const;
 
   void onComplete(bool connected);


### PR DESCRIPTION
# Bug: WiFi connection to a known-working 2.4GHz network repeatedly failed with "Connection timeout"

Status stayed at WL_DISCONNECTED(6) for the full timeout duration and never transitioned to WL_IDLE_STATUS(0), WL_NO_SSID_AVAIL(1), or WL_CONNECT_FAILED(4). The failure was intermittent: some attempts connected in ~2s, others hung the full 30s.

Evidence (serial logs, three attempts):
  Attempt 1: WL_IDLE_STATUS(0) at 2008ms → connected immediately
  Attempt 2: WL_DISCONNECTED(6) for entire 30s → timeout, never changed
  Attempt 3: WL_DISCONNECTED(6) for 14s → WL_IDLE_STATUS(0) → connected

Two root causes were isolated by tracing the ESP32 Arduino WiFi stack (STA.cpp, WiFiSTA.cpp, WiFiGeneric.cpp, NetworkEvents.cpp) and the activity code (WifiSelectionActivity.cpp):

1. Modem power-save interference (ESP32-C3-specific). WIFI_PS_MIN_MODEM is the default on ESP32-C3 (WiFiGeneric.cpp:379). It lets the WiFi modem sleep between DTIM beacons. During authentication and the 4-way handshake, if a probe response or auth frame is missed, the IDF state machine stalls waiting for a response that never arrives — and crucially does NOT fire any error events. Without an error event, the Arduino _onStaArduinoEvent handler never updates _status, which stays at WL_DISCONNECTED permanently.

2. Explicit disconnect racing the state machine. attemptConnection() called WiFi.disconnect(false, true) + delay(50) before WiFi.begin() to clear stale config. This introduced a race: esp_wifi_disconnect() is processed asynchronously by the WiFi task. If the state machine had not settled to IDLE by the time esp_wifi_connect() was called (in WiFi.begin() → STA::connect()), the IDF returned ESP_ERR_WIFI_CONN. connect() logged an error and returned false; WiFi.begin() returned WL_CONNECT_FAILED — but the return value was silently discarded. With no connection ever started, no WIFI_EVENT_STA_CONNECTED or WIFI_EVENT_STA_DISCONNECTED fired, so _status was marooned at WL_DISCONNECTED until the application timed out.

Fix (three changes):
  1. Remove explicit WiFi.disconnect() + delay(50) — WiFi.begin()s internal STA::connect() already handles prior-state disconnection with proper IDF sequencing (STA.cpp:248-251).
  2. Add WiFi.setSleep(WIFI_PS_NONE) before connecting, which calls esp_wifi_set_ps() immediately (WiFiGeneric.cpp:772-790) and prevents modem sleep during the critical connection phase.
  3. Check WiFi.begin() return value and surface synchronous failures (WL_CONNECT_FAILED) immediately instead of waiting 15s for events that will never arrive.


## Summary

I found the wifi connection to be flaky - failing a lot of the time, so I investigated and found that the existing code is fighting against the ESP32. This patch aims to fix that battle!

I trimmed out the parts of the code working around the ESP32 and replaced it with (hopefully) more efficient handling of its state machine. I left in the debug logging but that could be removed - it only fires if the connection is taking a while (>2s).

The connection is now really quick and data transfer (e.g. from Calibre over wifi) works nicely .


## Additional Context

The biggest risk is that this only works on my home router and my Android hotspot - which are the two devices I have available to test with. If the original code was working around device quirks then I may have mis-stepped. Though I'd still claim that the current code on develop is buggy as it breaks most of the time I try to connect!

---

### AI Usage

Did you use AI tools to help write this code? **PARTIALLY** - I used AI to help narrow my search, suggest some code, and adjust in preparation for a palatable PR, I also had it write up the issue and evidence more thoroughly than I normally would into the commit message!
