### PR TITLE
fix(css-parser): don't save unusable rules to RAM

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -431,6 +431,11 @@ CssStyle CssParser::parseDeclarations(std::string_view declBlock) {
 // Rule processing
 
 void CssParser::processRuleBlockWithStyle(std::string_view selectorGroup, const CssStyle& style) {
+  // Skip rules that don't define any supported properties to save RAM.
+  if (!style.defined.anySet()) {
+    return;
+  }
+
   // Check if we've reached the rule limit before processing
   if (rulesBySelector_.size() >= MAX_RULES) {
     LOG_DBG("CSS", "Reached max rules limit (%zu), stopping CSS parsing", MAX_RULES);

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -33,7 +33,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 7;
+  static constexpr uint8_t CSS_CACHE_VERSION = 8;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;


### PR DESCRIPTION
Problem: Due to hardware constraints, Crosspoint only supports a limited number of CSS rules. However, it still saves all unusable rules to RAM, even though they have been made empty. This makes it crash when open this EPUB file
https://www.daido-life-fd.or.jp/assets/files/ebooks/osanaikoro.epub, because it has thousands of lines of CSS. (While the work in the EPUB file is still protected by copyright law in Japan, it is shared for free by its copyright holder which is Daido Life Foundation 大同生命国際文化基金, so I think you guys can freely download and read it)

Solution: Return immediately if the rule is unusable, so it does not get into RAM. Also bumped `CSS_CACHE_VERSION` from `7` to `8`

## Summary

* **What is the goal of this PR?**: Resolve Out-of-Memory (OOM) heap exhaustion crashes on memory-constrained microcontroller targets (like the ESP32-C3 on XTEINK X4, which only has ~380KB usable SRAM). The crash is typically triggered when opening EPUB files containing large, boilerplate CSS stylesheets (e.g.,  standard Denshokyou 電書協 digital publishing templates) while reading with custom SD-card CJK/fallback fonts. 

* **What changes are included?**: See `Solution` above

## Additional Context

* **Performance Implications:**　Boilerplate stylesheets often contain thousands of utility classes. Previously, these filled up the `MAX_RULES` cap (1500 entries) in `rulesBySelector_` with empty style nodes, consuming **50 KB - 100 KB** of heap memory just for `std::unordered_map` overhead and `std::string` keys. By dropping these useless entries, we free up critical base memory. This provides enough headroom for SD card fonts to allocate their **16 KB temporary codepoint buffers** (`buildAdvanceTableRange`) during vertical/horizontal text layouts without invoking `abort()` due to heap exhaustion.


---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _** YES**_
