### PR TITLE
fix(kosync): reload Epub before reading upload metadata

### DIFF
--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -225,6 +225,10 @@ void KOReaderSyncActivity::performUpload() {
     progress.metadata = std::move(meta);
   }
 
+  // Release the Epub before the network call so the TLS handshake has enough free heap
+  // (consistent with the release-before-sync pattern in performSync); nothing below needs it.
+  epub.reset();
+
   const auto result = KOReaderSyncClient::updateProgress(progress);
 
   // Drop the radio while user reads the result; full teardown happens at silent reboot.

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -208,12 +208,20 @@ void KOReaderSyncActivity::performUpload() {
 
   // Optionally include document metadata (KOReader PR #15306)
   if (KOREADER_STORE.getSendMetadata()) {
+    // The Epub is released before the sync network calls and is only reloaded on the
+    // remote-progress path (performSync). When uploading from NO_REMOTE_PROGRESS the
+    // Epub is still null, so reload it here and guard the title/author reads to avoid
+    // dereferencing a null Epub. Filename is derived from the path and is always safe.
+    ensureEpubLoaded();
     KOReaderMetadata meta;
-    // Extract filename from path
     const auto lastSlash = epubPath.rfind('/');
     meta.filename = (lastSlash != std::string::npos) ? epubPath.substr(lastSlash + 1) : epubPath;
-    meta.title = epub->getTitle();
-    meta.authors = epub->getAuthor();
+    if (epub) {
+      meta.title = epub->getTitle();
+      meta.authors = epub->getAuthor();
+    } else {
+      LOG_ERR("KOSync", "Epub unavailable for metadata; sending filename only");
+    }
     progress.metadata = std::move(meta);
   }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a crash (null `Epub` dereference) that panics the
  device during a KOReader Sync **upload** when the sync server has no existing progress
  for the document.

* **What changes are included?** In `KOReaderSyncActivity::performUpload()`:
  1. Reload the `Epub` via the idempotent `ensureEpubLoaded()` before building the upload
     metadata, and guard the `getTitle()` / `getAuthor()` reads on a non-null `Epub`
     (`filename` is derived from the path and is always set). This is the crash fix.
  2. Release the `Epub` (`epub.reset()`) after extracting metadata and **before** the
     `updateProgress()` network call, so the TLS handshake has enough free heap — mirroring
     the release-before-sync pattern already used in `performSync()`. (Added from review
     feedback.)

## Additional Context

**Root cause.** The `Epub` is released before the sync network calls to free RAM, and is
only reloaded on the *remote-progress* path in `performSync()`. When the server returns
**404** for `GET /syncs/progress/:document` (no progress yet for that document, or an
unknown hash), `performSync()` takes the `NO_REMOTE_PROGRESS` branch and returns
**without** reloading the `Epub`. A subsequent **Upload** then reaches `performUpload()`,
which — when *Send Metadata* is enabled — dereferences `epub->getTitle()` /
`epub->getAuthor()` on a null `Epub`, panicking the device.

**Fix behavior.** `ensureEpubLoaded()` is already idempotent and used on the remote path,
so reusing it keeps document metadata working on both sync paths. If the reload ever fails,
the upload degrades to filename-only metadata (logged) instead of crashing. The remote-
progress path is unchanged (the `Epub` is already loaded there).

**Memory.** After the metadata is read, `epub.reset()` frees it before `updateProgress()`,
so the TLS handshake runs with the heap headroom the rest of the sync flow already relies
on. This also releases the `Epub` that lingered from the `SHOWING_RESULT` state on the
remote-progress path. Nothing after metadata extraction uses the `Epub`.

**Reproduction.**
1. Configure KOReader Sync against a server that has no progress for the book (any KOSync /
   self-hosted server that returns 404 for an unknown document — reproduced against a
   self-hosted Grimmory instance).
2. Ensure **Send Metadata** is ON.
3. Open the book, trigger sync, choose **Upload**.

Before: panic (null deref). Disabling *Send Metadata* avoided it, confirming the null
dereference in the metadata block. After: upload completes.

**Testing.**
* Builds clean: `pio run -e default` (ESP32-C3), both before and after the memory change.
* Flashed to an X3 and re-ran the repro (first-time upload with *Send Metadata* ON) — no
  longer panics; upload completes.

**Risk.** Low, and scoped to `performUpload()`. Worst case on a failed reload is a
filename-only metadata upload rather than a crash.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
