### PR TITLE
fix: ignore open-x4-sdk and fs_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea
 .DS_Store
 .vscode
+open-x4-sdk
+fs_
 lib/EpdFont/fontsrc
 lib/I18n/I18nKeys.h
 lib/I18n/I18nStrings.h


### PR DESCRIPTION
## Summary

The first is still used by older PRs, so we can delete it yet.
The second is used by the simulator. 
