### PR TITLE
feat: add Amiri font for Arabic script support

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -250,12 +250,14 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-BoldItalic.ttf"}
+
 # ── Arabic ─────────────────────────────────────────────────────────────
 
   - name: Amiri
     description: "Classical Naskh revival for Arabic script"
     intervals: arabic,latin-ext
     sizes: [12, 14, 16, 18]
+    intervals: "latin-ext,(0x0600-0x06FF),(0x0750-0x077F),(0x0870-0x089F),(0x08A0-0x08FF),(0xFE70-0xFEFF)"
     styles:
       regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Regular.ttf"}
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Bold.ttf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -250,4 +250,14 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-BoldItalic.ttf"}
+# ── Arabic ─────────────────────────────────────────────────────────────
 
+  - name: Amiri
+    description: "Classical Naskh revival for Arabic script"
+    intervals: arabic,latin-ext
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}


### PR DESCRIPTION
## Summary
* **What is the goal of this PR?**
  Adds Amiri as a bundled font for Arabic-script reading support.

* **What changes are included?**
  Added an `Amiri` entry to `lib/EpdFont/scripts/sd-fonts.yaml`, sourced from the `google/fonts` OFL mirror (the official `aliftype/amiri` release is zip-only and doesn't fit the manifest's per-file URL pattern).

## Additional Context
OFL-licensed.

---
### AI Usage
Did you use AI tools to help write this code? **NO**