### PR TITLE
fix: improve ZIP EOCD scanning for large/fragmented EPUBs

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -3,8 +3,10 @@
 #include <HalStorage.h>
 #include <InflateReader.h>
 #include <Logging.h>
+#include <Memory.h>
 
 #include <algorithm>
+#include <cstring>
 
 struct ZipInflateCtx {
   InflateReader reader;  // Must be first — callback casts uzlib_uncomp* to ZipInflateCtx*
@@ -229,44 +231,75 @@ bool ZipFile::loadZipDetails() {
     return false;  // Minimum EOCD size is 22 bytes
   }
 
-  // We scan the last 1KB (or the whole file if smaller) for the EOCD signature
-  // 0x06054b50 is stored as 0x50, 0x4b, 0x05, 0x06 in little-endian
-  const int scanRange = fileSize > 1024 ? 1024 : fileSize;
-  const auto buffer = static_cast<uint8_t*>(malloc(scanRange));
+  // Scan backwards from end-of-file for the EOCD signature (0x06054b50).
+  // ZIP spec allows up to 65535+22 bytes of comment after EOCD, so the
+  // signature can be up to 65557 bytes from the end.  To avoid a large
+  // heap allocation on the memory-constrained ESP32-C3, we use a fixed
+  // 4KB window that starts at end-of-file and steps backwards only when
+  // no signature is found, checking the window nearest EOF first.  This
+  // guarantees we resolve to the EOCD nearest EOF (the correct one per
+  // spec) instead of a false PK\x05\x06 sequence earlier in the file,
+  // and it keeps the common case (no archive comment) to a single 4KB
+  // read instead of scanning the full 65557-byte region.  Each step
+  // overlaps the previous window by 21 bytes so an EOCD record spanning
+  // a window boundary is never missed (EOCD minimum size is 22 bytes).
+  constexpr size_t BUF_SIZE = 4096;
+  constexpr size_t MAX_SCAN = 65557;
+  constexpr size_t OVERLAP = 21;  // EOCD min size - 1
+
+  auto buffer = makeUniqueNoThrow<uint8_t[]>(BUF_SIZE);
   if (!buffer) {
-    LOG_ERR("ZIP", "Failed to allocate memory for EOCD scan buffer");
+    LOG_ERR("ZIP", "Failed to allocate EOCD scan buffer (%zu bytes)", BUF_SIZE);
     return false;
   }
 
-  file.seek(fileSize - scanRange);
-  file.read(buffer, scanRange);
+  const size_t totalScannable = fileSize < MAX_SCAN ? fileSize : MAX_SCAN;
+  const size_t scanFloor = fileSize - totalScannable;
 
-  // Scan backwards for the signature
-  int foundOffset = -1;
-  for (int i = scanRange - 22; i >= 0; i--) {
-    constexpr uint32_t signature = 0x06054b50;
-    if (*reinterpret_cast<uint32_t*>(&buffer[i]) == signature) {
-      foundOffset = i;
-      break;
+  size_t windowEnd = fileSize;
+  while (true) {
+    const size_t windowStart = windowEnd > scanFloor + BUF_SIZE ? windowEnd - BUF_SIZE : scanFloor;
+    const size_t windowLen = windowEnd - windowStart;
+    if (windowLen < 22) break;  // Not enough bytes left to hold an EOCD record
+
+    if (!file.seek(windowStart)) {
+      LOG_ERR("ZIP", "EOCD scan: seek to %zu failed", windowStart);
+      return false;
     }
+
+    size_t filled = 0;
+    while (filled < windowLen) {
+      const int n = file.read(buffer.get() + filled, windowLen - filled);
+      if (n <= 0) {
+        LOG_ERR("ZIP", "EOCD scan: read failed in window [%zu, %zu), got %zu/%zu bytes", windowStart, windowEnd, filled,
+                windowLen);
+        return false;
+      }
+      filled += static_cast<size_t>(n);
+    }
+
+    // Search this window from the end towards the start so the match
+    // nearest EOF wins within the window (only one EOCD exists per valid
+    // ZIP, but this keeps behaviour well-defined if a comment happens to
+    // contain the signature bytes).
+    for (int i = static_cast<int>(windowLen) - 22; i >= 0; i--) {
+      uint32_t candidate;
+      memcpy(&candidate, &buffer[i], sizeof(candidate));
+      if (candidate == 0x06054b50) {
+        memcpy(&zipDetails.totalEntries, &buffer[i + 10], sizeof(zipDetails.totalEntries));
+        memcpy(&zipDetails.centralDirOffset, &buffer[i + 16], sizeof(zipDetails.centralDirOffset));
+        zipDetails.isSet = true;
+        LOG_DBG("ZIP", "EOCD found at offset %zu in file", windowStart + static_cast<size_t>(i));
+        return true;
+      }
+    }
+
+    if (windowStart <= scanFloor) break;
+    windowEnd = windowStart + OVERLAP;
   }
 
-  if (foundOffset == -1) {
-    LOG_ERR("ZIP", "EOCD signature not found in zip file");
-    free(buffer);
-    return false;
-  }
-
-  // Now extract the values we need from the EOCD record
-  // Relative positions within EOCD:
-  // Offset 10: Total number of entries (2 bytes)
-  // Offset 16: Offset of start of central directory with respect to the starting disk number (4 bytes)
-  zipDetails.totalEntries = *reinterpret_cast<uint16_t*>(&buffer[foundOffset + 10]);
-  zipDetails.centralDirOffset = *reinterpret_cast<uint32_t*>(&buffer[foundOffset + 16]);
-  zipDetails.isSet = true;
-
-  free(buffer);
-  return true;
+  LOG_ERR("ZIP", "EOCD signature not found in zip file (scanned last %zu bytes)", totalScannable);
+  return false;
 }
 
 bool ZipFile::open() {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the ZIP End-Of-Central-Directory (EOCD) lookup robust for large/fragmented EPUBs. The previous implementation only scanned the last 1KB of the file, so EPUBs with a larger archive comment (or fragmented trailing data) failed to open.
* **What changes are included?** `ZipFile::loadZipDetails()` now scans the full spec-allowed EOCD region (up to 65557 bytes from EOF) using a fixed 4KB window that starts at end-of-file and steps backwards only when no signature is found:
  * The window nearest EOF is checked first and searched high-to-low, so the EOCD nearest end-of-file always wins — a false `PK\x05\x06` byte sequence earlier in the file (compressed data, nested ZIP) can never be selected over the real record.
  * Common case (no archive comment, EOCD in the last 4KB) costs exactly one 4KB read.
  * Windows overlap by 21 bytes so a 22-byte EOCD record spanning a window boundary is never missed.
  * Each window is a fresh seek+read with a fill loop; a short read fails loudly (`LOG_ERR` + `return false`) instead of scanning stale buffer bytes.
  * Multi-byte fields are extracted with `memcpy` (RISC-V unaligned-load safety).
  * Scan buffer is allocated with `makeUniqueNoThrow` (no manual `free` on the five return paths).

## Additional Context

* **Memory**: one transient 4KB heap allocation during `loadZipDetails()`, freed on return; no persistent RAM cost.
* **I/O**: worst case (no EOCD found / max comment) is ~17 windows of 4KB; typical case is a single 4KB read. Note the pre-change code read 1KB in the typical case, so this is a small increase there, traded for actually finding the record when a comment exists.
* **Static checks**: `pio run` clean, `pio check --fail-on-defect low|medium|high` passes, clang-format applied.

### Verification (on device, Xteink X4)

Tested with purpose-built EPUBs that isolate each behaviour. Serial log evidence:

| Test EPUB | Property | Result |
|---|---|---|
| 60KB archive comment | real EOCD sits **60,049 bytes from EOF** | `[ZIP] EOCD found at offset 4219` — correct. The pre-change 1KB scan could not reach this record at all, so this book previously failed to open. Exercises the multi-window backwards walk. |
| Decoy signature | stored entry containing `PK\x05\x06` at offset **3567**, real EOCD at **4459** | `[ZIP] EOCD found at offset 4459` — correct. The decoy (lower offset, same 4KB window) is passed over in favour of the record nearest EOF. |
| Normal EPUBs (1.2MB, 645KB) | EOCD in final 22 bytes | Found and opened normally; chapters build and render. No regression. |

Both books indexed, built `book.bin`, and rendered. No `ZIP` errors, no watchdog, heap stable.

**Not covered by this testing**, flagged for reviewers: the short-read / genuinely fragmented-SD path is hard to force deliberately, so the fill-loop error branch is reasoned about rather than observed. Happy to add a test if someone has a reliable way to reproduce it.

The generator for these test EPUBs is a short Python script; I can attach it or open it as a follow-up if that's useful to the project.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
(Implemented and adversarially reviewed with Claude; findings from the review pass were fixed before opening this PR. Hardware testing and the test-EPUB design were done to validate the result rather than trusting the review.)
