### PR TITLE
feature/x4 software clock

### DIFF
--- a/lib/hal/HalClock.cpp
+++ b/lib/hal/HalClock.cpp
@@ -20,6 +20,7 @@ static uint8_t decToBcd(uint8_t dec) { return ((dec / 10) << 4) | (dec % 10); }
 void HalClock::begin() {
   if (!gpio.deviceIsX3()) {
     _available = false;
+    _softwareClockSynced = (time(nullptr) > 1577836800L);
     return;
   }
 
@@ -48,21 +49,43 @@ void HalClock::begin() {
 }
 
 bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
-  if (!_available) return false;
+  if (!_available && !_softwareClockSynced) return false;
 
-  const unsigned long now = millis();
-  if (_lastPollMs != 0 && (now - _lastPollMs) < CLOCK_POLL_MS) {
+  const unsigned long nowMs = millis();
+  if (_hasCachedTime && _lastPollMs != 0 && (nowMs - _lastPollMs) < CLOCK_POLL_MS) {
     hour = _cachedHour;
     minute = _cachedMinute;
     return true;
   }
 
-  // Read 3 bytes starting at register 0x00: seconds, minutes, hours
+  if (!_available) {
+    const time_t raw = time(nullptr);
+    if (raw <= 1577836800L) {
+      if (_hasCachedTime) { _lastPollMs = nowMs; hour = _cachedHour; minute = _cachedMinute; return true; }
+      return false;
+    }
+    time_t display = raw;
+    if (_anchorEpoch > 0 && _driftPpm != 0) {
+      const int32_t elapsed = static_cast<int32_t>(static_cast<uint32_t>(raw) - _anchorEpoch);
+      const int32_t corrected = static_cast<int32_t>((int64_t)elapsed * 1000000 / (1000000 + _driftPpm));
+      display = static_cast<time_t>(_anchorEpoch) + corrected;
+    }
+    struct tm tm_info;
+    gmtime_r(&display, &tm_info);
+    _cachedHour = static_cast<uint8_t>(tm_info.tm_hour);
+    _cachedMinute = static_cast<uint8_t>(tm_info.tm_min);
+    _hasCachedTime = true;
+    _lastPollMs = nowMs;
+    hour = _cachedHour;
+    minute = _cachedMinute;
+    return true;
+  }
+
   Wire.beginTransmission(I2C_ADDR_DS3231);
   Wire.write(DS3231_SEC_REG);
   if (Wire.endTransmission(false) != 0) {
     if (!_hasCachedTime) return false;
-    _lastPollMs = now;
+    _lastPollMs = nowMs;
     hour = _cachedHour;
     minute = _cachedMinute;
     return true;
@@ -70,7 +93,7 @@ bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
   Wire.requestFrom(I2C_ADDR_DS3231, (uint8_t)3);
   if (Wire.available() < 3) {
     if (!_hasCachedTime) return false;
-    _lastPollMs = now;
+    _lastPollMs = nowMs;
     hour = _cachedHour;
     minute = _cachedMinute;
     return true;
@@ -92,7 +115,7 @@ bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
     // 24h mode: bits 5-0 = hours (0-23)
     _cachedHour = bcdToDec(rawHour & 0x3F);
   }
-  _lastPollMs = now;
+  _lastPollMs = nowMs;
   _hasCachedTime = true;
 
   hour = _cachedHour;
@@ -150,12 +173,12 @@ bool HalClock::writeTimeToRTC(uint8_t hour, uint8_t minute, uint8_t second) {
 }
 
 bool HalClock::syncFromNTP() {
-  if (!_available) return false;
-
   if (WiFi.status() != WL_CONNECTED) {
     LOG_ERR("CLK", "WiFi not connected, cannot sync NTP");
     return false;
   }
+
+  const uint32_t preSyncEpoch = static_cast<uint32_t>(time(nullptr));
 
   LOG_INF("CLK", "Starting NTP sync...");
   configTzTime("UTC0", "pool.ntp.org", "time.nist.gov");
@@ -168,11 +191,27 @@ bool HalClock::syncFromNTP() {
       struct tm timeinfo;
       gmtime_r(&now, &timeinfo);
 
-      if (writeTimeToRTC(timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec)) {
-        LOG_INF("CLK", "RTC set to %02d:%02d:%02d UTC", timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
-        return true;
+      if (_available) {
+        if (!writeTimeToRTC(timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec)) return false;
+        LOG_INF("CLK", "DS3231 set to %02d:%02d:%02d UTC", timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+      } else {
+        const uint32_t trueNow = static_cast<uint32_t>(now);
+        if (_anchorEpoch > 0) {
+          const int32_t actualElapsed = static_cast<int32_t>(trueNow - _anchorEpoch);
+          const int32_t rtcElapsed = static_cast<int32_t>(preSyncEpoch - _anchorEpoch);
+          if (actualElapsed > 3600 && rtcElapsed > 0) {
+            int32_t newPpm = static_cast<int32_t>((int64_t)(rtcElapsed - actualElapsed) * 1000000 / actualElapsed);
+            newPpm = newPpm > 100000 ? 100000 : (newPpm < -100000 ? -100000 : newPpm);
+            _driftPpm = newPpm;
+            LOG_INF("CLK", "Drift updated: %d ppm", _driftPpm);
+          }
+        }
+        _anchorEpoch = trueNow;
+        _softwareClockSynced = true;
+        _lastPollMs = 0;
+        LOG_INF("CLK", "Software clock synced to %02d:%02d:%02d UTC", timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
       }
-      return false;
+      return true;
     }
     delay(100);
   }

--- a/lib/hal/HalClock.h
+++ b/lib/hal/HalClock.h
@@ -10,6 +10,9 @@ extern HalClock halClock;  // Singleton
 
 class HalClock {
   bool _available = false;
+  bool _softwareClockSynced = false;
+  uint32_t _anchorEpoch = 0;
+  int32_t _driftPpm = 0;
   mutable uint8_t _cachedHour = 0;
   mutable uint8_t _cachedMinute = 0;
   mutable bool _hasCachedTime = false;
@@ -21,26 +24,28 @@ class HalClock {
   // Call after gpio.begin() and powerManager.begin() (I2C already initialised for X3)
   void begin();
 
-  // True if the DS3231 RTC is present on this device
-  bool isAvailable() const { return _available; }
+  bool isAvailable() const { return _available || _softwareClockSynced; }
+  bool isHardwareAvailable() const { return _available; }
+
+  void setCalibration(uint32_t anchorEpoch, int32_t driftPpm) { _anchorEpoch = anchorEpoch; _driftPpm = driftPpm; }
+  uint32_t getAnchorEpoch() const { return _anchorEpoch; }
+  int32_t getDriftPpm() const { return _driftPpm; }
 
   // Get current hour (0-23) and minute (0-59).
-  // Returns false if RTC is not available.
+  // Returns false if no clock source is available.
   bool getTime(uint8_t& hour, uint8_t& minute) const;
 
   // Format time into a caller-provided buffer.
   // 24h mode produces "HH:MM" (needs >=6 bytes); 12h mode produces "H:MM AM"/"HH:MM PM" (needs >=9 bytes).
   // utcOffsetQuarterHoursBiased: biased quarter-hour offset (48 = UTC+0, 0 = UTC-12, 104 = UTC+14).
   // use12Hour: when true, format as 12-hour clock with AM/PM suffix.
-  // Returns false if RTC is not available.
+  // Returns false if no clock source is available.
   bool formatTime(char* buf, size_t bufSize, uint8_t utcOffsetQuarterHoursBiased = 48, bool use12Hour = false) const;
 
-  // Sync the DS3231 RTC from an NTP server. Requires WiFi to be connected.
+  // Sync the clock from an NTP server. Requires WiFi to be connected.
+  // On X3 writes the result to the DS3231. On X4 the SNTP stack updates time() directly.
   // Blocks for up to ~5s while waiting for SNTP response.
-  // Returns true if the RTC was successfully updated.
-  //
-  // Debouncing (skip if already synced once) is enforced by the caller, not here,
-  // so the HAL stays free of any app-layer settings dependency.
+  // Returns true on success. Debouncing is enforced by the caller.
   bool syncFromNTP();
 
  private:

--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -196,7 +196,7 @@ class CrossPointSettings {
   uint8_t statusBarTitle = CHAPTER_TITLE;
   uint8_t statusBarBattery = 1;
   uint8_t xtcStatusBarMode = XTC_STATUS_BAR_HIDE;
-  // Clock display in status bar (X3 only, requires DS3231 RTC)
+  // Clock display in status bar. Requires isAvailable(): DS3231 on X3, NTP-synced system time on X4.
   uint8_t statusBarClock = STATUS_BAR_CLOCK_HIDE;
   // Clock UTC offset in quarter-hour steps, biased by 48 so it fits in uint8_t.
   // Value 48 = UTC+0, 0 = UTC-12:00, 104 = UTC+14:00.
@@ -207,6 +207,8 @@ class CrossPointSettings {
   // Set once an NTP sync succeeds. Used to skip re-syncing on every WiFi connect.
   // Resetting to 0 (e.g. via the web UI) forces a re-sync on next WiFi connect.
   uint8_t clockHasBeenSynced = 0;
+  uint32_t clockAnchorEpoch = 0;
+  int32_t clockDriftPpm = 0;
   // Text rendering settings
   uint8_t extraParagraphSpacing = 1;
   uint8_t textAntiAliasing = 1;

--- a/src/JsonSettingsIO.cpp
+++ b/src/JsonSettingsIO.cpp
@@ -150,6 +150,9 @@ bool JsonSettingsIO::saveSettings(const CrossPointSettings& s, const char* path)
     doc["sdFontFamilyName"] = s.sdFontFamilyName;
   }
 
+  doc["clockAnchorEpoch"] = s.clockAnchorEpoch;
+  doc["clockDriftPpm"] = s.clockDriftPpm;
+
   // Language -- managed by LanguageSelectActivity, not in SettingsList.
   // Stored as ISO code string ("EN", "DE", ...) for stability across enum reorders.
   doc["language"] = (s.language < getLanguageCount()) ? LANGUAGE_CODES[s.language] : "EN";
@@ -255,6 +258,9 @@ bool JsonSettingsIO::loadSettings(CrossPointSettings& s, const char* json, bool*
   } else if (storedFontFamily >= CrossPointSettings::BUILTIN_FONT_COUNT) {
     if (needsResave) *needsResave = true;
   }
+
+  s.clockAnchorEpoch = doc["clockAnchorEpoch"] | static_cast<uint32_t>(0);
+  s.clockDriftPpm = doc["clockDriftPpm"] | static_cast<int32_t>(0);
 
   // Language -- stored as code string for stability across enum reorders.
   if (doc["language"].is<const char*>()) {

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -382,12 +382,12 @@ void WifiSelectionActivity::checkConnectionStatus() {
     connectedIP = ipStr;
     autoConnecting = false;
 
-    // Sync RTC from NTP on the first successful WiFi connection only. The DS3231
-    // drifts ~2 ppm so one sync is enough; users can force a re-sync from
-    // Settings > Customise Status Bar > Sync clock now.
-    if (halClock.isAvailable() && !SETTINGS.clockHasBeenSynced) {
+    const bool needsClockSync = !SETTINGS.clockHasBeenSynced || !halClock.isHardwareAvailable();
+    if (needsClockSync) {
       if (halClock.syncFromNTP()) {
         SETTINGS.clockHasBeenSynced = 1;
+        SETTINGS.clockAnchorEpoch = halClock.getAnchorEpoch();
+        SETTINGS.clockDriftPpm = halClock.getDriftPpm();
         SETTINGS.saveToFile();
       }
     }

--- a/src/activities/settings/ClockSyncActivity.cpp
+++ b/src/activities/settings/ClockSyncActivity.cpp
@@ -71,8 +71,9 @@ void ClockSyncActivity::runSync() {
     return;
   }
 
-  // Mark as synced so the auto-sync hook stops firing on future WiFi connects.
   SETTINGS.clockHasBeenSynced = 1;
+  SETTINGS.clockAnchorEpoch = halClock.getAnchorEpoch();
+  SETTINGS.clockDriftPpm = halClock.getDriftPpm();
   SETTINGS.saveToFile();
 
   // Read the freshly synced time back for the user-facing confirmation.

--- a/src/activities/settings/StatusBarSettingsActivity.h
+++ b/src/activities/settings/StatusBarSettingsActivity.h
@@ -23,7 +23,7 @@ class StatusBarSettingsActivity final : public Activity {
   OptionPopup optionPopup;
 
   int selectedIndex = 0;
-  // Decided in onEnter() based on halClock.isAvailable() so clock entries are hidden on X4.
+  // Decided in onEnter() based on halClock.isAvailable(); hidden until first NTP sync on X4.
   int visibleItemCount = 0;
 
   void handleSelection();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,6 +302,7 @@ void setup() {
   HalSystem::checkPanic();
 
   SETTINGS.loadFromFile();
+  halClock.setCalibration(SETTINGS.clockAnchorEpoch, SETTINGS.clockDriftPpm);
   APP_STATE.loadFromFile();
   RECENT_BOOKS.loadFromFile();
   I18N.setLanguage(static_cast<Language>(SETTINGS.language));


### PR DESCRIPTION
- **feat: add X4 software clock path to HalClock**
- **feat: persist clock drift calibration across reboots**
- **feat: wire X4 clock sync into WiFi and manual sync paths**

## Summary

* **What is the goal of this PR?** Adds a clock display to the X4. The X3 already has one via its DS3231 chip; the X4 has no hardware RTC so this uses the ESP32's internal oscillator + NTP. Drift is tracked between consecutive NTP syncs to keep display accuracy within seconds per day.

* **What changes are included?** All the display plumbing (status bar, settings UI, UTC offset, 12/24h format) already existed for the X3, gated on `halClock.isAvailable()`. Removing the `if (!_available) return false` guard in `syncFromNTP()` is what cascades through all of them — nothing else needed changing downstream. Sync piggybacks silently onto Wi-Fi sessions the user already initiates (file transfer, OPDS, OTA); no background task, no new sessions.

## Additional Context

* **No new Wi-Fi sessions.** Drift calibration compares the oscillator's elapsed time against NTP truth across consecutive syncs and applies a ppm correction ratio. X4 re-syncs on every Wi-Fi connect (no hardware RTC to hold accurate time between sessions); X3 keeps its existing one-time behaviour.
* **Chicken-and-egg fix in `WifiSelectionActivity`.** The sync gate previously required `halClock.isAvailable()`, which is false on X4 until after the first sync. The fix uses the new `isHardwareAvailable()` to distinguish the two devices.
* The clock settings menu on X4 stays hidden until after the first Wi-Fi connect triggers a sync — same out-of-the-box behaviour as X3, no extra wiring needed.

| File | +/- | Change |
|---|---|---|
| `lib/hal/HalClock.h` | +14 −9 | `_softwareClockSynced` flag; `isAvailable()` returns true for either DS3231 or software clock; `isHardwareAvailable()` to distinguish them; calibration getters/setters |
| `lib/hal/HalClock.cpp` | +52 −13 | `begin()` marks software clock valid if system time survived deep sleep; `syncFromNTP()` no longer gated on `_available`, X4 path sets flag instead of writing DS3231; `getTime()` X4 branch reads `time()` with drift correction applied |
| `src/CrossPointSettings.h` | +3 −1 | `clockAnchorEpoch` (uint32_t), `clockDriftPpm` (int32_t) |
| `src/JsonSettingsIO.cpp` | +6 | Serialize/deserialize the two new fields |
| `src/main.cpp` | +1 | `halClock.setCalibration(...)` after `SETTINGS.loadFromFile()` |
| `src/activities/network/WifiSelectionActivity.cpp` | +4 −4 | Sync gate changed from `isAvailable() && !clockHasBeenSynced` to always sync on X4; saves anchor/drift after sync |
| `src/activities/settings/ClockSyncActivity.cpp` | +2 −1 | Saves anchor/drift after manual sync |
| `src/activities/settings/StatusBarSettingsActivity.h` | +1 −1 | Stale comment updated |

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
