### PR TITLE
fix: prevent SD font advance cache overlap

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,16 +90,19 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
-### Version 30
+### Version 31
 
 Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
-Version 30 is binary-identical to version 29. The version was bumped because
-Arabic contextual shaping changed text measurement (`getTextAdvanceX` now
-measures the shaped visual text), so word positions cached by v29 no longer
-match what `drawText` renders.
+Version 31 is binary-identical to version 30. The version was bumped so
+SD-card font layouts are rebuilt with corrected glyph-advance measurement for
+CJK-heavy text.
+
+Version 30 was bumped because Arabic contextual shaping changed text
+measurement (`getTextAdvanceX` measures the shaped visual text), so word
+positions cached by v29 no longer match what `drawText` renders.
 
 Version 28 introduced serialized word style bits for underline, strikethrough,
 superscript, and subscript. The format also includes:

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -655,6 +655,41 @@ int32_t SdCardFont::findGlobalGlyphIndex(const PerStyle& s, uint32_t codepoint) 
   return -1;
 }
 
+bool SdCardFont::readAdvance(uint32_t codepoint, uint8_t style, uint16_t* outAdvance) const {
+  if (!outAdvance || !loaded_) return false;
+
+  const uint8_t styleIdx = resolveStyle(style);
+  if (styleIdx >= MAX_STYLES || !styles_[styleIdx].present) return false;
+  if (advanceTableLookup(styleIdx, codepoint, outAdvance)) return true;
+
+  const auto& s = styles_[styleIdx];
+  if (!s.fullIntervals && !s.bmpIntervals) return false;
+
+  int32_t glyphIndex = findGlobalGlyphIndex(s, codepoint);
+  if (glyphIndex < 0 && codepoint != REPLACEMENT_GLYPH) {
+    glyphIndex = findGlobalGlyphIndex(s, REPLACEMENT_GLYPH);
+  }
+  if (glyphIndex < 0) return false;
+
+  HalFile file;
+  if (!Storage.openFileForRead("SDCF", filePath_, file)) {
+    LOG_ERR("SDCF", "readAdvance: failed to open .cpfont for U+%04X style %u", codepoint, styleIdx);
+    return false;
+  }
+
+  const uint32_t fileOff = s.glyphsFileOffset + static_cast<uint32_t>(glyphIndex) * sizeof(EpdGlyph);
+  EpdGlyph glyph = {};
+  if (!file.seekSet(fileOff) || file.read(reinterpret_cast<uint8_t*>(&glyph), sizeof(EpdGlyph)) != sizeof(EpdGlyph)) {
+    LOG_ERR("SDCF", "readAdvance: failed to read glyph for U+%04X style %u", codepoint, styleIdx);
+    file.close();
+    return false;
+  }
+  file.close();
+
+  *outAdvance = glyph.advanceX;
+  return true;
+}
+
 // --- Prewarm ---
 
 int SdCardFont::prewarm(const char* utf8Text, uint8_t styleMask, bool metadataOnly) {
@@ -1098,10 +1133,21 @@ int SdCardFont::fetchAdvancesForCodepoints(uint32_t* codepoints, uint32_t cpCoun
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
     const auto& s = styles_[si];
 
-    // Stop fetching once the cache is full — further inserts would be dropped
-    // by the merge anyway. The renderer fast path tolerates missing entries
-    // (returns 0); the slow path is still correct for those codepoints.
-    if (advanceTableSize_[si] >= ADVANCE_CACHE_LIMIT) continue;
+    if (advanceTableSize_[si] >= ADVANCE_CACHE_LIMIT) {
+      bool cacheMissesRequestedCodepoint = false;
+      for (uint32_t i = 0; i < cpCount; i++) {
+        if (!advanceTableLookup(si, codepoints[i], nullptr)) {
+          cacheMissesRequestedCodepoint = true;
+          break;
+        }
+      }
+      if (!cacheMissesRequestedCodepoint) continue;
+
+      delete[] advanceTable_[si];
+      advanceTable_[si] = nullptr;
+      advanceTableSize_[si] = 0;
+      LOG_DBG("SDCF", "Advance table style %u: reset full cache for active text", si);
+    }
 
     // For each codepoint in `codepoints`, skip those already cached, then
     // resolve to a glyph index. Build a parallel array sorted by glyph index

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -57,6 +57,7 @@ class SdCardFont {
   // Look up advanceX for a codepoint from the advance table.
   // Returns the 12.4 fixed-point advance, or 0 if not found.
   uint16_t getAdvance(uint32_t codepoint, uint8_t style) const;
+  bool readAdvance(uint32_t codepoint, uint8_t style, uint16_t* outAdvance) const;
 
   // Returns true if advance table is populated for at least one style.
   bool hasAdvanceTable() const;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -17,7 +17,8 @@ namespace {
 // v30: Arabic shaping changed both drawing and measurement (getTextAdvanceX now
 //      measures the shaped visual text); cached word positions from v29 no longer
 //      match what drawText renders.
-constexpr uint8_t SECTION_FILE_VERSION = 30;
+// v31: busts caches for corrected SD-card font advance measurement in CJK-heavy layouts.
+constexpr uint8_t SECTION_FILE_VERSION = 31;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -21,6 +21,20 @@ namespace {
 uint8_t resolveSdCardStyle(const SdCardFont& font, const EpdFontFamily::Style style) {
   return font.resolveStyle(static_cast<uint8_t>(style));
 }
+
+int32_t resolveSdCardAdvanceFP(const SdCardFont& sdFont, const EpdFontFamily& font, const uint32_t cp,
+                               const EpdFontFamily::Style style, const uint8_t styleIdx) {
+  uint16_t advanceFP = sdFont.getAdvance(cp, styleIdx);
+  if (advanceFP != 0 || utf8IsCombiningMark(cp)) {
+    return advanceFP;
+  }
+  if (sdFont.readAdvance(cp, styleIdx, &advanceFP)) {
+    return advanceFP;
+  }
+
+  const EpdGlyph* glyph = font.getGlyph(cp, style);
+  return glyph ? glyph->advanceX : 0;
+}
 }  // namespace
 
 namespace {
@@ -1652,7 +1666,11 @@ int GfxRenderer::getSpaceWidth(const int fontId, const EpdFontFamily::Style styl
   auto sdIt = sdCardFonts_.find(fontId);
   if (sdIt != sdCardFonts_.end() && sdIt->second->hasAdvanceTable()) {
     const uint8_t resolvedStyle = resolveSdCardStyle(*sdIt->second, style);
-    return fp4::toPixel(sdIt->second->getAdvance(' ', resolvedStyle));
+    uint16_t advanceFP = sdIt->second->getAdvance(' ', resolvedStyle);
+    if (advanceFP == 0) {
+      sdIt->second->readAdvance(' ', resolvedStyle, &advanceFP);
+    }
+    return fp4::toPixel(advanceFP);
   }
 
   const auto fontIt = fontMap.find(fontId);
@@ -1673,7 +1691,11 @@ int GfxRenderer::getSpaceAdvance(const int fontId, const uint32_t leftCp, const 
   auto sdIt = sdCardFonts_.find(fontId);
   if (sdIt != sdCardFonts_.end() && sdIt->second->hasAdvanceTable()) {
     const uint8_t resolvedStyle = resolveSdCardStyle(*sdIt->second, style);
-    return fp4::toPixel(sdIt->second->getAdvance(' ', resolvedStyle));
+    uint16_t advanceFP = sdIt->second->getAdvance(' ', resolvedStyle);
+    if (advanceFP == 0) {
+      sdIt->second->readAdvance(' ', resolvedStyle, &advanceFP);
+    }
+    return fp4::toPixel(advanceFP);
   }
 
   const auto fontIt = fontMap.find(fontId);
@@ -1725,11 +1747,7 @@ int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFami
       if (BidiUtils::isTransparentMark(cp)) {
         continue;
       }
-      int32_t advFP = sdIt->second->getAdvance(cp, styleIdx);
-      if (advFP == 0 && !utf8IsCombiningMark(cp)) {
-        const EpdGlyph* glyph = font.getGlyph(cp, style);
-        advFP = glyph ? glyph->advanceX : 0;
-      }
+      const int32_t advFP = resolveSdCardAdvanceFP(*sdIt->second, font, cp, style, styleIdx);
       widthFP += isSupSub ? (advFP + 1) / 2 : advFP;
     }
     return fp4::toPixel(widthFP);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Prevent overlapping EPUB text when large SD-card fonts exhaust the glyph-advance cache. Closes #2002.
* **What changes are included?**
  * Refresh a full advance cache when it does not cover the active text.
  * Read missing glyph advances directly from `.cpfont` metadata instead of treating them as zero-width.
  * Apply the same fallback to space measurement.
  * Bump `section.bin` from version 30 to 31 so affected EPUB layouts rebuild automatically.
  * Document the cache-version change.

## Additional Context

* Ported from uxjulia/CrossInk@78a94233dbd9e82369f796a475a9989d58a27e0f.
* The persistent cache remains bounded at 768 entries per style and no long-lived allocation was added.
* Cache misses may require an additional SD metadata read during layout. Each file is closed immediately; this favors correct spacing over silently returning a zero width.
* Hardware reproduction with the issue’s CJK font and EPUB is still recommended.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
