### PR TITLE
fix: correct the settings enums for "blank" and "cover + custom" sleep screens

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -29,8 +29,8 @@ class CrossPointSettings {
     LIGHT = 1,
     CUSTOM = 2,
     COVER = 3,
-    BLANK = 4,
-    COVER_CUSTOM = 5,
+    COVER_CUSTOM = 4,
+    BLANK = 5,
     QUICK_RESUME = 6,
     SLEEP_SCREEN_MODE_COUNT
   };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
  * Fix the "Cover + custom" sleep screen option displaying a blank screen

* **What changes are included?**
  * Reorders the COVER_CUSTOM and BLANK enum values to match their positions in the device and web settings menus.

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks, specific areas to focus on).
  * The menu order changed in #2480, but the underlying enum order was not updated. As a result, selecting “Cover + Custom” stored the value interpreted as BLANK, while selecting “None” activated Cover + Custom.
---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
