### PR TITLE
feat: folder move/rename and bulk move in web file manager

### DIFF
--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -884,14 +884,10 @@ void CrossPointWebServer::handleRename() const {
 
   HalFile file = Storage.open(itemPath.c_str());
   if (!file) {
-    server->send(500, "text/plain", "Failed to open file");
+    server->send(500, "text/plain", "Failed to open item");
     return;
   }
-  if (file.isDirectory()) {
-    file.close();
-    server->send(400, "text/plain", "Only files can be renamed");
-    return;
-  }
+  const bool isDir = file.isDirectory();
 
   String parentPath = itemPath.substring(0, itemPath.lastIndexOf('/'));
   if (parentPath.isEmpty()) {
@@ -909,16 +905,18 @@ void CrossPointWebServer::handleRename() const {
     return;
   }
 
-  clearBookCache(itemPath.c_str());
+  if (!isDir) {
+    clearBookCache(itemPath.c_str());
+  }
   const bool success = file.rename(newPath.c_str());
   file.close();
 
   if (success) {
-    LOG_DBG("WEB", "Renamed file: %s -> %s", itemPath.c_str(), newPath.c_str());
+    LOG_DBG("WEB", "Renamed %s: %s -> %s", isDir ? "folder" : "file", itemPath.c_str(), newPath.c_str());
     server->send(200, "text/plain", "Renamed successfully");
   } else {
-    LOG_ERR("WEB", "Failed to rename file: %s -> %s", itemPath.c_str(), newPath.c_str());
-    server->send(500, "text/plain", "Failed to rename file");
+    LOG_ERR("WEB", "Failed to rename: %s -> %s", itemPath.c_str(), newPath.c_str());
+    server->send(500, "text/plain", "Failed to rename");
   }
 }
 
@@ -960,12 +958,15 @@ void CrossPointWebServer::handleMove() const {
 
   HalFile file = Storage.open(itemPath.c_str());
   if (!file) {
-    server->send(500, "text/plain", "Failed to open file");
+    server->send(500, "text/plain", "Failed to open item");
     return;
   }
-  if (file.isDirectory()) {
+  const bool isDir = file.isDirectory();
+
+  // Moving a folder into itself or a descendant would orphan the subtree
+  if (isDir && (destPath == itemPath || destPath.startsWith(itemPath + "/"))) {
     file.close();
-    server->send(400, "text/plain", "Only files can be moved");
+    server->send(400, "text/plain", "Cannot move a folder into itself");
     return;
   }
 
@@ -1002,16 +1003,18 @@ void CrossPointWebServer::handleMove() const {
     return;
   }
 
-  clearBookCache(itemPath.c_str());
+  if (!isDir) {
+    clearBookCache(itemPath.c_str());
+  }
   const bool success = file.rename(newPath.c_str());
   file.close();
 
   if (success) {
-    LOG_DBG("WEB", "Moved file: %s -> %s", itemPath.c_str(), newPath.c_str());
+    LOG_DBG("WEB", "Moved %s: %s -> %s", isDir ? "folder" : "file", itemPath.c_str(), newPath.c_str());
     server->send(200, "text/plain", "Moved successfully");
   } else {
-    LOG_ERR("WEB", "Failed to move file: %s -> %s", itemPath.c_str(), newPath.c_str());
-    server->send(500, "text/plain", "Failed to move file");
+    LOG_ERR("WEB", "Failed to move: %s -> %s", itemPath.c_str(), newPath.c_str());
+    server->send(500, "text/plain", "Failed to move");
   }
 }
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -134,6 +134,12 @@
     .folder-action-btn:hover {
       background-color: #d68910;
     }
+    .move-action-btn {
+      background-color: #3498db;
+    }
+    .move-action-btn:hover {
+      background-color: #2980b9;
+    }
     .delete-action-btn {
       background-color: #e74c3c;
     }
@@ -1518,6 +1524,7 @@
   <div class="action-buttons">
     <button class="action-btn upload-action-btn" onclick="openUploadModal()">📤 Upload</button>
     <button class="action-btn folder-action-btn" onclick="openFolderModal()">📁 New Folder</button>
+    <button class="action-btn move-action-btn" onclick="openMoveSelectedModal()">📂 Move Selected</button>
     <button class="action-btn delete-action-btn" onclick="openDeleteSelectedModal()">🗑️ Delete Selected</button>
   </div>
 </div>
@@ -1798,10 +1805,10 @@
 <div class="modal-overlay" id="renameModal">
   <div class="modal">
     <button class="modal-close" onclick="closeRenameModal()">&times;</button>
-    <h3>✏️ Rename File</h3>
+    <h3>✏️ Rename</h3>
     <div class="folder-form">
       <p class="file-info">Renaming <strong id="renameItemName"></strong></p>
-      <input type="text" id="renameNewName" class="folder-input" placeholder="New file name...">
+      <input type="text" id="renameNewName" class="folder-input" placeholder="New name...">
       <input type="hidden" id="renameItemPath">
       <button class="rename-btn-confirm" onclick="confirmRename()">Rename</button>
       <button class="delete-btn-cancel" onclick="closeRenameModal()">Cancel</button>
@@ -1813,12 +1820,11 @@
 <div class="modal-overlay" id="moveModal">
   <div class="modal">
     <button class="modal-close" onclick="closeMoveModal()">&times;</button>
-    <h3>📂 Move File</h3>
+    <h3>📂 Move</h3>
     <div class="folder-form">
       <p class="file-info">Moving <strong id="moveItemName"></strong></p>
       <input type="text" id="moveDestPath" class="folder-input" list="moveFolderOptions" placeholder="/Destination/Folder">
       <datalist id="moveFolderOptions"></datalist>
-      <input type="hidden" id="moveItemPath">
       <button class="move-btn-confirm" onclick="confirmMove()">Move</button>
       <button class="delete-btn-cancel" onclick="closeMoveModal()">Cancel</button>
     </div>
@@ -2050,7 +2056,11 @@
           fileTableContent += `<td><span class="file-icon">📁</span><a href="/files?path=${encodeURIComponent(folderPath)}" class="folder-link">${escapeHtml(file.name)}</a></td>`;
           fileTableContent += '<td><span class="folder-badge">FOLDER</span></td>';
           fileTableContent += '<td>-</td>';
-          fileTableContent += `<td class="actions-col"><div class="action-icon-group"><button class="delete-btn" onclick="openDeleteModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Delete folder">🗑️</button></div></td>`;
+          fileTableContent += `<td class="actions-col"><div class="action-icon-group">`;
+          fileTableContent += `<button class="move-btn" onclick="openMoveModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Move folder">📂</button>`;
+          fileTableContent += `<button class="rename-btn" onclick="openRenameModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Rename folder">✏️</button>`;
+          fileTableContent += `<button class="delete-btn" onclick="openDeleteModal('${file.name.replaceAll("'", "\\'")}', '${folderPath.replaceAll("'", "\\'")}', true)" title="Delete folder">🗑️</button>`;
+          fileTableContent += `</div></td>`;
           fileTableContent += '</tr>';
         } else {
           let filePath = currentPath;
@@ -5800,8 +5810,8 @@ function retryAllFailedUploads() {
   }
 
   // Rename functions
-  function openRenameModal(name, path) {
-    document.getElementById('renameItemName').textContent = '📄 ' + name;
+  function openRenameModal(name, path, isFolder) {
+    document.getElementById('renameItemName').textContent = (isFolder ? '📁 ' : '📄 ') + name;
     document.getElementById('renameItemPath').value = path;
     document.getElementById('renameNewName').value = name;
     document.getElementById('renameModal').classList.add('open');
@@ -5825,7 +5835,7 @@ function retryAllFailedUploads() {
       return;
     }
     if (newName.includes('/') || newName.includes('\\')) {
-      alert('File name cannot include slashes.');
+      alert('Name cannot include slashes.');
       return;
     }
 
@@ -5915,9 +5925,28 @@ function retryAllFailedUploads() {
     });
   }
 
-  function openMoveModal(name, path) {
-    document.getElementById('moveItemName').textContent = '📄 ' + name;
-    document.getElementById('moveItemPath').value = path;
+  let moveItemsGlobal = [];
+
+  function openMoveModal(name, path, isFolder) {
+    openMoveModalForItems([{ name: name, path: path, isFolder: !!isFolder }]);
+  }
+
+  // Open move modal for currently selected checkboxes
+  function openMoveSelectedModal() {
+    const items = getSelectedItems();
+    if (items.length === 0) {
+      alert('Please select at least one item to move.');
+      return;
+    }
+    openMoveModalForItems(items);
+  }
+
+  function openMoveModalForItems(items) {
+    moveItemsGlobal = items;
+    const label = items.length === 1
+      ? (items[0].isFolder ? '📁 ' : '📄 ') + items[0].name
+      : items.length + ' items';
+    document.getElementById('moveItemName').textContent = label;
     document.getElementById('moveDestPath').value = currentPath === '/' ? '/' : currentPath;
     document.getElementById('moveModal').classList.add('open');
     loadMoveFolderOptions();
@@ -5930,37 +5959,47 @@ function retryAllFailedUploads() {
     document.getElementById('moveModal').classList.remove('open');
   }
 
-  function confirmMove() {
-    const path = document.getElementById('moveItemPath').value;
+  async function confirmMove() {
     const destPath = normalizePath(document.getElementById('moveDestPath').value);
 
     if (!destPath) {
       alert('Please enter a destination folder.');
       return;
     }
+    if (!moveItemsGlobal || moveItemsGlobal.length === 0) {
+      closeMoveModal();
+      return;
+    }
 
-    const formData = new FormData();
-    formData.append('path', path);
-    formData.append('dest', destPath);
-
-    const xhr = new XMLHttpRequest();
-    xhr.open('POST', '/move', true);
-
-    xhr.onload = function() {
-      if (xhr.status === 200) {
-        window.location.reload();
-      } else {
-        alert('Failed to move: ' + xhr.responseText);
+    // Reject moving a folder into itself or its own subtree before hitting the server
+    for (const item of moveItemsGlobal) {
+      if (item.isFolder && (destPath === item.path || destPath.startsWith(item.path + '/'))) {
+        alert('Cannot move folder "' + item.name + '" into itself.');
+        return;
       }
-      closeMoveModal();
-    };
+    }
 
-    xhr.onerror = function() {
-      alert('Failed to move - network error');
-      closeMoveModal();
-    };
+    const failures = [];
+    // Move sequentially: the device serializes SD access, so parallel requests only add contention
+    for (const item of moveItemsGlobal) {
+      const formData = new FormData();
+      formData.append('path', item.path);
+      formData.append('dest', destPath);
+      try {
+        const res = await fetch('/move', { method: 'POST', body: formData });
+        if (!res.ok) {
+          failures.push(item.name + ': ' + await res.text());
+        }
+      } catch (e) {
+        failures.push(item.name + ': network error');
+      }
+    }
 
-    xhr.send(formData);
+    if (failures.length > 0) {
+      alert('Failed to move:\n' + failures.join('\n'));
+    }
+    closeMoveModal();
+    window.location.reload();
   }
   hydrate();
 </script>


### PR DESCRIPTION
## Summary

The web file manager could move and rename individual files (#630) but rejected folders ("Only files can be renamed/moved"), and the only bulk action was Delete Selected. This PR closes both gaps:

- **Folder move and rename**: `/rename` and `/move` now accept directories. SdFat's `FatFile::rename` supports subdirectories natively (including the dot-dot entry fix-up when reparenting), so this is a single FAT metadata operation — no copying. Folder rows in the file table get the same 📂 move / ✏️ rename buttons files already have.
- **Self-move guard**: `/move` refuses to move a folder into itself or its own subtree (which would orphan the subtree on the FAT chain); the same check runs client-side for a friendlier message.
- **Move Selected**: new toolbar action next to Delete Selected, reusing the existing checkbox selection. The move modal now handles multiple items and posts `/move` sequentially per item (SD access is serialized by the storage mutex, so parallel requests would only add contention); failures are collected and reported together.
- `clearBookCache` is skipped for directories — it only understands book file paths.