### PR TITLE
fix: bind settings labels to enum values

### DIFF
--- a/src/CrossPointSettings.h
+++ b/src/CrossPointSettings.h
@@ -72,7 +72,12 @@ class CrossPointSettings {
     XTC_STATUS_BAR_MODE_COUNT
   };
 
-  enum STATUS_BAR_CLOCK_MODE { STATUS_BAR_CLOCK_HIDE = 0, STATUS_BAR_CLOCK_RIGHT = 1, STATUS_BAR_CLOCK_LEFT = 2 };
+  enum STATUS_BAR_CLOCK_MODE {
+    STATUS_BAR_CLOCK_HIDE = 0,
+    STATUS_BAR_CLOCK_RIGHT = 1,
+    STATUS_BAR_CLOCK_LEFT = 2,
+    STATUS_BAR_CLOCK_MODE_COUNT
+  };
 
   enum ORIENTATION {
     PORTRAIT = 0,       // 480x800 logical coordinates (current default)

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -101,11 +101,25 @@ inline SettingInfo buildFontFamilySetting(const SdCardFontRegistry* registry) {
 // version. Callers without SD fonts pay only a vector copy.
 inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* registry = nullptr) {
   static const std::vector<SettingInfo> baseList = [] {
+    // Enum settings are persisted as numeric values. Assign these labels by enum
+    // value so a reordered menu or enum cannot silently swap their behavior.
+    std::vector<StrId> sleepScreenValues(CrossPointSettings::SLEEP_SCREEN_MODE_COUNT);
+    sleepScreenValues[CrossPointSettings::DARK] = StrId::STR_DARK;
+    sleepScreenValues[CrossPointSettings::LIGHT] = StrId::STR_LIGHT;
+    sleepScreenValues[CrossPointSettings::CUSTOM] = StrId::STR_CUSTOM;
+    sleepScreenValues[CrossPointSettings::COVER] = StrId::STR_COVER;
+    sleepScreenValues[CrossPointSettings::COVER_CUSTOM] = StrId::STR_COVER_CUSTOM;
+    sleepScreenValues[CrossPointSettings::BLANK] = StrId::STR_NONE_OPT;
+    sleepScreenValues[CrossPointSettings::QUICK_RESUME] = StrId::STR_QUICK_RESUME;
+
+    std::vector<StrId> statusBarClockValues(CrossPointSettings::STATUS_BAR_CLOCK_MODE_COUNT);
+    statusBarClockValues[CrossPointSettings::STATUS_BAR_CLOCK_HIDE] = StrId::STR_HIDE;
+    statusBarClockValues[CrossPointSettings::STATUS_BAR_CLOCK_RIGHT] = StrId::STR_DIR_RIGHT;
+    statusBarClockValues[CrossPointSettings::STATUS_BAR_CLOCK_LEFT] = StrId::STR_DIR_LEFT;
+
     std::vector<SettingInfo> v = {
         // --- Display ---
-        SettingInfo::Enum(StrId::STR_SLEEP_SCREEN, &CrossPointSettings::sleepScreen,
-                          {StrId::STR_DARK, StrId::STR_LIGHT, StrId::STR_CUSTOM, StrId::STR_COVER,
-                           StrId::STR_COVER_CUSTOM, StrId::STR_NONE_OPT, StrId::STR_QUICK_RESUME},
+        SettingInfo::Enum(StrId::STR_SLEEP_SCREEN, &CrossPointSettings::sleepScreen, std::move(sleepScreenValues),
                           "sleepScreen", StrId::STR_CAT_DISPLAY),
         SettingInfo::Enum(StrId::STR_SLEEP_COVER_MODE, &CrossPointSettings::sleepScreenCoverMode,
                           {StrId::STR_FIT, StrId::STR_CROP}, "sleepScreenCoverMode", StrId::STR_CAT_DISPLAY),
@@ -273,9 +287,8 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
                           StrId::STR_CUSTOMISE_STATUS_BAR),
         // Clock entries (web settings only; device UI uses ClockOffsetActivity for the offset).
         // Range 0..104 = quarter-hour steps from UTC-12:00 to UTC+14:00, biased by 48.
-        SettingInfo::Enum(StrId::STR_CLOCK, &CrossPointSettings::statusBarClock,
-                          {StrId::STR_HIDE, StrId::STR_DIR_LEFT, StrId::STR_DIR_RIGHT}, "statusBarClock",
-                          StrId::STR_CUSTOMISE_STATUS_BAR),
+        SettingInfo::Enum(StrId::STR_CLOCK, &CrossPointSettings::statusBarClock, std::move(statusBarClockValues),
+                          "statusBarClock", StrId::STR_CUSTOMISE_STATUS_BAR),
         SettingInfo::Value(StrId::STR_CLOCK_UTC_OFFSET, &CrossPointSettings::clockUtcOffsetQ, {0, 104, 1},
                            "clockUtcOffsetQ", StrId::STR_CUSTOMISE_STATUS_BAR),
         SettingInfo::Enum(StrId::STR_CLOCK_FORMAT, &CrossPointSettings::clockFormat,

--- a/src/activities/settings/StatusBarSettingsActivity.cpp
+++ b/src/activities/settings/StatusBarSettingsActivity.cpp
@@ -77,7 +77,7 @@ const StrId titleNames[TITLE_ITEMS] = {StrId::STR_BOOK, StrId::STR_CHAPTER, StrI
 constexpr int XTC_STATUS_BAR_ITEMS = 3;
 const StrId xtcStatusBarNames[XTC_STATUS_BAR_ITEMS] = {StrId::STR_HIDE, StrId::STR_BOTTOM, StrId::STR_TOP};
 
-constexpr int STATUS_BAR_CLOCK_ITEMS = 3;
+constexpr int STATUS_BAR_CLOCK_ITEMS = CrossPointSettings::STATUS_BAR_CLOCK_MODE_COUNT;
 const StrId statusBarClockNames[STATUS_BAR_CLOCK_ITEMS] = {StrId::STR_HIDE, StrId::STR_DIR_RIGHT, StrId::STR_DIR_LEFT};
 
 const int verticalPreviewPadding = 50;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Ensure persisted numeric settings always display and select the label belonging to their enum value.
  * Fix the web clock-position setting, whose enum order is Hide/Right/Left while the web label list is currently Hide/Left/Right.
* **What changes are included?**
  * Build the sleep-screen and status-bar clock label vectors by explicit enum index.
  * Add `STATUS_BAR_CLOCK_MODE_COUNT` and use it instead of a duplicated literal count in `StatusBarSettingsActivity`.

## Additional Context

* Numeric enum values and the persisted settings schema are unchanged.
* Upstream PR [#2635](https://github.com/crosspoint-reader/crosspoint-reader/pull/2635) corrected the immediate Blank versus Cover + custom sleep-screen ordering. This PR generalizes that mapping by binding every label to its explicit enum value and also fixes the independently mismatched status-bar clock ordering.
* The label vectors are created once inside the existing static settings-list initializer and moved into their `SettingInfo` entries, so this adds no recurring settings-view allocation.
* The earlier red firmware check was unrelated to this patch: it was the incomplete-`Activity` base-branch failure subsequently fixed upstream by [#2646](https://github.com/crosspoint-reader/crosspoint-reader/pull/2646).
* Validation:
  * Fresh GitHub CI against current `develop`: firmware build, unit tests, cppcheck, clang-format, title check, and aggregate status all pass.
  * `pio check`: no defects found.
  * The integration firmware containing the mapping fix was built and flashed successfully on Xteink X4 hardware.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools were used to reproduce the settings mismatch, audit merge-conflict patterns and open PRs, implement the enum-indexed mapping, and validate the firmware.
