### PR TITLE
fix: EndOfBookOptions fails to compile

### DIFF
--- a/src/activities/reader/EndOfBookOptions.cpp
+++ b/src/activities/reader/EndOfBookOptions.cpp
@@ -6,6 +6,10 @@
 
 #include "CrossPointSettings.h"
 #include "ReaderUtils.h"
+// ReaderUtils.h pulls in ActivityManager.h, which only forward-declares Activity while holding
+// std::unique_ptr<Activity> members. Destroying that unique_ptr needs the complete type, so the
+// definition must be visible here.
+#include "activities/Activity.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "util/ButtonNavigator.h"


### PR DESCRIPTION
ActivityManager.h forward-declares Activity but holds std::unique_ptr<Activity> members. Instantiating that unique_ptr's destructor requires the complete type, so any TU including ActivityManager.h without Activity.h fails to compile.

EndOfBookOptions.cpp reaches ActivityManager.h via ReaderUtils.h and does not otherwise include Activity.h, breaking the develop build since 3e1dd31e5.

Include Activity.h directly. Adding it to ActivityManager.h instead does not work: Activity.h depends on HomeMenuItem, which ActivityManager.h defines.
