### PR TITLE
fix: select strongest AP for matching WiFi SSID

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -354,6 +354,11 @@ void WifiSelectionActivity::attemptConnection() {
   WiFi.disconnect(true, true);  // Abort any in-progress SDK auto-connect and clear NVS-saved SSID
   delay(100);
 
+  // Scan all channels so networks with multiple APs use the strongest matching
+  // BSSID instead of the first match found by the framework's default fast scan.
+  WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+  WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+
   // Set hostname so routers show "CrossPoint-Reader-AABBCCDDEEFF" instead of "esp32-XXXXXXXXXXXX"
   String mac = WiFi.macAddress();
   mac.replace(":", "");
@@ -381,6 +386,16 @@ void WifiSelectionActivity::checkConnectionStatus() {
     snprintf(ipStr, sizeof(ipStr), "%d.%d.%d.%d", ip[0], ip[1], ip[2], ip[3]);
     connectedIP = ipStr;
     autoConnecting = false;
+
+#if defined(ENABLE_SERIAL_LOG) && LOG_LEVEL >= 2
+    uint8_t connectedBssid[6] = {};
+    WiFi.BSSID(connectedBssid);
+    LOG_DBG("WIFI", "Connected BSSID: %02x:%02x:%02x:%02x:%02x:%02x, channel: %d, RSSI: %d dBm",
+            static_cast<unsigned>(connectedBssid[0]), static_cast<unsigned>(connectedBssid[1]),
+            static_cast<unsigned>(connectedBssid[2]), static_cast<unsigned>(connectedBssid[3]),
+            static_cast<unsigned>(connectedBssid[4]), static_cast<unsigned>(connectedBssid[5]), WiFi.channel(),
+            WiFi.RSSI());
+#endif
 
     // Sync RTC from NTP on the first successful WiFi connection only. The DS3231
     // drifts ~2 ppm so one sync is enough; users can force a re-sync from


### PR DESCRIPTION
## Summary

* **Goal:** When one SSID is advertised by multiple access points, connect to the strongest compatible BSSID measured during association instead of accepting the first match found.
* **Changes:**
  * Configure the station connection to scan all Wi-Fi channels and sort matching APs by RSSI before calling `WiFi.begin()`.
  * Add a debug-only connection log containing the selected BSSID, channel, and RSSI so AP selection can be verified on hardware.

## Root cause

`WifiCredentialStore` persists the SSID, password, and last-connected SSID; it does not store or pin a BSSID. The connection path likewise passes only the SSID and password to `WiFi.begin()`.

Arduino-ESP32 defaults station association to `WIFI_FAST_SCAN`. ESP-IDF defines that mode as ending the scan after an SSID match is found. Although the default sort method is signal-based, sorting matching APs requires `WIFI_ALL_CHANNEL_SCAN`. On mesh or multi-AP networks, the default combination can therefore associate with an AP found earlier in the channel scan even when another matching AP has a stronger signal.

## Implementation

`WifiSelectionActivity::attemptConnection()` now selects:

* `WIFI_ALL_CHANNEL_SCAN`, so every channel is evaluated.
* `WIFI_CONNECT_AP_BY_SIGNAL`, so compatible matching APs are ranked by RSSI.

Both calls are immediately before `WiFi.begin()`, as required by the Arduino-ESP32 API. Credential storage and the existing connection flow are unchanged.

`WifiSelectionActivity::checkConnectionStatus()` logs the chosen BSSID, channel, and RSSI only when serial debug logging is enabled. This adds no heap allocation; the only new runtime storage is a six-byte stack array in the debug-only success path.

## User-visible behavior and trade-offs

* A new connection should favor the strongest compatible AP advertising the requested SSID at scan time.
* Connection setup can take a few seconds longer because the radio scans all channels.
* This affects AP selection when connecting; it does not add continuous roaming after association.
* This PR intentionally does not change RSSI measurement or the signal-bar UI.

## Validation

* Rebased onto current `origin/develop` (`3dfbc038`).
* `pio run -e default` — passed on commit `6e472466`.
  * RAM: 51,364 / 327,680 bytes (15.7%).
  * Flash: 5,415,237 / 6,553,600 bytes (82.6%).
* `pio check -e default --fail-on-defect low --fail-on-defect medium --fail-on-defect high` — no defects found.
* `clang-format --dry-run --Werror src/activities/network/WifiSelectionActivity.cpp` — passed.
* `git diff --check` — passed.
* Built and flashed the same Wi-Fi source patch to an X4; esptool write verification passed.
* Repeated hardware tests detected three BSSIDs advertising the same SSID on channels 1, 10, and 11. The selected BSSID changed between connections as the strongest scan-time RSSI changed, confirming that association was not pinned to one MAC address.

The build still emits existing warnings from third-party Arduino-wolfSSL macro redefinitions and WebSockets' deprecated `flush()` call; the changed source file emits no warnings.

## Additional Context

The full-channel scan deliberately prioritizes reliable AP choice over minimum connection latency. This is especially useful for File Transfer away from the AP near which the device was originally configured.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

Codex assisted with diagnosis, implementation, source review, local validation, device flashing/monitoring, and drafting this PR description.
