### PR TITLE
fix: duplicate User-Agent header on wolfSSL requests breaks strict servers (aiohttp 400)

### DIFF
--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -58,7 +58,10 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
       LOG_ERR("HTTP", "wolfSSL bad URL: %s", url.c_str());
       return HttpDownloader::HTTP_ERROR;
     }
-    http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION);
+    // setUserAgent replaces SecureHttpClient's built-in UA; addHeader would
+    // append a second User-Agent header, which strict servers reject (aiohttp
+    // answers 400 "Duplicate 'User-Agent' header found").
+    http.setUserAgent("CrossPoint-ESP32-" CROSSPOINT_VERSION);
     if (!username.empty() && !password.empty()) {
       const std::string credentials = username + ":" + password;
       const String encoded = base64::encode(credentials.c_str());


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a regression where wolfSSL HTTP requests send two `User-Agent` headers, which strict HTTP servers reject with `400 Bad Request`. On a CrossPoint device this surfaces as "failed to fetch feed" for OPDS (and affects any wolfSSL request path — KOSync and OTA — against a strict server).

* **What changes are included?**
  * In `src/network/HttpDownloader.cpp` (`runGetWolf`), replace `http.addHeader("User-Agent", ...)` with `http.setUserAgent(...)`.

**Root cause.** The FreeInk SDK's `SecureHttpClient` *always* emits its own built-in `User-Agent: FreeInk-ESP32` header, and its `addHeader()` appends rather than replaces. Commit `3e627112` (PR #2475, "fix: oom exceptions for OPDS, KOSync, and OTA via wolfssl", merged 2026-07-11) added `http.addHeader("User-Agent", "CrossPoint-ESP32-" CROSSPOINT_VERSION)` to `runGetWolf`. The result is that every wolfSSL request since that commit carries **two** `User-Agent` headers. `setUserAgent()` replaces the built-in value instead of appending, so exactly one header is sent.

Because this is on the wolfSSL request path shared by OPDS, KOSync, and OTA, every build since 2026-07-11 is affected when talking to a server that enforces the HTTP spec's single-`User-Agent` rule.

## Additional Context

**Observed failure.** Fetching an OPDS feed served by a Home Assistant instance on the local network (Home Assistant runs on `aiohttp`) fails: the device reports "failed to fetch feed". `aiohttp` rejects the request with `400 Bad Request: Duplicate 'User-Agent' header found`.

**Wire evidence** (captured via `tcpdump` on the server, 2026-07-20). The device's request contained two `User-Agent` headers:

```
User-Agent: FreeInk-ESP32
User-Agent: CrossPoint-ESP32-1.4.1-dev-...
```

and the server responded:

```
HTTP/1.1 400 Bad Request
...
Duplicate 'User-Agent' header found.
```

With the one-line fix applied, only `User-Agent: CrossPoint-ESP32-...` is sent and the same feed fetches successfully.

**Verification.** Built and flashed on X3 hardware and tested against a Home Assistant OPDS server on the local network: the feed fetch **succeeds with this fix and fails without it**. Build is green (`pio run -e default`) and `clang-format` is clean.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — written with Claude Code, human-reviewed and hardware-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
