### PR TITLE
fix: preserve custom font ligatures

### DIFF
--- a/lib/EpdFont/scripts/fontconvert_sdcard.py
+++ b/lib/EpdFont/scripts/fontconvert_sdcard.py
@@ -193,6 +193,51 @@ STANDARD_LIGATURE_MAP = {
 }
 
 
+def extract_ligature_glyph_indices_fonttools(font_path):
+    """Map standard ligature codepoints without a cmap entry to their glyph IDs.
+
+    Most fonts use unencoded glyphs such as ``f_f`` for standard ligatures.
+    The reader represents those substitutions with the Unicode compatibility
+    codepoints, so rasterize the GSUB target directly instead of falling back
+    to another font for a codepoint that the primary cmap does not contain.
+    """
+    from fontTools.ttLib import TTFont
+
+    font = TTFont(font_path)
+    cmap = font.getBestCmap() or {}
+    glyph_to_cp = {gname: cp for cp, gname in cmap.items()}
+    glyph_indices = {gname: index for index, gname in enumerate(font.getGlyphOrder())}
+    overrides = {}
+
+    if 'GSUB' in font:
+        gsub = font['GSUB'].table
+        liga_lookup_indices = set()
+        if gsub.FeatureList:
+            for fr in gsub.FeatureList.FeatureRecord:
+                if fr.FeatureTag in ('liga', 'rlig'):
+                    liga_lookup_indices.update(fr.Feature.LookupListIndex)
+
+        for li in liga_lookup_indices:
+            lookup = gsub.LookupList.Lookup[li]
+            for st in lookup.SubTable:
+                actual = st.ExtSubTable if lookup.LookupType == 7 and hasattr(st, 'ExtSubTable') else st
+                if not hasattr(actual, 'ligatures'):
+                    continue
+                for first_glyph, ligature_list in actual.ligatures.items():
+                    if first_glyph not in glyph_to_cp:
+                        continue
+                    for lig in ligature_list:
+                        if any(component not in glyph_to_cp for component in lig.Component):
+                            continue
+                        seq = tuple([glyph_to_cp[first_glyph]] + [glyph_to_cp[component] for component in lig.Component])
+                        lig_cp = STANDARD_LIGATURE_MAP.get(seq)
+                        if lig_cp is not None and lig_cp not in cmap:
+                            overrides[lig_cp] = glyph_indices[lig.LigGlyph]
+
+    font.close()
+    return overrides
+
+
 def _extract_pairpos_subtable(subtable, glyph_to_cp, raw_kern):
     """Extract kerning from a PairPos subtable (Format 1 or 2)."""
     if subtable.Format == 1:
@@ -533,6 +578,7 @@ def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=F
     # it before set_char_size() would waste work at the default size and risk
     # Invalid_Size_Handle on some fonts.
     face.set_char_size(size << 6, size << 6, 150, 150)
+    ligature_glyph_indices = extract_ligature_glyph_indices_fonttools(fontfile)
     fallback_face = None
     if fallback_fontfile:
         fallback_face = freetype.Face(fallback_fontfile)
@@ -544,6 +590,8 @@ def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=F
 
     def load_glyph(code_point):
         glyph_index = face.get_char_index(code_point)
+        if glyph_index == 0:
+            glyph_index = ligature_glyph_indices.get(code_point, 0)
         if glyph_index > 0:
             face.load_glyph(glyph_index, load_flags)
             return face
@@ -563,7 +611,7 @@ def rasterize_font_style(fontfile, size, intervals, style_id=0, force_autohint=F
     for i_start, i_end in intervals:
         start = i_start
         for code_point in range(i_start, i_end + 1):
-            has_primary = face.get_char_index(code_point) != 0
+            has_primary = face.get_char_index(code_point) != 0 or code_point in ligature_glyph_indices
             has_fallback = fallback_face and fallback_face.get_char_index(code_point) != 0
             if not has_primary and not has_fallback:
                 if start < code_point:


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix custom-font ligatures rendering in a fallback font instead of the selected font. Fixes #2672.
* **What changes are included?** Update the SD-card font converter to keep supported ligatures in the custom font when the font stores them internally rather than as separately encoded characters.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

Bitter and Literata represent `ff` with an internal `f_f` glyph. The converter previously substituted the `ff` ligature codepoint, then drew it using the configured fallback font because the selected font did not expose that codepoint directly. This produced the mixed-font ligature shown in #2672.

This covers every standard ligature supported by the converter: `ff`, `fi`, `fl`, `ffi`, `ffl`, long-s + `t`, and `st`, not only `ff`.

- The converter must be re-run for the fonts distributed through **Settings > System > Manage Fonts**.
- Memory / flash impact: none at firmware runtime; this changes the host-side font conversion script only.

Validation:

- `python3 -m py_compile lib/EpdFont/scripts/fontconvert_sdcard.py`
- Converted Bitter and Literata with their real font sources and verified their internal `f_f` glyphs are kept in the output.
- Tested on device and confirmed the issue is fixed (see how it was before in https://github.com/crosspoint-reader/crosspoint-reader/issues/2672):

<img width="3072" height="4080" alt="PXL_20260721_224350432" src="https://github.com/user-attachments/assets/d407491a-dffc-4043-8227-1789195b9a66" />

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
