### PR TITLE
fix: restore antialiasing after manual refresh

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -69,6 +69,7 @@
             packages = [
               pio
               fhsEnv
+              pkgs.clang-tools # for clang-format
             ];
 
             shellHook = setEnvs;

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -44,6 +44,9 @@ class Activity {
   virtual bool skipLoopDelay() { return false; }
   virtual bool preventAutoSleep() { return false; }
   virtual bool isReaderActivity() const { return false; }
+  // Whether a forced screen refresh should be followed by this activity's normal
+  // render path to restore its grayscale overlay.
+  virtual bool restoresGrayscaleAfterForcedRefresh() const { return false; }
   virtual bool isHomeActivity() const { return false; }
   virtual bool handleHomeGesture() { return false; }
   virtual ScreenshotInfo getScreenshotInfo() const { return {}; }

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -44,9 +44,8 @@ class Activity {
   virtual bool skipLoopDelay() { return false; }
   virtual bool preventAutoSleep() { return false; }
   virtual bool isReaderActivity() const { return false; }
-  // Whether a forced screen refresh should be followed by this activity's normal
-  // render path to restore its grayscale overlay.
-  virtual bool restoresGrayscaleAfterForcedRefresh() const { return false; }
+  // Returns true when the activity schedules its own forced refresh.
+  virtual bool handleForcedRefresh() { return false; }
   virtual bool isHomeActivity() const { return false; }
   virtual bool handleHomeGesture() { return false; }
   virtual ScreenshotInfo getScreenshotInfo() const { return {}; }

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -269,6 +269,10 @@ bool ActivityManager::isReaderActivity() const {
          (currentActivity && currentActivity->isReaderActivity());
 }
 
+bool ActivityManager::currentActivityRestoresGrayscaleAfterForcedRefresh() const {
+  return currentActivity && currentActivity->restoresGrayscaleAfterForcedRefresh();
+}
+
 bool ActivityManager::skipLoopDelay() const { return currentActivity && currentActivity->skipLoopDelay(); }
 
 ScreenshotInfo ActivityManager::getScreenshotInfo() const {

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -269,9 +269,7 @@ bool ActivityManager::isReaderActivity() const {
          (currentActivity && currentActivity->isReaderActivity());
 }
 
-bool ActivityManager::currentActivityRestoresGrayscaleAfterForcedRefresh() const {
-  return currentActivity && currentActivity->restoresGrayscaleAfterForcedRefresh();
-}
+bool ActivityManager::handleForcedRefresh() { return currentActivity && currentActivity->handleForcedRefresh(); }
 
 bool ActivityManager::skipLoopDelay() const { return currentActivity && currentActivity->skipLoopDelay(); }
 

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -102,7 +102,7 @@ class ActivityManager {
 
   bool preventAutoSleep() const;
   bool isReaderActivity() const;
-  bool currentActivityRestoresGrayscaleAfterForcedRefresh() const;
+  bool handleForcedRefresh();
   bool skipLoopDelay() const;
   ScreenshotInfo getScreenshotInfo() const;
 

--- a/src/activities/ActivityManager.h
+++ b/src/activities/ActivityManager.h
@@ -102,6 +102,7 @@ class ActivityManager {
 
   bool preventAutoSleep() const;
   bool isReaderActivity() const;
+  bool currentActivityRestoresGrayscaleAfterForcedRefresh() const;
   bool skipLoopDelay() const;
   ScreenshotInfo getScreenshotInfo() const;
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1478,6 +1478,8 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
 
   const bool pageHasImages = page->hasImages();
   const bool pageHasImagesNeedingDecode = pageHasImages && page->hasImagesNeedingDecode();
+  const bool manualRefreshPending = forcedRefreshPending;
+  forcedRefreshPending = false;
   const bool needsTextGrayscale = SETTINGS.textAntiAliasing;
   const bool needsAnyGrayscale = needsTextGrayscale || pageHasImages;
   const bool tiledGrayscale = needsAnyGrayscale && renderer.supportsStripGrayscale();
@@ -1514,6 +1516,11 @@ void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int or
     // Step 2: Re-render with images and display again (images appear clean)
     int16_t imgX, imgY, imgW, imgH;
     if (page->getImageBoundingBox(imgX, imgY, imgW, imgH)) {
+      // Image pages intentionally bypass the regular refresh cadence. Preserve
+      // the manual clean pass before their double-FAST grayscale pipeline.
+      if (manualRefreshPending) {
+        renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+      }
       renderer.fillRect(imgX + orientedMarginLeft, imgY + orientedMarginTop, imgW, imgH, false);
       renderer.displayBuffer(HalDisplay::FAST_REFRESH);
 

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -21,6 +21,9 @@ class EpubReaderActivity final : public Activity {
   // Cleared on the next render after the new section loads and resolves it to a page.
   std::string pendingAnchor;
   int pagesUntilFullRefresh = 0;
+  // Image pages use a dedicated double-FAST refresh path, so retain a manual
+  // refresh request until renderContents can issue its clean base pass.
+  bool forcedRefreshPending = false;
   int cachedSpineIndex = 0;
   int cachedChapterTotalPageCount = 0;
   unsigned long lastPageTurnTime = 0UL;
@@ -198,6 +201,7 @@ class EpubReaderActivity final : public Activity {
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
     pagesUntilFullRefresh = 1;
+    forcedRefreshPending = true;
     requestUpdate();
     return true;
   }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -196,6 +196,7 @@ class EpubReaderActivity final : public Activity {
   // speed would only burn battery; the paused gate still retries every loop pass).
   bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
   bool isReaderActivity() const override { return true; }
+  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
   ScreenshotInfo getScreenshotInfo() const override;
   CrossPointPosition getCurrentPosition() const;
 };

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -196,7 +196,11 @@ class EpubReaderActivity final : public Activity {
   // speed would only burn battery; the paused gate still retries every loop pass).
   bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
   bool isReaderActivity() const override { return true; }
-  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
+  bool handleForcedRefresh() override {
+    pagesUntilFullRefresh = 1;
+    requestUpdate();
+    return true;
+  }
   ScreenshotInfo getScreenshotInfo() const override;
   CrossPointPosition getCurrentPosition() const;
 };

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -200,8 +200,11 @@ class EpubReaderActivity final : public Activity {
   bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
-    pagesUntilFullRefresh = 1;
-    forcedRefreshPending = true;
+    {
+      RenderLock lock(*this);
+      pagesUntilFullRefresh = 1;
+      forcedRefreshPending = true;
+    }
     requestUpdate();
     return true;
   }

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -49,5 +49,6 @@ class TxtReaderActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
   ScreenshotInfo getScreenshotInfo() const override;
 };

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -49,6 +49,10 @@ class TxtReaderActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
-  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
+  bool handleForcedRefresh() override {
+    pagesUntilFullRefresh = 1;
+    requestUpdate();
+    return true;
+  }
   ScreenshotInfo getScreenshotInfo() const override;
 };

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -50,7 +50,10 @@ class TxtReaderActivity final : public Activity {
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
-    pagesUntilFullRefresh = 1;
+    {
+      RenderLock lock(*this);
+      pagesUntilFullRefresh = 1;
+    }
     requestUpdate();
     return true;
   }

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -47,7 +47,10 @@ class XtcReaderActivity final : public Activity {
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
   bool handleForcedRefresh() override {
-    pagesUntilFullRefresh = 1;
+    {
+      RenderLock lock(*this);
+      pagesUntilFullRefresh = 1;
+    }
     requestUpdate();
     return true;
   }

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -46,6 +46,10 @@ class XtcReaderActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
-  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
+  bool handleForcedRefresh() override {
+    pagesUntilFullRefresh = 1;
+    requestUpdate();
+    return true;
+  }
   ScreenshotInfo getScreenshotInfo() const override;
 };

--- a/src/activities/reader/XtcReaderActivity.h
+++ b/src/activities/reader/XtcReaderActivity.h
@@ -46,5 +46,6 @@ class XtcReaderActivity final : public Activity {
   void loop() override;
   void render(RenderLock&&) override;
   bool isReaderActivity() const override { return true; }
+  bool restoresGrayscaleAfterForcedRefresh() const override { return true; }
   ScreenshotInfo getScreenshotInfo() const override;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,15 +533,9 @@ void loop() {
   if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::FORCE_REFRESH &&
       mappedInputManager.wasReleased(MappedInputManager::Button::Power)) {
     LOG_DBG("MAIN", "Manual screen refresh triggered");
-    const bool restoreGrayscale = activityManager.currentActivityRestoresGrayscaleAfterForcedRefresh();
-    {
+    if (!activityManager.handleForcedRefresh()) {
       RenderLock lock;
       renderer.displayBuffer(HalDisplay::HALF_REFRESH);
-    }
-    if (restoreGrayscale) {
-      // The forced refresh only displays the 1-bit framebuffer. Re-render the
-      // visible reader page so its normal pipeline restores anti-aliasing.
-      activityManager.requestUpdate();
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -533,8 +533,16 @@ void loop() {
   if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::FORCE_REFRESH &&
       mappedInputManager.wasReleased(MappedInputManager::Button::Power)) {
     LOG_DBG("MAIN", "Manual screen refresh triggered");
-    RenderLock lock;
-    renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+    const bool restoreGrayscale = activityManager.currentActivityRestoresGrayscaleAfterForcedRefresh();
+    {
+      RenderLock lock;
+      renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+    }
+    if (restoreGrayscale) {
+      // The forced refresh only displays the 1-bit framebuffer. Re-render the
+      // visible reader page so its normal pipeline restores anti-aliasing.
+      activityManager.requestUpdate();
+    }
   }
 
   // Refresh the battery icon when USB is plugged or unplugged.


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Restore text anti-aliasing after a short power-button press configured to refresh the screen.
* **What changes are included?** The forced refresh retains its clean 1-bit pass, then schedules the active EPUB, TXT, or XTC reader page's normal render pipeline to restore its grayscale overlay. Menus and non-reader screens keep the existing one-pass behavior.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

This is a focused fix for an existing CrossPoint reader refresh behavior; it does not add a new feature category or touch the SDK/HAL, bootloader, OTA, or recovery code.

## Additional Context

The root cause is that the manual half refresh displays only the retained 1-bit framebuffer. The reader activities generate anti-aliasing/grayscale through additional render passes, which were not scheduled after the forced refresh.

Validation completed:

- `pio check`
- `pio run --target upload`
- On-device verification of the configured short power-button refresh

Memory/flash impact is limited to one activity capability and the redraw scheduling path; no persistent image buffers or settings are added.

---

### AI Usage

Did you use AI tools to help write this code? **PARTIALLY** — AI assisted implementation and review; the change was validated on device by the contributor.
