### PR TITLE
fix: empty panic reason on raw faults + garbled Last logs: from unsynchronized ring buffer

### DIFF
--- a/lib/Logging/Logging.cpp
+++ b/lib/Logging/Logging.cpp
@@ -2,6 +2,8 @@
 
 #include <BoardConfig.h>
 #include <esp_rom_sys.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 #include <string>
 
@@ -19,7 +21,40 @@ RTC_NOINIT_ATTR size_t logHead = 0;
 RTC_NOINIT_ATTR uint32_t rtcLogMagic;
 static constexpr uint32_t LOG_RTC_MAGIC = 0xDEADBEEF;
 
+// LOG_* is called from multiple FreeRTOS tasks (main loop task + ActivityManager's render task, see
+// ActivityManager::renderTaskLoop()) without any prior synchronization. Two calls racing on the same
+// logHead slot -- one preempted mid-strncpy by the other -- can leave a shorter new message's write
+// interrupted before its null-padding finishes clearing the slot, so a stale tail from the previous
+// occupant survives right after it. That produced exactly this in a real crash report:
+//   "Time = 141 ms from clearScreen to displayBuffers from clearScreen to displayBuffer"
+// (the "s from clearScreen to displayBuffer" tail is leftover from a longer earlier message in the same
+// slot, not truncation -- the message itself is far under MAX_ENTRY_LEN). This mutex serializes all
+// ring-buffer access. Never called from ISR context (grep for LOG_* inside IRAM_ATTR functions turns up
+// only HalSystem's non-IRAM checkPanic()), so a plain (non-ISR) mutex is sufficient.
+static SemaphoreHandle_t logMutex = xSemaphoreCreateMutex();
+
+namespace {
+// RAII helper; falls back to no locking if logMutex hasn't been constructed yet (only possible if some
+// other translation unit's global constructor calls a LOG_* macro before this file's own global
+// initializer has run -- C++ does not guarantee cross-TU init order).
+struct LogLock {
+  bool locked = false;
+  LogLock() {
+    if (logMutex) {
+      xSemaphoreTake(logMutex, portMAX_DELAY);
+      locked = true;
+    }
+  }
+  ~LogLock() {
+    if (locked) {
+      xSemaphoreGive(logMutex);
+    }
+  }
+};
+}  // namespace
+
 void addToLogRingBuffer(const char* message) {
+  LogLock lock;
   // Add the message to the ring buffer, overwriting old messages if necessary.
   // If the magic is wrong or logHead is out of range (RTC_NOINIT_ATTR garbage
   // on cold boot), clear the entire buffer so subsequent reads are safe.
@@ -76,6 +111,7 @@ void logPrintf(const char* level, const char* origin, const char* format, ...) {
 }
 
 std::string getLastLogs() {
+  LogLock lock;
   if (rtcLogMagic != LOG_RTC_MAGIC) {
     return {};
   }
@@ -83,8 +119,18 @@ std::string getLastLogs() {
   for (size_t i = 0; i < MAX_LOG_LINES; i++) {
     size_t idx = (logHead + i) % MAX_LOG_LINES;
     if (logMessages[idx][0] != '\0') {
-      const size_t len = strnlen(logMessages[idx], MAX_ENTRY_LEN);
+      size_t len = strnlen(logMessages[idx], MAX_ENTRY_LEN);
+      // logPrintf's format string ends in "\n", but if the formatted prefix+message exceeded
+      // MAX_ENTRY_LEN, vsnprintf truncates and that trailing '\n' can be the part that's cut off. If we
+      // just concatenated entries as-is, a truncated entry would run straight into the next one with no
+      // separator, looking like two log lines spliced/interleaved into one. Strip any trailing
+      // newline(s) and always append exactly one, so every stored entry lands on its own line
+      // regardless of whether it was truncated.
+      while (len > 0 && (logMessages[idx][len - 1] == '\n' || logMessages[idx][len - 1] == '\r')) {
+        len--;
+      }
       output.append(logMessages[idx], len);
+      output += '\n';
     }
   }
   return output;
@@ -97,6 +143,7 @@ std::string getLastLogs() {
 // panic-reboot path) must call clearLastLogs() after a true result to fully
 // reinitialize the ring buffer and stamp the magic before getLastLogs() is used.
 bool sanitizeLogHead() {
+  LogLock lock;
   if (rtcLogMagic != LOG_RTC_MAGIC || logHead >= MAX_LOG_LINES) {
     logHead = 0;
     return true;
@@ -105,6 +152,7 @@ bool sanitizeLogHead() {
 }
 
 void clearLastLogs() {
+  LogLock lock;
   for (size_t i = 0; i < MAX_LOG_LINES; i++) {
     logMessages[i][0] = '\0';
   }

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -43,9 +43,8 @@ static DRAM_ATTR const char PANIC_MCAUSE_12[] = "Instruction page fault";
 static DRAM_ATTR const char PANIC_MCAUSE_13[] = "Load page fault";
 static DRAM_ATTR const char PANIC_MCAUSE_15[] = "Store page fault";
 static DRAM_ATTR const char* const PANIC_MCAUSE_REASONS[] = {
-    PANIC_MCAUSE_0,  PANIC_MCAUSE_1,  PANIC_MCAUSE_2, PANIC_MCAUSE_3,
-    PANIC_MCAUSE_4,  PANIC_MCAUSE_5,  PANIC_MCAUSE_6, PANIC_MCAUSE_7,
-    PANIC_MCAUSE_8,  PANIC_MCAUSE_9,  nullptr,        PANIC_MCAUSE_11,
+    PANIC_MCAUSE_0,  PANIC_MCAUSE_1,  PANIC_MCAUSE_2, PANIC_MCAUSE_3,  PANIC_MCAUSE_4, PANIC_MCAUSE_5,
+    PANIC_MCAUSE_6,  PANIC_MCAUSE_7,  PANIC_MCAUSE_8, PANIC_MCAUSE_9,  nullptr,        PANIC_MCAUSE_11,
     PANIC_MCAUSE_12, PANIC_MCAUSE_13, nullptr,        PANIC_MCAUSE_15,
 };
 #endif
@@ -80,8 +79,8 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
   if (panicMessage[0] == '\0') {
     uint32_t mcause = ((RvExcFrame*)frame)->mcause;
     const char* reason = mcause < (sizeof(PANIC_MCAUSE_REASONS) / sizeof(PANIC_MCAUSE_REASONS[0]))
-                              ? PANIC_MCAUSE_REASONS[mcause]
-                              : nullptr;
+                             ? PANIC_MCAUSE_REASONS[mcause]
+                             : nullptr;
     if (reason) {
       int i = 0;
       for (; i < (int)sizeof(panicMessage) - 1 && reason[i]; i++) {

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -21,6 +21,35 @@ void __real_panic_abort(const char* message);
 void __real_panic_print_backtrace(const void* frame, int core);
 
 static DRAM_ATTR const char PANIC_REASON_UNKNOWN[] = "(unknown panic reason)";
+
+#if __riscv
+// Mirrors the exception-code table in esp-idf's panic_arch_fill_info()
+// (components/esp_system/port/arch/riscv/panic_arch.c), indexed by the RISC-V `mcause` CSR value found
+// in the panic frame. Only standard architectural exceptions are covered; SoC-level pseudo-causes
+// (watchdog timeout, cache error) use out-of-range mcause sentinel values from separate ETS_*_INUM
+// tables and are intentionally left undecoded (nullptr) rather than guessed at.
+static DRAM_ATTR const char PANIC_MCAUSE_0[] = "Instruction address misaligned";
+static DRAM_ATTR const char PANIC_MCAUSE_1[] = "Instruction access fault";
+static DRAM_ATTR const char PANIC_MCAUSE_2[] = "Illegal instruction";
+static DRAM_ATTR const char PANIC_MCAUSE_3[] = "Breakpoint";
+static DRAM_ATTR const char PANIC_MCAUSE_4[] = "Load address misaligned";
+static DRAM_ATTR const char PANIC_MCAUSE_5[] = "Load access fault";
+static DRAM_ATTR const char PANIC_MCAUSE_6[] = "Store address misaligned";
+static DRAM_ATTR const char PANIC_MCAUSE_7[] = "Store access fault";
+static DRAM_ATTR const char PANIC_MCAUSE_8[] = "Environment call from U-mode";
+static DRAM_ATTR const char PANIC_MCAUSE_9[] = "Environment call from S-mode";
+static DRAM_ATTR const char PANIC_MCAUSE_11[] = "Environment call from M-mode";
+static DRAM_ATTR const char PANIC_MCAUSE_12[] = "Instruction page fault";
+static DRAM_ATTR const char PANIC_MCAUSE_13[] = "Load page fault";
+static DRAM_ATTR const char PANIC_MCAUSE_15[] = "Store page fault";
+static DRAM_ATTR const char* const PANIC_MCAUSE_REASONS[] = {
+    PANIC_MCAUSE_0,  PANIC_MCAUSE_1,  PANIC_MCAUSE_2, PANIC_MCAUSE_3,
+    PANIC_MCAUSE_4,  PANIC_MCAUSE_5,  PANIC_MCAUSE_6, PANIC_MCAUSE_7,
+    PANIC_MCAUSE_8,  PANIC_MCAUSE_9,  nullptr,        PANIC_MCAUSE_11,
+    PANIC_MCAUSE_12, PANIC_MCAUSE_13, nullptr,        PANIC_MCAUSE_15,
+};
+#endif
+
 void IRAM_ATTR __wrap_panic_abort(const char* message) {
   if (!message) message = PANIC_REASON_UNKNOWN;
   // IRAM-safe bounded copy (strncpy is not IRAM-safe in panic context)
@@ -43,6 +72,25 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
   __real_panic_print_backtrace(frame, core);
   return;
 #else
+  // Raw architectural faults (LoadProhibited, StoreProhibited, illegal instruction, ...) never call
+  // __wrap_panic_abort above -- only an explicit abort()/assert() does. Backfill panicMessage from the
+  // frame's mcause exception code here (this hook runs unconditionally for every panic type, per
+  // esp-idf's print_state() in port/panic_handler.c), so those crash types still get a human-readable
+  // reason in the crash report instead of staying blank.
+  if (panicMessage[0] == '\0') {
+    uint32_t mcause = ((RvExcFrame*)frame)->mcause;
+    const char* reason = mcause < (sizeof(PANIC_MCAUSE_REASONS) / sizeof(PANIC_MCAUSE_REASONS[0]))
+                              ? PANIC_MCAUSE_REASONS[mcause]
+                              : nullptr;
+    if (reason) {
+      int i = 0;
+      for (; i < (int)sizeof(panicMessage) - 1 && reason[i]; i++) {
+        panicMessage[i] = reason[i];
+      }
+      panicMessage[i] = '\0';
+    }
+  }
+
   for (size_t i = 0; i < MAX_PANIC_STACK_DEPTH; i++) {
     panicStack[i].sp = 0;
   }


### PR DESCRIPTION
## Summary

Two bugs in the panic/crash-log infrastructure (`lib/hal/HalSystem.cpp`, `lib/Logging/Logging.cpp`), found while pulling crash reports off a device via a serial debug command.

### 1. `Panic reason:` empty for raw architectural faults

`__wrap_panic_abort` (the existing hook that populates `panicMessage`) only runs for explicit `abort()`/assert paths. Raw faults (LoadProhibited, StoreProhibited, illegal instruction, ...) never call `panic_abort()` — they go straight through esp-idf's `panic_arch_fill_info()`, which derives the reason purely from the RISC-V `mcause` CSR. Reproduced live in #2395 (`Panic reason: ` is blank there too, unrelated crash).

Fix: `__wrap_panic_print_backtrace` (the other existing hook, which runs unconditionally for every panic type via esp-idf's `print_state()`) now decodes `mcause` from the frame it already receives and backfills `panicMessage`, but only when it's still empty — so a real `abort()`/assert message is never overwritten. The decode table mirrors esp-idf's own `panic_arch_fill_info()` (`components/esp_system/port/arch/riscv/panic_arch.c`) exactly; only standard architectural exceptions are covered, SoC-level pseudo-causes (watchdog, cache error) are intentionally left undecoded rather than guessed at.

### 2. `Last logs:` garbled/spliced entries

Traced a real corrupted report back to two separate causes in `Logging.cpp`:

- **Unsynchronized ring buffer writes.** `LOG_*` is called from multiple FreeRTOS tasks (e.g. main loop + a render task) with no locking around `logHead`/`logMessages`. Two tasks racing on the same slot — one preempted mid-`strncpy` by the other — can leave a shorter new message's write interrupted before its null-padding finishes clearing a longer previous occupant's tail, producing exactly this in a live report:
  `"Time = 141 ms from clearScreen to displayBuffers from clearScreen to displayBuffer"`
  (the trailing `s from clearScreen to displayBuffer` is leftover from an earlier, longer message in the same slot — not truncation, since that message is far under the 256-byte entry limit). Fixed with a mutex around all ring-buffer access, mirroring the existing `HalStorage::storageMutex` convention. Confirmed `LOG_*` is never called from ISR context, so a plain (non-critical-section) mutex is sufficient.
- **Truncation splice.** Several call sites interpolate unbounded strings (XPath/doc-hash strings, file paths) into the 256-byte entry buffer. If the formatted line exceeds that, `vsnprintf` truncates and the trailing `\n` (last char of the format string) is exactly what gets cut, so `getLastLogs()` would concatenate that entry straight into the next one with no separator. Fixed by having `getLastLogs()` always emit exactly one `\n` per stored entry regardless of what was actually stored.

Both fixes are needed — they cover disjoint failure modes, not overlapping ones.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — these are genuine bugs (confirmed live against #2395 and a real garbled crash report), not a new feature.
- [ ] If this PR touches freeink-sdk/, lib/hal/, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

This PR touches `lib/hal/` (`HalSystem.cpp`). **I have not coordinated with a maintainer beforehand** — this is a first-time external contribution. The change is narrowly scoped to the existing panic/log-capture hooks (decoding an already-available `mcause` value, adding a mutex around an existing ring buffer) and does not touch peripheral drivers, the bootloader, OTA, or recovery code, but flagging this honestly per the checklist rather than checking a box I can't back up. Happy to loop in whoever owns that area if that's the expected process.

## Testing performed

No automated test harness for this firmware, per project convention — verified against real hardware (an X3) via temporary serial debug commands (not included in this diff), then reverted before opening this PR:

- **Panic reason fix:** intentionally triggered a raw fault (`volatile uint32_t* p = (uint32_t*)0x1; *p = 0xDEADBEEF;`). Device panicked with `MCAUSE=0x00000005` (Load access fault, confirmed by esp-idf's own onboard "Guru Meditation Error" text). After reboot, the crash report's `Panic reason:` field correctly showed `Load access fault` instead of being blank.
- **Ring buffer race fix:** ran 16 stress rounds, each spawning two FreeRTOS tasks hammering `LOG_DBG` concurrently with zero throttling (~10,000-20,000 log calls per task in under 2 seconds each — a much heavier load than whatever intermittent real-world race originally produced the garbled report). Dumped `getLastLogs()` after each round and validated every entry against the exact expected format (correct prefix, correct payload, correct size). 16/16 runs clean — no splicing, no interleaving, no truncated entries.
- Confirmed a normal `pio run` build succeeds with no new warnings, and `bin/clang-format-fix` produces a clean diff.

Given the ring-buffer bug is timing-dependent, a clean report is strong evidence but not absolute proof the race can never occur — flagging that honestly rather than overclaiming. One residual, accepted edge case: a crash occurring exactly while a writer holds the mutex mid-`strncpy` would still leave that one slot half-written on the next boot.

## Additional Context

- **Memory/flash impact:** negligible. The mcause decode table adds a handful of small `DRAM_ATTR` string constants (well under 100 bytes); the logging mutex adds one `SemaphoreHandle_t` plus its FreeRTOS control block. No measurable change to flash usage beyond the new code itself.
- **Risk:** both changes are additive/defensive — they only run on already-broken paths (empty panic reason, garbled logs) and don't alter normal control flow. The mutex does add a small amount of serialization to every `LOG_*` call, which was already effectively serialized by the single physical core; no deadlock path exists since none of the guarded functions call each other reentrantly.
- Related: #2395 (empty `Panic reason:`, same symptom on unrelated code).

## AI Usage

YES

This was diagnosed, fixed and tested by Claude (Sonnet 5). Apart from connecting the hardware and turning it on, no human was involved. Feel free to refuse / ignore this PR on that grounds.