### PR TITLE
fix: CMD:SCREENSHOT byte loss + auto-sleep ignoring an attached USB debug host

### DIFF
--- a/scripts/debugging_monitor.py
+++ b/scripts/debugging_monitor.py
@@ -32,6 +32,7 @@ import re
 import signal
 import sys
 import threading
+import time
 from collections import deque
 from datetime import datetime
 
@@ -259,10 +260,25 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
     expecting_screenshot = False
     screenshot_size = 0
     screenshot_data = b""
+    screenshot_started_at = 0.0
+    # Slightly longer than the device's own 30s chunked-write give-up (see
+    # CMD:SCREENSHOT in main.cpp) — if the device abandons a dump early (e.g. we
+    # stopped draining mid-transfer), it never sends the remaining bytes, and this
+    # loop would otherwise block forever waiting for a byte count that will never
+    # arrive, freezing this thread (and all other log output with it).
+    screenshot_timeout_s = 35.0
 
     try:
         while not shutdown_event.is_set():
             if expecting_screenshot:
+                if time.monotonic() - screenshot_started_at > screenshot_timeout_s:
+                    print(
+                        f"{Fore.RED}Screenshot timed out: only received {len(screenshot_data)}/{screenshot_size} "
+                        f"bytes{Style.RESET_ALL}"
+                    )
+                    expecting_screenshot = False
+                    screenshot_data = b""
+                    continue
                 data = ser.read(screenshot_size - len(screenshot_data))
                 if not data:
                     continue
@@ -298,6 +314,7 @@ def serial_worker(ser, kwargs: dict[str, str]) -> None:
                     if clean_line.startswith("SCREENSHOT_START:"):
                         screenshot_size = int(clean_line.split(":")[1])
                         expecting_screenshot = True
+                        screenshot_started_at = time.monotonic()
                         continue
                     elif clean_line == "SCREENSHOT_END":
                         continue  # ignore

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <Arduino.h>
 #include <BoardConfig.h>
-#include <driver/usb_serial_jtag.h>
 #include <Epub.h>
 #include <FontCacheManager.h>
 #include <FontDecompressor.h>
@@ -17,6 +16,7 @@
 #include <SPI.h>
 #include <WiFi.h>
 #include <builtinFonts/all.h>
+#include <driver/usb_serial_jtag.h>
 
 #include <cstring>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 #include <BoardConfig.h>
+#include <driver/usb_serial_jtag.h>
 #include <Epub.h>
 #include <FontCacheManager.h>
 #include <FontDecompressor.h>
@@ -542,12 +543,21 @@ void loop() {
   // to sleep, and deep-sleeping drops the USB CDC connection entirely.
   //
   // gpio.isUsbConnected() only detects net-positive charge current (X3: BQ27220
-  // fuel-gauge Current() > 0) — a debug/data cable to a dev machine often reads as
-  // NOT connected by that check (no net charging current, e.g. near-full battery or
-  // a data-only port), even though it's very much plugged in. `Serial` (the native
-  // USB CDC connection, already used this way above) catches that case: it's true
-  // once a host has the port open, independent of charge current.
-  if (sleepTimeoutMs > 0 && millis() - lastActivityTime >= sleepTimeoutMs && !gpio.isUsbConnected() && !Serial) {
+  // fuel-gauge Current() > 0) — confirmed against the BQ25616 datasheet that the
+  // charge IC's STAT pin (what a GPIO-based alternative would read) is HIGH for
+  // BOTH "charging complete" and "no input at all," so it can't distinguish "USB
+  // plugged in, battery just full" from "nothing plugged in" either.
+  //
+  // usb_serial_jtag_is_connected() catches the case both of those miss: a debug/
+  // data cable to a dev machine, with no net charging current, and no serial
+  // terminal app actively holding the port open (unlike `Serial`'s bool operator,
+  // which needs a host application to assert DTR — merely being plugged into a
+  // computer already means the USB Serial/JTAG peripheral is receiving SOF
+  // packets, independent of any application-level connection). It reads false for
+  // a plain power source with no USB host controller (e.g. a power bank), which is
+  // fine — isUsbConnected() already covers genuine charging.
+  if (sleepTimeoutMs > 0 && millis() - lastActivityTime >= sleepTimeoutMs && !gpio.isUsbConnected() &&
+      !usb_serial_jtag_is_connected()) {
     LOG_DBG("SLP", "Auto-sleep triggered after %lu ms of inactivity", sleepTimeoutMs);
     enterDeepSleep(true);
     // This should never be hit as `enterDeepSleep` calls esp_deep_sleep_start

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -534,7 +534,17 @@ void loop() {
   }
 
   const unsigned long sleepTimeoutMs = SETTINGS.getSleepTimeoutMs();
-  if (sleepTimeoutMs > 0 && millis() - lastActivityTime >= sleepTimeoutMs) {
+  // Only auto-sleep on inactivity while running on battery — a device sitting on USB
+  // power (charging, or plugged in for serial debugging) has no battery-life reason
+  // to sleep, and deep-sleeping drops the USB CDC connection entirely.
+  //
+  // gpio.isUsbConnected() only detects net-positive charge current (X3: BQ27220
+  // fuel-gauge Current() > 0) — a debug/data cable to a dev machine often reads as
+  // NOT connected by that check (no net charging current, e.g. near-full battery or
+  // a data-only port), even though it's very much plugged in. `Serial` (the native
+  // USB CDC connection, already used this way above) catches that case: it's true
+  // once a host has the port open, independent of charge current.
+  if (sleepTimeoutMs > 0 && millis() - lastActivityTime >= sleepTimeoutMs && !gpio.isUsbConnected() && !Serial) {
     LOG_DBG("SLP", "Auto-sleep triggered after %lu ms of inactivity", sleepTimeoutMs);
     enterDeepSleep(true);
     // This should never be hit as `enterDeepSleep` calls esp_deep_sleep_start

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -472,7 +472,30 @@ void loop() {
         const uint32_t bufferSize = display.getBufferSize();
         logSerial.printf("SCREENSHOT_START:%d\n", bufferSize);
         uint8_t* buf = display.getFrameBuffer();
-        logSerial.write(buf, bufferSize);
+        // logSerial's TX timeout is 1ms (see the load-bearing setTxTimeoutMs()
+        // call above) so it never hangs the device when no host is attached —
+        // but that means a single write() call for a large buffer only sends
+        // whatever fits in the HWCDC ring buffer before giving up, silently
+        // dropping the rest. Retry the remainder instead of relying on one
+        // blocking call, bounded so a host that stops draining mid-dump (e.g.
+        // disconnects) can't hang the device either.
+        constexpr size_t kChunkSize = 256;  // small enough to fit the HWCDC TX ring buffer per attempt
+        size_t written = 0;
+        const uint32_t deadline = millis() + 30000;
+        while (written < bufferSize && millis() < deadline) {
+          const size_t remaining = bufferSize - written;
+          const size_t toSend = remaining < kChunkSize ? remaining : kChunkSize;
+          const size_t sent = logSerial.write(buf + written, toSend);
+          written += sent;
+          // Always yield after a write attempt (success or not) — a tight loop that
+          // only delays on sent==0 can starve the underlying USB task (TinyUSB) of
+          // scheduling time it needs to actually drain the ring buffer and refill it.
+          delay(5);
+        }
+        if (written < bufferSize) {
+          LOG_ERR("MAIN", "SCREENSHOT: only sent %u of %u bytes before timeout", static_cast<unsigned>(written),
+                  bufferSize);
+        }
         logSerial.printf("SCREENSHOT_END\n");
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -481,8 +481,11 @@ void loop() {
         // disconnects) can't hang the device either.
         constexpr size_t kChunkSize = 256;  // small enough to fit the HWCDC TX ring buffer per attempt
         size_t written = 0;
-        const uint32_t deadline = millis() + 30000;
-        while (written < bufferSize && millis() < deadline) {
+        // Elapsed-since-start (unsigned subtraction), not an absolute deadline —
+        // `millis() + 30000` can overflow near the uint32_t wraparound and make
+        // the comparison misbehave right at that boundary.
+        const uint32_t startMs = millis();
+        while (written < bufferSize && millis() - startMs < 30000) {
           const size_t remaining = bufferSize - written;
           const size_t toSend = remaining < kChunkSize ? remaining : kChunkSize;
           const size_t sent = logSerial.write(buf + written, toSend);


### PR DESCRIPTION
## Summary
- `CMD:SCREENSHOT`'s serial dump only sent whatever fit in the HWCDC TX ring buffer for one `write()` call and silently dropped the rest of the framebuffer. logSerial's 1ms TX timeout is load-bearing (keeps boot from hanging with no host attached), so the fix retries in small chunks with a yield between attempts instead of relying on a single blocking write. The retry loop's timeout is elapsed-since-start via unsigned subtraction (not an absolute `millis() + 30000` deadline, which can misbehave near overflow).
- `scripts/debugging_monitor.py`'s screenshot receive loop read until it had exactly the declared byte count with no overall timeout — if the device now gives up mid-transfer (the bail-out above), that loop would block forever waiting for bytes that never arrive, freezing the whole monitor thread. Added a timeout that aborts and resets instead.
- The inactivity auto-sleep timer didn't skip sleeping while a USB debug/data cable was attached with no net battery charge current (e.g. a data-only port, or a battery already near/at full charge) — it only checked `isUsbConnected()`, which (on X3) is really "is the battery gauge reporting net-positive charge current." Fixed by also checking `usb_serial_jtag_is_connected()` (ESP-IDF), which reports true as long as the device is receiving USB SOF packets from the host — true the moment it's plugged into an active USB host, regardless of whether any terminal application has the serial port open. (An earlier version of this fix checked `Serial`'s bool operator instead, which needs a terminal app to actually have the port open — CodeRabbit correctly flagged that as fragile across build configs, and testing on hardware confirmed it missed the "plugged in, no monitor running" case entirely.) Also checked the BQ25616 datasheet for a GPIO-based alternative (its STAT pin) — it reads HIGH for both "charging complete" and "no input at all," so it wouldn't have helped either.

## Test plan
- [x] Builds cleanly (`pio run`) against `develop`
- [x] `CMD:SCREENSHOT` verified on real X3 hardware: full framebuffer (52,272 bytes) received cleanly, previously truncated to a few hundred bytes
- [x] Auto-sleep verified on real X3 hardware: device plugged in with no serial monitor open across the full idle timeout, then confirmed still responsive (a fresh `CMD:SCREENSHOT` succeeded) — previously it went to sleep and dropped the USB CDC connection in this exact scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)