### PR TITLE
fix: Move sunlight fading fix setting to different group

### DIFF
--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -363,15 +363,15 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
   std::vector<SettingInfo> v = baseList;
   if (!BoardConfig::hasTouch()) {
     v.erase(std::remove_if(v.begin(), v.end(),
-                           [](const SettingInfo& s) {
-                             return s.nameId == StrId::STR_TOUCH_READER_CONTROLS ||
-                                    s.nameId == StrId::STR_SUNLIGHT_FADING_FIX;
-                           }),
+                           [](const SettingInfo& s) { return s.nameId == StrId::STR_TOUCH_READER_CONTROLS; }),
             v.end());
   }
   if (BoardConfig::hasTouch()) {
     v.erase(std::remove_if(v.begin(), v.end(),
-                           [](const SettingInfo& s) { return s.nameId == StrId::STR_FRONT_BTN_FOLLOW_ORIENTATION; }),
+                           [](const SettingInfo& s) {
+                             return s.nameId == StrId::STR_FRONT_BTN_FOLLOW_ORIENTATION ||
+                                    s.nameId == StrId::STR_SUNLIGHT_FADING_FIX;
+                           }),
             v.end());
   }
   if (registry && registry->getFamilyCount() > 0) {


### PR DESCRIPTION
Relocate STR_SUNLIGHT_FADING_FIX from the touch reader controls group to the front button orientation group in the settings filter logic. Sunlight fix was accidentally being hidden on non-touch where it should have been hidden on touch instead. Closes #2030 