### PR TITLE
fix: Prevent opening ePubs that contain DRM (#565)

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -357,6 +357,14 @@ void Epub::parseCssFiles() const {
 bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   LOG_DBG("EBP", "Loading ePub: %s", filepath.c_str());
 
+  // Don't try to open an ePub containing DRM
+  constexpr auto encryptionPath = "META-INF/encryption.xml";
+  size_t encryptionFileSize = 0;
+  if (getItemSize(encryptionPath, &encryptionFileSize) && encryptionFileSize > 0) {
+    LOG_ERR("EBP", "ePub contains DRM");
+    return false;
+  }
+
   // Initialize spine/TOC cache
   bookMetadataCache.reset(new BookMetadataCache(cachePath));
   // Always create CssParser - needed for inline style parsing even without CSS files


### PR DESCRIPTION
## Summary

Currently, if you try to open an ePub that contains DRM, Crosspoint will try to open the file and put you into a position where the eReader is unusable unless you either delete the cache, or back out of the book without any visual cues. This change prevents Crosspoint from attempting to open an ePub that contains DRM.

Addresses #565 

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This PR improves ePub handling, which is directly within scope.

## Additional Context

* Minimal to no performance impact. A single conditional is added.
* Memory impact: Minimal. A single compile-time constant was added, and a single size_t was added during epub loading.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
