### PR TITLE
feat: Add packages to nix dev shell required for clang-format-fix and…

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -66,10 +66,15 @@
         in
         {
           default = pkgs.mkShell {
-            packages = [
+            packages = with pkgs; [
               pio
               fhsEnv
-              pkgs.clang-tools # for clang-format
+              clang-tools # for clang-format
+              (python3.withPackages (ps: with ps; [ # for debugging monitor
+                matplotlib
+                pyserial
+                colorama
+              ]))
             ];
 
             shellHook = setEnvs;


### PR DESCRIPTION
… debugging monitor

## Summary

The nix flake was set up primarily to make a dev environment that could run pio, however, it was not set up for other tasks that need to be performed as part of development. This change adds the packages to the developer shell required to run clang-format-fix and to run the debugging monitor.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

## Additional Context

* This is purely improving dev tooling for anyone using the nix package manager or developing on NixOS.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**NO**_
