### PR TITLE
feat: Adding Snapping for Percentages and Interval Selection

### DIFF
--- a/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.cpp
@@ -37,6 +37,24 @@ void EpubReaderPercentSelectionActivity::adjustPercent(const int delta) {
   requestUpdate();
 }
 
+void EpubReaderPercentSelectionActivity::adjustPercentSnapped(const int delta) {
+  // Snap to the next/previous multiple of kLargeStep rather than adding kLargeStep directly.
+  // E.g. at 1 with delta > 0: (1/10 + 1)*10 = 10, not 11.
+  int newPercent;
+  if (delta > 0) {
+    newPercent = (percent / kLargeStep + 1) * kLargeStep;
+  } else {
+    newPercent = ((percent - 1) / kLargeStep) * kLargeStep;
+  }
+  if (newPercent < 0) {
+    newPercent = 0;
+  } else if (newPercent > 100) {
+    newPercent = 100;
+  }
+  percent = newPercent;
+  requestUpdate();
+}
+
 void EpubReaderPercentSelectionActivity::loop() {
   auto& theme = UITheme::getInstance();
   auto metrics = theme.getMetrics();
@@ -110,9 +128,10 @@ void EpubReaderPercentSelectionActivity::loop() {
   // direction there so the left button decreases and the right button increases, matching the layout.
   const int upDelta = gpio.deviceIsX3() ? -kLargeStep : kLargeStep;
   const int downDelta = gpio.deviceIsX3() ? kLargeStep : -kLargeStep;
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this, upDelta] { adjustPercent(upDelta); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up},
+                                       [this, upDelta] { adjustPercentSnapped(upDelta); });
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down},
-                                       [this, downDelta] { adjustPercent(downDelta); });
+                                       [this, downDelta] { adjustPercentSnapped(downDelta); });
 }
 
 void EpubReaderPercentSelectionActivity::render(RenderLock&&) {

--- a/src/activities/reader/EpubReaderPercentSelectionActivity.h
+++ b/src/activities/reader/EpubReaderPercentSelectionActivity.h
@@ -27,4 +27,6 @@ class EpubReaderPercentSelectionActivity final : public Activity {
 
   // Change the current percent by a delta and clamp within bounds.
   void adjustPercent(int delta);
+  // Like adjustPercent but snaps to the nearest multiple of kLargeStep in the direction of delta.
+  void adjustPercentSnapped(int delta);
 };

--- a/src/activities/util/IntervalSelectionActivity.cpp
+++ b/src/activities/util/IntervalSelectionActivity.cpp
@@ -26,6 +26,17 @@ void IntervalSelectionActivity::adjustValue(const int delta) {
   requestUpdate();
 }
 
+void IntervalSelectionActivity::adjustValueSnapped(const int delta) {
+  int newValue;
+  if (delta > 0) {
+    newValue = (value / largeStep + 1) * largeStep;
+  } else {
+    newValue = ((value - 1) / largeStep) * largeStep;
+  }
+  value = clampedValue(newValue);
+  requestUpdate();
+}
+
 void IntervalSelectionActivity::drawStepHintLine(const int y, const StrId labelId, const int step) {
   char stepText[24];
   if (valueFormatId != StrId::STR_NONE_OPT) {
@@ -122,9 +133,10 @@ void IntervalSelectionActivity::loop() {
   // direction there so the left button decreases and the right button increases, matching the layout.
   const int upDelta = gpio.deviceIsX3() ? -largeStep : largeStep;
   const int downDelta = gpio.deviceIsX3() ? largeStep : -largeStep;
-  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up}, [this, upDelta] { adjustValue(upDelta); });
+  buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Up},
+                                       [this, upDelta] { adjustValueSnapped(upDelta); });
   buttonNavigator.onPressAndContinuous({MappedInputManager::Button::Down},
-                                       [this, downDelta] { adjustValue(downDelta); });
+                                       [this, downDelta] { adjustValueSnapped(downDelta); });
 }
 
 void IntervalSelectionActivity::render(RenderLock&&) {

--- a/src/activities/util/IntervalSelectionActivity.h
+++ b/src/activities/util/IntervalSelectionActivity.h
@@ -47,6 +47,7 @@ class IntervalSelectionActivity final : public Activity {
   ButtonNavigator buttonNavigator;
 
   void adjustValue(int delta);
+  void adjustValueSnapped(int delta);
   int clampedValue(int candidate) const;
   void drawStepHintLine(int y, StrId labelId, int step);
 };


### PR DESCRIPTION
## Summary

The Sliders for Percentages and Interval Selections allow incremental jumps, but this leads to uneven numbers and back and forth fidgeting to get back to round increments

e.g. starting at 1 and clicking with the side button adds 5 so we're landing on 6 - which is mathematically correct, but the user intent is more to land at 5. For example when setting the standby time.

Using snapping does this and jumps to the nearest increment.

I'll let the maintainers and discussion decide if we should include this into crosspoint-reader.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
