### PR TITLE
feat: Add UC8279 panel controller detection for X3 devices

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -4,6 +4,7 @@
 #include <Preferences.h>
 #include <SPI.h>
 #include <Wire.h>
+#include <XteinkDetect.h>
 #include <esp_sleep.h>
 
 // Global HalGPIO instance
@@ -189,14 +190,58 @@ HalGPIO::DeviceType detectDeviceTypeWithFingerprint() {
   return HalGPIO::DeviceType::X4;
 }
 
+// --- X3 panel-controller fingerprint (UC8253 vs UC8279) ----------------------
+// Newer X3 production units ship a UC8279d panel controller on the same board,
+// glass and pins. The SDK probe reads the UC8279's VER/FLG registers over a
+// bit-banged half-duplex SPI on the EPD pins; same override/cache scheme as
+// the device fingerprint (values reuse NvsDeviceValue: 1 = UC8253, 2 = UC8279).
+constexpr char NVS_KEY_EPD_OVERRIDE[] = "epd_ovr";  // 0=auto, 1=uc8253, 2=uc8279
+constexpr char NVS_KEY_EPD_CACHED[] = "epd_det";    // 0=unknown, 1=uc8253, 2=uc8279
+
+bool detectX3DisplayIsUc8279() {
+  const NvsDeviceValue overrideValue = readNvsDeviceValue(NVS_KEY_EPD_OVERRIDE, NvsDeviceValue::Unknown);
+  if (overrideValue != NvsDeviceValue::Unknown) {
+    LOG_INF("HW", "EPD controller override active: %s", overrideValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
+    return overrideValue == NvsDeviceValue::X3;
+  }
+
+  const NvsDeviceValue cachedValue = readNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::Unknown);
+  if (cachedValue != NvsDeviceValue::Unknown) {
+    LOG_INF("HW", "Using cached EPD controller: %s", cachedValue == NvsDeviceValue::X3 ? "UC8279" : "UC8253");
+    return cachedValue == NvsDeviceValue::X3;
+  }
+
+  uint8_t ver[5] = {0};
+  uint8_t flg = 0;
+  const freeink::X3DisplayVerdict verdict = freeink::detectX3DisplayController(ver, &flg);
+  LOG_INF("HW", "EPD probe: ver=%02X %02X %02X %02X %02X flg=%02X verdict=%u", ver[0], ver[1], ver[2], ver[3], ver[4],
+          flg, static_cast<unsigned>(verdict));
+  if (verdict == freeink::X3DisplayVerdict::Uc8279Confirmed) {
+    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::X3);
+    return true;
+  }
+  if (verdict == freeink::X3DisplayVerdict::Uc8253Assumed) {
+    writeNvsDeviceValue(NVS_KEY_EPD_CACHED, NvsDeviceValue::X4);
+  }
+  // Inconclusive: run as UC8253 (the shipping controller) but don't persist,
+  // so a flaky first boot gets re-probed.
+  return false;
+}
+
 }  // namespace
 
 void HalGPIO::begin() {
 #if FREEINK_MCU_C3
-  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
-
   _deviceType = detectDeviceTypeWithFingerprint();
-  BoardConfig::selectDevice(deviceIsX3() ? BoardConfig::Board::XteinkX3 : BoardConfig::Board::XteinkX4);
+  // The panel-controller probe bit-bangs the EPD pins, so it must run before
+  // SPI.begin() attaches them to the SPI matrix. I2C-only device fingerprint
+  // above doesn't care about SPI ordering.
+  const bool x3IsUc8279 = deviceIsX3() && detectX3DisplayIsUc8279();
+  BoardConfig::selectDevice(!deviceIsX3() ? BoardConfig::Board::XteinkX4
+                            : x3IsUc8279  ? BoardConfig::Board::XteinkX3Uc8279
+                                          : BoardConfig::Board::XteinkX3);
+
+  SPI.begin(EPD_SCLK, SPI_MISO, EPD_MOSI, EPD_CS);
 
   if (deviceIsX4()) {
     pinMode(BAT_GPIO0, INPUT);

--- a/platformio.ini
+++ b/platformio.ini
@@ -131,6 +131,7 @@ lib_deps =
   EInkDisplay=symlink://freeink-sdk/libs/display/FreeInkDisplay
   SDCardManager=symlink://freeink-sdk/libs/hardware/SDCardManager
   BoardConfig=symlink://freeink-sdk/libs/hardware/BoardConfig
+  XteinkDetect=symlink://freeink-sdk/libs/hardware/XteinkDetect
   PowerManager=symlink://freeink-sdk/libs/hardware/PowerManager
   Rtc=symlink://freeink-sdk/libs/hardware/Rtc
   Imu=symlink://freeink-sdk/libs/hardware/Imu


### PR DESCRIPTION
Probe X3 display controller type (UC8253 vs UC8279) by reading VER/FLG registers over bit-banged SPI before initializing hardware SPI. Results are cached in NVS with manual override support. Detection must run before SPI.begin() to avoid pin conflicts.