### PR TITLE
fix(epub): bump FOOTNOTE_HREF_LEN 96→256 for long calibre paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ lib/EpdFont/scripts/output/
 /sdkconfig.default
 /sdkconfig.defaults
 sdkconfig.sticky
+flake.*

--- a/lib/Epub/Epub/FootnoteEntry.h
+++ b/lib/Epub/Epub/FootnoteEntry.h
@@ -3,7 +3,10 @@
 #include <cstring>
 
 #define FOOTNOTE_NUMBER_LEN 32
-#define FOOTNOTE_HREF_LEN 96
+#define FOOTNOTE_HREF_LEN 256
+// ponytail: bumped from 96 to 256; calibre-generated EPUBs with long filenames
+// and URL-encoded characters routinely exceed 96 chars (e.g.
+// "Author-Title_split_NNN.html#_ftnN" encoded is ~150 chars).
 
 struct FootnoteEntry {
   char number[FOOTNOTE_NUMBER_LEN];


### PR DESCRIPTION
Calibre-generated EPUBs with long filenames and URL-encoded characters can produce footnote hrefs exceeding 96 chars (observed: 150 chars on a Terry Pratchett EPUB). The truncated href loses the `#anchor` fragment and the tail of the filename, so `resolveHrefToSpineIndex` fails and the reader stays on the current page instead of jumping to the footnote.

This is the second time this ceiling is hit — the previous fix (#1723, 8154f88) bumped from 64 to 96. 256 provides enough headroom for the longest reasonable epub paths while remaining a fixed-size buffer (preferable to `std::string` on ESP32's constrained heap).

Fixes #2555 — same symptom (footnote link lands on page 0 / current page instead of the specific anchor), different root cause than #2382.