### PR TITLE
feat: show hidden files toggle in web file manager

### DIFF
--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -68,6 +68,7 @@ Query parameters:
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `path` | No | `/` | Directory to list |
+| `hidden` | No | `false` | `true` includes dotfiles regardless of the `showHiddenFiles` setting |
 
 Response:
 
@@ -79,7 +80,8 @@ Response:
 ```
 
 Hidden dotfiles are omitted unless the device setting `showHiddenFiles` is
-enabled. `System Volume Information` and `XTCache` are always hidden/protected.
+enabled or `hidden=true` is passed. `System Volume Information` and `XTCache`
+are always hidden/protected.
 
 ### `GET /download`
 

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -435,7 +435,8 @@ void CrossPointWebServer::handleStatus() const {
   server->send(200, "application/json", response);
 }
 
-void CrossPointWebServer::scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const {
+void CrossPointWebServer::scanFiles(const char* path, bool includeHidden,
+                                    const std::function<void(FileInfo)>& callback) const {
   HalFile root = Storage.open(path);
   if (!root) {
     LOG_DBG("WEB", "Failed to open directory: %s", path);
@@ -457,7 +458,7 @@ void CrossPointWebServer::scanFiles(const char* path, const std::function<void(F
     auto fileName = String(name);
 
     // Skip hidden items (starting with ".")
-    bool shouldHide = !SETTINGS.showHiddenFiles && fileName.startsWith(".");
+    bool shouldHide = !includeHidden && !SETTINGS.showHiddenFiles && fileName.startsWith(".");
 
     // Check against explicitly hidden items list
     if (!shouldHide) {
@@ -500,6 +501,9 @@ void CrossPointWebServer::handleFileList() const {
 }
 
 void CrossPointWebServer::handleFileListData() const {
+  // "hidden=true" lists dot-prefixed items regardless of the showHiddenFiles setting
+  const bool includeHidden = server->hasArg("hidden") && server->arg("hidden") == "true";
+
   // Get current path from query string (default to root)
   String currentPath = "/";
   if (server->hasArg("path")) {
@@ -522,7 +526,7 @@ void CrossPointWebServer::handleFileListData() const {
   bool seenFirst = false;
   JsonDocument doc;
 
-  scanFiles(currentPath.c_str(), [this, &output, &doc, seenFirst](const FileInfo& info) mutable {
+  scanFiles(currentPath.c_str(), includeHidden, [this, &output, &doc, seenFirst](const FileInfo& info) mutable {
     doc.clear();
     doc["name"] = info.name;
     doc["size"] = info.size;

--- a/src/network/CrossPointWebServer.h
+++ b/src/network/CrossPointWebServer.h
@@ -85,7 +85,7 @@ class CrossPointWebServer {
   void abortWsUpload(const char* tag);
 
   // File scanning
-  void scanFiles(const char* path, const std::function<void(FileInfo)>& callback) const;
+  void scanFiles(const char* path, bool includeHidden, const std::function<void(FileInfo)>& callback) const;
   String formatFileSize(size_t bytes) const;
   bool isEpubFile(const String& filename) const;
 

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -985,6 +985,20 @@
       color: var(--label-color);
       font-size: 0.9em;
     }
+    .contents-header-right {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .show-hidden-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: var(--label-color);
+      font-size: 0.9em;
+      cursor: pointer;
+      user-select: none;
+    }
     #progress-container {
       display: none;
       margin-top: 10px;
@@ -1535,7 +1549,12 @@
 <div class="card">
   <div class="contents-header">
     <div class="breadcrumb-inline" id="directory-breadcrumbs"></div>
-    <span class="summary-inline" id="folder-summary"></span>
+    <div class="contents-header-right">
+      <label class="show-hidden-toggle" title="Show files and folders starting with a dot">
+        <input type="checkbox" id="showHiddenToggle"> Show hidden
+      </label>
+      <span class="summary-inline" id="folder-summary"></span>
+    </div>
   </div>
 
   <div id="file-table">
@@ -1849,6 +1868,14 @@
     if (leaf) document.title = leaf + ' - Files - CrossPoint Reader';
   }
 
+  // Show hidden (dot-prefixed) items; persisted per browser
+  const SHOW_HIDDEN_STORAGE_KEY = 'showHiddenFiles';
+  let showHidden = localStorage.getItem(SHOW_HIDDEN_STORAGE_KEY) === 'true';
+
+  function hiddenParam() {
+    return showHidden ? '&hidden=true' : '';
+  }
+
   // Network status monitoring
   let isNetworkOnline = navigator.onLine;
 
@@ -1953,6 +1980,18 @@
       });
     });
 
+    const showHiddenToggle = document.getElementById('showHiddenToggle');
+    showHiddenToggle.checked = showHidden;
+    showHiddenToggle.addEventListener('change', function() {
+      showHidden = this.checked;
+      localStorage.setItem(SHOW_HIDDEN_STORAGE_KEY, showHidden);
+      loadFileList();
+    });
+
+    loadFileList();
+  }
+
+  async function loadFileList() {
     const breadcrumbs = document.getElementById('directory-breadcrumbs');
     const fileTable = document.getElementById('file-table');
 
@@ -1997,7 +2036,7 @@
 
     let files = [];
     try {
-      const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + '&_=' + Date.now());
+      const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + hiddenParam() + '&_=' + Date.now());
       if (!response.ok) {
         throw new Error('Failed to load files: ' + response.status + ' ' + response.statusText);
       }
@@ -3961,7 +4000,7 @@ function reserveAvailableUploadFilename(fileName, usedFileNames) {
 }
 
 async function fetchExistingUploadNames() {
-  const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + '&_=' + Date.now());
+  const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + hiddenParam() + '&_=' + Date.now());
   if (!response.ok) {
     throw new Error(response.status + ' ' + response.statusText);
   }
@@ -5879,7 +5918,7 @@ function retryAllFailedUploads() {
 
     async function fetchFolders(path) {
       try {
-        const response = await fetch('/api/files?path=' + encodeURIComponent(path));
+        const response = await fetch('/api/files?path=' + encodeURIComponent(path) + hiddenParam());
         if (!response.ok) return [];
         return await response.json();
       } catch (e) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Implements #2445 — keep dot-prefixed folders hidden when browsing on the device, but reachable from the web File Manager (e.g. uploading sleep images to `.sleep`) without toggling the device setting.
* **What changes are included?**
  * `GET /api/files` accepts an optional `hidden=true` parameter that includes dot-prefixed items regardless of the `showHiddenFiles` setting. `System Volume Information` and `XTCache` stay hidden unconditionally.
  * A "Show hidden" checkbox in the web File Manager, persisted in browser `localStorage`.
  * `docs/webserver-endpoints.md` updated.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. *(N/A — none touched.)*

## Additional Context

* Backward compatible: without the parameter the API is unchanged, and on-device browsing is untouched.
* No RAM/flash impact beyond one `bool` parameter; no settings writes (toggle state is browser-side).
* Verified on an Xteink X4: device still hides dot-items, web toggle shows/hides them live and survives reload, upload into `.sleep` works. Build, cppcheck, and clang-format all clean.

Closes #2445

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — implemented with Claude Code under my direction; I chose the approach, reviewed the changes, and verified on hardware.
