### PR TITLE
chore: remove redundant wolfSSL TLS defines

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -51,12 +51,11 @@ build_flags =
 # SP_SMALL trades the large precomputed point tables for smaller flash.
   -DWOLFSSL_HAVE_SP_ECC
   -DWOLFSSL_SP_SMALL
-  -DHAVE_TLS_EXTENSIONS
-  -DHAVE_SUPPORTED_CURVES
-  -DHAVE_HKDF
+# Arduino-wolfSSL's user_settings.h enables TLS extensions, supported curves,
+# HKDF, and RSA-PSS when WOLFSSL_TLS13 is set. Do not repeat those defines here:
+# GCC reports every library translation unit as a macro redefinition.
   -DHAVE_FFDHE_2048
   -DHAVE_CURVE25519
-  -DWC_RSA_PSS
   -DHAVE_SNI
   -Wno-bidi-chars
   -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort,--wrap=bootloader_common_check_efuse_blk_validity


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Remove the macro-redefinition warning storm from the normal ESP32-C3 build
    without changing enabled TLS features.
* **What changes are included?**
  * Stop repeating four TLS feature macros already enabled by
    Arduino-wolfSSL's `user_settings.h` when `WOLFSSL_TLS13` is set.
  * Document which configuration layer owns those features.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, browser, media, or
      PDF feature.
- [x] No issue or pending PR removes these redundant definitions.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or
      recovery code.

## Additional Context

`HAVE_TLS_EXTENSIONS`, `HAVE_SUPPORTED_CURVES`, `HAVE_HKDF`, and
`WC_RSA_PSS` remain enabled by the installed Arduino-wolfSSL configuration.
This removes duplicate command-line definitions; it does not disable those
features.

Validation:

- Full ESP32-C3 `default` rebuild passed.
- Reported size: 52,028 bytes RAM and 5,505,149 bytes flash.
- The wolfSSL macro-redefinition warnings are gone.
- The only remaining warning in that build was an unrelated deprecated
  `NetworkClient::flush()` call inside the vendored WebSockets library.
- `git diff --check`.

Memory/flash impact: no intentional change. The effective preprocessor feature
set is unchanged.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools were used to trace the duplicate definitions to the library
configuration and compare the full build output before and after cleanup.


## Emulator disclosure

The ESP32-C3 firmware was compiled locally and the warning output was checked on Intel macOS. Runtime smoke testing used the desktop emulator; this PR was not flashed to a physical X3 or X4.
