### PR TITLE
fix: derive file-transfer WebSocket port from HTTP

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -3274,7 +3274,10 @@ let operationCancelled = false; // Set by Cancel to stop conversion loops and up
 let uploadGeneration = 0;       // Incremented each uploadFile() call; guards stale restoreAfterCancel()
 let currentUploadWs = null;     // Active WebSocket reference for external abort
 let currentUploadXhr = null;    // Active XHR reference for external abort
-const WS_PORT = 81;
+// On-device HTTP uses port 80 and WebSocket uses 81. The simulator maps the
+// same adjacent-port contract to an unprivileged host pair such as 8080/8081.
+const HTTP_PORT = Number(window.location.port || 80);
+const WS_PORT = HTTP_PORT + 1;
 const WS_CHUNK_SIZE = 4096; // 4KB chunks - smaller for ESP32 stability
 
 // ============================================================================


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Preserve the firmware's adjacent HTTP/WebSocket port contract when the web
    UI is served from a mapped host port in the desktop simulator.
* **What changes are included?**
  * Use the current page's HTTP port, defaulting to 80 on-device.
  * Connect WebSocket uploads to the next port instead of always using host
    port 81.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, browser, media, or
      PDF feature.
- [x] The current file-transfer page does not handle simulator port mapping and
      no pending PR fixes it.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or
      recovery code.

## Additional Context

On hardware the page is served from port 80 and WebSocket remains port 81, so
device behavior is unchanged. In the simulator, a page served from 8080 now
uses 8081; a configured 18080 listener uses 18081.

Validation:

- Built the real CrossPoint file-transfer server in the simulator.
- Loaded the page through `http://127.0.0.1:18080/`.
- Verified a WebSocket upgrade on port 18081 returns HTTP 101.
- Exercised WebSocket upload progress and the HTTP fallback path.
- `git diff --check`.

Memory impact: no firmware heap allocation is added. The change is JavaScript
inside the existing compressed web asset.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools were used to reproduce the browser/simulator port mismatch and verify
the HTTP and WebSocket listeners together.


## Emulator disclosure

The mapped-port HTTP/WebSocket behavior was reproduced and validated with the desktop emulator on Intel macOS. The on-device port-80/81 behavior was established from the unchanged firmware contract; no physical device was used for runtime validation.
