### PR TITLE
feat: quick-resume when coming from other sleep screen modes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -196,22 +196,18 @@ void enterDeepSleep(bool fromTimeout = false) {
   HalPowerManager::Lock powerLock;  // Ensure we are at normal CPU frequency for sleep preparation
   APP_STATE.lastSleepFromReader = activityManager.isReaderActivity();
 
-  const bool isQuickResumeSleep =
-      SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::QUICK_RESUME ||
-      (fromTimeout &&
-       SETTINGS.quickResumeSleepScreen == CrossPointSettings::QUICK_RESUME_SLEEP_SCREEN::QUICK_RESUME_AFTER_TIMEOUT);
-  APP_STATE.showBootScreen = !isQuickResumeSleep;
-
+  // Always skip the boot splash and restore the last frame on wake,
+  // regardless of which sleep screen mode is shown on the panel.
+  APP_STATE.showBootScreen = false;
   APP_STATE.saveToFile();
+
+  // Save framebuffer BEFORE goToSleep() overwrites it with the sleep screen
+  saveSleepFrameBuffer();
 
   // Commit to sleeping before goToSleep() runs the outgoing activity's onExit():
   // a WiFi activity would otherwise silentRestart() here and reboot instead.
   deepSleepInProgress = true;
   activityManager.goToSleep(fromTimeout);
-
-  if (isQuickResumeSleep) {
-    saveSleepFrameBuffer();
-  }
 
   // Tear down WiFi so the modem power domain isn't held alive across deep sleep.
   // Wake from deep sleep is effectively a chip reset, so no state needs to survive.
@@ -381,18 +377,25 @@ void setup() {
       APP_STATE.showBootScreen = true;
       APP_STATE.saveToFile();
       if (loadSleepFrameBuffer()) {
-        const bool useDifferentialRefresh = gpio.deviceIsX3();
+        const bool isX3 = gpio.deviceIsX3();
+        // X3 quick-resume sleep screen shows only a moon overlay on the last
+        // frame, so a differential refresh is clean. All other sleep modes
+        // (cover, dark, etc.) overwrite the entire panel and need at least a half refresh
+        // to avoid ghosting from the sleep image.
+        const bool useDifferentialRefresh =
+            isX3 && SETTINGS.sleepScreen == CrossPointSettings::SLEEP_SCREEN_MODE::QUICK_RESUME;
         if (useDifferentialRefresh) {
-          // begin() clears the X3 controller RAM, so restore the saved frame as
-          // the baseline before replacing the moon with the loading icon.
           renderer.cleanupGrayscaleWithFrameBuffer();
         }
 
         const auto pageHeight = renderer.getScreenHeight();
         renderer.drawImage(LoadingIcon, 0, pageHeight - LOADINGICON_HEIGHT, LOADINGICON_WIDTH, LOADINGICON_HEIGHT);
+        if (isX3) {
+          // we dont need to refresh the screen again after the initial HALF_REFRESH
+          allowFastInitialReaderRefresh = true;
+        }
         if (useDifferentialRefresh) {
           renderer.displayGrayscaleBase(HalDisplay::FAST_REFRESH);
-          allowFastInitialReaderRefresh = true;
         } else {
           renderer.displayBuffer(HalDisplay::HALF_REFRESH);
         }


### PR DESCRIPTION
## Summary

The goal of this pull request is to make crosspoint "Quick-resume" from other sleep screens other than the quick resume one.

Only change i have made is moving the framebuffer saving before drawing the sleep screen and using half-refresh on the x3 when drawing it back/

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.
 - a framebuffer dump is saved every time while going to sleep instead of only when using the quick-resume sleep option

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**<  PARTIALLY  >**_
i have used deepseek v4 to help me get an understanding of the codebase much faster