### PR TITLE
perf: open dictionary index files once per lookup

### DIFF
--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdio>
 #include <cstring>
 
 #include "DictZip.h"
@@ -96,8 +97,23 @@ bool Dictionary::open(const char* folderName) {
     LOG_ERR("DICT", "%s uses 64-bit index offsets (unsupported)", resolved.c_str());
     return false;
   }
+  // Checked once here so buildPath() can never fail on the lookup path.
+  if (resolved.size() + strlen(LONGEST_SUFFIX) + 1 > PATH_BUF_BYTES) {
+    LOG_ERR("DICT", "Dictionary path too long (%u chars, max %u)", static_cast<unsigned>(resolved.size()),
+            static_cast<unsigned>(PATH_BUF_BYTES - strlen(LONGEST_SUFFIX) - 1));
+    return false;
+  }
 
   basePath = std::move(resolved);
+  return true;
+}
+
+bool Dictionary::buildPath(char* buf, size_t bufSize, const char* suffix) const {
+  const int n = snprintf(buf, bufSize, "%s%s", basePath.c_str(), suffix);
+  if (n < 0 || static_cast<size_t>(n) >= bufSize) {
+    LOG_ERR("DICT", "Path too long: %s%s", basePath.c_str(), suffix);
+    return false;
+  }
   return true;
 }
 
@@ -221,12 +237,17 @@ int Dictionary::readWordInto(HalFile& file, char* buf, size_t bufSize) {
 
 bool Dictionary::openSession(LookupSession& session) {
   if (!isOpen()) return false;
-  if (!Storage.openFileForRead("DICT", basePath + ".idx", session.idx)) return false;
+
+  // One buffer reused for both paths — no transient heap on the lookup path.
+  char path[PATH_BUF_BYTES];
+  if (!buildPath(path, sizeof(path), ".idx")) return false;
+  if (!Storage.openFileForRead("DICT", path, session.idx)) return false;
   session.idxSize = static_cast<uint32_t>(session.idx.fileSize());
 
   // The sidecar is optional and its header only has to be validated once per
   // lookup; without a usable one locate() scans from byte 0.
-  if (Storage.openFileForRead("DICT", basePath + ".qidx", session.qidx)) {
+  if (!buildPath(path, sizeof(path), ".qidx")) return true;
+  if (Storage.openFileForRead("DICT", path, session.qidx)) {
     const QidxHeader header = readQidxHeader(session.qidx, SAMPLE_INTERVAL);
     if (header.valid && header.idxFileSize == session.idxSize) session.sampleCount = header.sampleCount;
   }
@@ -310,19 +331,21 @@ bool Dictionary::readDefinition(const DictLocation& location, std::string& out, 
     return fail(LookupResult::LowMemory);
   }
 
-  std::string path;
+  char pathBuf[PATH_BUF_BYTES];
+  const char* path = pathBuf;
   uint32_t offset = 0;
   if (hasPlainDict) {
-    path = basePath + ".dict";
+    if (!buildPath(pathBuf, sizeof(pathBuf), ".dict")) return fail(LookupResult::ReadError);
     offset = location.offset;
   } else {
+    if (!buildPath(pathBuf, sizeof(pathBuf), ".dict.dz")) return fail(LookupResult::ReadError);
     HalFile tmp = Storage.open(DICT_TMP_FILE, O_WRITE | O_CREAT | O_TRUNC);
     if (!tmp) {
       LOG_ERR("DICT", "Failed to open %s", DICT_TMP_FILE);
       return fail(LookupResult::ReadError);
     }
     DictZip::ExtractError xerr = DictZip::ExtractError::None;
-    if (!DictZip::extractEntry((basePath + ".dict.dz").c_str(), location.offset, size, tmp, &xerr)) {
+    if (!DictZip::extractEntry(pathBuf, location.offset, size, tmp, &xerr)) {
       // Map the specific extraction cause to the lookup result: allocation
       // failure (heap fragmentation) vs corrupt/truncated .dz vs an IO error.
       LOG_ERR("DICT", "dictzip extraction failed for %s (error %d)", basePath.c_str(), static_cast<int>(xerr));

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -219,59 +219,63 @@ int Dictionary::readWordInto(HalFile& file, char* buf, size_t bufSize) {
   return static_cast<int>(bufSize - 1);
 }
 
-DictLocation Dictionary::locate(const char* target, std::string* matchedHeadwordOut) {
-  DictLocation result;
-  if (!isOpen()) return result;
+bool Dictionary::openSession(LookupSession& session) {
+  if (!isOpen()) return false;
+  if (!Storage.openFileForRead("DICT", basePath + ".idx", session.idx)) return false;
+  session.idxSize = static_cast<uint32_t>(session.idx.fileSize());
 
-  HalFile idx;
-  if (!Storage.openFileForRead("DICT", basePath + ".idx", idx)) {
-    result.readError = true;
-    return result;
+  // The sidecar is optional and its header only has to be validated once per
+  // lookup; without a usable one locate() scans from byte 0.
+  if (Storage.openFileForRead("DICT", basePath + ".qidx", session.qidx)) {
+    const QidxHeader header = readQidxHeader(session.qidx, SAMPLE_INTERVAL);
+    if (header.valid && header.idxFileSize == session.idxSize) session.sampleCount = header.sampleCount;
   }
-  const uint32_t idxSize = static_cast<uint32_t>(idx.fileSize());
+  return true;
+}
+
+// Both files stay open across the stem-variant probes; every read below seeks
+// absolutely first, so a shared handle carries no position state between calls.
+DictLocation Dictionary::locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut) {
+  DictLocation result;
 
   // Bisect the sampled offsets to the last sample whose headword <= target.
   // Falls back to a full scan from byte 0 when the sidecar is unusable.
   uint32_t startByte = 0;
-  HalFile qidx;
-  if (Storage.openFileForRead("DICT", basePath + ".qidx", qidx)) {
-    const QidxHeader header = readQidxHeader(qidx, SAMPLE_INTERVAL);
-    if (header.valid && header.idxFileSize == idxSize && header.sampleCount > 0) {
-      uint32_t lo = 0;
-      uint32_t hi = header.sampleCount - 1;
-      while (lo < hi) {
-        const uint32_t mid = (lo + hi + 1) / 2;
-        uint32_t offset = 0;
-        if (!readSampleOffset(qidx, mid, &offset) || !idx.seekSet(offset) ||
-            readWordInto(idx, wordBuf, sizeof(wordBuf)) < 0) {
-          lo = 0;
-          break;
-        }
-        if (StringUtils::asciiCaseCmp(wordBuf, target) <= 0) {
-          lo = mid;
-        } else {
-          hi = mid - 1;
-        }
+  if (session.sampleCount > 0) {
+    uint32_t lo = 0;
+    uint32_t hi = session.sampleCount - 1;
+    while (lo < hi) {
+      const uint32_t mid = (lo + hi + 1) / 2;
+      uint32_t offset = 0;
+      if (!readSampleOffset(session.qidx, mid, &offset) || !session.idx.seekSet(offset) ||
+          readWordInto(session.idx, wordBuf, sizeof(wordBuf)) < 0) {
+        lo = 0;
+        break;
       }
-      readSampleOffset(qidx, lo, &startByte);
+      if (StringUtils::asciiCaseCmp(wordBuf, target) <= 0) {
+        lo = mid;
+      } else {
+        hi = mid - 1;
+      }
     }
+    readSampleOffset(session.qidx, lo, &startByte);
   }
 
   // Linear scan of at most SAMPLE_INTERVAL entries: headword NUL, BE32 offset,
   // BE32 size. The index is sorted, so stop at the first headword > target.
-  if (!idx.seekSet(startByte)) {
+  if (!session.idx.seekSet(startByte)) {
     LOG_ERR("DICT", "Index seek to %lu failed", static_cast<unsigned long>(startByte));
     result.readError = true;
     return result;
   }
-  while (static_cast<uint32_t>(idx.position()) < idxSize) {
+  while (static_cast<uint32_t>(session.idx.position()) < session.idxSize) {
     // Not flagged as readError: readWordInto returns -1 for EOF and IO error
     // alike, so a short tail can't be told from a truncated .idx. Treat it as
     // the end of the index rather than risk reporting a read failure for what
     // is really a miss.
-    if (readWordInto(idx, wordBuf, sizeof(wordBuf)) < 0) break;
+    if (readWordInto(session.idx, wordBuf, sizeof(wordBuf)) < 0) break;
     uint8_t suffix[8];
-    if (idx.read(suffix, 8) != 8) break;
+    if (session.idx.read(suffix, 8) != 8) break;
 
     const int cmp = StringUtils::asciiCaseCmp(wordBuf, target);
     if (cmp == 0) {
@@ -412,15 +416,29 @@ bool Dictionary::lookup(const char* word, std::string& definitionOut, std::strin
   const std::string cleaned = cleanWord(word);
   if (cleaned.empty() || !isOpen()) return false;
 
-  DictLocation location = locate(cleaned.c_str(), &matchedHeadwordOut);
-  bool searchFailed = location.readError;
-  if (!location.found) {
-    std::vector<std::string> variants;
-    stemVariants(cleaned, variants);
-    for (const auto& variant : variants) {
-      location = locate(variant.c_str(), &matchedHeadwordOut);
-      searchFailed = searchFailed || location.readError;
-      if (location.found) break;
+  // One set of open handles for the exact-match probe and every stem variant,
+  // scoped so .idx/.qidx close before readDefinition() opens the data file.
+  DictLocation location;
+  bool searchFailed = false;
+  {
+    LookupSession session;
+    // Couldn't open .idx: the search never reached a verdict, so this is a read
+    // failure, not a miss.
+    if (!openSession(session)) {
+      setResult(LookupResult::ReadError);
+      return false;
+    }
+
+    location = locate(session, cleaned.c_str(), &matchedHeadwordOut);
+    searchFailed = location.readError;
+    if (!location.found) {
+      std::vector<std::string> variants;
+      stemVariants(cleaned, variants);
+      for (const auto& variant : variants) {
+        location = locate(session, variant.c_str(), &matchedHeadwordOut);
+        searchFailed = searchFailed || location.readError;
+        if (location.found) break;
+      }
     }
   }
   if (!location.found) {

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -77,11 +77,27 @@ class Dictionary {
  private:
   static constexpr uint32_t SAMPLE_INTERVAL = 256;
 
+  // Longest "<basePath><suffix>" the lookup path builds, rounded up. basePath is
+  // "/dictionaries/<folder>/<stem>" (14 fixed chars) and the longest suffix is
+  // ".dict.dz", leaving ~137 chars for folder + stem — far beyond any real
+  // dictionary. open() rejects anything that would not fit, so the hot path
+  // cannot fail on length. Kept under the 256-byte stack-local guideline.
+  static constexpr size_t PATH_BUF_BYTES = 160;
+
+  // Longest suffix appended to basePath; used for the open()-time length check.
+  static constexpr const char* LONGEST_SUFFIX = ".dict.dz";
+
+  // Compose "<basePath><suffix>" into a caller-supplied stack buffer. The
+  // lookup path runs this instead of `basePath + suffix` so probing a word
+  // costs no transient heap at all — see LookupSession. False (and logs) when
+  // the path would not fit, which open() has already ruled out.
+  bool buildPath(char* buf, size_t bufSize, const char* suffix) const;
+
   // The .idx / .qidx handles shared by every locate() call in one lookup. A
-  // lookup probes up to ~5 stem variants; opening the two files and building
-  // their path strings per probe cost ~10 SD opens and ~10 std::string
-  // temporaries per word, churning the same heap whose fragmentation makes
-  // lookups fail mid-session. Opened once per lookup instead.
+  // lookup probes up to ~5 stem variants; opening the two files per probe cost
+  // ~10 SD opens and ~10 std::string path temporaries per word, churning the
+  // same heap whose fragmentation makes lookups fail mid-session. Opened once
+  // per lookup instead, with the paths built via buildPath().
   struct LookupSession {
     HalFile idx;
     HalFile qidx;

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -77,7 +77,23 @@ class Dictionary {
  private:
   static constexpr uint32_t SAMPLE_INTERVAL = 256;
 
-  DictLocation locate(const char* target, std::string* matchedHeadwordOut);
+  // The .idx / .qidx handles shared by every locate() call in one lookup. A
+  // lookup probes up to ~5 stem variants; opening the two files and building
+  // their path strings per probe cost ~10 SD opens and ~10 std::string
+  // temporaries per word, churning the same heap whose fragmentation makes
+  // lookups fail mid-session. Opened once per lookup instead.
+  struct LookupSession {
+    HalFile idx;
+    HalFile qidx;
+    uint32_t idxSize = 0;
+    uint32_t sampleCount = 0;  // 0 when the sidecar is absent, stale or empty
+  };
+
+  // Open .idx (required) and .qidx (optional — locate() falls back to a full
+  // scan without it). False when the dictionary is closed or .idx won't open.
+  bool openSession(LookupSession& session);
+
+  DictLocation locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut);
   // Read the definition at location. On failure returns false and, if outResult
   // is given, sets it to the specific reason (Decompress / LowMemory / ReadError).
   bool readDefinition(const DictLocation& location, std::string& out, LookupResult* outResult = nullptr);


### PR DESCRIPTION
## Summary

* **Goal:** Stop the dictionary lookup path from churning the heap it depends on. `Dictionary::locate()` opened **both** `.idx` and `.qidx` and built both path strings as `std::string` temporaries on *every call* — and `lookup()` calls it once for the cleaned word and then once per stem variant, up to ~5 probes for a word like "stories". That's roughly **10 SD opens and 10 string allocations for a single lookup**.

  This is the supply side of the bug named in #2706: fragmentation is what makes dictionary lookups start failing mid-session (the ~32 KB contiguous inflate window for `.dict.dz` can no longer be allocated, and a reset "fixes" it). The lookup path was itself a fragmentation source. It also cuts against CLAUDE.md's *"avoid repeated `new`/`delete` in loops"* and the `std::string` hot-path rule.

* **Changes:** a private `LookupSession` holds the two `HalFile` handles plus the validated sidecar state, opened once by `openSession()` and passed into `locate()`.

  | | Before | After |
  |---|---|---|
  | SD opens per lookup | ~10 | **2** |
  | `std::string` path temporaries | ~10 | **2** |
  | `.qidx` header validations | once per probe | **once per lookup** |
  | Peak open file handles | 2 | 2 (unchanged) |

  Counts are per lookup regardless of how many stem variants get probed.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] No new feature surface at all — this is a pure internal refactor of an existing in-scope feature (dictionary lookup). Behaviour is unchanged.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, so no maintainer coordination is required on that basis.

## Additional Context

* **Why sharing the handles is behaviour-preserving:** every read in `locate()` seeks absolutely before reading — `readSampleOffset()` seeks to its computed offset, the bisect seeks per probe, and the linear scan seeks to `startByte` before the loop. No call inherits file position from a previous one, so reuse changes nothing observable.
* **Peak handles deliberately unchanged:** the session is scoped in a block so `.idx`/`.qidx` close before `readDefinition()` opens the data file. Without that scoping the peak would have gone 2 → 4.
* **Memory / flash impact:** no new persistent RAM. `LookupSession` is a stack struct in `lookup()` holding two `HalFile` handles that previously lived on `locate()`'s stack anyway. The win is fewer transient heap allocations and fewer SD transactions per lookup, not a static saving.
* **Relationship to #2706:** that PR touches the same `locate()` — it adds failure-cause plumbing (`readError`) so an `.idx` failure isn't reported as "Not found". This PR changes where the handles come from. **They will conflict.** Deliberately opened as a draft: I'd suggest landing #2706 first, then I'll rebase this on top. Raising it now so the approach can be sanity-checked before I do that work.

### Testing

* Builds clean for the device `default` env (ESP32-C3).
* `pio check` clean, clang-format clean, 129/129 unit tests pass.
* **Not yet tested on hardware.** No dictionary lookup has been exercised on a device with this change. That verification is still outstanding and I'll do it before marking ready for review.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — the churn was identified and the refactor implemented with Claude Code. Not yet hardware-verified by me (see Testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
