### PR TITLE
perf: skip ruby scratch allocations on ruby-less lines

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -174,6 +174,16 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
   uint16_t count;
   serialization::readPod(file, count);
 
+  // Reserve up front so a page load costs one allocation for the element vector
+  // instead of a grow-copy-free cycle every doubling. `count` is untrusted (it
+  // comes straight off the SD cache), so clamp it: a real page holds a few dozen
+  // elements, while a corrupt header could ask for 65535 * sizeof(shared_ptr) and
+  // abort() on the failed allocation (vector's operator new is throwing, and this
+  // firmware builds with -fno-exceptions). Under-reserving is harmless -- the
+  // push_back path below still grows normally.
+  static constexpr uint16_t RESERVE_CAP = 256;
+  page->elements.reserve(std::min(count, RESERVE_CAP));
+
   for (uint16_t i = 0; i < count; i++) {
     uint8_t tag;
     serialization::readPod(file, tag);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -142,9 +142,16 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
     std::string text;
     BidiUtils::BidiBaseDir baseDir;
   };
-  std::vector<int> wordShiftArr(numWords, 0);
-  std::vector<RubyDrawInfo> rubies(numWords);
-  if (hasRuby()) {
+  // hasRuby() is an O(numWords) scan, so resolve it once here rather than per word.
+  // Both arrays below are only ever read when the line carries ruby, so they stay
+  // empty (zero allocations) for the ruby-less case, which is every line of a
+  // non-CJK book. Sized lazily inside the branch.
+  const bool blockHasRuby = hasRuby();
+  std::vector<int> wordShiftArr;
+  std::vector<RubyDrawInfo> rubies;
+  if (blockHasRuby) {
+    wordShiftArr.assign(numWords, 0);
+    rubies.resize(numWords);
     int accumulatedShift = 0;
     int lastEnd = -9999;
     for (uint16_t i = 0; i < numWords; i++) {
@@ -245,6 +252,10 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
     }
   };
 
+  // Loop-invariant: hoisted out of the word loop so rubyTexts is scanned once,
+  // not once per word.
+  const int rubyShift = getRubyShift(ascender);
+
   for (uint16_t i = 0; i < numWords; i++) {
     const char* word = wordText(i);
     const int wordX = xposArr[i] + x;
@@ -257,7 +268,6 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
     // drawText, so these offsets are chosen relative to the full-size ascender:
     //   SUP: raise by 40% of ascender — sits clearly above the cap-height
     //   SUB: lower by 25% of ascender — descends below baseline without clashing with ascenders below
-    const int rubyShift = getRubyShift(ascender);
     int wordY = y + rubyShift;
     if ((currentStyle & EpdFontFamily::SUP) != 0) {
       wordY -= ascender * 2 / 5;
@@ -265,7 +275,7 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
       wordY += ascender / 4;
     }
 
-    const int drawX = wordX + wordShiftArr[i];
+    const int drawX = wordX + (blockHasRuby ? wordShiftArr[i] : 0);
 
     if (boundary > 0) {
       // Focus split: draw bold prefix, then the regular suffix at a pre-computed x offset.
@@ -289,7 +299,8 @@ void TextBlock::render(const GfxRenderer& renderer, const int fontId, const int 
     }
 
     // Horizontal ruby text rendering
-    if (i < rubyTexts.size() && !rubyTexts[i].empty() && (wordStyle(i) & EpdFontFamily::RUBY_CONTINUE) == 0) {
+    if (blockHasRuby && i < rubyTexts.size() && !rubyTexts[i].empty() &&
+        (wordStyle(i) & EpdFontFamily::RUBY_CONTINUE) == 0) {
       const int rubyY = wordY - ascender;
       renderer.drawText(fontId, rubies[i].x, rubyY, rubies[i].text.c_str(), true, EpdFontFamily::SUP,
                         rubies[i].baseDir);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Remove the per-line heap churn that `<ruby>` support reintroduced into the render hot path, and give `TextBlock` its first host test coverage.
* **What changes are included?**
  - `TextBlock::render()` no longer allocates on ruby-less lines (**2 → 0 allocations per line, 56 → 0 per page render**).
  - `Page::deserialize()` reserves the element vector before its `push_back` loop.
  - New host tests: 12 behavioural + 3 allocation-accounting.

## Background

[#2547](https://github.com/crosspoint-reader/crosspoint-reader/pull/2547) flattened `TextBlock` word storage into a single arena, taking word-storage allocations per page load from ~250 to ~30. [#2665](https://github.com/crosspoint-reader/crosspoint-reader/pull/2665) (merged 19 days later) added `<ruby>` support, which reintroduced per-word storage into the same path.

CodeRabbit flagged both instances in review on #2665 four days before merge, tagged *🔵 Trivial / Quick win*, and neither was addressed. This is that follow-up.

## What was happening

`TextBlock::render()` allocated two per-word vectors *before* the `hasRuby()` gate that decides whether either is ever read:

```cpp
std::vector<int> wordShiftArr(numWords, 0);
std::vector<RubyDrawInfo> rubies(numWords);   // RubyDrawInfo holds a std::string
if (hasRuby()) {
```

Every line of every non-CJK book paid for both, on **every render** — not just page load. These are transient: taken and freed per line, so on a device with no heap compaction they churn DRAM rather than occupying it.

`getRubyShift()` was also called once per word, and it rescans `rubyTexts` each time, making that part of the loop O(numWords²). The value is loop-invariant.

## Measured

Host-side allocation counting (`TextBlockAllocTest`), 12-word ruby-less line:

| | before | after |
|---|---|---|
| allocations per line render | 2 | **0** |
| allocations per 28-line page render | 56 | **0** |

Reproducible by anyone via `ctest` — no hardware needed. `RubyRenderStillAllocatesAndDraws` passes on both sides, pinning that the ruby path was made conditional rather than disabled.

## Behaviour is unchanged

- `wordShiftArr` was all-zero whenever `hasRuby()` was false, so `drawX` is identical.
- `rubyShift` is the same expression `getRubyShift()` would return, hoisted out of the loop.
- The ruby draw site was already unreachable without a non-empty `rubyTexts[i]`, so the added `blockHasRuby &&` is a short-circuit no-op that only makes the vector access safe.

## Tests

`TextBlock` had **no host coverage**, so ruby layout (group ruby, adjacent-annotation collision resolution, the baseline shift) was only checkable on device. Follows the `minibidi_arabic` pattern: a `stubs/` dir first on the include path shadows the four headers that can't build on the host (`Logging.h`, `HalStorage.h`, `EpdFontFamily.h`, `GfxRenderer.h`); the real `TextBlock.cpp` is compiled against them.

The 12 behavioural tests were **written and verified green on `develop` first**, then mutation-tested to confirm they can fail:

| Mutation on develop | Caught by |
|---|---|
| `getRubyShift()` → always `0` | `RubyLineShiftsBaselineAndDrawsAnnotation` |
| drop per-word `wordShiftArr[i]` offset | `WideRubyRecentresBaseWord` |

Those are exactly the two axes this change touches.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this is a regression against #2547's measured baseline.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact.** No change to static footprint — DRAM stays at 119,013 bytes (`.text` 66,988 / `.bss` 35,416 / `.data` 16,609). The win is heap churn, not residency.

**The `Page::deserialize` reserve is clamped**, deliberately. `count` is read straight off the SD cache and is `uint16_t`, so an unclamped `reserve(count)` would let a corrupt header request 65535 × `sizeof(shared_ptr)` ≈ 512 KB — and since `std::vector`'s `operator new` is throwing under `-fno-exceptions`, that is an `abort()`, converting a corrupt-cache miss into a hard crash. Capped at 256; under-reserving just falls back to normal growth. Same pattern as #2435 and #2519.

**Not hardware-verified.** The allocation counts are exact and host-measured, but reduced fragmentation is an inference from them — glibc's allocator behaves nothing like ESP-IDF's. Confirming the actual DRAM benefit wants a device run in #2547's terms (`maxAlloc / free` ratio sampled during steady-state reading, `ESP.getMinFreeHeap()` across ~100 page turns, same book, `.crosspoint/` cleared between runs). **Left as draft pending that.**

**One pre-existing warning surfaced.** The test target's `-Wall -Wextra -pedantic` exposes a sign-compare at `TextBlock.cpp:415` (`file.read(...)` returns `int`, compared against `size_t`). Benign — a `-1` error return converts to a huge unsigned and still takes the error path — and pre-existing, so production code was left alone. Happy to silence it with a cast if reviewers prefer a quiet CI log.

**Deliberately not included:** the third finding from the same audit — `Page::elements` is `vector<shared_ptr<PageElement>>` and `PageLine` holds `shared_ptr<TextBlock>`, both constructed *from* `unique_ptr`, so each pays a separately allocated control block plus atomic refcounting on a single-core RISC-V. Ownership on the read path is unique. Left out because 10 open PRs touch `Page.cpp`/`Page.h`/`TextBlock.*` and the conflict surface isn't worth it right now.

**Related open work:** [#2554](https://github.com/crosspoint-reader/crosspoint-reader/pull/2554) (shared bidi scratch buffer, ~1.5 KB static) and [#2437](https://github.com/crosspoint-reader/crosspoint-reader/pull/2437) (cache section LUT offset) are both complementary and non-conflicting.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — written with Claude Code. Build (`pio run -e default`) and `pio check` clean, host tests green, mutation-tested for sensitivity. Not yet flash-tested; see the draft note above.
