### PR TITLE
fix: TextSettingsActivity default to selected font

### DIFF
--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -73,6 +73,7 @@ void TextSettingsActivity::onEnter() {
   std::fill(std::begin(selectedIndex_), std::end(selectedIndex_), 1);       // default to the first list row
   selectedIndex_[static_cast<int>(Tab::Family)] = currentFamilyIndex_ + 1;  // Family/Size open on current selection
   selectedIndex_[static_cast<int>(Tab::Size)] = currentSizeIndex_ + 1;
+  selectedIndex_[static_cast<int>(tab_)] = 0;  // screen opens with the tab bar focused, not a list row
 
   requestUpdate();
 }


### PR DESCRIPTION
## Summary

fix the bug report in RC1
"Text settings defaults to highlighting a font instead of selecting the menu bar first. It gets annoying if you’re trying to do something other than selecting a font, like tweaking the layout."