### PR TITLE
fix: orient dictionary navigation buttons

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -17,6 +17,38 @@ bool MappedInputManager::isNavDirectionSwapped() const {
          (orientation == GfxRenderer::PortraitInverted || orientation == GfxRenderer::LandscapeCounterClockwise);
 }
 
+MappedInputManager::Button MappedInputManager::mapScreenDirection(const Button button) const {
+  // Rows follow GfxRenderer::Orientation's declared order.
+  static constexpr Button directions[][4] = {
+      {Button::Left, Button::Right, Button::Up, Button::Down},
+      {Button::Down, Button::Up, Button::Left, Button::Right},
+      {Button::Right, Button::Left, Button::Down, Button::Up},
+      {Button::Up, Button::Down, Button::Right, Button::Left},
+  };
+
+  uint8_t direction = 0;
+  switch (button) {
+    case Button::ScreenLeft:
+      direction = 0;
+      break;
+    case Button::ScreenRight:
+      direction = 1;
+      break;
+    case Button::ScreenUp:
+      direction = 2;
+      break;
+    case Button::ScreenDown:
+      direction = 3;
+      break;
+    default:
+      return button;
+  }
+
+  const uint8_t orientation =
+      SETTINGS.frontButtonFollowOrientation ? static_cast<uint8_t>(renderer.getOrientation()) : 0;
+  return directions[orientation][direction];
+}
+
 bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint8_t) const) const {
   const auto sideLayout = SETTINGS.sideButtonLayout;
 
@@ -73,6 +105,11 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       // Logical "previous item" navigation: side Up + front Left, axis-flipped in the same orientations.
       return isNavDirectionSwapped() ? (mapButton(Button::Down, fn) || mapButton(Button::Right, fn))
                                      : (mapButton(Button::Up, fn) || mapButton(Button::Left, fn));
+    case Button::ScreenLeft:
+    case Button::ScreenRight:
+    case Button::ScreenUp:
+    case Button::ScreenDown:
+      return mapButton(mapScreenDirection(button), fn);
   }
 
   return false;
@@ -304,6 +341,24 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
   const char* leftLabel = swapLabels ? next : previous;
   const char* rightLabel = swapLabels ? previous : next;
 
+  return mapFrontLabels(back, confirm, leftLabel, rightLabel);
+}
+
+MappedInputManager::Labels MappedInputManager::mapDirectionalLabels(const char* back, const char* confirm,
+                                                                    const char* left, const char* right, const char* up,
+                                                                    const char* down) const {
+  const auto labelForButton = [&](const Button rawButton) {
+    if (mapScreenDirection(Button::ScreenLeft) == rawButton) return left;
+    if (mapScreenDirection(Button::ScreenRight) == rawButton) return right;
+    if (mapScreenDirection(Button::ScreenUp) == rawButton) return up;
+    if (mapScreenDirection(Button::ScreenDown) == rawButton) return down;
+    return "";
+  };
+  return mapFrontLabels(back, confirm, labelForButton(Button::Left), labelForButton(Button::Right));
+}
+
+MappedInputManager::Labels MappedInputManager::mapFrontLabels(const char* back, const char* confirm, const char* left,
+                                                              const char* right) const {
   // Build the label order based on the configured hardware mapping.
   auto labelForHardware = [&](uint8_t hw) -> const char* {
     // Compare against configured logical roles and return the matching label.
@@ -314,10 +369,10 @@ MappedInputManager::Labels MappedInputManager::mapLabels(const char* back, const
       return confirm;
     }
     if (hw == SETTINGS.frontButtonLeft) {
-      return leftLabel;
+      return left;
     }
     if (hw == SETTINGS.frontButtonRight) {
-      return rightLabel;
+      return right;
     }
     return "";
   };

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -6,7 +6,23 @@ class GfxRenderer;
 
 class MappedInputManager {
  public:
-  enum class Button { Back, Confirm, Left, Right, Up, Down, Power, PageBack, PageForward, NavNext, NavPrevious };
+  enum class Button {
+    Back,
+    Confirm,
+    Left,
+    Right,
+    Up,
+    Down,
+    Power,
+    PageBack,
+    PageForward,
+    NavNext,
+    NavPrevious,
+    ScreenLeft,
+    ScreenRight,
+    ScreenUp,
+    ScreenDown
+  };
   enum class SwipeDir { None, Left, Right, Up, Down };
 
   struct Labels {
@@ -52,6 +68,10 @@ class MappedInputManager {
   unsigned long getHeldTime() const;
   const GfxRenderer& getRenderer() const { return renderer; }
   Labels mapLabels(const char* back, const char* confirm, const char* previous, const char* next) const;
+  // Maps four screen-direction labels onto the two physical front-button roles
+  // using the same live-orientation transform as ScreenLeft/Right/Up/Down.
+  Labels mapDirectionalLabels(const char* back, const char* confirm, const char* left, const char* right,
+                              const char* up, const char* down) const;
   // Returns the raw front button index that was pressed this frame (or -1 if none).
   int getPressedFrontButton() const;
 
@@ -70,6 +90,8 @@ class MappedInputManager {
   // preference and stays "rotated" even while portrait UI like home/settings is on screen.
   const GfxRenderer& renderer;
 
+  Button mapScreenDirection(Button button) const;
+  Labels mapFrontLabels(const char* back, const char* confirm, const char* left, const char* right) const;
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;
   bool wasBackGesture() const;
   // Fetch the pending swipe (if any) and map both endpoints to logical screen coords

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -9,7 +9,6 @@
 #include <cctype>
 #include <climits>
 #include <cstdlib>
-#include <utility>
 
 #include "CrossPointSettings.h"
 #include "DictionaryDefinitionActivity.h"
@@ -264,45 +263,16 @@ void DictionaryWordSelectActivity::loop() {
     return;
   }
 
-  auto previousWord = MappedInputManager::Button::Left;
-  auto nextWord = MappedInputManager::Button::Right;
-  auto up = MappedInputManager::Button::Up;
-  auto down = MappedInputManager::Button::Down;
-  if (SETTINGS.frontButtonFollowOrientation) {
-    // The raw button roles describe the portrait frame. Rotate both axes into
-    // the live frame so navigation follows the physical position of each button.
-    switch (renderer.getOrientation()) {
-    case GfxRenderer::PortraitInverted:
-      std::swap(previousWord, nextWord);
-      std::swap(up, down);
-      break;
-    case GfxRenderer::LandscapeClockwise:
-      previousWord = MappedInputManager::Button::Down;
-      nextWord = MappedInputManager::Button::Up;
-      up = MappedInputManager::Button::Left;
-      down = MappedInputManager::Button::Right;
-      break;
-    case GfxRenderer::LandscapeCounterClockwise:
-      previousWord = MappedInputManager::Button::Up;
-      nextWord = MappedInputManager::Button::Down;
-      up = MappedInputManager::Button::Right;
-      down = MappedInputManager::Button::Left;
-      break;
-    case GfxRenderer::Portrait:
-    default:
-      break;
-    }
-  }
-
-  if (mappedInput.wasPressed(previousWord) && selected > 0) {
+  const bool hasNextWord = selected + 1 < static_cast<int>(words.size());
+  if (mappedInput.wasPressed(MappedInputManager::Button::ScreenLeft) && selected > 0) {
     selected--;
     requestUpdate();
-  } else if (mappedInput.wasPressed(nextWord) && selected + 1 < static_cast<int>(words.size())) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenRight) && hasNextWord) {
     selected++;
     requestUpdate();
-  } else if (mappedInput.wasPressed(up)) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenUp)) {
     moveVertical(-1);
-  } else if (mappedInput.wasPressed(down)) {
+  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenDown)) {
     moveVertical(1);
   }
 }
@@ -356,16 +326,8 @@ void DictionaryWordSelectActivity::drawHints() const {
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     return;
   }
-  const bool isLandscape = SETTINGS.frontButtonFollowOrientation && renderer.getScreenWidth() > renderer.getScreenHeight();
-  // In landscape the front buttons move between rows, while the side buttons
-  // move between words.
-  const char* previousLabel = tr(STR_DIR_LEFT);
-  const char* nextLabel = tr(STR_DIR_RIGHT);
-  if (isLandscape) {
-    previousLabel = tr(STR_DIR_UP);
-    nextLabel = tr(STR_DIR_DOWN);
-  }
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_LOOKUP), previousLabel, nextLabel);
+  const auto labels = mappedInput.mapDirectionalLabels(tr(STR_BACK), tr(STR_LOOKUP), tr(STR_DIR_LEFT),
+                                                       tr(STR_DIR_RIGHT), tr(STR_DIR_UP), tr(STR_DIR_DOWN));
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 }
 

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <climits>
 #include <cstdlib>
+#include <utility>
 
 #include "CrossPointSettings.h"
 #include "DictionaryDefinitionActivity.h"
@@ -263,17 +264,35 @@ void DictionaryWordSelectActivity::loop() {
     return;
   }
 
-  // Match the reader menu's orientation-aware direction mapping.  When the
-  // controls follow the reader orientation and its axis is flipped, every
-  // directional role flips too: physical Up/Left become logical Down/Right
-  // and vice versa.  Keep this keyed to MappedInputManager's live-renderer
-  // check rather than the persisted setting, so the selector follows the
-  // orientation currently visible to the user.
-  const bool directionSwapped = mappedInput.isNavDirectionSwapped();
-  const auto previousWord = directionSwapped ? MappedInputManager::Button::Right : MappedInputManager::Button::Left;
-  const auto nextWord = directionSwapped ? MappedInputManager::Button::Left : MappedInputManager::Button::Right;
-  const auto up = directionSwapped ? MappedInputManager::Button::Down : MappedInputManager::Button::Up;
-  const auto down = directionSwapped ? MappedInputManager::Button::Up : MappedInputManager::Button::Down;
+  auto previousWord = MappedInputManager::Button::Left;
+  auto nextWord = MappedInputManager::Button::Right;
+  auto up = MappedInputManager::Button::Up;
+  auto down = MappedInputManager::Button::Down;
+  if (SETTINGS.frontButtonFollowOrientation) {
+    // The raw button roles describe the portrait frame. Rotate both axes into
+    // the live frame so navigation follows the physical position of each button.
+    switch (renderer.getOrientation()) {
+    case GfxRenderer::PortraitInverted:
+      std::swap(previousWord, nextWord);
+      std::swap(up, down);
+      break;
+    case GfxRenderer::LandscapeClockwise:
+      previousWord = MappedInputManager::Button::Down;
+      nextWord = MappedInputManager::Button::Up;
+      up = MappedInputManager::Button::Left;
+      down = MappedInputManager::Button::Right;
+      break;
+    case GfxRenderer::LandscapeCounterClockwise:
+      previousWord = MappedInputManager::Button::Up;
+      nextWord = MappedInputManager::Button::Down;
+      up = MappedInputManager::Button::Right;
+      down = MappedInputManager::Button::Left;
+      break;
+    case GfxRenderer::Portrait:
+    default:
+      break;
+    }
+  }
 
   if (mappedInput.wasPressed(previousWord) && selected > 0) {
     selected--;
@@ -326,11 +345,10 @@ bool DictionaryWordSelectActivity::drawHighlightWithSnapshot() {
 // Front-button bar (Back/Confirm/Left/Right). Drawn last on every repaint
 // path, including the differential highlight-only path, so it always ends
 // up as the top layer even when a highlighted word's box falls under a
-// hint's screen area. No side-button hints: Up/Down row jump has no spare
-// screen area on this page (it reuses the reader's full-bleed layout), and
-// a hint box there would hide text instead of sitting in a reserved gutter.
+// hint's screen area. No side-button hints: the full-bleed reader page has no
+// spare gutter for them, so a hint box there would hide text.
 void DictionaryWordSelectActivity::drawHints() const {
-  // No selectable word on this page: Confirm/Left/Right are all no-ops
+  // No selectable word on this page: Confirm and navigation are all no-ops
   // (guarded by words.empty() in loop()/performLookup), so only Back does
   // anything and only Back is hinted.
   if (words.empty()) {
@@ -338,7 +356,16 @@ void DictionaryWordSelectActivity::drawHints() const {
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
     return;
   }
-  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_LOOKUP), tr(STR_DIR_LEFT), tr(STR_DIR_RIGHT));
+  const bool isLandscape = SETTINGS.frontButtonFollowOrientation && renderer.getScreenWidth() > renderer.getScreenHeight();
+  // In landscape the front buttons move between rows, while the side buttons
+  // move between words.
+  const char* previousLabel = tr(STR_DIR_LEFT);
+  const char* nextLabel = tr(STR_DIR_RIGHT);
+  if (isLandscape) {
+    previousLabel = tr(STR_DIR_UP);
+    nextLabel = tr(STR_DIR_DOWN);
+  }
+  const auto labels = mappedInput.mapLabels(tr(STR_BACK), tr(STR_LOOKUP), previousLabel, nextLabel);
   GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
 }
 

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -263,16 +263,27 @@ void DictionaryWordSelectActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Left) && selected > 0) {
+  // Match the reader menu's orientation-aware direction mapping.  When the
+  // controls follow the reader orientation and its axis is flipped, every
+  // directional role flips too: physical Up/Left become logical Down/Right
+  // and vice versa.  Keep this keyed to MappedInputManager's live-renderer
+  // check rather than the persisted setting, so the selector follows the
+  // orientation currently visible to the user.
+  const bool directionSwapped = mappedInput.isNavDirectionSwapped();
+  const auto previousWord = directionSwapped ? MappedInputManager::Button::Right : MappedInputManager::Button::Left;
+  const auto nextWord = directionSwapped ? MappedInputManager::Button::Left : MappedInputManager::Button::Right;
+  const auto up = directionSwapped ? MappedInputManager::Button::Down : MappedInputManager::Button::Up;
+  const auto down = directionSwapped ? MappedInputManager::Button::Up : MappedInputManager::Button::Down;
+
+  if (mappedInput.wasPressed(previousWord) && selected > 0) {
     selected--;
     requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Right) &&
-             selected + 1 < static_cast<int>(words.size())) {
+  } else if (mappedInput.wasPressed(nextWord) && selected + 1 < static_cast<int>(words.size())) {
     selected++;
     requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Up)) {
+  } else if (mappedInput.wasPressed(up)) {
     moveVertical(-1);
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::Down)) {
+  } else if (mappedInput.wasPressed(down)) {
     moveVertical(1);
   }
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix #2713: make dictionary word-selection navigation follow the reader's current orientation.
* **What changes are included?** Dictionary word selection now uses the same live orientation-aware direction swap as reader menus, so Up/Down and Left/Right select words in the displayed direction when controls follow orientation.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

The root cause was that this activity handled the raw directional roles directly, bypassing `MappedInputManager`'s orientation-aware navigation rule used by reader menus. The change has no expected memory or flash impact.

Validation: tested on Xteink X4. This is a bug for the release 1.5.0, so it should probably be backported.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
