### PR TITLE
fix(koreader): resolve KOReader XPath sync positions

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -923,3 +923,34 @@ std::optional<uint16_t> Section::getPageForListItemIndex(const uint16_t liIndex)
 
   return resultPage;
 }
+
+std::optional<uint16_t> Section::getPageForImageSource(const std::string& sourcePath, const uint16_t occurrence) const {
+  if (sourcePath.empty() || occurrence == 0) return std::nullopt;
+
+  // A sync can be opened while the target chapter is still being indexed. Its
+  // suspended cache nevertheless contains valid pages and ImageBlocks, even
+  // though getCachedPageCount() intentionally rejects partial files because
+  // their count is not the chapter total.
+  HalFile cacheFile;
+  if (!Storage.openFileForRead("SCT", filePath, cacheFile)) return std::nullopt;
+  uint8_t version;
+  serialization::readPod(cacheFile, version);
+  if (version != SECTION_FILE_VERSION && version != SECTION_FILE_PARTIAL_VERSION) return std::nullopt;
+  cacheFile.seek(HEADER_SIZE - sizeof(uint32_t) * 4 - sizeof(uint16_t));
+  uint16_t storedPageCount;
+  serialization::readPod(cacheFile, storedPageCount);
+  if (storedPageCount == 0) return std::nullopt;
+
+  uint16_t matched = 0;
+  for (uint16_t pageIndex = 0; pageIndex < storedPageCount; pageIndex++) {
+    const auto page = loadPageAt(pageIndex);
+    if (!page) continue;
+    for (const auto& element : page->elements) {
+      if (element->getTag() != TAG_PageImage) continue;
+      const auto& image = static_cast<const PageImage&>(*element);
+      if (image.getImageBlock().getSourcePath() != sourcePath) continue;
+      if (++matched == occurrence) return pageIndex;
+    }
+  }
+  return std::nullopt;
+}

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -941,9 +941,17 @@ std::optional<uint16_t> Section::getPageForImageSource(const std::string& source
   serialization::readPod(cacheFile, storedPageCount);
   if (storedPageCount == 0) return std::nullopt;
 
+  uint32_t lutOffset;
+  cacheFile.seek(HEADER_SIZE - sizeof(uint32_t) * 4);
+  serialization::readPod(cacheFile, lutOffset);
+
   uint16_t matched = 0;
   for (uint16_t pageIndex = 0; pageIndex < storedPageCount; pageIndex++) {
-    const auto page = loadPageAt(pageIndex);
+    cacheFile.seek(lutOffset + sizeof(uint32_t) * pageIndex);
+    uint32_t pageOffset;
+    serialization::readPod(cacheFile, pageOffset);
+    cacheFile.seek(pageOffset);
+    const auto page = Page::deserialize(cacheFile);
     if (!page) continue;
     for (const auto& element : page->elements) {
       if (element->getTag() != TAG_PageImage) continue;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -144,6 +144,11 @@ class Section {
   // Look up the page number for a running list-item index from the li LUT.
   std::optional<uint16_t> getPageForListItemIndex(uint16_t liIndex) const;
 
+  // Locate a rendered inline image by its normalised EPUB source path and its
+  // 1-based occurrence within this spine item. Used to apply KOReader image
+  // XPath positions without falling back to an incompatible book percentage.
+  std::optional<uint16_t> getPageForImageSource(const std::string& sourcePath, uint16_t occurrence) const;
+
   // Look up the synthetic paragraph index for the given rendered page.
   std::optional<uint16_t> getParagraphIndexForPage(uint16_t page) const;
 };

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -12,6 +12,9 @@ class ImageBlock final : public Block {
   ~ImageBlock() override = default;
 
   const std::string& getImagePath() const { return imagePath; }
+  // Book-internal path (normalised relative to the EPUB root). This remains
+  // available after lazy extraction so sync can identify the rendered image.
+  const std::string& getSourcePath() const { return srcPath; }
   int16_t getWidth() const { return width; }
   int16_t getHeight() const { return height; }
 

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -127,7 +127,7 @@ bool isChapterStartXPath(const std::string& xpath) {
 // Parsed representation of one step in the XPath ancestry.
 struct XPathStep {
   char tag[12];      // element name, null-terminated
-  int siblingIndex;  // 1-based sibling index, or 0 if unspecified (treat as 1)
+  int siblingIndex;  // 1-based sibling index, or 0 if unspecified (match any sibling)
 };
 
 static constexpr int MAX_XPATH_DEPTH = 16;
@@ -707,10 +707,18 @@ class ParagraphStreamer final : public Print {
 // missing Kindle's unindexed wrapper paths. Images have no visible text, so
 // use the XML parser here to match the real XHTML tree and identify the image
 // that CrossPoint laid out.
+std::string normaliseImageSource(const std::string& spineHref, std::string source) {
+  const size_t fragmentPos = source.find('#');
+  if (fragmentPos != std::string::npos) source.resize(fragmentPos);
+  const size_t slash = spineHref.rfind('/');
+  const std::string base = slash == std::string::npos ? "" : spineHref.substr(0, slash + 1);
+  return FsHelpers::normalisePath(FsHelpers::decodeUriEscapes(base + source));
+}
+
 class ImageXPathResolver final : public Print {
  public:
-  ImageXPathResolver(const XPathStep* targetSteps, const int targetStepCount)
-      : steps(targetSteps), stepCount(targetStepCount) {
+  ImageXPathResolver(const XPathStep* targetSteps, const int targetStepCount, std::string spineHref)
+      : steps(targetSteps), stepCount(targetStepCount), spineHref(std::move(spineHref)) {
     parser = XML_ParserCreate(nullptr);
     if (!parser) return;
     XML_SetUserData(parser, this);
@@ -819,14 +827,18 @@ class ImageXPathResolver final : public Print {
     if (strcasecmp(name.c_str(), "p") == 0) paragraphCount++;
 
     std::string candidateSource;
+    std::string candidateKey;
     uint16_t candidateOccurrence = 0;
     if (strcasecmp(name.c_str(), "img") == 0) {
       candidateSource = imageSourceFromAttributes(attrs);
-      candidateOccurrence = 1;
-      for (const auto& earlierSource : imageSources) {
-        if (earlierSource == candidateSource) candidateOccurrence++;
+      if (!candidateSource.empty()) {
+        candidateKey = normaliseImageSource(spineHref, candidateSource);
+        candidateOccurrence = 1;
+        for (const auto& earlierKey : imageSources) {
+          if (earlierKey == candidateKey) candidateOccurrence++;
+        }
+        imageSources.push_back(std::move(candidateKey));
       }
-      if (!candidateSource.empty()) imageSources.push_back(candidateSource);
     }
 
     if (pathMatches()) {
@@ -861,6 +873,7 @@ class ImageXPathResolver final : public Print {
   XML_Parser parser = nullptr;
   const XPathStep* steps;
   int stepCount;
+  std::string spineHref;
   bool parseOk = true;
   bool insideBody = false;
   bool foundTarget = false;
@@ -881,7 +894,7 @@ bool streamSpine(const std::shared_ptr<Epub>& epub, int spineIndex, Print& s) {
 
 bool resolveImageXPath(const std::shared_ptr<Epub>& epub, const int spineIndex, const XPathStep* steps,
                        const int stepCount, std::string& source, uint16_t& occurrence) {
-  ImageXPathResolver resolver(steps, stepCount);
+  ImageXPathResolver resolver(steps, stepCount, epub->getSpineItem(spineIndex).href);
   if (!streamSpine(epub, spineIndex, resolver) || !resolver.finish() || !resolver.found()) return false;
   source = resolver.imageSource();
   occurrence = resolver.imageOccurrence();
@@ -890,19 +903,14 @@ bool resolveImageXPath(const std::shared_ptr<Epub>& epub, const int spineIndex, 
 
 bool resolveXPathParagraph(const std::shared_ptr<Epub>& epub, const int spineIndex, const XPathStep* steps,
                            const int stepCount, uint16_t& paragraphIndex) {
-  ImageXPathResolver resolver(steps, stepCount);
+  ImageXPathResolver resolver(steps, stepCount, epub->getSpineItem(spineIndex).href);
   if (!streamSpine(epub, spineIndex, resolver) || !resolver.finish() || !resolver.matched()) return false;
   paragraphIndex = resolver.paragraphIndex();
   return paragraphIndex > 0;
 }
 
 std::string resolveImageSource(const std::shared_ptr<Epub>& epub, const int spineIndex, std::string source) {
-  const size_t fragmentPos = source.find('#');
-  if (fragmentPos != std::string::npos) source.resize(fragmentPos);
-  const auto href = epub->getSpineItem(spineIndex).href;
-  const size_t slash = href.rfind('/');
-  const std::string base = slash == std::string::npos ? "" : href.substr(0, slash + 1);
-  return FsHelpers::normalisePath(FsHelpers::decodeUriEscapes(base + source));
+  return normaliseImageSource(epub->getSpineItem(spineIndex).href, std::move(source));
 }
 }  // namespace
 

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -715,6 +715,7 @@ class ImageXPathResolver final : public Print {
     if (!parser) return;
     XML_SetUserData(parser, this);
     XML_SetElementHandler(parser, &ImageXPathResolver::startElement, &ImageXPathResolver::endElement);
+    XML_SetDefaultHandlerExpand(parser, &ImageXPathResolver::defaultHandlerExpand);
   }
 
   ~ImageXPathResolver() override { destroyXmlParser(parser); }
@@ -789,6 +790,8 @@ class ImageXPathResolver final : public Print {
   static void XMLCALL endElement(void* userData, const XML_Char* name) {
     static_cast<ImageXPathResolver*>(userData)->onEndElement(name);
   }
+
+  static void XMLCALL defaultHandlerExpand(void*, const XML_Char*, int) {}
 
   bool pathMatches() const {
     if (static_cast<int>(path.size()) != stepCount) return false;
@@ -1045,6 +1048,7 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
         Section tempSection(epub, result.spineIndex, renderer);
         if (const auto imagePage = tempSection.getPageForImageSource(imageSource, imageOccurrence)) {
           if (const auto cachedCount = tempSection.getCachedPageCount()) result.totalPages = *cachedCount;
+          result.totalPages = std::max(result.totalPages, static_cast<int>(*imagePage) + 1);
           result.pageNumber = *imagePage;
           LOG_DBG("PM", "Image XPath %s source=%s occurrence=%u -> page=%d/%d", koPos.xpath.c_str(),
                   imageSource.c_str(), imageOccurrence, result.pageNumber, result.totalPages);
@@ -1087,6 +1091,7 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
         Section tempSection(epub, result.spineIndex, renderer);
         if (const auto paragraphPage = tempSection.getPageForParagraphIndex(paragraphIndex)) {
           if (const auto cachedCount = tempSection.getCachedPageCount()) result.totalPages = *cachedCount;
+          result.totalPages = std::max(result.totalPages, static_cast<int>(*paragraphPage) + 1);
           result.paragraphIndex = paragraphIndex;
           result.hasParagraphIndex = true;
           result.pageNumber = *paragraphPage;

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -1,11 +1,16 @@
 #include "ProgressMapper.h"
 
+#include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Print.h>
+#include <XmlParserUtils.h>
+#include <expat.h>
 
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <vector>
 
 #include "ChapterXPathResolver.h"
 #include "Epub/Section.h"
@@ -174,7 +179,7 @@ int parseXPathSteps(const std::string& xpath, XPathStep steps[MAX_XPATH_DEPTH]) 
       }
       step.siblingIndex = idx;
     } else {
-      step.siblingIndex = 1;
+      step.siblingIndex = 0;  // An omitted XPath index selects any matching sibling.
     }
 
     count++;
@@ -464,7 +469,7 @@ class ParagraphStreamer final : public Print {
         const bool atCorrectDepth = (matchedDepth == 0) || (htmlDepth == stepEnteredAtDepth[matchedDepth - 1] + 1);
         if (!atCorrectDepth) return;
         siblingCounters[matchedDepth]++;
-        if (siblingCounters[matchedDepth] == target.siblingIndex) {
+        if (target.siblingIndex == 0 || siblingCounters[matchedDepth] == target.siblingIndex) {
           insideStep[matchedDepth] = true;
           stepEnteredAtDepth[matchedDepth] = htmlDepth;
           matchedDepth++;
@@ -697,9 +702,182 @@ class ParagraphStreamer final : public Print {
   }
 };
 
-bool streamSpine(const std::shared_ptr<Epub>& epub, int spineIndex, ParagraphStreamer& s) {
+// Expat-backed resolver for KOReader image positions. The lightweight text
+// streamer above deliberately does not retain a DOM, which makes it prone to
+// missing Kindle's unindexed wrapper paths. Images have no visible text, so
+// use the XML parser here to match the real XHTML tree and identify the image
+// that CrossPoint laid out.
+class ImageXPathResolver final : public Print {
+ public:
+  ImageXPathResolver(const XPathStep* targetSteps, const int targetStepCount)
+      : steps(targetSteps), stepCount(targetStepCount) {
+    parser = XML_ParserCreate(nullptr);
+    if (!parser) return;
+    XML_SetUserData(parser, this);
+    XML_SetElementHandler(parser, &ImageXPathResolver::startElement, &ImageXPathResolver::endElement);
+  }
+
+  ~ImageXPathResolver() override { destroyXmlParser(parser); }
+
+  size_t write(uint8_t c) override { return write(&c, 1); }
+
+  size_t write(const uint8_t* buffer, const size_t size) override {
+    if (!parser || !parseOk || foundImage) return size;
+    if (XML_Parse(parser, reinterpret_cast<const char*>(buffer), static_cast<int>(size), XML_FALSE) != XML_STATUS_OK) {
+      if (XML_GetErrorCode(parser) != XML_ERROR_ABORTED) {
+        LOG_DBG("PM", "Image XPath XML parse failed: %s", XML_ErrorString(XML_GetErrorCode(parser)));
+        parseOk = false;
+      }
+    }
+    return size;
+  }
+
+  bool finish() {
+    if (!parser || !parseOk) return false;
+    if (!foundImage && XML_Parse(parser, "", 0, XML_TRUE) != XML_STATUS_OK) {
+      LOG_DBG("PM", "Image XPath XML final parse failed: %s", XML_ErrorString(XML_GetErrorCode(parser)));
+      parseOk = false;
+    }
+    return parseOk;
+  }
+
+  bool found() const { return foundImage && !source.empty() && occurrence > 0; }
+  const std::string& imageSource() const { return source; }
+  uint16_t imageOccurrence() const { return occurrence; }
+
+ private:
+  struct ChildCount {
+    std::string name;
+    int count = 0;
+  };
+
+  struct ParentState {
+    std::vector<ChildCount> children;
+
+    int nextIndex(const std::string& name) {
+      for (auto& child : children) {
+        if (child.name == name) return ++child.count;
+      }
+      children.push_back({name, 1});
+      return 1;
+    }
+  };
+
+  static std::string localName(const XML_Char* rawName) {
+    if (!rawName) return "";
+    const char* colon = strrchr(rawName, ':');
+    return colon ? std::string(colon + 1) : std::string(rawName);
+  }
+
+  static std::string imageSourceFromAttributes(const XML_Char** attrs) {
+    if (!attrs) return "";
+    for (int i = 0; attrs[i]; i += 2) {
+      const std::string name = localName(attrs[i]);
+      if (strcasecmp(name.c_str(), "src") == 0 || strcasecmp(name.c_str(), "href") == 0) {
+        return attrs[i + 1] ? attrs[i + 1] : "";
+      }
+    }
+    return "";
+  }
+
+  static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** attrs) {
+    static_cast<ImageXPathResolver*>(userData)->onStartElement(name, attrs);
+  }
+
+  static void XMLCALL endElement(void* userData, const XML_Char* name) {
+    static_cast<ImageXPathResolver*>(userData)->onEndElement(name);
+  }
+
+  bool pathMatches() const {
+    if (static_cast<int>(path.size()) != stepCount) return false;
+    for (int i = 0; i < stepCount; i++) {
+      if (strcasecmp(path[i].name.c_str(), steps[i].tag) != 0) return false;
+      if (steps[i].siblingIndex > 0 && path[i].index != steps[i].siblingIndex) return false;
+    }
+    return true;
+  }
+
+  void onStartElement(const XML_Char* rawName, const XML_Char** attrs) {
+    const std::string name = localName(rawName);
+    if (!insideBody) {
+      if (strcasecmp(name.c_str(), "body") == 0) {
+        insideBody = true;
+        parents.emplace_back();
+      }
+      return;
+    }
+
+    const int index = parents.back().nextIndex(name);
+    path.push_back({name, index});
+    parents.emplace_back();
+
+    if (strcasecmp(name.c_str(), "img") != 0) return;
+    const std::string candidateSource = imageSourceFromAttributes(attrs);
+    uint16_t candidateOccurrence = 1;
+    for (const auto& earlierSource : imageSources) {
+      if (earlierSource == candidateSource) candidateOccurrence++;
+    }
+    if (!candidateSource.empty()) imageSources.push_back(candidateSource);
+
+    if (pathMatches() && !candidateSource.empty()) {
+      source = candidateSource;
+      occurrence = candidateOccurrence;
+      foundImage = true;
+      XML_StopParser(parser, XML_FALSE);
+    }
+  }
+
+  void onEndElement(const XML_Char* rawName) {
+    const std::string name = localName(rawName);
+    if (!insideBody) return;
+    if (path.empty() && strcasecmp(name.c_str(), "body") == 0) {
+      insideBody = false;
+      parents.clear();
+      return;
+    }
+    if (!path.empty()) path.pop_back();
+    if (parents.size() > 1) parents.pop_back();
+  }
+
+  struct PathNode {
+    std::string name;
+    int index;
+  };
+
+  XML_Parser parser = nullptr;
+  const XPathStep* steps;
+  int stepCount;
+  bool parseOk = true;
+  bool insideBody = false;
+  bool foundImage = false;
+  std::vector<ParentState> parents;
+  std::vector<PathNode> path;
+  std::vector<std::string> imageSources;
+  std::string source;
+  uint16_t occurrence = 0;
+};
+
+bool streamSpine(const std::shared_ptr<Epub>& epub, int spineIndex, Print& s) {
   const auto href = epub->getSpineItem(spineIndex).href;
   return !href.empty() && epub->readItemContentsToStream(href, s, 1024);
+}
+
+bool resolveImageXPath(const std::shared_ptr<Epub>& epub, const int spineIndex, const XPathStep* steps,
+                       const int stepCount, std::string& source, uint16_t& occurrence) {
+  ImageXPathResolver resolver(steps, stepCount);
+  if (!streamSpine(epub, spineIndex, resolver) || !resolver.finish() || !resolver.found()) return false;
+  source = resolver.imageSource();
+  occurrence = resolver.imageOccurrence();
+  return true;
+}
+
+std::string resolveImageSource(const std::shared_ptr<Epub>& epub, const int spineIndex, std::string source) {
+  const size_t fragmentPos = source.find('#');
+  if (fragmentPos != std::string::npos) source.resize(fragmentPos);
+  const auto href = epub->getSpineItem(spineIndex).href;
+  const size_t slash = href.rfind('/');
+  const std::string base = slash == std::string::npos ? "" : href.substr(0, slash + 1);
+  return FsHelpers::normalisePath(FsHelpers::decodeUriEscapes(base + source));
 }
 }  // namespace
 
@@ -837,6 +1015,26 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
   float intra = 0.0f;
   bool resolvedIntra = false;
   if (useAncestry) {
+    if (strcasecmp(xpathSteps[xpathStepCount - 1].tag, "img") == 0) {
+      std::string rawImageSource;
+      uint16_t imageOccurrence = 0;
+      if (resolveImageXPath(epub, result.spineIndex, xpathSteps, xpathStepCount, rawImageSource, imageOccurrence)) {
+        const std::string imageSource = resolveImageSource(epub, result.spineIndex, rawImageSource);
+        Section tempSection(epub, result.spineIndex, renderer);
+        if (const auto imagePage = tempSection.getPageForImageSource(imageSource, imageOccurrence)) {
+          if (const auto cachedCount = tempSection.getCachedPageCount()) result.totalPages = *cachedCount;
+          result.pageNumber = *imagePage;
+          LOG_DBG("PM", "Image XPath %s source=%s occurrence=%u -> page=%d/%d", koPos.xpath.c_str(),
+                  imageSource.c_str(), imageOccurrence, result.pageNumber, result.totalPages);
+          return result;
+        }
+        LOG_DBG("PM", "Image XPath %s source=%s occurrence=%u not found in section cache", koPos.xpath.c_str(),
+                imageSource.c_str(), imageOccurrence);
+      } else {
+        LOG_DBG("PM", "Image XPath %s did not resolve in spine %d", koPos.xpath.c_str(), result.spineIndex);
+      }
+    }
+
     ParagraphStreamer s(xpathSteps, xpathStepCount, xpathChar, xpathTextNode);
     if (streamSpine(epub, result.spineIndex, s) && s.found()) {
       intra = s.progress();

--- a/lib/KOReaderSync/ProgressMapper.cpp
+++ b/lib/KOReaderSync/ProgressMapper.cpp
@@ -722,7 +722,7 @@ class ImageXPathResolver final : public Print {
   size_t write(uint8_t c) override { return write(&c, 1); }
 
   size_t write(const uint8_t* buffer, const size_t size) override {
-    if (!parser || !parseOk || foundImage) return size;
+    if (!parser || !parseOk || foundTarget) return size;
     if (XML_Parse(parser, reinterpret_cast<const char*>(buffer), static_cast<int>(size), XML_FALSE) != XML_STATUS_OK) {
       if (XML_GetErrorCode(parser) != XML_ERROR_ABORTED) {
         LOG_DBG("PM", "Image XPath XML parse failed: %s", XML_ErrorString(XML_GetErrorCode(parser)));
@@ -734,16 +734,18 @@ class ImageXPathResolver final : public Print {
 
   bool finish() {
     if (!parser || !parseOk) return false;
-    if (!foundImage && XML_Parse(parser, "", 0, XML_TRUE) != XML_STATUS_OK) {
+    if (!foundTarget && XML_Parse(parser, "", 0, XML_TRUE) != XML_STATUS_OK) {
       LOG_DBG("PM", "Image XPath XML final parse failed: %s", XML_ErrorString(XML_GetErrorCode(parser)));
       parseOk = false;
     }
     return parseOk;
   }
 
+  bool matched() const { return foundTarget; }
   bool found() const { return foundImage && !source.empty() && occurrence > 0; }
   const std::string& imageSource() const { return source; }
   uint16_t imageOccurrence() const { return occurrence; }
+  uint16_t paragraphIndex() const { return targetParagraph; }
 
  private:
   struct ChildCount {
@@ -811,18 +813,27 @@ class ImageXPathResolver final : public Print {
     path.push_back({name, index});
     parents.emplace_back();
 
-    if (strcasecmp(name.c_str(), "img") != 0) return;
-    const std::string candidateSource = imageSourceFromAttributes(attrs);
-    uint16_t candidateOccurrence = 1;
-    for (const auto& earlierSource : imageSources) {
-      if (earlierSource == candidateSource) candidateOccurrence++;
-    }
-    if (!candidateSource.empty()) imageSources.push_back(candidateSource);
+    if (strcasecmp(name.c_str(), "p") == 0) paragraphCount++;
 
-    if (pathMatches() && !candidateSource.empty()) {
-      source = candidateSource;
-      occurrence = candidateOccurrence;
-      foundImage = true;
+    std::string candidateSource;
+    uint16_t candidateOccurrence = 0;
+    if (strcasecmp(name.c_str(), "img") == 0) {
+      candidateSource = imageSourceFromAttributes(attrs);
+      candidateOccurrence = 1;
+      for (const auto& earlierSource : imageSources) {
+        if (earlierSource == candidateSource) candidateOccurrence++;
+      }
+      if (!candidateSource.empty()) imageSources.push_back(candidateSource);
+    }
+
+    if (pathMatches()) {
+      targetParagraph = paragraphCount;
+      foundTarget = true;
+      if (!candidateSource.empty()) {
+        source = std::move(candidateSource);
+        occurrence = candidateOccurrence;
+        foundImage = true;
+      }
       XML_StopParser(parser, XML_FALSE);
     }
   }
@@ -849,7 +860,10 @@ class ImageXPathResolver final : public Print {
   int stepCount;
   bool parseOk = true;
   bool insideBody = false;
+  bool foundTarget = false;
   bool foundImage = false;
+  uint16_t paragraphCount = 0;
+  uint16_t targetParagraph = 0;
   std::vector<ParentState> parents;
   std::vector<PathNode> path;
   std::vector<std::string> imageSources;
@@ -869,6 +883,14 @@ bool resolveImageXPath(const std::shared_ptr<Epub>& epub, const int spineIndex, 
   source = resolver.imageSource();
   occurrence = resolver.imageOccurrence();
   return true;
+}
+
+bool resolveXPathParagraph(const std::shared_ptr<Epub>& epub, const int spineIndex, const XPathStep* steps,
+                           const int stepCount, uint16_t& paragraphIndex) {
+  ImageXPathResolver resolver(steps, stepCount);
+  if (!streamSpine(epub, spineIndex, resolver) || !resolver.finish() || !resolver.matched()) return false;
+  paragraphIndex = resolver.paragraphIndex();
+  return paragraphIndex > 0;
 }
 
 std::string resolveImageSource(const std::shared_ptr<Epub>& epub, const int spineIndex, std::string source) {
@@ -1059,6 +1081,21 @@ CrossPointPosition ProgressMapper::toCrossPoint(const std::shared_ptr<Epub>& epu
               xpathSteps[xpathStepCount - 1].tag, xpathSteps[xpathStepCount - 1].siblingIndex, xpathTextNode, xpathChar,
               intra * 100, s.getTargetVisChars(), s.getTotalVisChars(), pAtMatch,
               result.hasLiIndex ? static_cast<int>(result.liIndex) : 0, anchorId ? anchorId : "none");
+    } else {
+      uint16_t paragraphIndex = 0;
+      if (resolveXPathParagraph(epub, result.spineIndex, xpathSteps, xpathStepCount, paragraphIndex)) {
+        Section tempSection(epub, result.spineIndex, renderer);
+        if (const auto paragraphPage = tempSection.getPageForParagraphIndex(paragraphIndex)) {
+          if (const auto cachedCount = tempSection.getCachedPageCount()) result.totalPages = *cachedCount;
+          result.paragraphIndex = paragraphIndex;
+          result.hasParagraphIndex = true;
+          result.pageNumber = *paragraphPage;
+          LOG_DBG("PM", "XPath fallback %s paragraph %u -> page=%d/%d", koPos.xpath.c_str(), paragraphIndex,
+                  result.pageNumber, result.totalPages);
+          return result;
+        }
+        LOG_DBG("PM", "XPath fallback %s paragraph %u not found in section LUT", koPos.xpath.c_str(), paragraphIndex);
+      }
     }
   } else if (xpathP > 0) {
     ParagraphStreamer s(xpathP, xpathChar, xpathTextNode);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make Kindle → CrossPoint KOReader sync use the local EPUB position when Kindle’s XPath is more reliable than its global percentage.
* **What changes are included?**
  * Resolve inline-image XPaths to the locally rendered image page, including partial section caches.
  * Resolve text XPaths with unindexed Kindle wrapper elements through the local paragraph-to-page cache.

### Fixed use cases

- **Inline image anchor:** a Kindle position ending in `img` opens the page containing the corresponding local image, even when image optimisation changed image bytes or dimensions.
- **Text anchor below a different wrapper:** when the lightweight mapper cannot match paths such as `p[5]/span[2]/text()`, CrossPoint resolves the local paragraph and opens its cached page.

### Not fixed

- Positions without a usable or matchable XPath still use percentage-based mapping and may remain inaccurate across differently rendered copies.
- Text anchors still require a locally available paragraph-to-page cache; otherwise the existing percentage fallback applies.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code; maintainer coordination is not applicable.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the relevant Discussion or issue so reviewers can see the history.**

Not applicable; this is a focused fix to existing KOReader sync behavior.

## Additional Context

The issue occurs because Kindle uploads structural paths such as `/body/DocFragment[15]/body/div/section/div[1]/div/div/div/span/img.0` and `/body/DocFragment[15]/body/div/section/p[5]/span[2]/text().41`, while its percentage represents a different rendering environment.

- Built and flashed on an Xteink X4.
- Verified the image anchor resolves `Art_sborn.jpg` occurrence 1 to UI page 1/57.
- Verified a text anchor previously mapped to page 12/57 now maps near the expected second page.
- No known memory or flash impact beyond the small XPath-resolution logic.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_ — AI assisted investigation and implementation; the issue was reproduced and validated on-device.