### PR TITLE
fix: Restrict CrossPoint position extension to official server

### DIFF
--- a/lib/KOReaderSync/KOReaderCredentialStore.cpp
+++ b/lib/KOReaderSync/KOReaderCredentialStore.cpp
@@ -132,6 +132,8 @@ std::string KOReaderCredentialStore::getBaseUrl() const {
   return url;
 }
 
+bool KOReaderCredentialStore::usesCrossPointSyncServer() const { return getBaseUrl() == DEFAULT_SERVER_URL; }
+
 void KOReaderCredentialStore::setMatchMethod(DocumentMatchMethod method) {
   matchMethod = method;
   LOG_DBG("KRS", "Set match method: %s", method == DocumentMatchMethod::FILENAME ? "Filename" : "Binary");

--- a/lib/KOReaderSync/KOReaderCredentialStore.h
+++ b/lib/KOReaderSync/KOReaderCredentialStore.h
@@ -65,6 +65,9 @@ class KOReaderCredentialStore : public PersistableStore<KOReaderCredentialStore>
   // Get base URL for API calls (with http:// normalization if no protocol, falls back to default)
   std::string getBaseUrl() const;
 
+  // Whether API calls target the CrossPoint sync server that supports protocol extensions.
+  bool usesCrossPointSyncServer() const;
+
   // Document matching method
   void setMatchMethod(DocumentMatchMethod method);
   DocumentMatchMethod getMatchMethod() const { return matchMethod; }

--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -183,22 +183,23 @@ KOReaderSyncClient::Error KOReaderSyncClient::getProgress(const std::string& doc
     outProgress.deviceId = doc["device_id"].as<std::string>();
     outProgress.timestamp = doc["timestamp"].as<int64_t>();
 
-    // Extended crosspoint-sync field; absent on plain kosync servers.
     outProgress.position.reset();
-    const JsonObjectConst pos = doc["position"].as<JsonObjectConst>();
-    if (!pos.isNull()) {
-      KOReaderRichPosition rich;
-      rich.pctQ = pos["pctQ"].as<uint32_t>();
-      rich.spineIndex = pos["spine"].as<uint16_t>();
-      rich.pageNumber = pos["page"].as<uint16_t>();
-      const uint16_t pages = pos["pages"].as<uint16_t>();
-      rich.totalPages = pages > 0 ? pages : 1;
-      const uint16_t para = pos["para"].as<uint16_t>();
-      if (para > 0) rich.paragraphIndex = para;
-      rich.xpath = pos["xpath"].as<const char*>() ? pos["xpath"].as<const char*>() : "";
-      LOG_DBG("KOSync", "Got rich position: spine=%u page=%u/%u para=%u", rich.spineIndex, rich.pageNumber,
-              rich.totalPages, para);
-      outProgress.position = std::move(rich);
+    if (KOREADER_STORE.usesCrossPointSyncServer()) {
+      const JsonObjectConst pos = doc["position"].as<JsonObjectConst>();
+      if (!pos.isNull()) {
+        KOReaderRichPosition rich;
+        rich.pctQ = pos["pctQ"].as<uint32_t>();
+        rich.spineIndex = pos["spine"].as<uint16_t>();
+        rich.pageNumber = pos["page"].as<uint16_t>();
+        const uint16_t pages = pos["pages"].as<uint16_t>();
+        rich.totalPages = pages > 0 ? pages : 1;
+        const uint16_t para = pos["para"].as<uint16_t>();
+        if (para > 0) rich.paragraphIndex = para;
+        rich.xpath = pos["xpath"].as<const char*>() ? pos["xpath"].as<const char*>() : "";
+        LOG_DBG("KOSync", "Got rich position: spine=%u page=%u/%u para=%u", rich.spineIndex, rich.pageNumber,
+                rich.totalPages, para);
+        outProgress.position = std::move(rich);
+      }
     }
 
     LOG_DBG("KOSync", "Got progress: %.2f%% at %s", outProgress.percentage * 100, outProgress.progress.c_str());
@@ -235,8 +236,8 @@ KOReaderSyncClient::Error KOReaderSyncClient::updateProgress(const KOReaderProgr
   doc["percentage"] = progress.percentage;
   doc["device"] = DEVICE_NAME;
   doc["device_id"] = DEVICE_ID;
-  if (progress.position.has_value()) {
-    // Extended crosspoint-sync field; kosync servers ignore unknown keys.
+  if (progress.position.has_value() && KOREADER_STORE.usesCrossPointSyncServer()) {
+    // CrossPoint-specific extension: do not send it to third-party KOSync servers.
     const auto& p = *progress.position;
     auto pos = doc["position"].to<JsonObject>();
     pos["pctQ"] = p.pctQ;

--- a/lib/KOReaderSync/KOReaderSyncClient.h
+++ b/lib/KOReaderSync/KOReaderSyncClient.h
@@ -17,8 +17,8 @@ struct KOReaderMetadata {
 /**
  * Rich CrossPoint position sent alongside progress uploads. Maps 1:1 onto the
  * crosspoint-sync extended `position` object (see crosspoint-sync docs/API.md).
- * The official KOSync server ignores unknown fields; crosspoint-sync stores it
- * so CrossPoint<->CrossPoint sync is lossless instead of xpath-approximated.
+ * It is only transmitted to sync.crosspointreader.com, where it makes
+ * CrossPoint<->CrossPoint sync lossless instead of xpath-approximated.
  */
 struct KOReaderRichPosition {
   uint32_t pctQ = 0;                       // Percentage quantized 0..1,000,000 (authoritative)

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -232,9 +232,8 @@ void KOReaderSyncActivity::performSync() {
     return;
   }
 
-  // Prefer the exact spine/page from a crosspoint-sync rich position (lossless
-  // CrossPoint<->CrossPoint sync); fall back to the approximate XPath mapping
-  // for plain kosync servers or when the rich position cannot be applied.
+  // Prefer the exact spine/page supplied by the CrossPoint sync server; fall
+  // back to the approximate XPath mapping when it cannot be applied.
   std::optional<CrossPointPosition> richMapped;
   if (remoteProgress.position.has_value()) {
     richMapped = ProgressMapper::fromRichPosition(epub, *remoteProgress.position, renderer);
@@ -298,9 +297,10 @@ void KOReaderSyncActivity::performUpload() {
   progress.progress = localProgress.xpath;
   progress.percentage = localProgress.percentage;
 
-  // Rich CrossPoint position for crosspoint-sync servers (lossless
-  // CrossPoint<->CrossPoint sync); plain kosync servers ignore the extra field.
-  {
+  // Rich CrossPoint position for the default CrossPoint sync server (lossless
+  // CrossPoint<->CrossPoint sync). The HTTP client also enforces this boundary
+  // before serializing the extension.
+  if (KOREADER_STORE.usesCrossPointSyncServer()) {
     KOReaderRichPosition pos;
     const float pct = localProgress.percentage < 0.0f   ? 0.0f
                       : localProgress.percentage > 1.0f ? 1.0f


### PR DESCRIPTION
Only send the rich position field to sync.crosspointreader.com to avoid transmitting proprietary extensions to third-party KOSync servers. Adds usesCrossPointSyncServer() check to conditionally include the extension based on the configured server URL.

Fixes #2714 