### PR TITLE
fix: dictionary lookup OOM on .dict.dz definitions

### DIFF
--- a/lib/InflateReader/InflateReader.cpp
+++ b/lib/InflateReader/InflateReader.cpp
@@ -27,12 +27,14 @@ bool InflateReader::init(const bool streaming) {
   return true;
 }
 
-void InflateReader::initWithRing(uint8_t* ring) {
+bool InflateReader::initWithRing(uint8_t* ring) {
   deinit();  // free any owned ring buffer and reset state
+  if (!ring) return false;
   ringBuffer = ring;
   ownsRing = false;  // caller's buffer: never freed here
   memset(ringBuffer, 0, INFLATE_DICT_SIZE);
   uzlib_uncompress_init(&decomp, ringBuffer, INFLATE_DICT_SIZE);
+  return true;
 }
 
 void InflateReader::deinit() {

--- a/lib/InflateReader/InflateReader.cpp
+++ b/lib/InflateReader/InflateReader.cpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 
 namespace {
-constexpr size_t INFLATE_DICT_SIZE = 32768;
+constexpr size_t INFLATE_DICT_SIZE = InflateReader::RING_BYTES;
 }
 
 // Guarantee the cast pattern in the header comment is valid.
@@ -19,6 +19,7 @@ bool InflateReader::init(const bool streaming) {
   if (streaming) {
     ringBuffer = static_cast<uint8_t*>(malloc(INFLATE_DICT_SIZE));
     if (!ringBuffer) return false;
+    ownsRing = true;
     memset(ringBuffer, 0, INFLATE_DICT_SIZE);
   }
 
@@ -26,11 +27,18 @@ bool InflateReader::init(const bool streaming) {
   return true;
 }
 
+void InflateReader::initWithRing(uint8_t* ring) {
+  deinit();  // free any owned ring buffer and reset state
+  ringBuffer = ring;
+  ownsRing = false;  // caller's buffer: never freed here
+  memset(ringBuffer, 0, INFLATE_DICT_SIZE);
+  uzlib_uncompress_init(&decomp, ringBuffer, INFLATE_DICT_SIZE);
+}
+
 void InflateReader::deinit() {
-  if (ringBuffer) {
-    free(ringBuffer);
-    ringBuffer = nullptr;
-  }
+  if (ringBuffer && ownsRing) free(ringBuffer);
+  ringBuffer = nullptr;
+  ownsRing = false;
   memset(&decomp, 0, sizeof(decomp));
 }
 

--- a/lib/InflateReader/InflateReader.h
+++ b/lib/InflateReader/InflateReader.h
@@ -49,12 +49,27 @@ class InflateReader {
   InflateReader(const InflateReader&) = delete;
   InflateReader& operator=(const InflateReader&) = delete;
 
+  // Size of the streaming ring buffer, exposed so callers using initWithRing()
+  // can allocate it themselves.
+  static constexpr size_t RING_BYTES = 32768;
+
   // Initialise decompressor. streaming=true allocates a 32KB ring buffer needed
   // when read() or readAtMost() will be called multiple times.
   // Returns false only in streaming mode if the ring buffer allocation fails.
   bool init(bool streaming = false);
 
-  // Release the ring buffer and reset internal state.
+  // Initialise streaming mode over a caller-owned ring buffer of RING_BYTES.
+  //
+  // Exists for allocation ordering. The ring is by far the largest block a
+  // streaming decode needs, and on a heap where every allocation is carved from
+  // one big free run, taking any smaller buffer first can leave the largest
+  // block just short of 32KB — measured on device at 32756 bytes against a
+  // 32768 requirement. A caller that allocates the ring FIRST, then its own
+  // state, never hits that. The buffer must outlive the reader; deinit() does
+  // not free it.
+  void initWithRing(uint8_t* ring);
+
+  // Release the ring buffer (only if this reader owns it) and reset state.
   void deinit();
 
   // Set the entire compressed input as a contiguous memory buffer.
@@ -87,4 +102,5 @@ class InflateReader {
  private:
   uzlib_uncomp decomp = {};
   uint8_t* ringBuffer = nullptr;
+  bool ownsRing = false;
 };

--- a/lib/InflateReader/InflateReader.h
+++ b/lib/InflateReader/InflateReader.h
@@ -67,7 +67,9 @@ class InflateReader {
   // 32768 requirement. A caller that allocates the ring FIRST, then its own
   // state, never hits that. The buffer must outlive the reader; deinit() does
   // not free it.
-  void initWithRing(uint8_t* ring);
+  // Returns false if ring is null (e.g. a forwarded failed allocation), leaving
+  // the reader deinitialised.
+  bool initWithRing(uint8_t* ring);
 
   // Release the ring buffer (only if this reader owns it) and reset state.
   void deinit();

--- a/src/util/DictZip.cpp
+++ b/src/util/DictZip.cpp
@@ -75,6 +75,15 @@ bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compre
   };
   if (extractSize == 0) return true;
 
+  // Largest block FIRST. Every allocation here is carved from the same big free
+  // run, so taking the ~3KB ChunkSource before the 32KB ring left the ring's
+  // block 12 bytes short on device (largest=32756 against need=32768) even on a
+  // barely fragmented heap. Ordering by size removes that failure mode: the ring
+  // gets the big block while it is still whole, and the small buffers fit in
+  // what remains — or in one of the smaller free blocks.
+  auto window = makeUniqueNoThrow<uint8_t[]>(InflateReader::RING_BYTES);
+  if (!window) return fail(ExtractError::LowMemory);
+
   auto src = makeUniqueNoThrow<ChunkSource>();
   if (!src) return fail(ExtractError::LowMemory);
   src->file = &file;
@@ -84,9 +93,11 @@ bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compre
   // seek is possible — guard it rather than reading from the prior position.
   if (!file.seekSet(compressedOffset)) return fail(ExtractError::ReadError);
 
-  if (!src->reader.init(true)) return fail(ExtractError::LowMemory);  // 32KB inflate window
-  // After init() source/source_limit are both null, so the very first byte
-  // already comes through the callback. Set it after init(), which resets state.
+  // `window` outlives the reader (declared above it, destroyed after), as
+  // initWithRing() requires.
+  src->reader.initWithRing(window.get());
+  // initWithRing() leaves source/source_limit null, so the very first byte
+  // already comes through the callback. Set it after, which resets state.
   src->reader.setReadCallback(&chunkReadCb);
 
   auto buf = makeUniqueNoThrow<uint8_t[]>(512);

--- a/src/util/DictZip.cpp
+++ b/src/util/DictZip.cpp
@@ -4,6 +4,8 @@
 #include <InflateReader.h>
 #include <Memory.h>
 
+#include <cstddef>
+
 namespace DictZip {
 namespace {
 
@@ -22,6 +24,49 @@ bool readLe16(HalFile& file, uint16_t* out) {
   return true;
 }
 
+// Compressed input for one chunk, pulled from the file on demand instead of
+// buffered whole. A dictzip chunk is ~58KB uncompressed (measured at 18KB
+// compressed for a real dictionary), so the old whole-chunk buffer was a large
+// contiguous request made while the 32KB inflate window was about to be taken
+// as well — two big blocks live at once, on a heap that during a reading
+// session has well under 50KB free (#2744). This holds INPUT_BUF_BYTES instead.
+//
+// InflateReader MUST stay the first member: the uzlib callback receives only a
+// uzlib_uncomp* and recovers this struct by casting it (see InflateReader.h).
+constexpr size_t INPUT_BUF_BYTES = 2048;
+
+struct ChunkSource {
+  InflateReader reader;  // must be first
+  HalFile* file = nullptr;
+  uint32_t remaining = 0;  // compressed bytes left in this chunk
+  bool readFailed = false;
+  uint8_t buf[INPUT_BUF_BYTES] = {};
+};
+
+static_assert(offsetof(ChunkSource, reader) == 0, "InflateReader must be first for the uzlib callback cast");
+
+// Refills from the file and returns the next byte, or -1 at the chunk's end.
+// Never reads past compressedSize: the following bytes belong to the next
+// chunk, and stopping there reproduces exactly the hard limit the whole-chunk
+// buffer used to impose.
+int chunkReadCb(uzlib_uncomp* u) {
+  auto* src = reinterpret_cast<ChunkSource*>(u);
+  if (src->remaining == 0) return -1;
+
+  const uint32_t want = src->remaining < INPUT_BUF_BYTES ? src->remaining : INPUT_BUF_BYTES;
+  const int n = src->file->read(src->buf, static_cast<int>(want));
+  if (n <= 0) {
+    // Remember the cause: uzlib collapses this into a generic decode failure,
+    // but an IO error is a ReadError, not a corrupt .dz.
+    src->readFailed = true;
+    return -1;
+  }
+  src->remaining -= static_cast<uint32_t>(n);
+  u->source = src->buf + 1;
+  u->source_limit = src->buf + n;
+  return src->buf[0];
+}
+
 bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compressedSize, uint32_t discardSize,
                        uint32_t extractSize, HalFile& outFile, ExtractError* outError) {
   const auto fail = [outError](ExtractError e) {
@@ -29,32 +74,40 @@ bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compre
     return false;
   };
   if (extractSize == 0) return true;
-  auto compBuf = makeUniqueNoThrow<uint8_t[]>(compressedSize);
-  if (!compBuf) return fail(ExtractError::LowMemory);  // couldn't get the compressed-chunk buffer
+
+  auto src = makeUniqueNoThrow<ChunkSource>();
+  if (!src) return fail(ExtractError::LowMemory);
+  src->file = &file;
+  src->remaining = compressedSize;
 
   // compressedOffset comes from the untrusted .dz chunk table, so an out-of-range
   // seek is possible — guard it rather than reading from the prior position.
   if (!file.seekSet(compressedOffset)) return fail(ExtractError::ReadError);
-  if (file.read(compBuf.get(), static_cast<int>(compressedSize)) != static_cast<int>(compressedSize))
-    return fail(ExtractError::ReadError);
 
-  InflateReader reader;
-  if (!reader.init(true)) return fail(ExtractError::LowMemory);  // 32KB inflate window allocation failed
-  reader.setSource(compBuf.get(), compressedSize);
+  if (!src->reader.init(true)) return fail(ExtractError::LowMemory);  // 32KB inflate window
+  // After init() source/source_limit are both null, so the very first byte
+  // already comes through the callback. Set it after init(), which resets state.
+  src->reader.setReadCallback(&chunkReadCb);
 
   auto buf = makeUniqueNoThrow<uint8_t[]>(512);
   if (!buf) return fail(ExtractError::LowMemory);
 
+  // A decode failure after the callback hit an IO error is a read failure, not
+  // a corrupt stream — keep the two distinguishable for the caller.
+  const auto decodeFail = [&src, &fail] {
+    return fail(src->readFailed ? ExtractError::ReadError : ExtractError::Decompress);
+  };
+
   uint32_t batch;
   while (discardSize > 0) {
     batch = discardSize < 512 ? discardSize : 512;
-    if (!reader.read(buf.get(), batch)) return fail(ExtractError::Decompress);
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
     discardSize -= batch;
   }
 
   while (extractSize > 0) {
     batch = extractSize < 512 ? extractSize : 512;
-    if (!reader.read(buf.get(), batch)) return fail(ExtractError::Decompress);
+    if (!src->reader.read(buf.get(), batch)) return decodeFail();
     if (outFile.write(buf.get(), batch) != batch) return fail(ExtractError::ReadError);
     extractSize -= batch;
   }

--- a/src/util/DictZip.cpp
+++ b/src/util/DictZip.cpp
@@ -95,7 +95,7 @@ bool extractChunkSlice(HalFile& file, uint32_t compressedOffset, uint32_t compre
 
   // `window` outlives the reader (declared above it, destroyed after), as
   // initWithRing() requires.
-  src->reader.initWithRing(window.get());
+  if (!src->reader.initWithRing(window.get())) return fail(ExtractError::LowMemory);
   // initWithRing() leaves source/source_limit null, so the very first byte
   // already comes through the callback. Set it after, which resets state.
   src->reader.setReadCallback(&chunkReadCb);


### PR DESCRIPTION
## Summary

* **Goal:** Fix `.dict.dz` dictionary lookups failing with **"Not enough memory"** (#2744). Two independent causes on the definition-extraction path, one commit each.

* **Changes:**

  **1. Stop buffering the whole compressed chunk.** `extractChunkSlice()` read the entire compressed chunk into one heap buffer before inflating it. A dictzip chunk is ~58 KB uncompressed — **18,428 bytes compressed** for a real dictionary — and that block was held live while the 32 KB inflate window was allocated on top of it. Two large contiguous requests at once, on a heap sitting under 50 KB free mid-book. uzlib supports a pull callback, so the input is now fed from the file through a 2 KB refill buffer.

  **2. Allocate largest-first.** Even after (1), the lookup still failed — and the instrumented margin was *twelve bytes*:

  ```
  chunkSlice:enter          largest=36852   <- would have fit the ring
  after chunkSource (3348)  largest=32756
  inflateWindow need=32768  WILL FAIL
  ```

  Every buffer the lookup needs is carved from the same big free run, so **allocation order decides the outcome**. The ~3 KB `ChunkSource` was taken first, out of the only block large enough for the 32 KB ring. Reversing the order gives the ring the big block while it is still whole.

  | | Before | After |
  |---|---|---|
  | Largest block alongside the 32 KB ring | ~18 KB (whole chunk) | **~2.2 KB** |
  | Ring allocated | after the small buffers | **first** |

  Note the heap here is **not** badly fragmented — `frag=15%`, 14 free blocks. This was a shortfall-and-ordering bug, not a fragmentation one.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] No new feature surface at all — this is a bugfix to an already-in-scope feature (dictionary lookup). Stock reports this case as an error the user can do nothing about.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, so no maintainer coordination is required on that basis.

## Additional Context

* **Behaviour is unchanged on success.** A hit returns the same bytes; only the peak heap needed to produce them changed.
* **The chunk boundary is still enforced.** `ChunkSource::remaining` stops the callback at `compressedSize`, so it never reads into the next chunk — exactly the hard limit the whole-chunk buffer imposed.
* **IO errors stay distinguishable from corruption.** uzlib collapses a callback `-1` into a generic decode failure, which would have turned every SD hiccup into `Decompress` and partly undone #2706. `readFailed` records the cause and maps it back to `ReadError`.
* **`InflateReader::initWithRing()`** is new: streaming mode over a caller-owned ring, needed because the reader is embedded in the struct whose allocation must come second. `ownsRing` keeps `deinit()` from freeing a buffer it doesn't own, so the existing `init(true)` callers in `ZipFile` and `PngToBmpConverter` are unaffected.
* **Memory / flash impact:** no new persistent RAM; peak transient demand per lookup drops by ~16 KB, and the 32 KB ring now comes out of the largest free block rather than whatever is left after it. `ChunkSource` (~2.2 KB, mostly the 2 KB refill buffer) is heap-allocated rather than stacked, to stay clear of the task stack budget.
* **Reviewer focus:** the uzlib callback contract in `chunkReadCb` (refill, set `source`/`source_limit` to the tail, return the first byte) and the `window`/`src` declaration order in `extractChunkSlice` — the ring must outlive the reader.
* **Possible latency shift:** SD access changes from one bulk chunk read to interleaved 2 KB reads. The discard phase stays pure sequential reads; only the extract phase (definition-sized, typically a few KB) alternates reads with writes to the temp file. No slowdown noticed in use, but it isn't benchmarked.
* **Relationship to #2733:** disjoint files (that PR is `Dictionary.{h,cpp}`, the index-search path; this is `DictZip.cpp` + `InflateReader`). Neither depends on the other and they should not conflict. #2733 does **not** fix this OOM — the failure is entirely downstream of what it changes.

### Testing

* Builds clean for the device `default` env (ESP32-C3); clang-format clean.
* **Host-verified against `lib/uzlib`** with a real 58,315-byte chunk: full-chunk decode, mid-chunk slice (the case every lookup takes), and a slice ending exactly at the chunk boundary all match the source bytes; a truncated `compressedSize` is refused rather than over-read.
* **Tested on hardware (Xteink X3):** the lookup that reliably reproduced "Not enough memory" (focus reading + book style + anti-aliasing on) now succeeds, and no OOM has recurred in use since. This is hands-on use rather than a systematic soak, so I can't claim the failure mode is fully eliminated — but the specific reproducer is fixed.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — diagnosed with Claude Code using temporary heap instrumentation (largest-free-block probes, not included in this PR), and the fix was implemented with it. Reviewed and tested on hardware (X3) by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
