### PR TITLE
refactor: resume by paragraph anchor after a re-pagination

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -330,3 +330,50 @@ if (parsedSize != fileSize) {
     std::warning(std::format("Unparsed data detected: {} bytes remaining at offset 0x{:X}", fileSize - parsedSize, parsedSize));
 }
 ```
+
+## `progress.bin`
+
+Stores the reader's resume position for a book (one file per book, at the cache
+root). Unlike `book.bin` / `section.bin`, `progress.bin` is **irreplaceable user
+state**, so a format change is *migrated, never discarded*: older records are still
+read and upgraded to the current version on the next save.
+
+Records are discriminated by **length**. Legacy records have no version field:
+
+- **4 bytes** — `{ u16 spineIndex; u16 page; }`
+- **6 bytes** — `{ u16 spineIndex; u16 page; u16 totalPages; }`
+
+Versioned records lead with a `version` byte (currently `1`). A legacy record is
+never 27 bytes, so length alone separates the two; the version byte then carries
+format evolution past v1.
+
+### Version 1 (27 bytes)
+
+Adds the paragraph anchor and the render spec so a resume can tell *same
+pagination* (use the exact page) from *re-paginated* (remap to the saved
+paragraph). `totalPages` is display-only (the "page X of Y" total shown before the
+section finishes loading). `paragraphIndex == 0xFFFF` means "no anchor recorded".
+See `src/activities/reader/EpubReaderUtils.h`.
+
+```c++
+struct ProgressBinV1 {
+    u8  version;          // == 1
+    u16 spineIndex;
+    u16 page;
+    u16 paragraphIndex;   // 0xFFFF = unknown
+    u16 totalPages;       // display-only
+    // ReaderRenderSpec, in the same field order Section serializes its header:
+    s32 fontId;
+    float lineCompression;
+    u8  extraParagraphSpacing;
+    u8  paragraphAlignment;
+    u16 viewportWidth;
+    u16 viewportHeight;
+    u8  hyphenationEnabled;
+    u8  embeddedStyle;
+    u8  imageRendering;
+    u8  focusReadingEnabled;
+};
+
+ProgressBinV1 progress @ 0x00;
+```

--- a/lib/Epub/Epub/ReaderRenderSpec.h
+++ b/lib/Epub/Epub/ReaderRenderSpec.h
@@ -21,4 +21,10 @@ struct ReaderRenderSpec {
   bool embeddedStyle = true;
   uint8_t imageRendering = 0;
   bool focusReadingEnabled = false;
+
+  // Field-for-field equality: the resume fast path compares the spec a saved position was taken
+  // under against the current spec to decide "same pagination (use the exact page)" vs. "re-paginated
+  // (remap by paragraph anchor)". lineCompression is derived deterministically from settings, so the
+  // same settings reproduce bit-identical floats and == is exact.
+  bool operator==(const ReaderRenderSpec&) const = default;
 };

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -863,12 +863,13 @@ std::optional<uint16_t> Section::getPageForParagraphIndex(const uint16_t pIndex)
 }
 
 std::optional<uint16_t> Section::getParagraphIndexForPage(const uint16_t page) const {
-  if (build_) {
-    // While a build is live the LUT is in RAM, not on disk (uncommitted until finalize/suspend), so
-    // read it here -- else an anchor captured mid-build comes back wrongly "unknown". Past it -> none.
-    if (page < build_->lut.size()) return build_->lut[page].paragraphIndex;
-    return std::nullopt;
+  // While a build is live the LUT is in RAM, not on disk (uncommitted until finalize/suspend), so read
+  // it here -- else an anchor captured mid-build comes back wrongly "unknown".
+  if (build_ && page < build_->lut.size()) {
+    return build_->lut[page].paragraphIndex;
   }
+  // Beyond the live build (or no build): fall through to the committed file, like loadPage() -- a
+  // finalized section, or a previous session's partial whose pages the rebuild hasn't re-reached.
   HalFile f;
   if (!Storage.openFileForRead("SCT", filePath, f)) {
     return std::nullopt;

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -458,6 +458,20 @@ std::optional<uint16_t> Section::findAnchor(const std::string& anchor) const {
   return getPageForAnchor(anchor);
 }
 
+std::optional<uint16_t> Section::findPageForParagraph(const uint16_t pIndex) const {
+  if (build_) {
+    // build_->lut grows in page order with a non-decreasing paragraphIndex, so the first page that
+    // reaches pIndex is the landing page. Not reached yet -> nullopt (build more). The on-disk file
+    // was deleted on the spec-mismatch load, so it must not be consulted while this build runs.
+    for (uint16_t i = 0; i < build_->lut.size(); i++) {
+      if (build_->lut[i].paragraphIndex >= pIndex) return i;
+    }
+    return std::nullopt;
+  }
+  // No active build: a finalized (or partial) on-disk file carries the paragraph LUT.
+  return getPageForParagraphIndex(pIndex);
+}
+
 uint16_t Section::estimatedTotalPages() const {
   // Extrapolation from a suspended session's watermark trailer. A static snapshot, so no EMA
   // damping is needed. Also the best guess while a rebuild is running but hasn't laid out
@@ -849,6 +863,12 @@ std::optional<uint16_t> Section::getPageForParagraphIndex(const uint16_t pIndex)
 }
 
 std::optional<uint16_t> Section::getParagraphIndexForPage(const uint16_t page) const {
+  if (build_) {
+    // While a build is live the LUT is in RAM, not on disk (uncommitted until finalize/suspend), so
+    // read it here -- else an anchor captured mid-build comes back wrongly "unknown". Past it -> none.
+    if (page < build_->lut.size()) return build_->lut[page].paragraphIndex;
+    return std::nullopt;
+  }
   HalFile f;
   if (!Storage.openFileForRead("SCT", filePath, f)) {
     return std::nullopt;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -141,6 +141,14 @@ class Section {
   // Look up the page number for a synthetic paragraph index from XPath p[N].
   std::optional<uint16_t> getPageForParagraphIndex(uint16_t pIndex) const;
 
+  // Resolve the landing page for a saved paragraph index during a settings-change resume. Prefers
+  // the in-progress build's RAM LUT: a spec mismatch deletes the old on-disk file at load
+  // (loadSectionFile -> clearCache), so during the fresh rebuild only build_->lut reflects the new
+  // pagination. Falls back to the on-disk paragraph LUT once no build is active (finalized/partial).
+  // The paragraph LUT is non-decreasing across pages, so the first page whose start paragraph
+  // reaches pIndex is the landing page. nullopt while a build has not laid out that paragraph yet.
+  std::optional<uint16_t> findPageForParagraph(uint16_t pIndex) const;
+
   // Look up the page number for a running list-item index from the li LUT.
   std::optional<uint16_t> getPageForListItemIndex(uint16_t liIndex) const;
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -173,23 +173,40 @@ void EpubReaderActivity::onEnter() {
 
   HalFile f;
   if (Storage.openFileForRead("ERS", epub->getCachePath() + "/progress.bin", f)) {
-    uint8_t data[6];
-    int dataSize = f.read(data, 6);
+    uint8_t data[EpubReaderUtils::PROGRESS_RECORD_SIZE];
+    int dataSize = f.read(data, sizeof(data));
+    // UINT16_MAX in the page field is an in-memory "open previous chapter on its last page"
+    // navigation sentinel; it must never be treated as persisted resume state after sleep or reopen.
     if (dataSize == 4 || dataSize == 6) {
+      // Legacy unversioned record: {spine, page[, total]}. No spec/paragraph anchor, so resume as a
+      // plain same-settings resume (resumeTarget stays empty); it upgrades to the versioned format on
+      // the next save.
       currentSpineIndex = data[0] + (data[1] << 8);
       nextPageNumber = data[2] + (data[3] << 8);
       if (nextPageNumber == UINT16_MAX) {
-        // UINT16_MAX is an in-memory navigation sentinel for "open previous
-        // chapter on its last page". It should never be treated as persisted
-        // resume state after sleep or reopen.
         LOG_DBG("ERS", "Ignoring stale last-page sentinel from progress cache");
         nextPageNumber = 0;
       }
-      cachedSpineIndex = currentSpineIndex;
-      LOG_DBG("ERS", "Loaded cache: %d, %d", currentSpineIndex, nextPageNumber);
-    }
-    if (dataSize == 6) {
-      cachedChapterTotalPageCount = data[4] + (data[5] << 8);
+      if (dataSize == 6) {
+        cachedChapterTotalPageCount = data[4] + (data[5] << 8);
+      }
+      LOG_DBG("ERS", "Loaded legacy progress: %d, %d", currentSpineIndex, nextPageNumber);
+    } else if (dataSize >= static_cast<int>(EpubReaderUtils::PROGRESS_RECORD_SIZE) &&
+               data[0] == EpubReaderUtils::PROGRESS_VERSION) {
+      EpubReaderUtils::ProgressRecord rec;
+      EpubReaderUtils::decodeProgress(data, rec);
+      currentSpineIndex = rec.spineIndex;
+      nextPageNumber = rec.page;
+      if (nextPageNumber == UINT16_MAX) {
+        LOG_DBG("ERS", "Ignoring stale last-page sentinel from progress cache");
+        nextPageNumber = 0;
+      }
+      cachedChapterTotalPageCount = rec.totalPages;
+      // Resume by paragraph anchor iff the pagination changed since this position was saved: the
+      // first render compares rec.spec against the then-current spec (same -> exact page).
+      resumeTarget = ResumeTarget{static_cast<int>(rec.spineIndex), rec.paragraphIndex, rec.spec};
+      LOG_DBG("ERS", "Loaded progress: spine=%d page=%d para=%u", currentSpineIndex, nextPageNumber,
+              rec.paragraphIndex);
     }
   }
   // We may want a better condition to detect if we are opening for the first time.
@@ -812,14 +829,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
                                // layout: preserve position and force a re-layout, mirroring
                                // applyOrientation()'s reflow.
                                RenderLock lock(*this);
-                               if (section) {
-                                 cachedSpineIndex = currentSpineIndex;
-                                 cachedChapterTotalPageCount = section->pageCount;
-                                 nextPageNumber = section->currentPage;
-                                 // A real settings change: force the resume remap even if a cache for
-                                 // the new settings already exists on SD (see repositionAfterSettingsChange).
-                                 repositionAfterSettingsChange = true;
-                               }
+                               captureResumeTarget();
                                section.reset();
                              });
       break;
@@ -868,10 +878,11 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
           uint16_t backupSpine = currentSpineIndex;
           uint16_t backupPage = section->currentPage;
           uint16_t backupPageCount = section->pageCount;
+          const auto backupParagraph = currentPageParagraphAnchor();
           section.reset();
           epub->clearCache();
           epub->setupCacheDir();
-          if (!saveProgress(backupSpine, backupPage, backupPageCount)) {
+          if (!saveProgress(backupSpine, backupPage, backupPageCount, backupParagraph)) {
             LOG_ERR("ERS", "Failed to save progress before cache clear");
           }
         }
@@ -909,14 +920,7 @@ bool EpubReaderActivity::launchKOReaderSync() {
 
   const int currentPage = section ? section->currentPage : nextPageNumber;
   const int totalPages = section ? section->estimatedTotalPages() : cachedChapterTotalPageCount;
-  std::optional<uint16_t> paragraphIndex;
-  if (section && currentPage >= 0 && currentPage < section->pageCount) {
-    const uint16_t paragraphPage =
-        currentPage > 0 ? static_cast<uint16_t>(currentPage - 1) : static_cast<uint16_t>(currentPage);
-    if (const auto pIdx = section->getParagraphIndexForPage(paragraphPage)) {
-      paragraphIndex = *pIdx;
-    }
-  }
+  const std::optional<uint16_t> paragraphIndex = currentPageParagraphAnchor();
 
   // Pre-compute local KO position and chapter name while Epub is still in RAM.
   CrossPointPosition localPos = getCurrentPosition();
@@ -965,11 +969,7 @@ void EpubReaderActivity::applyOrientation(const uint8_t orientation) {
   // Preserve current reading position so we can restore after reflow.
   {
     RenderLock lock(*this);
-    if (section) {
-      cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = section->pageCount;
-      nextPageNumber = section->currentPage;
-    }
+    captureResumeTarget();
 
     // Persist the selection so the reader keeps the new orientation on next launch.
     SETTINGS.orientation = orientation;
@@ -999,11 +999,7 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
   if (statusBarHeight == 0 || statusBarHeight == UITheme::getInstance().getProgressBarHeight()) {
     // Preserve current reading position so we can restore after reflow.
     RenderLock lock(*this);
-    if (section) {
-      cachedSpineIndex = currentSpineIndex;
-      cachedChapterTotalPageCount = section->pageCount;
-      nextPageNumber = section->currentPage;
-    }
+    captureResumeTarget();
     section.reset();
   }
 }
@@ -1114,6 +1110,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   buildViewportHeight = viewportHeight;
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+  // Remember the spec this render (and any section built in it) uses: persisted with progress for the
+  // resume fast-path comparison, and read by captureResumeTarget() as the pre-change "old" spec.
+  currentRenderSpec = renderSpec;
 
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
@@ -1128,16 +1127,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // out the rest -- it re-parses from the top in the background (HTML already cached,
     // pages are deterministic) and finalizes, so the partial machinery retires itself.
     const bool cacheLoaded = section->loadSectionFile(renderSpec);
-    if (cacheLoaded && !repositionAfterSettingsChange) {
-      // Matching render params means identical pagination, so the saved page number is valid
-      // as-is: consume any pending settings-change reposition. Without this, a chapter total
-      // saved while the section was still building (i.e. a watermark, not the real count)
-      // would remap the resume page against the finalized count and teleport the reader.
-      // A genuine settings change (repositionAfterSettingsChange) is exempt: the cache that
-      // loaded here belongs to the NEW settings, so the old saved page still needs remapping
-      // against the new pagination -- estimatedTotalPages() is the exact count in that case.
-      cachedChapterTotalPageCount = 0;
-    }
+    // A pending resume whose saved spec differs from the current one means the chapter re-paginated,
+    // so the saved absolute page is stale: land by paragraph anchor instead. The spec mismatch just
+    // deleted the old on-disk file inside loadSectionFile(), so a paragraph remap always faces a
+    // fresh build (never a partial/finalized match) and the build below runs to the target paragraph
+    // rather than to the stale old page number. A matching spec keeps the exact page (fast path).
+    // An unusable anchor (see isUsableResumeAnchor) skips the remap -- otherwise findPageForParagraph()
+    // never resolves and the loop below builds the whole chapter synchronously; resolveResumeTarget()
+    // clamps the old page instead.
+    const bool paragraphRemap = resumeTarget && resumeTarget->spineIndex == currentSpineIndex &&
+                                resumeTarget->savedSpec != renderSpec && !pendingPageJump.has_value() &&
+                                pendingAnchor.empty() &&
+                                EpubReaderUtils::isUsableResumeAnchor(resumeTarget->paragraphIndex);
     const bool cacheComplete = cacheLoaded && !section->isPartial();
     if (!cacheComplete) {
       if (section->isPartial()) {
@@ -1151,10 +1152,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       // front (percent -> page needs the final page count), so it alone takes the full (blocking)
       // build with the indexing popup. Anchor jumps (TOC / chapter select / footnotes) resolve
       // incrementally below -- the anchor is recorded as its page is laid out, so a chapter-top
-      // anchor lands on page 0 without indexing the whole chapter. The settings-change reposition
-      // (cachedChapterTotal*) is likewise NOT a full-build trigger: it remaps the resume page against
-      // estimatedTotalPages() before the build-to-page loops (see repositionResumeForSettingsChange),
-      // so it never blocks the first page.
+      // anchor lands on page 0 without indexing the whole chapter. A settings-change resume
+      // (paragraphRemap) resolves the same way: the build runs until the saved paragraph is laid out,
+      // so it never blocks longer than reaching that paragraph.
       const bool needsFullBuild = pendingPercentJump;
       if (needsFullBuild) {
         GUI.drawPopup(renderer, tr(STR_INDEXING));
@@ -1185,13 +1185,23 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         // build in a blink and stay popup-free.
         const int target = pendingPageJump.has_value() ? *pendingPageJump : (nextPageNumber < 0 ? 0 : nextPageNumber);
         const bool anchorJump = !pendingAnchor.empty();
+        // Anchor jumps and settings-change resumes both build to a *content position* rather than a
+        // page number. resolveContentPage() returns the landing page once it is laid out (nullopt =
+        // build more), so it drives both the popup gating and the build-to-target loop below.
+        const bool contentJump = anchorJump || paragraphRemap;
+        const auto resolveContentPage = [&]() -> std::optional<uint16_t> {
+          if (anchorJump) return section->findAnchor(pendingAnchor);
+          if (paragraphRemap) return section->findPageForParagraph(resumeTarget->paragraphIndex);
+          return std::nullopt;
+        };
 
         // Landing well inside a partial: the page (or anchor, via the on-disk map) is already
         // servable, so don't restart the extension build now -- it re-lays out the WHOLE chapter
         // from page 0 (minutes of background CPU + SD writes on a giant spine), pure waste when
         // the reader never nears the watermark this session. loop() starts it lazily once the
-        // reader is within PARTIAL_REBUILD_START_MARGIN pages of the watermark.
-        if (section->isPartial() &&
+        // reader is within PARTIAL_REBUILD_START_MARGIN pages of the watermark. A paragraph remap
+        // always faces a fresh (non-partial) build, so it never reaches this deferral.
+        if (section->isPartial() && !paragraphRemap &&
             (anchorJump ? section->getPageForAnchor(pendingAnchor).has_value()
                         : target + PARTIAL_REBUILD_START_MARGIN < static_cast<int>(section->pageCount))) {
           LOG_DBG("ERS", "Partial covers target %d of %d; deferring extension build", target, section->pageCount);
@@ -1205,13 +1215,13 @@ void EpubReaderActivity::render(RenderLock&& lock) {
           // A partial cache that already covers the target page shows it instantly: never popup.
           const bool willInflate = !section->hasHtmlCache();
           bool showPopup;
-          if (anchorJump) {
-            // An anchor jump's cost is bounded by the anchor's page, not `target`. An anchor already
-            // in the on-disk map (partial or finalized cache) lands instantly: no popup. Otherwise it
-            // lies beyond the indexed watermark and the build may lay out the whole spine to find it,
-            // so gate on spine size alone -- laying out a big spine takes seconds even with cached
-            // HTML. Ordinary chapter-top TOC jumps resolve on page 0 and stay popup-free.
-            showPopup = !section->findAnchor(pendingAnchor).has_value() && spineBytes > BUILD_POPUP_BYTE_THRESHOLD;
+          if (contentJump) {
+            // A content jump's (anchor or paragraph-remap) cost is bounded by its landing page, not
+            // `target`. Already resolvable (anchor in the on-disk map) lands instantly: no popup.
+            // Otherwise it may lay out much of the spine to reach it, so gate on spine size alone --
+            // laying out a big spine takes seconds even with cached HTML. Chapter-top anchors resolve
+            // on page 0 and stay popup-free; a paragraph remap always builds fresh so it gates on size.
+            showPopup = !resolveContentPage().has_value() && spineBytes > BUILD_POPUP_BYTE_THRESHOLD;
           } else {
             const bool targetAvailable = target < static_cast<int>(section->pageCount);
             showPopup = !targetAvailable && ((spineBytes > BUILD_POPUP_BYTE_THRESHOLD && willInflate) ||
@@ -1245,10 +1255,11 @@ void EpubReaderActivity::render(RenderLock&& lock) {
             return;
           }
           while (!section->isBuildComplete() &&
-                 (anchorJump ? !section->findAnchor(pendingAnchor) : static_cast<int>(section->pageCount) <= target)) {
-            // Anchor jump: build until the anchor's page is laid out (usually page 0), checking a
-            // partial's on-disk anchor map too so an already-indexed anchor resolves immediately.
-            // Otherwise: build until the target page exists. loop() builds the rest behind it.
+                 (contentJump ? !resolveContentPage() : static_cast<int>(section->pageCount) <= target)) {
+            // Content jump (anchor or paragraph remap): build until its landing page is laid out --
+            // an anchor's page (usually page 0, checking a partial's on-disk map too), or the page
+            // holding the saved paragraph. Otherwise: build until the target page exists. loop()
+            // builds the rest behind it.
             if (buildPopupPending && millis() - buildStartMs >= BUILD_POPUP_DEADLINE_MS) {
               // The predictive gates guessed fast but the build blew the silent budget.
               showBuildPopup();
@@ -1271,16 +1282,18 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (pendingPageJump.has_value()) {
       section->currentPage = *pendingPageJump;
       pendingPageJump.reset();
+      // An explicit page jump supersedes any pending settings-change resume: the reader chose this
+      // page, so a stale ResumeTarget must not fire on a later render.
+      resumeTarget.reset();
     } else {
       section->currentPage = nextPageNumber;
       if (section->currentPage < 0) {
         section->currentPage = 0;
       }
-      // Remap the resume page now, before the build-to-page loops below lay out up to it, so the
-      // first page shown already lands in the right place after a text-settings change (no visible
-      // jump). No-op for a plain resume (cachedChapterTotalPageCount == 0). Explicit page/anchor/
-      // percent jumps set their own target and never enter this branch, so they are never remapped.
-      repositionResumeForSettingsChange();
+      // Land the resume now, before the render below reads the page. Fast path keeps this exact page
+      // (spec unchanged); a re-pagination re-derives it from the saved paragraph. The build-to-target
+      // loop above already laid out the paragraph's page for a remap, so this resolves without waiting.
+      resolveResumeTarget(renderSpec);
     }
 
     if (!pendingAnchor.empty()) {
@@ -1426,7 +1439,10 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   // Every real page turn changes currentPage, so progress durability is unaffected.
   if (currentSpineIndex != lastSavedSpineIndex || section->currentPage != lastSavedPage ||
       section->pageCount != lastSavedPageCount) {
-    if (saveProgress(currentSpineIndex, section->currentPage, section->estimatedTotalPages())) {
+    // Persist the paragraph the current page starts with so a later resume under changed settings can
+    // remap by content position rather than the stale absolute page.
+    const auto paragraph = currentPageParagraphAnchor();
+    if (saveProgress(currentSpineIndex, section->currentPage, section->estimatedTotalPages(), paragraph)) {
       lastSavedSpineIndex = currentSpineIndex;
       lastSavedPage = section->currentPage;
       lastSavedPageCount = section->estimatedTotalPages();
@@ -1449,38 +1465,67 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
 }
 
-void EpubReaderActivity::repositionResumeForSettingsChange() {
-  const int oldTotal = cachedChapterTotalPageCount;
-  cachedChapterTotalPageCount = 0;        // consumed on the first render; never remap the same resume twice
-  repositionAfterSettingsChange = false;  // one-shot: consumed alongside the total it guards
-  // oldTotal == 0 means a plain resume (matching cache zeroed it at load), so there is nothing to
-  // remap. cachedSpineIndex guards against a resume that navigated to a different chapter first.
-  if (oldTotal <= 0 || !section || currentSpineIndex != cachedSpineIndex) {
-    return;
-  }
-  const int savedPage = section->currentPage;  // still the raw resume page (== nextPageNumber) here
-  // estimatedTotalPages() stands in for the exact new-settings count, which isn't known until the
-  // whole chapter is laid out. Forcing that full build on every settings change would reintroduce
-  // the blocking indexing freeze the incremental builder exists to avoid; the fractional position
-  // is what matters, and any small overshoot past the real end is clamped downstream once the build
-  // finalizes (see the !isBuilding clamp below the build-to-page loops).
-  const int newTotal = section->estimatedTotalPages();
-  if (savedPage <= 0 || newTotal <= 0) {
-    return;  // chapter start or no estimate: page 0 maps to page 0
-  }
-  // Clamp the fraction to [0,1]: the old total may have been an under-estimate saved mid-build, so
-  // a page read past it must map to the new chapter's end, not overshoot it (the last-page bug).
-  float progress = static_cast<float>(savedPage) / static_cast<float>(oldTotal);
-  if (progress > 1.0f) progress = 1.0f;
-  int newPage = static_cast<int>(progress * static_cast<float>(newTotal));
-  if (newPage < 0) newPage = 0;
-  if (newPage >= newTotal) newPage = newTotal - 1;
-  section->currentPage = newPage;
-  LOG_DBG("ERS", "Settings-change resume remap: page %d/%d -> %d/~%d", savedPage, oldTotal, newPage, newTotal);
+std::optional<uint16_t> EpubReaderActivity::currentPageParagraphAnchor() const {
+  if (!section) return std::nullopt;
+  const int page = section->currentPage;
+  if (page < 0 || page >= static_cast<int>(section->pageCount)) return std::nullopt;
+  // The LUT records each page's LAST paragraph, so the paragraph a page STARTS with is the previous
+  // page's entry; page 0 has no predecessor, so use its own entry (the chapter's first paragraph).
+  const uint16_t anchorPage = page > 0 ? static_cast<uint16_t>(page - 1) : 0;
+  return section->getParagraphIndexForPage(anchorPage);
 }
 
-bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {
-  return EpubReaderUtils::saveProgress(*epub, spineIndex, currentPage, pageCount);
+void EpubReaderActivity::captureResumeTarget() {
+  // Called by every in-reader reflow site (text settings, orientation, auto-page-turn) before the
+  // section is dropped, so none can forget the settings-change signal. Records the paragraph the
+  // current page starts with plus the spec the section was built with (currentRenderSpec is still the
+  // pre-change spec here -- it is only updated in render()). The next render sees a different spec and
+  // remaps to that paragraph under the new pagination.
+  if (!section) return;
+  nextPageNumber = section->currentPage;
+  const uint16_t para = currentPageParagraphAnchor().value_or(EpubReaderUtils::PROGRESS_PARAGRAPH_UNKNOWN);
+  resumeTarget = ResumeTarget{currentSpineIndex, para, currentRenderSpec};
+  // Keep the display total fresh for the pre-section-load window.
+  cachedChapterTotalPageCount = section->estimatedTotalPages();
+}
+
+void EpubReaderActivity::resolveResumeTarget(const ReaderRenderSpec& currentSpec) {
+  if (!resumeTarget) return;
+  const ResumeTarget rt = *resumeTarget;
+  // Consume it: once the reader has landed, paging forward must not be yanked back by a re-resolve.
+  // A build failure returns before this point, so the target survives to the next (identical) render.
+  resumeTarget.reset();
+  if (!section || rt.spineIndex != currentSpineIndex) {
+    return;  // navigated to a different chapter before the resume resolved
+  }
+  if (rt.savedSpec == currentSpec) {
+    return;  // same pagination: the exact page (already set from nextPageNumber) is valid
+  }
+  // Re-pagination: land on the page holding the saved paragraph. The build-to-target loop already
+  // laid it out, so findPageForParagraph resolves without further building.
+  if (EpubReaderUtils::isUsableResumeAnchor(rt.paragraphIndex)) {
+    if (const auto page = section->findPageForParagraph(rt.paragraphIndex)) {
+      section->currentPage = *page;
+      LOG_DBG("ERS", "Settings-change resume: paragraph %u -> page %d", rt.paragraphIndex, *page);
+      return;
+    }
+  }
+  // No usable anchor (unknown, a paragraph-0/div-only chapter, or the chapter no longer contains it):
+  // clamp the old absolute page into the new range so the reader never overshoots the chapter end.
+  const int newTotal = section->estimatedTotalPages();
+  if (newTotal > 0 && section->currentPage >= newTotal) {
+    section->currentPage = newTotal - 1;
+  }
+  if (section->currentPage < 0) {
+    section->currentPage = 0;
+  }
+}
+
+bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount,
+                                      std::optional<uint16_t> paragraphIndex) {
+  return EpubReaderUtils::saveProgress(*epub, spineIndex, currentPage, pageCount,
+                                       paragraphIndex.value_or(EpubReaderUtils::PROGRESS_PARAGRAPH_UNKNOWN),
+                                       currentRenderSpec);
 }
 void EpubReaderActivity::renderContents(std::unique_ptr<Page> page, const int orientedMarginTop,
                                         const int orientedMarginRight, const int orientedMarginBottom,
@@ -1966,14 +2011,7 @@ ScreenshotInfo EpubReaderActivity::getScreenshotInfo() const {
 CrossPointPosition EpubReaderActivity::getCurrentPosition() const {
   const int currentPage = section ? section->currentPage : nextPageNumber;
   const int totalPages = section ? section->estimatedTotalPages() : cachedChapterTotalPageCount;
-  std::optional<uint16_t> paragraphIndex;
-  if (section && currentPage >= 0 && currentPage < section->pageCount) {
-    const uint16_t paragraphPage =
-        currentPage > 0 ? static_cast<uint16_t>(currentPage - 1) : static_cast<uint16_t>(currentPage);
-    if (const auto pIdx = section->getParagraphIndexForPage(paragraphPage)) {
-      paragraphIndex = *pIdx;
-    }
-  }
+  const std::optional<uint16_t> paragraphIndex = currentPageParagraphAnchor();
 
   CrossPointPosition localPos = {currentSpineIndex, currentPage, totalPages};
   if (paragraphIndex.has_value()) {

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -406,10 +406,6 @@ void EpubReaderActivity::loop() {
         LOG_ERR("ERS", "Background section build failed");
         section.reset();
         requestUpdate();
-      } else if (section->isBuildComplete() && applyDeferredReposition()) {
-        // The chapter re-paginated since the saved progress (settings changed): we now know the
-        // real page count, so re-render at the remapped page. No-op for an unchanged resume.
-        requestUpdate();
       }
     }
   }
@@ -820,6 +816,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
                                  cachedSpineIndex = currentSpineIndex;
                                  cachedChapterTotalPageCount = section->pageCount;
                                  nextPageNumber = section->currentPage;
+                                 // A real settings change: force the resume remap even if a cache for
+                                 // the new settings already exists on SD (see repositionAfterSettingsChange).
+                                 repositionAfterSettingsChange = true;
                                }
                                section.reset();
                              });
@@ -1129,11 +1128,14 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // out the rest -- it re-parses from the top in the background (HTML already cached,
     // pages are deterministic) and finalizes, so the partial machinery retires itself.
     const bool cacheLoaded = section->loadSectionFile(renderSpec);
-    if (cacheLoaded) {
+    if (cacheLoaded && !repositionAfterSettingsChange) {
       // Matching render params means identical pagination, so the saved page number is valid
       // as-is: consume any pending settings-change reposition. Without this, a chapter total
       // saved while the section was still building (i.e. a watermark, not the real count)
       // would remap the resume page against the finalized count and teleport the reader.
+      // A genuine settings change (repositionAfterSettingsChange) is exempt: the cache that
+      // loaded here belongs to the NEW settings, so the old saved page still needs remapping
+      // against the new pagination -- estimatedTotalPages() is the exact count in that case.
       cachedChapterTotalPageCount = 0;
     }
     const bool cacheComplete = cacheLoaded && !section->isPartial();
@@ -1144,18 +1146,15 @@ void EpubReaderActivity::render(RenderLock&& lock) {
         LOG_DBG("ERS", "Cache not found, building...");
       }
 
-      // Jumps that need the final pagination or the anchor map -- explicit page jumps,
-      // fragment anchors, percent jumps, and cross-setting progress repositioning -- can't
-      // resolve their landing page until the whole chapter is laid out, so they take the full
-      // (blocking) build with the indexing popup. Everything else -- plain forward reads, resume,
-      // and explicit page jumps -- only needs a specific page, so it builds incrementally to that
-      // page and finishes the rest in loop(). The settings-change reposition (cachedChapterTotal*)
-      // is NOT a full-build trigger: it's deferred to applyDeferredReposition() once the real page
-      // count is known, so it never blocks the first page.
-      // Only a percent jump truly needs the whole chapter up front (percent -> page needs the final
-      // page count). Anchor jumps (TOC / chapter select / footnotes) resolve incrementally below --
-      // the anchor is recorded as its page is laid out, so a chapter-top anchor lands on page 0
-      // without indexing the whole chapter.
+      // Everything but a percent jump only needs a specific page, so it builds incrementally to that
+      // page and finishes the rest in loop(). Only a percent jump truly needs the whole chapter up
+      // front (percent -> page needs the final page count), so it alone takes the full (blocking)
+      // build with the indexing popup. Anchor jumps (TOC / chapter select / footnotes) resolve
+      // incrementally below -- the anchor is recorded as its page is laid out, so a chapter-top
+      // anchor lands on page 0 without indexing the whole chapter. The settings-change reposition
+      // (cachedChapterTotal*) is likewise NOT a full-build trigger: it remaps the resume page against
+      // estimatedTotalPages() before the build-to-page loops (see repositionResumeForSettingsChange),
+      // so it never blocks the first page.
       const bool needsFullBuild = pendingPercentJump;
       if (needsFullBuild) {
         GUI.drawPopup(renderer, tr(STR_INDEXING));
@@ -1277,6 +1276,11 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       if (section->currentPage < 0) {
         section->currentPage = 0;
       }
+      // Remap the resume page now, before the build-to-page loops below lay out up to it, so the
+      // first page shown already lands in the right place after a text-settings change (no visible
+      // jump). No-op for a plain resume (cachedChapterTotalPageCount == 0). Explicit page/anchor/
+      // percent jumps set their own target and never enter this branch, so they are never remapped.
+      repositionResumeForSettingsChange();
     }
 
     if (!pendingAnchor.empty()) {
@@ -1354,10 +1358,6 @@ void EpubReaderActivity::render(RenderLock&& lock) {
       section->currentPage >= static_cast<int>(section->pageCount)) {
     section->currentPage = section->pageCount - 1;
   }
-
-  // Apply a deferred settings-change reposition now that the real page count is known (a no-op for
-  // a plain resume / unchanged pagination). If still building, this defers to loop() on completion.
-  applyDeferredReposition();
 
   renderer.clearScreen();
 
@@ -1449,28 +1449,34 @@ void EpubReaderActivity::render(RenderLock&& lock) {
   }
 }
 
-bool EpubReaderActivity::applyDeferredReposition() {
-  if (cachedChapterTotalPageCount == 0 || !section || section->isBuilding()) {
-    return false;
+void EpubReaderActivity::repositionResumeForSettingsChange() {
+  const int oldTotal = cachedChapterTotalPageCount;
+  cachedChapterTotalPageCount = 0;        // consumed on the first render; never remap the same resume twice
+  repositionAfterSettingsChange = false;  // one-shot: consumed alongside the total it guards
+  // oldTotal == 0 means a plain resume (matching cache zeroed it at load), so there is nothing to
+  // remap. cachedSpineIndex guards against a resume that navigated to a different chapter first.
+  if (oldTotal <= 0 || !section || currentSpineIndex != cachedSpineIndex) {
+    return;
   }
-  bool changed = false;
-  // Only remap when the chapter actually re-paginated (e.g. after a settings change). A plain
-  // resume has identical pagination, so section->pageCount == cachedChapterTotalPageCount and
-  // nothing moves.
-  if (currentSpineIndex == cachedSpineIndex && section->pageCount != cachedChapterTotalPageCount) {
-    const float progress = static_cast<float>(section->currentPage) / static_cast<float>(cachedChapterTotalPageCount);
-    int newPage = static_cast<int>(progress * static_cast<float>(section->pageCount));
-    if (newPage < 0) newPage = 0;
-    if (section->pageCount > 0 && newPage >= static_cast<int>(section->pageCount)) {
-      newPage = section->pageCount - 1;
-    }
-    if (newPage != section->currentPage) {
-      section->currentPage = newPage;
-      changed = true;
-    }
+  const int savedPage = section->currentPage;  // still the raw resume page (== nextPageNumber) here
+  // estimatedTotalPages() stands in for the exact new-settings count, which isn't known until the
+  // whole chapter is laid out. Forcing that full build on every settings change would reintroduce
+  // the blocking indexing freeze the incremental builder exists to avoid; the fractional position
+  // is what matters, and any small overshoot past the real end is clamped downstream once the build
+  // finalizes (see the !isBuilding clamp below the build-to-page loops).
+  const int newTotal = section->estimatedTotalPages();
+  if (savedPage <= 0 || newTotal <= 0) {
+    return;  // chapter start or no estimate: page 0 maps to page 0
   }
-  cachedChapterTotalPageCount = 0;  // consumed; don't read cached progress again
-  return changed;
+  // Clamp the fraction to [0,1]: the old total may have been an under-estimate saved mid-build, so
+  // a page read past it must map to the new chapter's end, not overshoot it (the last-page bug).
+  float progress = static_cast<float>(savedPage) / static_cast<float>(oldTotal);
+  if (progress > 1.0f) progress = 1.0f;
+  int newPage = static_cast<int>(progress * static_cast<float>(newTotal));
+  if (newPage < 0) newPage = 0;
+  if (newPage >= newTotal) newPage = newTotal - 1;
+  section->currentPage = newPage;
+  LOG_DBG("ERS", "Settings-change resume remap: page %d/%d -> %d/~%d", savedPage, oldTotal, newPage, newTotal);
 }
 
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -24,14 +24,25 @@ class EpubReaderActivity final : public Activity {
   // Image pages use a dedicated double-FAST refresh path, so retain a manual
   // refresh request until renderContents can issue its clean base pass.
   bool forcedRefreshPending = false;
-  int cachedSpineIndex = 0;
+  // Display-only cache of the chapter's total page count, loaded from progress.bin and used to show
+  // "page X of Y" / progress in the window before the section finishes loading (section ?
+  // estimatedTotalPages() : cachedChapterTotalPageCount). Not part of the resume-reposition decision.
   int cachedChapterTotalPageCount = 0;
-  // Set when text settings are changed from inside the reader (the in-reader TextSettings path),
-  // which drops the section and resumes via cachedChapterTotalPageCount. Distinguishes a genuine
-  // settings change from a plain same-settings resume: without it, a still-present cache for the new
-  // settings (a partial, or a size the reader visited before) would suppress the resume remap and
-  // land on the stale absolute page. Consumed by repositionResumeForSettingsChange().
-  bool repositionAfterSettingsChange = false;
+  // The render spec the current section was built with (stashed each render). Persisted with progress
+  // so a later load can compare it against the then-current spec, and read by captureResumeTarget() as
+  // the "old" spec when a re-pagination is triggered from inside the reader.
+  ReaderRenderSpec currentRenderSpec{};
+  // A pending settings-aware resume: preserve the reader's *content* position (paragraph anchor)
+  // across a re-pagination instead of a stale absolute page. Set from persisted progress on open and
+  // by captureResumeTarget() on an in-reader font/orientation/auto-turn change; consumed by
+  // resolveResumeTarget() on the next render. If savedSpec matches the current spec the page is exact
+  // (fast path); otherwise the page is re-derived from paragraphIndex.
+  struct ResumeTarget {
+    int spineIndex = 0;
+    uint16_t paragraphIndex = 0;
+    ReaderRenderSpec savedSpec{};
+  };
+  std::optional<ResumeTarget> resumeTarget;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
   // Signals that the next render should reposition within the newly loaded section
@@ -165,12 +176,21 @@ class EpubReaderActivity final : public Activity {
   bool buildPopupPending = false;
   // Draw the indexing popup mid-build (parser image-probe callback and deadline backstop).
   void showBuildPopup();
-  // Remap a resume page saved under different text settings to the equivalent fractional
-  // position under the current pagination. Called on the first render (before the build-to-page
-  // loops) so the very first page shown already lands correctly. No-op for a plain resume with
-  // unchanged settings (cachedChapterTotalPageCount is 0). Consumes cachedChapterTotalPageCount.
-  void repositionResumeForSettingsChange();
-  bool saveProgress(int spineIndex, int currentPage, int pageCount);
+  // Capture the reader's content position (paragraph anchor + the spec the current section was built
+  // with) before dropping the section for a re-pagination. Called by every in-reader reflow site
+  // (text settings, orientation, auto-page-turn) so none can forget the settings-change signal.
+  void captureResumeTarget();
+  // Apply a pending ResumeTarget on the first render after a section (re)loads. Fast path: the saved
+  // spec matches the current spec, so the exact page is kept. Otherwise re-derive the page from the
+  // saved paragraph. One-shot: consumed on a successful landing so forward reading is never yanked
+  // back.
+  void resolveResumeTarget(const ReaderRenderSpec& currentSpec);
+  // Paragraph the current page starts with -- the single source of truth for every progress/anchor
+  // writer (saves, KOReader sync, getCurrentPosition) so a resume lands on the same content whoever
+  // wrote it. nullopt when there is no section or the page is out of range.
+  std::optional<uint16_t> currentPageParagraphAnchor() const;
+  bool saveProgress(int spineIndex, int currentPage, int pageCount,
+                    std::optional<uint16_t> paragraphIndex = std::nullopt);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);
   void onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction action);

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -26,6 +26,12 @@ class EpubReaderActivity final : public Activity {
   bool forcedRefreshPending = false;
   int cachedSpineIndex = 0;
   int cachedChapterTotalPageCount = 0;
+  // Set when text settings are changed from inside the reader (the in-reader TextSettings path),
+  // which drops the section and resumes via cachedChapterTotalPageCount. Distinguishes a genuine
+  // settings change from a plain same-settings resume: without it, a still-present cache for the new
+  // settings (a partial, or a size the reader visited before) would suppress the resume remap and
+  // land on the stale absolute page. Consumed by repositionResumeForSettingsChange().
+  bool repositionAfterSettingsChange = false;
   unsigned long lastPageTurnTime = 0UL;
   unsigned long pageTurnDuration = 0UL;
   // Signals that the next render should reposition within the newly loaded section
@@ -159,10 +165,11 @@ class EpubReaderActivity final : public Activity {
   bool buildPopupPending = false;
   // Draw the indexing popup mid-build (parser image-probe callback and deadline backstop).
   void showBuildPopup();
-  // Remap the cached relative reading position once the section's real page count is known
-  // (used after a settings change re-paginates a chapter). Returns true if currentPage moved.
-  // No-op while the section is still building or when the pagination is unchanged (plain resume).
-  bool applyDeferredReposition();
+  // Remap a resume page saved under different text settings to the equivalent fractional
+  // position under the current pagination. Called on the first render (before the build-to-page
+  // loops) so the very first page shown already lands correctly. No-op for a plain resume with
+  // unchanged settings (cachedChapterTotalPageCount is 0). Consumes cachedChapterTotalPageCount.
+  void repositionResumeForSettingsChange();
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.
   void jumpToPercent(int percent);

--- a/src/activities/reader/EpubReaderUtils.h
+++ b/src/activities/reader/EpubReaderUtils.h
@@ -1,13 +1,121 @@
 #pragma once
 
 #include <Epub.h>
+#include <Epub/ReaderRenderSpec.h>
 #include <Logging.h>
+
+#include <cstring>
+#include <optional>
 
 #include "ProgressFile.h"
 
 namespace EpubReaderUtils {
 
-// Persists reader progress for an EPUB to its cache directory. Returns true on success.
+// progress.bin is irreplaceable user state (the reader's place in the book), so unlike the
+// regenerable section/book caches it is *migrated, never discarded* on a format change: an older
+// record is still read, then upgraded on the next save. Legacy records had no version field and are
+// detected by length (4 or 6 bytes); every versioned record leads with PROGRESS_VERSION.
+//
+// v1 layout (27 bytes, all little-endian; ints/floats copied raw -- device-local cache):
+//   [0]      version (== PROGRESS_VERSION)
+//   [1..2]   spineIndex   u16
+//   [3..4]   page         u16
+//   [5..6]   paragraphIndex u16   (PROGRESS_PARAGRAPH_UNKNOWN if the save site had no anchor)
+//   [7..8]   totalPages   u16     (display-only: feeds the status bar before the section loads)
+//   [9..26]  ReaderRenderSpec fields, in the same order Section serializes its header
+constexpr uint8_t PROGRESS_VERSION = 1;
+constexpr uint16_t PROGRESS_PARAGRAPH_UNKNOWN = 0xFFFF;
+constexpr size_t PROGRESS_RECORD_SIZE = 27;
+
+struct ProgressRecord {
+  uint16_t spineIndex = 0;
+  uint16_t page = 0;
+  uint16_t paragraphIndex = PROGRESS_PARAGRAPH_UNKNOWN;
+  uint16_t totalPages = 0;
+  ReaderRenderSpec spec{};
+};
+
+// Usable only when it names a real paragraph. UNKNOWN = the save site had no LUT. 0 = "before the first
+// <p>", which is the chapter top for a normal book but ALSO every page of a <div>-per-paragraph chapter
+// (the layout parser counts only <p>/<li>), so 0 can't be trusted as a position. Both fall back to the
+// saved absolute page rather than remapping to a bogus one (page 0, or a hang -- see the callers).
+constexpr bool isUsableResumeAnchor(uint16_t paragraphIndex) {
+  return paragraphIndex != PROGRESS_PARAGRAPH_UNKNOWN && paragraphIndex != 0;
+}
+
+// Ties PROGRESS_RECORD_SIZE to the layout by summing each field's on-wire size (not sizeof, which has
+// padding), so a width change fails the build until encode/decode and the size agree. Does NOT catch an
+// *added* ReaderRenderSpec field: when you add one, update encode/decodeProgress and this sum too, or it
+// won't survive a save/reload despite operator== comparing it.
+static_assert(PROGRESS_RECORD_SIZE ==
+                  sizeof(PROGRESS_VERSION) + sizeof(ProgressRecord::spineIndex) + sizeof(ProgressRecord::page) +
+                      sizeof(ProgressRecord::paragraphIndex) + sizeof(ProgressRecord::totalPages) +
+                      sizeof(ReaderRenderSpec::fontId) + sizeof(ReaderRenderSpec::lineCompression) +
+                      sizeof(uint8_t) /*extraParagraphSpacing*/ + sizeof(ReaderRenderSpec::paragraphAlignment) +
+                      sizeof(ReaderRenderSpec::viewportWidth) + sizeof(ReaderRenderSpec::viewportHeight) +
+                      sizeof(uint8_t) /*hyphenationEnabled*/ + sizeof(uint8_t) /*embeddedStyle*/ +
+                      sizeof(ReaderRenderSpec::imageRendering) + sizeof(uint8_t) /*focusReadingEnabled*/,
+              "PROGRESS_RECORD_SIZE out of sync with encodeProgress/decodeProgress layout");
+
+inline void encodeProgress(const ProgressRecord& r, uint8_t* out) {
+  size_t o = 0;
+  const auto putU16 = [&](uint16_t v) {
+    out[o++] = v & 0xFF;
+    out[o++] = (v >> 8) & 0xFF;
+  };
+  const auto putRaw = [&](const void* src, size_t n) {
+    memcpy(out + o, src, n);
+    o += n;
+  };
+  out[o++] = PROGRESS_VERSION;
+  putU16(r.spineIndex);
+  putU16(r.page);
+  putU16(r.paragraphIndex);
+  putU16(r.totalPages);
+  putRaw(&r.spec.fontId, sizeof(r.spec.fontId));
+  putRaw(&r.spec.lineCompression, sizeof(r.spec.lineCompression));
+  out[o++] = r.spec.extraParagraphSpacing ? 1 : 0;
+  out[o++] = r.spec.paragraphAlignment;
+  putU16(r.spec.viewportWidth);
+  putU16(r.spec.viewportHeight);
+  out[o++] = r.spec.hyphenationEnabled ? 1 : 0;
+  out[o++] = r.spec.embeddedStyle ? 1 : 0;
+  out[o++] = r.spec.imageRendering;
+  out[o++] = r.spec.focusReadingEnabled ? 1 : 0;
+}
+
+// Precondition: the caller has verified `in` holds a PROGRESS_RECORD_SIZE-byte v1 record
+// (in[0] == PROGRESS_VERSION). Reads are little-endian / raw memcpy, mirroring encodeProgress.
+inline void decodeProgress(const uint8_t* in, ProgressRecord& r) {
+  size_t o = 1;  // skip version byte (already validated by caller)
+  const auto getU16 = [&]() -> uint16_t {
+    const uint16_t v = static_cast<uint16_t>(in[o] | (in[o + 1] << 8));
+    o += 2;
+    return v;
+  };
+  const auto getRaw = [&](void* dst, size_t n) {
+    memcpy(dst, in + o, n);
+    o += n;
+  };
+  r.spineIndex = getU16();
+  r.page = getU16();
+  r.paragraphIndex = getU16();
+  r.totalPages = getU16();
+  getRaw(&r.spec.fontId, sizeof(r.spec.fontId));
+  getRaw(&r.spec.lineCompression, sizeof(r.spec.lineCompression));
+  r.spec.extraParagraphSpacing = in[o++] != 0;
+  r.spec.paragraphAlignment = in[o++];
+  r.spec.viewportWidth = getU16();
+  r.spec.viewportHeight = getU16();
+  r.spec.hyphenationEnabled = in[o++] != 0;
+  r.spec.embeddedStyle = in[o++] != 0;
+  r.spec.imageRendering = in[o++];
+  r.spec.focusReadingEnabled = in[o++] != 0;
+}
+
+// Legacy writer (unversioned 6-byte record). Kept for callers without spec/paragraph context
+// (e.g. KOReader sync return): the reader reopens under the same settings, so a plain resume is
+// correct and the record self-heals to versioned on the next in-reader save.
 inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int pageCount) {
   if (spineIndex < 0 || spineIndex > 0xFFFF || pageNumber < 0 || pageNumber > 0xFFFF || pageCount < 0 ||
       pageCount > 0xFFFF) {
@@ -24,7 +132,31 @@ inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int p
   if (!ProgressFile::writeAtomic(epub.getCachePath(), data, sizeof(data))) {
     return false;
   }
-  LOG_DBG("ERS", "Progress saved: spine=%d page=%d", spineIndex, pageNumber);
+  LOG_DBG("ERS", "Progress saved (legacy): spine=%d page=%d", spineIndex, pageNumber);
+  return true;
+}
+
+// Versioned writer: persists the paragraph anchor and the render spec so a later resume can decide
+// same-pagination (exact page) vs. re-paginated (remap by paragraph). Used by the reader's own saves.
+inline bool saveProgress(const Epub& epub, int spineIndex, int pageNumber, int pageCount, uint16_t paragraphIndex,
+                         const ReaderRenderSpec& spec) {
+  if (spineIndex < 0 || spineIndex > 0xFFFF || pageNumber < 0 || pageNumber > 0xFFFF || pageCount < 0 ||
+      pageCount > 0xFFFF) {
+    LOG_ERR("ERS", "Progress values out of range: spine=%d page=%d count=%d", spineIndex, pageNumber, pageCount);
+    return false;
+  }
+  ProgressRecord rec;
+  rec.spineIndex = static_cast<uint16_t>(spineIndex);
+  rec.page = static_cast<uint16_t>(pageNumber);
+  rec.paragraphIndex = paragraphIndex;
+  rec.totalPages = static_cast<uint16_t>(pageCount);
+  rec.spec = spec;
+  uint8_t data[PROGRESS_RECORD_SIZE];
+  encodeProgress(rec, data);
+  if (!ProgressFile::writeAtomic(epub.getCachePath(), data, sizeof(data))) {
+    return false;
+  }
+  LOG_DBG("ERS", "Progress saved: spine=%d page=%d para=%u", spineIndex, pageNumber, paragraphIndex);
   return true;
 }
 


### PR DESCRIPTION
# Summary

## The problem

When you're reading and you change something that reflows the text — font, font size, line spacing, screen orientation, auto page-turn — the book has to be re-laid-out from scratch. All the page breaks land in different places than before.

The reader used to remember your position as a page number ("you were on page 142"). But after a reflow, page 142 is no longer the same content — smaller text means more pages, so the old page 142 might now be a completely different passage. The result: you'd change a setting and get dumped somewhere other than where you were reading, and have to hunt to find your spot again.

## The fix

This branch changes what "your place in the book" means. Instead of remembering a page number, the reader now remembers which paragraph you were reading. A paragraph is the same paragraph no matter how the text is re-laid-out, so after any setting change the reader re-finds that paragraph under the new layout and puts you right back on it.

To keep things fast, it still uses the exact page number as a shortcut whenever nothing changed — so a normal "close and reopen" is instant, and the paragraph re-matching only kicks in when a setting actually forced a reflow.

fix #2778 

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
