### PR TITLE
fix: stop the cached page-load path aborting on OOM or corruption

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -74,6 +74,14 @@ bool Epub::parseContentOpf(BookMetadataCache::BookMetadata& bookMetadata, const 
     return false;
   }
 
+  // A failed item-store read drops the itemref that needed it, so the spine
+  // would be cached a chapter short and nothing would ever notice. Fail the
+  // parse instead: the caller abandons this build, so the next open rebuilds.
+  if (!opfParser.spineIsComplete()) {
+    LOG_ERR("EBP", "Spine incomplete: item store read failed, discarding metadata build");
+    return false;
+  }
+
   // Grab data from opfParser into epub. Normalize titles to NFC so NFD (combining
   // mark) text renders correctly — the device fonts have no mark positioning.
   bookMetadata.title = utf8ComposeNfc(opfParser.title);

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -475,11 +475,16 @@ bool BookMetadataCache::load() {
   serialization::readPod(bookFile, spineCount);
   serialization::readPod(bookFile, tocCount);
 
-  serialization::readString(bookFile, coreMetadata.title);
-  serialization::readString(bookFile, coreMetadata.author);
-  serialization::readString(bookFile, coreMetadata.language);
-  serialization::readString(bookFile, coreMetadata.coverItemHref);
-  serialization::readString(bookFile, coreMetadata.textReferenceHref);
+  if (!serialization::readString(bookFile, coreMetadata.title) ||
+      !serialization::readString(bookFile, coreMetadata.author) ||
+      !serialization::readString(bookFile, coreMetadata.language) ||
+      !serialization::readString(bookFile, coreMetadata.coverItemHref) ||
+      !serialization::readString(bookFile, coreMetadata.textReferenceHref)) {
+    LOG_ERR("BMC", "Corrupt core metadata; cache will be rebuilt");
+    // Explicit close() required: member variable persists beyond function scope
+    bookFile.close();
+    return false;
+  }
 
   loaded = true;
   LOG_DBG("BMC", "Loaded cache data: %d spine, %d TOC entries", spineCount, tocCount);

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -172,7 +172,10 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
   auto page = std::unique_ptr<Page>(new Page());
 
   uint16_t count;
-  serialization::readPod(file, count);
+  if (!serialization::readPod(file, count)) {
+    LOG_ERR("PGE", "Deserialization failed: element count");
+    return nullptr;
+  }
 
   // Reserve up front so a page load costs one allocation for the element vector
   // instead of a grow-copy-free cycle every doubling. `count` is untrusted (it

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -36,8 +36,10 @@ bool PageLine::serialize(HalFile& file) {
 std::unique_ptr<PageLine> PageLine::deserialize(HalFile& file) {
   int16_t xPos;
   int16_t yPos;
-  serialization::readPod(file, xPos);
-  serialization::readPod(file, yPos);
+  if (!serialization::readPod(file, xPos) || !serialization::readPod(file, yPos)) {
+    LOG_ERR("PGE", "Deserialization failed: line position");
+    return nullptr;
+  }
 
   auto tb = TextBlock::deserialize(file);
   if (!tb) {
@@ -73,8 +75,10 @@ bool PageImage::serialize(HalFile& file) {
 std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   int16_t xPos;
   int16_t yPos;
-  serialization::readPod(file, xPos);
-  serialization::readPod(file, yPos);
+  if (!serialization::readPod(file, xPos) || !serialization::readPod(file, yPos)) {
+    LOG_ERR("PGE", "Deserialization failed: image position");
+    return nullptr;
+  }
 
   auto ib = ImageBlock::deserialize(file);
   if (!ib) {
@@ -204,7 +208,10 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
 
   for (uint16_t i = 0; i < count; i++) {
     uint8_t tag;
-    serialization::readPod(file, tag);
+    if (!serialization::readPod(file, tag)) {
+      LOG_ERR("PGE", "Deserialization failed: element tag %u of %u", i, count);
+      return nullptr;
+    }
 
     if (tag == TAG_PageLine) {
       auto pl = PageLine::deserialize(file);
@@ -232,7 +239,10 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
 
   // Deserialize footnotes
   uint16_t fnCount;
-  serialization::readPod(file, fnCount);
+  if (!serialization::readPod(file, fnCount)) {
+    LOG_ERR("PGE", "Deserialization failed: footnote count");
+    return nullptr;
+  }
   if (fnCount > MAX_FOOTNOTES_PER_PAGE) {
     LOG_ERR("PGE", "Invalid footnote count %u", fnCount);
     return nullptr;

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
 
 #include <new>
@@ -76,7 +77,17 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  if (!ib) {
+    LOG_ERR("PGE", "Deserialization failed: null ImageBlock");
+    return nullptr;
+  }
+
+  auto* image = new (std::nothrow) PageImage(std::move(ib), xPos, yPos);
+  if (!image) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageImage");
+    return nullptr;
+  }
+  return std::unique_ptr<PageImage>(image);
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -169,7 +180,11 @@ bool Page::serialize(HalFile& file) const {
 }
 
 std::unique_ptr<Page> Page::deserialize(HalFile& file) {
-  auto page = std::unique_ptr<Page>(new Page());
+  auto page = makeUniqueNoThrow<Page>();
+  if (!page) {
+    LOG_ERR("PGE", "OOM: Page");
+    return nullptr;
+  }
 
   uint16_t count;
   if (!serialization::readPod(file, count)) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -799,8 +799,10 @@ std::optional<uint16_t> Section::getPageForAnchor(const std::string& anchor) con
   for (uint16_t i = 0; i < count; i++) {
     std::string key;
     uint16_t page;
-    serialization::readString(f, key);
-    serialization::readPod(f, page);
+    if (!serialization::readString(f, key) || !serialization::readPod(f, page)) {
+      LOG_ERR("SCT", "Corrupt anchor map at entry %u of %u", i, count);
+      return std::nullopt;
+    }
     if (key == anchor) {
       return page;
     }

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -438,7 +438,9 @@ std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile& file) {
     return nullptr;
   }
   int16_t w, h;
-  serialization::readPod(file, w);
-  serialization::readPod(file, h);
+  if (!serialization::readPod(file, w) || !serialization::readPod(file, h)) {
+    LOG_ERR("IMG", "Deserialization failed: image dimensions");
+    return nullptr;
+  }
   return std::unique_ptr<ImageBlock>(new (std::nothrow) ImageBlock(path, src, w, h));
 }

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -433,8 +433,10 @@ bool ImageBlock::serialize(HalFile& file) {
 std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile& file) {
   std::string path;
   std::string src;
-  serialization::readString(file, path);
-  serialization::readString(file, src);
+  if (!serialization::readString(file, path) || !serialization::readString(file, src)) {
+    LOG_ERR("IMG", "Deserialization failed: image paths");
+    return nullptr;
+  }
   int16_t w, h;
   serialization::readPod(file, w);
   serialization::readPod(file, h);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -477,22 +477,24 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
     block->rubyTexts[i] = std::move(scratch);
   }
 
-  // Style (alignment + margins/padding/indent)
+  // Style (alignment + margins/padding/indent). A short read here zeroes the
+  // field rather than leaving the BlockStyle default (alignment defaults to
+  // Justify, not 0), so a truncated tail must fail the whole block instead of
+  // rendering it with silently wrong geometry.
   BlockStyle& blockStyle = block->blockStyle;
-  serialization::readPod(file, blockStyle.alignment);
-  serialization::readPod(file, blockStyle.textAlignDefined);
-  serialization::readPod(file, blockStyle.marginTop);
-  serialization::readPod(file, blockStyle.marginBottom);
-  serialization::readPod(file, blockStyle.marginLeft);
-  serialization::readPod(file, blockStyle.marginRight);
-  serialization::readPod(file, blockStyle.paddingTop);
-  serialization::readPod(file, blockStyle.paddingBottom);
-  serialization::readPod(file, blockStyle.paddingLeft);
-  serialization::readPod(file, blockStyle.paddingRight);
-  serialization::readPod(file, blockStyle.textIndent);
-  serialization::readPod(file, blockStyle.textIndentDefined);
-  serialization::readPod(file, blockStyle.isRtl);
-  serialization::readPod(file, blockStyle.directionDefined);
+  const bool styleRead =
+      serialization::readPod(file, blockStyle.alignment) && serialization::readPod(file, blockStyle.textAlignDefined) &&
+      serialization::readPod(file, blockStyle.marginTop) && serialization::readPod(file, blockStyle.marginBottom) &&
+      serialization::readPod(file, blockStyle.marginLeft) && serialization::readPod(file, blockStyle.marginRight) &&
+      serialization::readPod(file, blockStyle.paddingTop) && serialization::readPod(file, blockStyle.paddingBottom) &&
+      serialization::readPod(file, blockStyle.paddingLeft) && serialization::readPod(file, blockStyle.paddingRight) &&
+      serialization::readPod(file, blockStyle.textIndent) &&
+      serialization::readPod(file, blockStyle.textIndentDefined) && serialization::readPod(file, blockStyle.isRtl) &&
+      serialization::readPod(file, blockStyle.directionDefined);
+  if (!styleRead) {
+    LOG_ERR("TXB", "Deserialization failed: block style");
+    return nullptr;
+  }
 
   return block;
 }

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -466,7 +466,10 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   // overwrites every byte, so a moved-from value carries nothing into the next iteration.
   std::string scratch;
   for (uint16_t i = 0; i < wc; i++) {
-    serialization::readString(file, scratch);
+    if (!serialization::readString(file, scratch)) {
+      LOG_ERR("TXB", "Deserialization failed: ruby text %u of %u", i, wc);
+      return nullptr;
+    }
     if (scratch.empty()) continue;
     if (block->rubyTexts.empty()) {
       block->rubyTexts.resize(wc);

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -126,7 +126,8 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
   if (self->state == IN_PACKAGE && (strcmp(name, "manifest") == 0 || strcmp(name, "opf:manifest") == 0)) {
     self->state = IN_MANIFEST;
     if (!Storage.openFileForWrite("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for writing. This is probably going to be a fatal error.");
+      LOG_ERR("COF", "Couldn't open temp items file for writing; spine cannot be resolved");
+      self->itemStoreUnusable = true;
     }
     return;
   }
@@ -134,7 +135,8 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
   if (self->state == IN_PACKAGE && (strcmp(name, "spine") == 0 || strcmp(name, "opf:spine") == 0)) {
     self->state = IN_SPINE;
     if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+      LOG_ERR("COF", "Couldn't open temp items file for reading; spine cannot be resolved");
+      self->itemStoreUnusable = true;
     }
 
     // Sort the (unconditionally-built) item index so every idref lookup uses binary
@@ -155,7 +157,11 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
     // TODO Remove print
     LOG_DBG("COF", "Entering guide state.");
     if (!Storage.openFileForRead("COF", self->cachePath + itemCacheFile, self->tempItemStore)) {
-      LOG_ERR("COF", "Couldn't open temp items file for reading. This is probably going to be a fatal error.");
+      // Not marked unusable, unlike the manifest and spine opens: nothing in the
+      // guide state reads the item store (every read lives in the itemref handler,
+      // which has already run by now), so failing here costs the spine nothing and
+      // discarding the build over it would throw away good work.
+      LOG_ERR("COF", "Couldn't open temp items file for reading in guide state");
     }
     return;
   }
@@ -275,16 +281,23 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
 
             // Check for match (may need to check a few due to hash collisions)
             while (it != self->itemIndex.end() && it->idHash == targetHash) {
-              self->tempItemStore.seek(it->fileOffset);
+              // A failed seek leaves the cursor on whatever record it was already
+              // on, so the reads below would succeed against the wrong entry and
+              // hand back another item's href -- worse than dropping the itemref.
+              if (!self->tempItemStore.seek(it->fileOffset)) {
+                LOG_ERR("COF", "Item store seek to %u failed", it->fileOffset);
+                self->itemStoreUnusable = true;
+                break;
+              }
               std::string itemId;
               if (!serialization::readString(self->tempItemStore, itemId)) {
-                self->itemStoreReadFailed = true;
+                self->itemStoreUnusable = true;
                 break;
               }
               if (itemId == idref) {
                 found = serialization::readString(self->tempItemStore, href);
                 if (!found) {
-                  self->itemStoreReadFailed = true;
+                  self->itemStoreUnusable = true;
                 }
                 break;
               }
@@ -293,15 +306,20 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
           } else {
             // Fallback linear scan, only reached when the index is empty (no manifest
             // items). The fast binary-search path above is used for all real manifests.
-            self->tempItemStore.seek(0);
+            // Without a successful rewind the scan would start mid-record and
+            // misparse every field after it, so treat a failed seek as unusable.
+            if (!self->tempItemStore.seek(0)) {
+              LOG_ERR("COF", "Item store rewind failed");
+              self->itemStoreUnusable = true;
+            }
             std::string itemId;
-            while (self->tempItemStore.available()) {
+            while (!self->itemStoreUnusable && self->tempItemStore.available()) {
               if (!serialization::readString(self->tempItemStore, itemId) ||
                   !serialization::readString(self->tempItemStore, href)) {
                 // Distinguish a read failure from a clean walk to EOF: the loop
                 // condition already excludes the latter, so arriving here means
                 // the store itself is unreadable, not that the id is absent.
-                self->itemStoreReadFailed = true;
+                self->itemStoreUnusable = true;
                 break;
               }
               if (itemId == idref) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -277,10 +277,11 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             while (it != self->itemIndex.end() && it->idHash == targetHash) {
               self->tempItemStore.seek(it->fileOffset);
               std::string itemId;
-              serialization::readString(self->tempItemStore, itemId);
+              if (!serialization::readString(self->tempItemStore, itemId)) {
+                break;
+              }
               if (itemId == idref) {
-                serialization::readString(self->tempItemStore, href);
-                found = true;
+                found = serialization::readString(self->tempItemStore, href);
                 break;
               }
               ++it;
@@ -291,8 +292,10 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             self->tempItemStore.seek(0);
             std::string itemId;
             while (self->tempItemStore.available()) {
-              serialization::readString(self->tempItemStore, itemId);
-              serialization::readString(self->tempItemStore, href);
+              if (!serialization::readString(self->tempItemStore, itemId) ||
+                  !serialization::readString(self->tempItemStore, href)) {
+                break;
+              }
               if (itemId == idref) {
                 found = true;
                 break;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -278,10 +278,14 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
               self->tempItemStore.seek(it->fileOffset);
               std::string itemId;
               if (!serialization::readString(self->tempItemStore, itemId)) {
+                self->itemStoreReadFailed = true;
                 break;
               }
               if (itemId == idref) {
                 found = serialization::readString(self->tempItemStore, href);
+                if (!found) {
+                  self->itemStoreReadFailed = true;
+                }
                 break;
               }
               ++it;
@@ -294,6 +298,10 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             while (self->tempItemStore.available()) {
               if (!serialization::readString(self->tempItemStore, itemId) ||
                   !serialization::readString(self->tempItemStore, href)) {
+                // Distinguish a read failure from a clean walk to EOF: the loop
+                // condition already excludes the latter, so arriving here means
+                // the store itself is unreadable, not that the id is absent.
+                self->itemStoreReadFailed = true;
                 break;
               }
               if (itemId == idref) {

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -32,6 +32,11 @@ class ContentOpfParser final : public Print {
   HalFile tempItemStore;
   std::string coverItemId;
   bool hasExplicitStartReference = false;
+  // Set when a read from the temporary item store fails mid-spine. Such a read
+  // yields no href, so the itemref is silently skipped and the spine would be
+  // written a chapter short -- and the resulting book.bin looks valid forever
+  // after. Surfaced so the caller can discard the build and rebuild instead.
+  bool itemStoreReadFailed = false;
 
   // Index for fast idref→href lookup (binary search over .items.bin)
   struct ItemIndexEntry {
@@ -73,6 +78,10 @@ class ContentOpfParser final : public Print {
   ~ContentOpfParser() override;
 
   bool setup();
+
+  // False when a spine itemref could not be resolved because the item store
+  // read failed. The parsed spine is incomplete and must not be cached.
+  [[nodiscard]] bool spineIsComplete() const { return !itemStoreReadFailed; }
 
   size_t write(uint8_t) override;
   size_t write(const uint8_t* buffer, size_t size) override;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.h
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.h
@@ -32,11 +32,16 @@ class ContentOpfParser final : public Print {
   HalFile tempItemStore;
   std::string coverItemId;
   bool hasExplicitStartReference = false;
-  // Set when a read from the temporary item store fails mid-spine. Such a read
-  // yields no href, so the itemref is silently skipped and the spine would be
-  // written a chapter short -- and the resulting book.bin looks valid forever
+  // Set when the temporary item store could not be opened, sought, or read.
+  // Any of those leaves an idref unresolved, which is indistinguishable from a
+  // genuinely absent id: the itemref is silently skipped and the spine is
+  // written a chapter short, and the resulting book.bin looks valid forever
   // after. Surfaced so the caller can discard the build and rebuild instead.
-  bool itemStoreReadFailed = false;
+  //
+  // A failed open matters on its own: with no store, the manifest index stays
+  // empty, so lookups take the fallback path, where available() reports zero,
+  // no read is ever attempted, and nothing else would notice.
+  bool itemStoreUnusable = false;
 
   // Index for fast idref→href lookup (binary search over .items.bin)
   struct ItemIndexEntry {
@@ -79,9 +84,9 @@ class ContentOpfParser final : public Print {
 
   bool setup();
 
-  // False when a spine itemref could not be resolved because the item store
-  // read failed. The parsed spine is incomplete and must not be cached.
-  [[nodiscard]] bool spineIsComplete() const { return !itemStoreReadFailed; }
+  // False when a spine itemref could not be resolved because the item store was
+  // unusable. The parsed spine is incomplete and must not be cached.
+  [[nodiscard]] bool spineIsComplete() const { return !itemStoreUnusable; }
 
   size_t write(uint8_t) override;
   size_t write(const uint8_t* buffer, size_t size) override;

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -111,6 +111,15 @@ class BufferedFileReader {
   // Logical read position.
   size_t position() const { return bufStart + off; }
 
+  // Bytes between the logical cursor and end of file. Measured against the file
+  // rather than the buffer, so it is the true remaining count even when the
+  // buffer is empty or holds a window that ends before EOF.
+  size_t available() const {
+    const size_t end = file.size();
+    const size_t pos = position();
+    return end > pos ? end - pos : 0;
+  }
+
   bool seek(const size_t target) {
     // Within the buffered window: just move the cursor.
     if (cap != 0 && target >= bufStart && target < bufStart + fill) {
@@ -160,8 +169,9 @@ inline bool readString(BufferedFileReader& in, std::string& s) {
     s.clear();
     return false;
   }
-  if (len > MAX_STRING_LEN) {
-    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+  const size_t remaining = in.available();
+  if (len > remaining) {
+    LOG_ERR("SER", "String length %u exceeds %u bytes remaining", len, static_cast<unsigned>(remaining));
     s.clear();
     return false;
   }
@@ -169,7 +179,11 @@ inline bool readString(BufferedFileReader& in, std::string& s) {
   if (len == 0) {
     return true;
   }
-  return in.read(&s[0], len) == len;
+  if (in.read(&s[0], len) != len) {
+    s.clear();
+    return false;
+  }
+  return true;
 }
 
 }  // namespace serialization

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <HalStorage.h>
 #include <Memory.h>
+#include <Serialization.h>
 
 #include <algorithm>
 #include <cstring>
@@ -139,8 +140,8 @@ void writePod(BufferedFileWriter& out, const T& value) {
 }
 
 template <typename T>
-void readPod(BufferedFileReader& in, T& value) {
-  in.read(&value, sizeof(T));
+bool readPod(BufferedFileReader& in, T& value) {
+  return in.read(&value, sizeof(T)) == sizeof(T);
 }
 
 inline void writeString(BufferedFileWriter& out, const std::string& s) {
@@ -149,13 +150,25 @@ inline void writeString(BufferedFileWriter& out, const std::string& s) {
   out.write(s.data(), len);
 }
 
-inline void readString(BufferedFileReader& in, std::string& s) {
-  uint32_t len;
-  readPod(in, len);
-  s.resize(len);
-  if (len > 0) {
-    in.read(&s[0], len);
+// Bounded for the same reason as the HalFile overload in Serialization.h: the
+// length comes off the file before it can be trusted, and an unbounded resize()
+// is a throwing allocation that aborts under -fno-exceptions.
+inline bool readString(BufferedFileReader& in, std::string& s) {
+  uint32_t len = 0;
+  if (!readPod(in, len)) {
+    s.clear();
+    return false;
   }
+  if (len > MAX_STRING_LEN) {
+    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+    s.clear();
+    return false;
+  }
+  s.resize(len);
+  if (len == 0) {
+    return true;
+  }
+  return in.read(&s[0], len) == len;
 }
 
 }  // namespace serialization

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -141,6 +141,7 @@ void writePod(BufferedFileWriter& out, const T& value) {
 
 template <typename T>
 bool readPod(BufferedFileReader& in, T& value) {
+  value = T{};
   return in.read(&value, sizeof(T)) == sizeof(T);
 }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -1,9 +1,21 @@
 #pragma once
 #include <HalStorage.h>
+#include <Logging.h>
 
 #include <iostream>
 
 namespace serialization {
+
+// Upper bound on any length-prefixed string in a cache file. Every string these
+// helpers carry is a book metadata field, an EPUB href, an anchor id or a ruby
+// annotation -- hundreds of bytes at the very most. The bound exists because the
+// length is read from the file before it is trusted: a truncated read leaves it
+// unset and a desynced cursor makes it arbitrary, and `resize()` on a bogus
+// length is a throwing allocation, which under -fno-exceptions aborts the
+// firmware (field crash: bad_alloc -> terminate -> abort on the page-load path).
+// Same rationale as the `wc > 10000` guard in TextBlock::deserialize.
+inline constexpr uint32_t MAX_STRING_LEN = 4096;
+
 template <typename T>
 void writePod(std::ostream& os, const T& value) {
   os.write(reinterpret_cast<const char*>(&value), sizeof(T));
@@ -14,14 +26,18 @@ void writePod(HalFile& file, const T& value) {
   file.write(reinterpret_cast<const uint8_t*>(&value), sizeof(T));
 }
 
+// Return false when the source could not supply a whole T. Callers that do not
+// care may ignore the result, but anything that then uses `value` as a size or
+// an offset must check it.
 template <typename T>
-void readPod(std::istream& is, T& value) {
+bool readPod(std::istream& is, T& value) {
   is.read(reinterpret_cast<char*>(&value), sizeof(T));
+  return is.gcount() == static_cast<std::streamsize>(sizeof(T));
 }
 
 template <typename T>
-void readPod(HalFile& file, T& value) {
-  file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T));
+bool readPod(HalFile& file, T& value) {
+  return file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T)) == static_cast<int>(sizeof(T));
 }
 
 inline void writeString(std::ostream& os, const std::string& s) {
@@ -36,17 +52,40 @@ inline void writeString(HalFile& file, const std::string& s) {
   file.write(reinterpret_cast<const uint8_t*>(s.data()), len);
 }
 
-inline void readString(std::istream& is, std::string& s) {
-  uint32_t len;
-  readPod(is, len);
+inline bool readString(std::istream& is, std::string& s) {
+  uint32_t len = 0;
+  if (!readPod(is, len)) {
+    s.clear();
+    return false;
+  }
+  if (len > MAX_STRING_LEN) {
+    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+    s.clear();
+    return false;
+  }
   s.resize(len);
+  if (len == 0) {
+    return true;
+  }
   is.read(&s[0], len);
+  return is.gcount() == static_cast<std::streamsize>(len);
 }
 
-inline void readString(HalFile& file, std::string& s) {
-  uint32_t len;
-  readPod(file, len);
+inline bool readString(HalFile& file, std::string& s) {
+  uint32_t len = 0;
+  if (!readPod(file, len)) {
+    s.clear();
+    return false;
+  }
+  if (len > MAX_STRING_LEN) {
+    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+    s.clear();
+    return false;
+  }
   s.resize(len);
-  file.read(&s[0], len);
+  if (len == 0) {
+    return true;
+  }
+  return file.read(&s[0], len) == static_cast<int>(len);
 }
 }  // namespace serialization

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -26,17 +26,20 @@ void writePod(HalFile& file, const T& value) {
   file.write(reinterpret_cast<const uint8_t*>(&value), sizeof(T));
 }
 
-// Return false when the source could not supply a whole T. Callers that do not
-// care may ignore the result, but anything that then uses `value` as a size or
-// an offset must check it.
+// Return false when the source could not supply a whole T, leaving `value`
+// zeroed rather than holding whatever was already on the stack. Callers that do
+// not care may ignore the result, but anything that then uses `value` as a size
+// or an offset must check it.
 template <typename T>
 bool readPod(std::istream& is, T& value) {
+  value = T{};
   is.read(reinterpret_cast<char*>(&value), sizeof(T));
   return is.gcount() == static_cast<std::streamsize>(sizeof(T));
 }
 
 template <typename T>
 bool readPod(HalFile& file, T& value) {
+  value = T{};
   return file.read(reinterpret_cast<uint8_t*>(&value), sizeof(T)) == static_cast<int>(sizeof(T));
 }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -6,15 +6,20 @@
 
 namespace serialization {
 
-// Upper bound on any length-prefixed string in a cache file. Every string these
-// helpers carry is a book metadata field, an EPUB href, an anchor id or a ruby
-// annotation -- hundreds of bytes at the very most. The bound exists because the
-// length is read from the file before it is trusted: a truncated read leaves it
-// unset and a desynced cursor makes it arbitrary, and `resize()` on a bogus
-// length is a throwing allocation, which under -fno-exceptions aborts the
-// firmware (field crash: bad_alloc -> terminate -> abort on the page-load path).
-// Same rationale as the `wc > 10000` guard in TextBlock::deserialize.
-inline constexpr uint32_t MAX_STRING_LEN = 4096;
+// A length-prefixed string is bounded by the bytes actually left in the source,
+// never by a fixed content cap. The length is read from the file before it can
+// be trusted: a truncated read leaves it unset and a desynced cursor makes it
+// arbitrary, and `resize()` on a bogus length is a throwing allocation, which
+// under -fno-exceptions aborts the firmware (field crash: bad_alloc ->
+// terminate -> abort on the page-load path).
+//
+// A fixed cap would be the wrong bound here. `writeString` is unbounded and so
+// is the parser feeding it -- ruby <rt> text accumulates into an unbounded
+// std::string in ChapterHtmlSlimParser -- so any cap the reader enforces and
+// the writer does not turns a legitimately long string into a cache that
+// serializes fine and then fails every reload, rebuilding forever. Bounding by
+// remaining bytes rejects exactly the corrupt lengths (which point past EOF)
+// while leaving every string the writer can actually produce readable.
 
 template <typename T>
 void writePod(std::ostream& os, const T& value) {
@@ -61,8 +66,14 @@ inline bool readString(std::istream& is, std::string& s) {
     s.clear();
     return false;
   }
-  if (len > MAX_STRING_LEN) {
-    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+  // Bytes left in the stream, restoring the cursor afterwards.
+  const auto cur = is.tellg();
+  is.seekg(0, std::ios::end);
+  const auto endPos = is.tellg();
+  is.seekg(cur);
+  if (cur < 0 || endPos < cur || len > static_cast<uint64_t>(endPos - cur)) {
+    LOG_ERR("SER", "String length %u exceeds %lld bytes remaining", len,
+            static_cast<long long>(endPos < cur ? 0 : endPos - cur));
     s.clear();
     return false;
   }
@@ -84,8 +95,9 @@ inline bool readString(HalFile& file, std::string& s) {
     s.clear();
     return false;
   }
-  if (len > MAX_STRING_LEN) {
-    LOG_ERR("SER", "String length %u exceeds maximum %u", len, MAX_STRING_LEN);
+  const int remaining = file.available();
+  if (remaining < 0 || len > static_cast<uint32_t>(remaining)) {
+    LOG_ERR("SER", "String length %u exceeds %d bytes remaining", len, remaining);
     s.clear();
     return false;
   }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -71,7 +71,11 @@ inline bool readString(std::istream& is, std::string& s) {
     return true;
   }
   is.read(&s[0], len);
-  return is.gcount() == static_cast<std::streamsize>(len);
+  if (is.gcount() != static_cast<std::streamsize>(len)) {
+    s.clear();
+    return false;
+  }
+  return true;
 }
 
 inline bool readString(HalFile& file, std::string& s) {
@@ -89,6 +93,10 @@ inline bool readString(HalFile& file, std::string& s) {
   if (len == 0) {
     return true;
   }
-  return file.read(&s[0], len) == static_cast<int>(len);
+  if (file.read(&s[0], len) != static_cast<int>(len)) {
+    s.clear();
+    return false;
+  }
+  return true;
 }
 }  // namespace serialization


### PR DESCRIPTION
## Where this came from

A user [reported a crash on 1.5.0 RC2](https://github.com/crosspoint-reader/crosspoint-reader/discussions/2693#discussioncomment-17833067) while reading, on an X3:

```
Panic reason: abort() was called at PC 0x4219e9fb on core 0
```

The report's "Last logs" ended at `[279] ms` — boot. That is not a bug in the ring buffer ([Logging.cpp:78-91](https://github.com/crosspoint-reader/crosspoint-reader/blob/develop/lib/Logging/Logging.cpp#L78-L91) is correct): at `LOG_LEVEL=1` the reading path emits nothing, so those five boot lines were genuinely all 16 slots ever received. Two `millis()` samples one word apart in the stack dump (`0x002CA1C4` / `0x002CA1C3`) put uptime at ~49 minutes, so the device really had been reading for a while. The dump was the only evidence.

## How it was symbolized

No ELF is published for RC builds, so this took a detour worth writing down.

`CROSSPOINT_VERSION` in the report is `1.5.0-rc+` with an empty hash, meaning `CROSSPOINT_RC_HASH` was unset — so RC02 was built locally, not by [`release_candidate.yml`](https://github.com/crosspoint-reader/crosspoint-reader/blob/develop/.github/workflows/release_candidate.yml) (whose most recent run was `release/1.3.1` in May). The release assets are zips containing `firmware.bin` only.

The ESP app descriptor at offset `0x20` of `firmware.bin` carries `git describe` of the project repo plus the build timestamp. For the published `xteink_x4_x3-1.5.0_beta_RC02.zip` that reads `1.5.0-1-g90785b71f`, project dir `rc1`, built `Jul 27 2026 16:11:34`. But rebuilding `90785b71` gives an image 15,168 bytes off, while rebuilding `develop@99c0e504b` (tip four minutes before the asset upload, top commit #2739 matching the RC02 changelog) lands within 128 bytes. That pattern fits a build from a tree at HEAD `90785b71` with the RC02 changes applied but uncommitted.

Symbolizing against the `99c0e504b` rebuild, all 15 text addresses in the dump land *inside* symbols forming a properly nested chain — verified with `nm --print-size` so nothing sits near a boundary where a small layout shift could mislead:

```
abort()
  __cxxabiv1::__terminate            (eh_terminate.cc)
  std::__throw_bad_alloc             (bad_alloc.cc)
  operator new(unsigned int)  +74/78   <- the failure branch
  TextBlock::deserialize      +940
  PageLine::deserialize        +50
  Page::deserialize           +154
  Section::loadPageAt         +126
  Section::loadPage            +86
  EpubReaderActivity::loop    +242
  ActivityManager::loop() -> loop() -> loopTask()
```

Not an assert (`NDEBUG` is not defined in any env, so asserts are live — but this isn't one) and not a stack overflow (~1KB of stack in use; the trailing `0xBAAD5678` is the heap tail canary past the stack top). It is a **throwing** `operator new` hitting OOM: under `-fno-exceptions`, `bad_alloc` goes to `std::terminate` and `abort()` rather than anywhere a caller can handle it.

`EpubReaderActivity::loop()` contains exactly one `loadPage` call — the **idle prewarm** at [EpubReaderActivity.cpp:345](https://github.com/crosspoint-reader/crosspoint-reader/blob/develop/src/activities/reader/EpubReaderActivity.cpp#L345). Deferrable work, killing the device.

## Root cause, and what this PR does *not* claim to fix

The allocation that actually failed was the ruby-text materialization in `TextBlock::deserialize` — a `std::vector<std::string> rubyTexts(wc)` plus a heap block per line, for a feature the reporter's novel almost certainly doesn't use. **That is already fixed on `develop` by #2772**, which landed 2026-07-28, one day after RC02 was cut. RC3 should resolve this reporter's crash without anything in this PR.

The gate above the prewarm ([EpubReaderActivity.h](https://github.com/crosspoint-reader/crosspoint-reader/blob/develop/src/activities/reader/EpubReaderActivity.h)) already anticipates this hazard by name — *"Page deserialization (TextBlock word vectors/strings) and glyph caching allocate through throwing paths that abort() on OOM"* — but 24 KB free / 16 KB maxAlloc wasn't enough. So this PR closes the remaining ways that same path can abort rather than fail.

## The commits

Split so the crash fix stands alone and the optional parts are separable.

**1. `reject bogus string lengths in cache deserialization`** — the fix. Both serialization headers, nothing else.

```cpp
uint32_t len;            // uninitialized
readPod(file, len);      // result ignored
s.resize(len);           // throwing
```

A truncated read left `len` holding stack garbage; a desynced cursor made it arbitrary. Either way `resize()` was asked for hundreds of megabytes and the abort was *certain*, not merely possible. `readPod` now reports whether it got a whole `T`, and `readString` validates the length before allocating. (This commit used a fixed 4096-byte cap; commit 6 replaces that with a bytes-remaining check — see below.) The `BufferedFileReader` overloads used by the metadata build path carried both bugs verbatim and are fixed identically so the two readers can't drift.

**2. `act on deserialization read failures instead of ignoring them`** — checks the new return value in `TextBlock`, `ImageBlock`, `Page`, `BookMetadataCache::load` (returns false, so the cache rebuilds), `Section::getPageForAnchor`, and both `ContentOpfParser` lookups. `readSpineEntryFrom`/`readTocEntryFrom` are left unchecked deliberately — they return entries by value with no error channel, and reshaping them is wider than this fix. They can no longer abort either way.

**3. `zero readPod targets that fail to read`** — optional, isolated for that reason. The crash fix doesn't need it (`readString` validates its own length before allocating), and it's the only commit that changes what *unchecked* callers observe. It also forces the one behaviour change in the series: `BlockStyle::alignment` defaults to `Justify`, not 0, so zeroing on a short read would silently alter geometry — hence the style-tail check that fails the block instead. **Drop this commit if you'd rather not carry it**; 1, 2 and 4 stay intact (commit 1 initializes `len = 0` explicitly so it doesn't depend on this one).

**4. `use nothrow allocation in Page deserialization`** — `new Page()` and `new PageImage()` were bare `new`, which aborts on OOM under `-fno-exceptions`, on this same path and against CLAUDE.md's own rule. `PageImage::deserialize` also wasn't null-checking the `ImageBlock` it had just deserialized — now reachable, since commit 2 makes that return `nullptr`.

**5. `clear the output string when a length-prefixed read comes up short`** — review follow-up to commit 1, same two headers. `readString` cleared `s` on both branches that reject the length, but not on the third failure: a good length whose payload read comes up short returned false with the string still resized and holding the partial bytes. Checked callers never saw it; the unchecked ones in `BookMetadataCache.cpp:48,57-59` would have carried a truncated field forward as if it were real. Now `false` uniformly means empty, never partially filled.

## Review round (commits 6–8)

All four @coderabbitai findings verified against the code and fixed. Detail in the individual threads; summary:

**6. `bound cache strings by bytes remaining, not a fixed cap`** — CodeRabbit was right and my "Known limitation" note below was wrong. I had called the reader-only 4096 cap unreachable in practice. It isn't: `ChapterHtmlSlimParser` accumulates ruby `<rt>` text into an unbounded `std::string` ([line 1122](https://github.com/crosspoint-reader/crosspoint-reader/blob/develop/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp#L1122)), and a book with a missing `</rt>` accumulates a whole paragraph before the next clear. That string writes fine and then fails every reload → discard → rebuild → write the same string → **rebuild loop**, on a book that is unusual rather than corrupt. This is also exactly the hazard called out in the #2772 review.

Bounding by bytes remaining in the source is the right shape: corruption produces lengths pointing past EOF, which is precisely what gets rejected, while every string the writer can produce stays readable. The bogus-`resize()` ceiling drops from 4 GB to the size of the file being read. `BufferedFileReader` gains `available()` for this, measured against the file rather than the buffer.

**7. `check the remaining POD reads in page and image deserialization`** — the element tag, `PageLine`/`PageImage` coordinates, `ImageBlock` width/height, and the footnote count were all still unchecked. Zeroing made most of them fail safely-ish, but the footnote count silently reported *no footnotes* on a truncated tail, losing data with no error. `PageHorizontalRule` already rejected zeroed reads and is untouched.

**8. `don't cache a spine that lost entries to a failed item-store read`** — the Major one, and correct. Both idref lookup paths `break` on a failed read leaving `found == false`, which is indistinguishable from a genuinely absent id, so the itemref is skipped and the spine is cached one chapter short — structurally valid and trusted on every subsequent open. Now tracked separately and surfaced via `spineIsComplete()`; `Epub::parseContentOpf` fails the parse so the build is abandoned and the next open rebuilds. The expat callback has no error channel, hence a flag on the parser rather than a return value.

**9. `treat a failed item-store open or seek as an incomplete spine too`** — second review round. Commit 8 tracked failed *reads* only, leaving two holes with the same consequence. A failed **open** set nothing, and that was the one path that could still silently truncate a spine: with no store the manifest index stays empty, so lookups take the fallback, `available()` reports zero, no read is attempted, and nothing notices. A failed **seek** set nothing and is worse than a failed read — the cursor stays on the previous record, so the reads that follow succeed against the *wrong* entry and return another item's href, which nothing downstream can detect. Flag renamed `itemStoreUnusable` to match what it now guards. The guide-state open is deliberately excluded (nothing in that state reads the store).

## Known limitation

Bounding `resize()` removes the guaranteed-abort mode; it does not eliminate OOM. A large `std::string` allocation can still fail on a fragmented heap, and the bound is now the file size rather than a small constant. Making these fields genuinely nothrow means moving them off `std::string` — a much larger change, deliberately out of scope. Worth being explicit that this hardens the *corruption* path while only narrowing the *pressure* path.

## Testing

- `pio run -e default` clean at every commit in the series, no new warnings.
- `clang-format --dry-run -Werror` passes on all changed files.
- **Not yet tested on hardware.** Worth checking: page turns across a chapter boundary with a `.crosspoint/` cache present; a book with images; a book with CJK ruby text (exercises the propagation path in commit 2); and deleting `.crosspoint/` to confirm the metadata-cache rejection path doesn't misfire on a clean re-parse.

## Unrelated, but surfaced by this

Two things made a one-line diagnosis into a two-build investigation, both cheap to fix and neither in this PR:

- **No ELF for RC builds.** `release_candidate.yml` already uploads `firmware.elf` and `firmware.map`; it just wasn't the thing that built RC02. Using it, or attaching those two files to prereleases, makes every future RC crash report symbolizable directly.
- **Crash reports carry no heap data.** The single most useful number for an OOM abort — free heap and largest free block at the moment of failure — isn't captured, nor is the failing allocation size. Both could go into the existing `RTC_NOINIT_ATTR` panic block that already holds the message and stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



