### PR TITLE
fix: deliver the Hangul word-gap fix (bump section cache version) and keep it off Han/Kana

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -96,11 +96,12 @@ Each file in `sections/*.bin` stores one laid-out spine section. The header is
 also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
-Version 34 is binary-identical to version 33. The version was bumped because
-word-gap suppression was narrowed to tokens glued together in the source: v33
-dropped the gap between any two words meeting at a CJK break opportunity, which
-collapsed the spaces between Hangul words, so v33 word positions no longer match
-what the layout engine now produces.
+Version 35 is binary-identical to version 34. The version was bumped because
+word-gap suppression was narrowed: v34 dropped the gap between any two words
+meeting at a CJK break opportunity, which collapsed the spaces between Hangul
+words. The gap is now suppressed only for tokens glued together in the source,
+plus whitespace-separated pairs where neither side is Hangul, so v34 word
+positions no longer match what the layout engine produces.
 
 Version 30 is binary-identical to version 29. The version was bumped because
 Arabic contextual shaping changed text measurement (`getTextAdvanceX` now

--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -97,11 +97,22 @@ also the cache-busting key: if any layout-affecting setting differs from the
 current reader settings, the section is discarded and rebuilt.
 
 Version 35 is binary-identical to version 34. The version was bumped because
-word-gap suppression was narrowed: v34 dropped the gap between any two words
-meeting at a CJK break opportunity, which collapsed the spaces between Hangul
-words. The gap is now suppressed only for tokens glued together in the source,
-plus whitespace-separated pairs where neither side is Hangul, so v34 word
-positions no longer match what the layout engine produces.
+word-gap suppression changed twice while the version field stayed at 34, so a
+v34 file does not describe one layout. In all three cases the gap is only ever
+dropped where `hasCjkBreakOpportunityBetween()` reports a break opportunity
+between the two adjoining codepoints; what changed is which such pairs qualify:
+
+- v33 and v34 as originally shipped dropped the gap for *every* qualifying
+  pair, which collapsed the spaces between Hangul words.
+- v34 after the word-gap fix dropped it only when no whitespace separated the
+  two tokens in the source. This restored Hangul spacing, but also re-added a
+  gap between Han/Kana whose source is line-wrapped mid-paragraph, where
+  browsers drop it.
+- v35 drops it when no whitespace separated the tokens, or when whitespace did
+  but neither side is Hangul.
+
+So v34 word positions may or may not match what the layout engine now produces,
+depending on which build wrote them. v35 makes the distinction observable.
 
 Version 30 is binary-identical to version 29. The version was bumped because
 Arabic contextual shaping changed text measurement (`getTextAdvanceX` now

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -284,14 +284,21 @@ void ParsedText::addWord(std::string word, const EpdFontFamily::Style fontStyle,
 
   bool effectiveAttachToPrevious = attachToPrevious;
   bool effectiveNoSpaceBefore = false;
-  // Only a glued token (attachToPrevious == true, i.e. no whitespace separated it from the
-  // previous one in the source) may be turned into a gap-less break opportunity. When real
-  // whitespace separated the two words, that space is content and must be rendered: Korean
-  // is a space-delimited script written in Hangul, which utf8IsCjkBreakable() covers.
-  if (attachToPrevious && !words.empty() &&
-      hasCjkBreakOpportunityBetween(lastCodepoint(words.back()), firstCodepoint(word))) {
-    effectiveAttachToPrevious = false;
-    effectiveNoSpaceBefore = true;
+  // A glued token (attachToPrevious == true, i.e. no whitespace separated it from the
+  // previous one in the source) always becomes a gap-less break opportunity. When real
+  // whitespace separated the two words, the gap may only be dropped away from Hangul:
+  // Korean is a space-delimited script that utf8IsCjkBreakable() covers, so there the
+  // space is content and must be rendered. Between Han/Kana the collapsed whitespace is
+  // almost always a source line wrap, which browsers drop (CSS text segment-break rules),
+  // so suppressing the gap there matches how the same book renders elsewhere.
+  if (!words.empty()) {
+    const uint32_t leftCp = lastCodepoint(words.back());
+    const uint32_t rightCp = firstCodepoint(word);
+    const bool spanHangul = utf8IsHangul(leftCp) || utf8IsHangul(rightCp);
+    if ((attachToPrevious || !spanHangul) && hasCjkBreakOpportunityBetween(leftCp, rightCp)) {
+      effectiveAttachToPrevious = false;
+      effectiveNoSpaceBefore = true;
+    }
   }
 
   const auto ensureTokenCapacity = [&](const size_t additionalTokens) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -21,16 +21,16 @@ namespace {
 //      (lazy extraction: images are header-probed at build time and extracted on
 //      first render).
 // v33: Support <ruby> and <rt> tags. Skip <rp> tags
-// v34: Word gaps are only suppressed for tokens glued in the source, so spaces between
-//      Hangul words survive again; ruby element boundaries carry the continuation flag
-//      instead. Invalidates v33 caches, whose word positions have the spaces collapsed.
-
 // v34: <br> handling changed layout — a <br> after text is now a margin-stripped
 //      line break (browser-like) and only a <br> whose block stays empty injects
 //      the scene-break gap, so cached pages laid out by older versions no longer
 //      match. Keeps <br>-per-paragraph books (common CJK formatting) from
 //      re-adding container spacing at every paragraph.
-constexpr uint8_t SECTION_FILE_VERSION = 34;
+// v35: Word gaps are only suppressed for tokens glued in the source (and, when real
+//      whitespace separated them, only away from Hangul), so spaces between Hangul
+//      words survive again; ruby element boundaries carry the continuation flag
+//      instead. Invalidates v34 caches, whose word positions have the spaces collapsed.
+constexpr uint8_t SECTION_FILE_VERSION = 35;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -26,10 +26,13 @@ namespace {
 //      the scene-break gap, so cached pages laid out by older versions no longer
 //      match. Keeps <br>-per-paragraph books (common CJK formatting) from
 //      re-adding container spacing at every paragraph.
-// v35: Word gaps are only suppressed for tokens glued in the source (and, when real
-//      whitespace separated them, only away from Hangul), so spaces between Hangul
-//      words survive again; ruby element boundaries carry the continuation flag
-//      instead. Invalidates v34 caches, whose word positions have the spaces collapsed.
+// v35: At a CJK break opportunity, the word gap is now dropped only when no whitespace
+//      separated the two tokens in the source, or when whitespace did but neither side
+//      is Hangul; ruby element boundaries carry the continuation flag instead. Bumped
+//      because the rule changed twice under version 34 -- as first shipped it dropped
+//      the gap at every break opportunity (collapsing Hangul spaces), then the word-gap
+//      fix narrowed it to glued tokens only -- so a v34 file does not identify one
+//      layout. 35 makes the current rule distinguishable from both.
 constexpr uint8_t SECTION_FILE_VERSION = 35;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -44,6 +44,19 @@ inline bool utf8IsCjkBreakable(const uint32_t cp) {
          || (cp >= 0x2A700 && cp <= 0x2B73F);  // CJK Extension C
 }
 
+// Returns true for Hangul codepoints only (Jamo, Compatibility Jamo, Syllables, the
+// Jamo extensions, and the halfwidth Jamo tail of the Halfwidth/Fullwidth Forms block).
+// Korean is the one script inside utf8IsCjkBreakable() that delimits words with real
+// spaces, so layout must treat it differently from Han/Kana when deciding whether an
+// inter-word gap is content or collapsible whitespace.
+inline bool utf8IsHangul(const uint32_t cp) {
+  return (cp >= 0x1100 && cp <= 0x11FF)      // Hangul Jamo
+         || (cp >= 0x3130 && cp <= 0x318F)   // Hangul Compatibility Jamo
+         || (cp >= 0xA960 && cp <= 0xA97F)   // Hangul Jamo Extended-A
+         || (cp >= 0xAC00 && cp <= 0xD7FF)   // Hangul Syllables, Hangul Jamo Extended-B
+         || (cp >= 0xFFA0 && cp <= 0xFFDF);  // Halfwidth Hangul Jamo
+}
+
 // Returns true for any codepoint in a CJK script block (Han, Kana, Hangul, Bopomofo,
 // radicals, and CJK punctuation/compatibility/enclosed forms). Used for fallback font
 // selection — deliberately broader than utf8IsCjkBreakable, whose ranges are tuned to


### PR DESCRIPTION
## Summary

* **Goal:** actually deliver the #2761 fix, and stop it over-correcting for Chinese/Japanese.
* **Changes:** bump `SECTION_FILE_VERSION` 34 → 35 so existing caches invalidate, and narrow the word-gap suppression so it keys on script rather than on `attachToPrevious` alone.

**#2761 is closed but not delivered.** #2768 added a `v34` entry to the version log in `Section.cpp` saying the change "Invalidates v33 caches", but left the constant at 34 — the value #2710 had already shipped for the `<br>` change. `develop` currently carries *two different* `v34` entries and no bump.

That is not cosmetic, because `section.bin` caches laid-out geometry rather than source text. `TextBlock` stores per-word x positions (`wordXpos()`) and `deserialize()` fills them directly with no re-layout, so a v34 cache of a Korean book has the collapsed positions baked in. An RC2 user upgrading to RC3 keeps that cache and sees exactly the same missing spaces the issue reported, unless they know to delete `.crosspoint/` by hand.

## The two commits

**1. `keep CJK word-gap suppression away from Hangul`**

#2768 suppresses the gap only when `attachToPrevious` is set. Right for Korean, but it also re-enables the gap for Chinese and Japanese whose source is line-wrapped mid-paragraph: `characterData` clears `nextWordContinues` on any whitespace, so a source newline between two Han characters now draws a visible space. Browsers drop that one — CSS text segment-break rules remove a break between two non-Hangul CJK characters — so the same book renders differently on-device than everywhere else.

Gate on script instead: a glued token is still always a gap-less break opportunity, and whitespace-separated pairs lose the gap only when neither side is Hangul.

`utf8IsHangul()` is new and deliberately narrow — it covers only Hangul ranges already inside `utf8IsCjkBreakable()`, so it cannot change *which* pairs are break opportunities, only whether a gap is drawn at one.

**2. `bump section cache version so the CJK word-gap fix reaches users`**

35, with both word-gap entries folded into one. `docs/file-formats.md` updated to match (its v34 note claimed binary-identity with v33 while an unrelated v34 already existed).

## Additional Context

**Cost of the bump is close to zero.** `1.5.0` ships `SECTION_FILE_VERSION = 32` — v33 (#2665) and v34 (#2710) both landed after the tag and are in no release. Every released user re-lays out on the next release no matter which number it carries; only develop/RC testers from the last few days pay one extra rebuild. Waiting to batch the bump buys nothing and leaves a format that renders Korean wrong.

Memory/flash: no measurable change. `utf8IsHangul()` is an `inline constexpr`-style range check called once per word pair at layout time.

**Worth a reviewer's eye:** I can't distinguish a source newline from an intentional space at `addWord()` — `characterData` has already collapsed both. Keying on Hangul is a proxy for that, and it is the same split the CSS spec makes. If someone has a Korean book that deliberately uses spaces *between Han characters*, that case still loses its gap.

**Not tested on hardware.** Needs: a Korean EPUB (ideally the one from #2761) with `.crosspoint/` deleted, and a line-wrapped Chinese/Japanese EPUB to confirm no space appears at wrap points — @botkrabs's book from the #2710 thread would be the right one.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Bug fix to existing CJK layout; no new surface.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery.

Fixes #2761

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
