### PR TITLE
fix: don't rewrite settings and re-layout when text settings close unchanged

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -12,6 +12,8 @@
 #include <esp_system.h>
 
 #include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <functional>
 #include <iterator>
 #include <limits>
@@ -46,6 +48,47 @@ namespace {
 constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
 constexpr size_t initialBookmarkCacheCapacity = 16;
 constexpr float bookmarkProgressEpsilon = 0.0001f;
+
+// Every setting TextSettingsActivity can edit. Snapshotted before the activity is
+// pushed and compared on return so backing out unchanged costs neither a SPIFFS
+// write nor a full chapter re-layout, mirroring applyOrientation()'s no-op guard.
+struct TextSettingsSnapshot {
+  uint8_t fontFamily;
+  uint8_t fontPointSize;
+  uint8_t lineSpacing;
+  uint8_t paragraphAlignment;
+  uint8_t extraParagraphSpacing;
+  uint8_t screenMargin;
+  uint8_t hyphenationEnabled;
+  uint8_t embeddedStyle;
+  uint8_t focusReadingEnabled;
+  uint8_t textAntiAliasing;
+  char sdFontFamilyName[sizeof(CrossPointSettings::getInstance().sdFontFamilyName)];
+
+  static TextSettingsSnapshot capture() {
+    TextSettingsSnapshot s{};
+    s.fontFamily = SETTINGS.fontFamily;
+    s.fontPointSize = SETTINGS.fontPointSize;
+    s.lineSpacing = SETTINGS.lineSpacing;
+    s.paragraphAlignment = SETTINGS.paragraphAlignment;
+    s.extraParagraphSpacing = SETTINGS.extraParagraphSpacing;
+    s.screenMargin = SETTINGS.screenMargin;
+    s.hyphenationEnabled = SETTINGS.hyphenationEnabled;
+    s.embeddedStyle = SETTINGS.embeddedStyle;
+    s.focusReadingEnabled = SETTINGS.focusReadingEnabled;
+    s.textAntiAliasing = SETTINGS.textAntiAliasing;
+    snprintf(s.sdFontFamilyName, sizeof(s.sdFontFamilyName), "%s", SETTINGS.sdFontFamilyName);
+    return s;
+  }
+
+  bool operator==(const TextSettingsSnapshot& o) const {
+    return fontFamily == o.fontFamily && fontPointSize == o.fontPointSize && lineSpacing == o.lineSpacing &&
+           paragraphAlignment == o.paragraphAlignment && extraParagraphSpacing == o.extraParagraphSpacing &&
+           screenMargin == o.screenMargin && hyphenationEnabled == o.hyphenationEnabled &&
+           embeddedStyle == o.embeddedStyle && focusReadingEnabled == o.focusReadingEnabled &&
+           textAntiAliasing == o.textAntiAliasing && strcmp(sdFontFamilyName, o.sdFontFamilyName) == 0;
+  }
+};
 
 int clampPercent(int percent) {
   if (percent < 0) {
@@ -808,9 +851,16 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::TEXT_SETTINGS: {
+      const TextSettingsSnapshot before = TextSettingsSnapshot::capture();
       startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
                                                                     TextSettingsActivity::Tab::Family),
-                             [this](const ActivityResult&) {
+                             [this, before](const ActivityResult&) {
+                               // Backing out without touching anything must not write SPIFFS
+                               // (finite erase cycles) or throw away the laid-out chapter.
+                               if (TextSettingsSnapshot::capture() == before) {
+                                 requestUpdate();  // still need to repaint over the settings UI
+                                 return;
+                               }
                                SETTINGS.saveToFile();
                                // Font/size/spacing/margin changes invalidate the current
                                // layout: preserve position and force a re-layout, mirroring


### PR DESCRIPTION
## Summary

* **Goal:** opening the reader's text settings and backing out without changing anything should cost nothing.
* **Changes:** snapshot the settings `TextSettingsActivity` can edit, compare on return, and skip the save and the re-layout when nothing moved.

The `TEXT_SETTINGS` callback added in #2788 runs unconditionally:

```cpp
[this](const ActivityResult&) {
  SETTINGS.saveToFile();
  ...
  section.reset();
}
```

So merely opening the menu to look at it and pressing back costs a `SETTINGS.saveToFile()` and a `section.reset()`. Two separate problems:

* **The write burns a SPIFFS erase cycle for no change.** CLAUDE.md's write-throttling rule asks for a `if (newVal == _current) return;` guard on exactly this shape.
* **The reset discards the laid-out chapter.** On a long chapter that means a full re-layout and a fresh incremental build, for a menu the user only looked at.

`applyOrientation()` already guards this way — it early-returns when the selected orientation matches settings. This does the same.

## Additional Context

The snapshot covers all eleven settings `TextSettingsActivity` can write (`fontFamily`, `fontPointSize`, `sdFontFamilyName`, `lineSpacing`, `paragraphAlignment`, `extraParagraphSpacing`, `screenMargin`, `hyphenationEnabled`, `embeddedStyle`, `focusReadingEnabled`, `textAntiAliasing`).

`textAntiAliasing` is included even though it affects rendering rather than geometry, so a change to it still triggers the re-layout path. Over-invalidating on one flag is cheaper than letting a real change slip through; happy to special-case it to a repaint-only path if a reviewer prefers.

Memory: ~42 bytes of stack, captured by value into the existing callback. No heap.

**Related but explicitly not fixed:** #2778 (wrong resume page after a text settings change). This removes one *trigger* — closing unchanged no longer resets the section and runs the reposition path — but the root cause that issue identifies, `applyDeferredReposition` short-circuiting while `section->isBuilding()`, is untouched.

**Not tested on hardware.** Needs: open text settings and back out unchanged (page should not re-layout, no SPIFFS write in the log), then change font size and confirm the re-layout still happens and position is preserved.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Bug fix to an existing menu path; no new surface.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
