### PR TITLE
fix: match the official sync server on host, not on the whole URL

### DIFF
--- a/lib/KOReaderSync/KOReaderCredentialStore.cpp
+++ b/lib/KOReaderSync/KOReaderCredentialStore.cpp
@@ -4,6 +4,7 @@
 #include <MD5Builder.h>
 #include <ObfuscationUtils.h>
 
+#include <algorithm>
 #include <cctype>
 #include <string>
 
@@ -26,14 +27,17 @@ constexpr char DEFAULT_SERVER_HOST[] = "sync.crosspointreader.com";
 // Bumped when a change to defaults would alter behavior for existing configs.
 constexpr uint8_t CONFIG_VERSION = 2;
 
-// Host component of a base URL: scheme stripped, path and port removed. Returns
-// lowercase so the comparison is case-insensitive, as host names are.
+// Host component of a base URL: scheme stripped, port and everything from the
+// path/query/fragment onward removed. Returns lowercase so the comparison is
+// case-insensitive, as host names are.
 std::string urlHost(const std::string& url) {
   size_t start = url.find("://");
   start = (start == std::string::npos) ? 0 : start + 3;
+  // The authority ends at the first '/', '?' or '#'. Stopping only at '/' would
+  // leave a query or fragment glued to the host ("host?x=1"), which then matches
+  // nothing. getBaseUrl() strips trailing slashes but not either of those.
+  const size_t authorityEnd = std::min(url.find_first_of("/?#", start), url.size());
   // Skip any userinfo ("user:pass@host") so it cannot masquerade as the host.
-  const size_t pathEnd = url.find('/', start);
-  const size_t authorityEnd = (pathEnd == std::string::npos) ? url.size() : pathEnd;
   const size_t at = url.rfind('@', authorityEnd);
   if (at != std::string::npos && at >= start) {
     start = at + 1;

--- a/lib/KOReaderSync/KOReaderCredentialStore.cpp
+++ b/lib/KOReaderSync/KOReaderCredentialStore.cpp
@@ -4,6 +4,9 @@
 #include <MD5Builder.h>
 #include <ObfuscationUtils.h>
 
+#include <cctype>
+#include <string>
+
 namespace {
 // Default sync server URL. crosspoint-sync speaks the full KOSync protocol, so
 // pointing at any other kosync server (e.g. https://sync.koreader.rocks:443)
@@ -14,8 +17,38 @@ constexpr char DEFAULT_SERVER_URL[] = "https://sync.crosspointreader.com";
 // empty serverUrl were implicitly syncing here — they get pinned on upgrade.
 constexpr char LEGACY_DEFAULT_SERVER_URL[] = "https://sync.koreader.rocks:443";
 
+// Host of the official sync server, matched on its own so the CrossPoint position
+// extension survives an equivalent hand-typed URL. getBaseUrl() prefixes a
+// scheme-less entry with "http://", so a plain "sync.crosspointreader.com" would
+// never equal DEFAULT_SERVER_URL as a whole string.
+constexpr char DEFAULT_SERVER_HOST[] = "sync.crosspointreader.com";
+
 // Bumped when a change to defaults would alter behavior for existing configs.
 constexpr uint8_t CONFIG_VERSION = 2;
+
+// Host component of a base URL: scheme stripped, path and port removed. Returns
+// lowercase so the comparison is case-insensitive, as host names are.
+std::string urlHost(const std::string& url) {
+  size_t start = url.find("://");
+  start = (start == std::string::npos) ? 0 : start + 3;
+  // Skip any userinfo ("user:pass@host") so it cannot masquerade as the host.
+  const size_t pathEnd = url.find('/', start);
+  const size_t authorityEnd = (pathEnd == std::string::npos) ? url.size() : pathEnd;
+  const size_t at = url.rfind('@', authorityEnd);
+  if (at != std::string::npos && at >= start) {
+    start = at + 1;
+  }
+  size_t end = authorityEnd;
+  const size_t colon = url.find(':', start);
+  if (colon != std::string::npos && colon < end) {
+    end = colon;
+  }
+  std::string host = url.substr(start, end - start);
+  for (char& c : host) {
+    c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  }
+  return host;
+}
 }  // namespace
 
 void KOReaderCredentialStore::toJson(JsonDocument& doc) const {
@@ -132,7 +165,7 @@ std::string KOReaderCredentialStore::getBaseUrl() const {
   return url;
 }
 
-bool KOReaderCredentialStore::usesCrossPointSyncServer() const { return getBaseUrl() == DEFAULT_SERVER_URL; }
+bool KOReaderCredentialStore::usesCrossPointSyncServer() const { return urlHost(getBaseUrl()) == DEFAULT_SERVER_HOST; }
 
 void KOReaderCredentialStore::setMatchMethod(DocumentMatchMethod method) {
   matchMethod = method;


### PR DESCRIPTION
## Summary

* **Goal:** typing the official sync server's hostname by hand shouldn't silently disable the CrossPoint position extension.
* **Changes:** `usesCrossPointSyncServer()` compares the URL's *host* instead of the whole string.

#2790 gates the position extension behind `usesCrossPointSyncServer()`, which is an exact string compare:

```cpp
return getBaseUrl() == DEFAULT_SERVER_URL;   // "https://sync.crosspointreader.com"
```

But `getBaseUrl()` prefixes a scheme-less entry with `http://`. So a user who types `sync.crosspointreader.com` into the server field — the official server, reached the obvious way — produces `http://sync.crosspointreader.com`, fails the compare, and silently loses the rich position for the rest of that install. A trailing slash or a case variant does the same. Nothing surfaces; sync appears to work and just degrades.

`urlHost()` strips the scheme, drops the path and port, and lowercases, so equivalent spellings of the official host agree.

## Additional Context

**#2714 stays fixed.** That regression was BookOrbit rejecting the `position` object with a 400. Its host is `l2.fabiobarbon.com`, which is still not a host match, so the extension is still suppressed for it and every other third-party kosync server. This change only widens the gate to spellings of the *official* host.

`urlHost()` skips userinfo explicitly, so `https://sync.crosspointreader.com@example.com` reads as `example.com` rather than as the official host. Worth noting this is a feature gate and not a security boundary — the credentials go wherever the user points them either way — but there's no reason to be sloppy about it.

Memory/flash: one small `std::string` built per call. `usesCrossPointSyncServer()` is called on sync paths, not in the render loop.

**Not tested on hardware.** Needs: set the server to `sync.crosspointreader.com` (no scheme) and confirm the `position` object appears in the update-progress request body; set it to a third-party kosync server and confirm it does not.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector — fixes gating on the existing KOReader sync path.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Bug fix to an existing check; no new surface.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
