### PR TITLE
fix: Save text settings immediately on each change

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -811,7 +811,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
                                                                     TextSettingsActivity::Tab::Family),
                              [this](const ActivityResult&) {
-                               SETTINGS.saveToFile();
+                               // TextSettingsActivity saves on each change; no save needed here.
                                // Font/size/spacing/margin changes invalidate the current
                                // layout: preserve position and force a re-layout, mirroring
                                // applyOrientation()'s reflow.

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -402,7 +402,7 @@ void SettingsActivity::toggleCurrentSetting() {
         startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
                                                                       TextSettingsActivity::Tab::Family),
                                [this](const ActivityResult&) {
-                                 SETTINGS.saveToFile();
+                                 // TextSettingsActivity saves on each change; no save needed here.
                                  rebuildSettingsLists();
                                });
         break;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -339,12 +339,21 @@ void TextSettingsActivity::activateRow(int row) {
     case Tab::Family:
       if (row != currentFamilyIndex_) {
         applyFamily(row);
+        // Persist immediately (like SettingsActivity's per-change saves): the
+        // parent's result callback only runs on a normal finish(), so relying
+        // on it loses the change when this screen is left via the home
+        // gesture/key or a sleep. Saved here, not inside applyFamily, so the
+        // SD write happens outside its RenderLock.
+        if (currentFamilyIndex_ == row) {
+          SETTINGS.saveToFile();
+        }
         requestUpdate();
       }
       break;
     case Tab::Size:
       if (row != currentSizeIndex_) {
         applySize(row);
+        SETTINGS.saveToFile();
         requestUpdate();
       }
       break;
@@ -373,17 +382,23 @@ void TextSettingsActivity::confirmLayoutRow(int row) {
   switch (static_cast<LayoutRow>(row)) {
     case LayoutRow::ParaSpacing:
       SETTINGS.extraParagraphSpacing = !SETTINGS.extraParagraphSpacing;
+      SETTINGS.saveToFile();
       requestUpdate();
       break;
     case LayoutRow::LineSpacing:
       optionPopup_.show(StrId::STR_LINE_SPACING, LINE_SPACING_IDS, static_cast<int>(std::size(LINE_SPACING_IDS)),
-                        SETTINGS.lineSpacing, [](int idx) { SETTINGS.lineSpacing = static_cast<uint8_t>(idx); });
+                        SETTINGS.lineSpacing, [](int idx) {
+                          SETTINGS.lineSpacing = static_cast<uint8_t>(idx);
+                          SETTINGS.saveToFile();
+                        });
       requestUpdate();
       break;
     case LayoutRow::Alignment:
       optionPopup_.show(StrId::STR_ALIGNMENT, ALIGNMENT_IDS, static_cast<int>(std::size(ALIGNMENT_IDS)),
-                        SETTINGS.paragraphAlignment,
-                        [](int idx) { SETTINGS.paragraphAlignment = static_cast<uint8_t>(idx); });
+                        SETTINGS.paragraphAlignment, [](int idx) {
+                          SETTINGS.paragraphAlignment = static_cast<uint8_t>(idx);
+                          SETTINGS.saveToFile();
+                        });
       requestUpdate();
       break;
     case LayoutRow::ScreenMargin: {
@@ -391,8 +406,10 @@ void TextSettingsActivity::confirmLayoutRow(int row) {
       options.reserve((MARGIN_MAX - MARGIN_MIN) / MARGIN_STEP + 1);
       for (int m = MARGIN_MIN; m <= MARGIN_MAX; m += MARGIN_STEP) options.push_back(std::to_string(m));
       const int cur = (std::clamp<int>(SETTINGS.screenMargin, MARGIN_MIN, MARGIN_MAX) - MARGIN_MIN) / MARGIN_STEP;
-      optionPopup_.show(StrId::STR_SCREEN_MARGIN, options, cur,
-                        [](int idx) { SETTINGS.screenMargin = static_cast<uint8_t>(MARGIN_MIN + idx * MARGIN_STEP); });
+      optionPopup_.show(StrId::STR_SCREEN_MARGIN, options, cur, [](int idx) {
+        SETTINGS.screenMargin = static_cast<uint8_t>(MARGIN_MIN + idx * MARGIN_STEP);
+        SETTINGS.saveToFile();
+      });
       requestUpdate();
       break;
     }
@@ -440,6 +457,7 @@ void TextSettingsActivity::confirmStyleRow(int row) {
     default:
       return;
   }
+  SETTINGS.saveToFile();
   requestUpdate();
 }
 


### PR DESCRIPTION
Previously, text settings were only saved when the activity finished normally, causing changes to be lost when exiting via home gesture or sleep. Now each setting change (font family, line spacing, paragraph alignment, screen margin) immediately persists to disk, matching the behavior of other settings screens.