### PR TITLE
fix: avoid duplicate OTA update actions

### DIFF
--- a/src/activities/settings/OtaUpdateActivity.cpp
+++ b/src/activities/settings/OtaUpdateActivity.cpp
@@ -126,13 +126,15 @@ void OtaUpdateActivity::render(RenderLock&&) {
     renderer.drawText(UI_10_FONT_ID, metrics.contentSidePadding, top + height * 2 + metrics.verticalSpacing * 2,
                       (std::string(tr(STR_NEW_VERSION)) + updater.getLatestVersion()).c_str());
 
-    const auto actionRects = getOtaActionRects(renderer);
-    const int cancelTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_CANCEL));
-    renderer.drawText(UI_10_FONT_ID, actionRects.cancel.x + (actionRects.cancel.width - cancelTextWidth) / 2,
-                      actionRects.cancel.y + 28, tr(STR_CANCEL));
-    const int updateTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_UPDATE));
-    renderer.drawText(UI_10_FONT_ID, actionRects.update.x + (actionRects.update.width - updateTextWidth) / 2,
-                      actionRects.update.y + 28, tr(STR_UPDATE));
+    if (mappedInput.hasTouch()) {
+      const auto actionRects = getOtaActionRects(renderer);
+      const int cancelTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_CANCEL));
+      renderer.drawText(UI_10_FONT_ID, actionRects.cancel.x + (actionRects.cancel.width - cancelTextWidth) / 2,
+                        actionRects.cancel.y + 28, tr(STR_CANCEL));
+      const int updateTextWidth = renderer.getTextWidth(UI_10_FONT_ID, tr(STR_UPDATE));
+      renderer.drawText(UI_10_FONT_ID, actionRects.update.x + (actionRects.update.width - updateTextWidth) / 2,
+                        actionRects.update.y + 28, tr(STR_UPDATE));
+    }
 
     const auto labels = mappedInput.mapLabels(tr(STR_CANCEL), tr(STR_UPDATE), "", "");
     GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
Fix duplicate Cancel and Update actions on the OTA update confirmation screen for devices without touch input.
* **What changes are included?**
  - Render the large bottom-screen Cancel and Update action labels only when touch input is available.
  - Preserve the existing mapped physical-button hints on non-touch devices.
  - Preserve the existing touch hit areas and button input handling.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.


## Additional Context

This is a small UI regression fix for existing CrossPoint functionality rather than a new capability. The touch actions were added alongside the existing physical-button hints, causing both sets of labels to be rendered on non-touch devices.

On the OTA confirmation screen, the large Cancel and Update labels are intended to represent touch targets. The screen also renders mapped physical-button hints through `drawButtonHints()`.

`drawButtonHints()` already suppresses physical-button hints on touch devices. This PR applies the complementary condition to the large touch labels, so each device type displays only its appropriate controls:

- Touch devices: large tappable Cancel and Update actions.
- Non-touch devices: mapped physical-button hints.

Input handling remains unchanged for both device types.

<img width="300" height="512" alt="image" src="https://github.com/user-attachments/assets/19ea3c19-62ec-4ed2-b798-2963d60200c1" />



---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES **_
