### PR TITLE
fix: recognize watchdog-triggered resets as panics

### DIFF
--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -148,7 +148,8 @@ std::string getPanicInfo(bool full) {
 
 bool isRebootFromPanic() {
   const auto resetReason = esp_reset_reason();
-  return resetReason == ESP_RST_PANIC || resetReason == ESP_RST_CPU_LOCKUP;
+  return resetReason == ESP_RST_PANIC || resetReason == ESP_RST_CPU_LOCKUP || resetReason == ESP_RST_INT_WDT ||
+         resetReason == ESP_RST_TASK_WDT || resetReason == ESP_RST_WDT;
 }
 
 }  // namespace HalSystem


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** `HalSystem::isRebootFromPanic()` only checks `esp_reset_reason()` for `ESP_RST_PANIC` and `ESP_RST_CPU_LOCKUP`. A watchdog-triggered reset (`ESP_RST_TASK_WDT`, `ESP_RST_INT_WDT`, `ESP_RST_WDT` — all enabled with panic-on-timeout in this project's sdkconfig) is not recognized as a panic, so the existing crash-report machinery (`HalSystem::checkPanic()`, the on-boot Crash screen) never runs for that reset cause. The device just reboots silently to Home with no diagnostic trail.
* **What changes are included?** Widen the `isRebootFromPanic()` check to also match `ESP_RST_INT_WDT`, `ESP_RST_TASK_WDT`, and `ESP_RST_WDT`.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This is a bug fix in existing crash-diagnostic infrastructure, not new user-facing functionality.
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

This PR touches `lib/hal/HalSystem.cpp`. I have not coordinated with a maintainer beforehand. The change is a single-line widening of an existing enum comparison in a function whose only callers are the existing panic-dump path (`checkPanic()`) and the boot-time log-clearing path (`begin()`) — it does not touch peripheral drivers, the bootloader, OTA, or recovery code.

## Testing performed

Verified live on an X4 while tracking down a separate bug (see the companion PR fixing the actual crash trigger, and the PR adding the `CMD:WIFI` serial debug command used to drive this without physical button access):

- Reproduced a real watchdog panic (device wedged inside the web server under concurrent HTTP requests). Reset reason was `ESP_RST_TASK_WDT`. Before this fix, `isRebootFromPanic()` returned `false` and no crash report was written. After this fix, the next boot correctly showed the Crash screen and wrote `/crash_report.txt` to the SD card with the preserved last-logs/stack trace.
- `pio run` builds clean.

## Additional Context

Related: #2686 also touches `lib/hal/HalSystem.cpp`'s panic-capture code (decoding `mcause` into `panicMessage` for raw faults) — different function (`__wrap_panic_print_backtrace` vs `isRebootFromPanic`), should merge without conflict either order, but flagging since it's the same file.

Memory/flash impact: none (widens an existing boolean comparison, no new state).

---

### AI Usage

YES — diagnosed and fixed by Claude (Sonnet 5) while investigating a user-reported "WiFi session crashes and returns to the main menu" bug, driving a real device via serial/network tools.