### PR TITLE
feat: add CMD:WIFI serial debug command

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,8 +32,10 @@
 #include "components/UITheme.h"
 #include "fontIds.h"
 #include "images/LoadingIcon.h"
+#include "network/CrossPointWebServer.h"
 #include "util/ButtonNavigator.h"
 #include "util/ScreenshotUtil.h"
+#include "util/TaskWatchdog.h"
 
 GfxRenderer renderer(display);
 MappedInputManager mappedInputManager(gpio, renderer);
@@ -42,6 +44,13 @@ FontDecompressor fontDecompressor;
 SdCardFontSystem sdFontSystem;
 FontCacheManager fontCacheManager(renderer.getFontMap(), renderer.getSdCardFonts());
 static unsigned long allowSleepAt = 0;
+
+// Debug hook: CMD:WIFI:<ssid>:<password> over serial joins WiFi and starts
+// the web server directly, bypassing on-device button navigation. Useful for
+// exercising the web server (e.g. reproducing network-related bugs) without
+// physical access to the device.
+static bool debugWifiConnecting = false;
+static std::unique_ptr<CrossPointWebServer> debugWebServer;
 
 // Fonts
 EpdFont notoserif14RegularFont(&notoserif_14_regular);
@@ -486,14 +495,56 @@ void loop() {
         uint8_t* buf = display.getFrameBuffer();
         logSerial.write(buf, bufferSize);
         logSerial.printf("SCREENSHOT_END\n");
+      } else if (cmd.startsWith("WIFI:")) {
+        const String rest = cmd.substring(5);
+        const int sep = rest.indexOf(':');
+        if (sep < 0) {
+          LOG_ERR("DEBUGHOOK", "Usage: CMD:WIFI:<ssid>:<password>");
+        } else {
+          const String ssid = rest.substring(0, sep);
+          const String password = rest.substring(sep + 1);
+          LOG_INF("DEBUGHOOK", "Connecting to WiFi SSID '%s'", ssid.c_str());
+          powerManager.setPowerSaving(false);  // avoid WiFi init during clock-scaled low-power mode
+          WiFi.mode(WIFI_STA);
+          WiFi.begin(ssid.c_str(), password.c_str());
+          debugWifiConnecting = true;
+        }
       }
+    }
+  }
+
+  // Debug hook: poll WiFi connection state and start the web server once
+  // joined, then pump handleClient() every loop tick.
+  if (debugWifiConnecting) {
+    if (WiFi.status() == WL_CONNECTED) {
+      debugWifiConnecting = false;
+      LOG_INF("DEBUGHOOK", "WiFi connected, IP=%s", WiFi.localIP().toString().c_str());
+      debugWebServer.reset(new CrossPointWebServer());
+      debugWebServer->begin();
+      LOG_INF("DEBUGHOOK", "Web server running: %d", debugWebServer->isRunning());
+    } else {
+      static unsigned long lastWifiLog = 0;
+      if (millis() - lastWifiLog > 2000) {
+        lastWifiLog = millis();
+        LOG_DBG("DEBUGHOOK", "WiFi status: %d", WiFi.status());
+      }
+    }
+  }
+  if (debugWebServer && debugWebServer->isRunning()) {
+    // Mirror CrossPointWebServerActivity::loop()'s watchdog-safe burst
+    // handling so this debug hook doesn't trip the watchdog on its own.
+    resetTaskWatchdogIfSubscribed();
+    for (int i = 0; i < 500 && debugWebServer->isRunning(); i++) {
+      debugWebServer->handleClient();
+      if ((i & 0x1F) == 0x1F) resetTaskWatchdogIfSubscribed();
+      if ((i & 0x3F) == 0x3F) yield();
     }
   }
 
   // Check for any user activity (button press or release) or active background work
   static unsigned long lastActivityTime = millis();
   if (gpio.wasAnyPressed() || gpio.wasAnyReleased() || gpio.wasTouchActivity() || halTiltSensor.hadActivity() ||
-      activityManager.preventAutoSleep()) {
+      activityManager.preventAutoSleep() || (debugWebServer && debugWebServer->isRunning())) {
     lastActivityTime = millis();         // Reset inactivity timer
     powerManager.setPowerSaving(false);  // Restore normal CPU frequency on user activity
   }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let the web server be exercised from a host machine over serial without physical button access to the device — useful for reproducing and diagnosing network-related bugs (this is what let me track down the crash fixed in a companion PR without hands on the hardware).
* **What changes are included?** Adds `CMD:WIFI:<ssid>:<password>` alongside the existing `CMD:SCREENSHOT` serial command in `main.cpp`. It joins WiFi and starts the web server directly, bypassing the on-device Network Mode / Wi-Fi Selection activities. Mirrors `CrossPointWebServerActivity::loop()`'s watchdog-safe burst handling for `handleClient()` (reset every 32 iterations, yield every 64) so the debug hook doesn't trip the watchdog on its own, and disables power-saving / feeds the inactivity timer while the debug server is running so the device doesn't clock down or auto-sleep out from under it.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector — it doesn't add any new user-facing network feature, it's a developer/debug-only serial command.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This extends existing debug tooling (the `CMD:SCREENSHOT` serial command) rather than duplicating something the firmware already does.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code (only `src/main.cpp`).

## Testing performed

Verified live on an X4:

- `CMD:WIFI:<ssid>:<password>` reliably joins WiFi and starts the web server, confirmed via `/api/status` over HTTP from a host machine.
- Used it to drive dozens of test requests (single-shot, concurrent, and a 60-request hammer loop) against the web server across ~40 minutes of testing, including deliberately reproducing a watchdog crash under concurrent load and reconnecting afterward, with no issues attributable to the debug hook itself (isolated by first confirming it mirrors the real activity's watchdog-petting cadence).
- `pio run` builds clean; `clang-format` produces no diff beyond the new code.

## Additional Context

Memory/flash impact: negligible — one `bool`, one `unique_ptr<CrossPointWebServer>` (null until the command is used), and the added command-handling branch.

Risk: low. The new code path only activates when `CMD:WIFI:...` is received over serial (requires physical/USB access to the device already); it doesn't change any existing behavior when unused. Note this touches the same `if (cmd == "SCREENSHOT")` region of `main.cpp` as #2688 (byte-loss fix for the existing `CMD:SCREENSHOT` command) — different command, adjacent code, should merge fine either order but flagging for awareness.

---

### AI Usage

YES — written by Claude (Sonnet 5) as a debugging tool while investigating a user-reported crash, then cleaned up into a standalone PR.