### PR TITLE
feat: render HTML dictionary definitions via EPUB engine

### DIFF
--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -13,7 +13,7 @@ A dictionary folder must contain:
 - `.syn` — synonym index (optional; maps alternate spellings and irregular forms to their headword)
 - `.ifo` — metadata (optional)
 
-Not supported: dictionaries with 64-bit index offsets (`idxoffsetbits=64` in the `.ifo` — rare, and rejected with an error), and HTML-formatted definitions render as raw markup rather than styled text.
+Not supported: dictionaries with 64-bit index offsets (`idxoffsetbits=64` in the `.ifo` — rare, and rejected with an error).
 
 ## Setting Up a Dictionary
 
@@ -48,6 +48,8 @@ On the very first lookup with a dictionary (and again whenever the `.idx` or `.s
 ## The Definition Screen
 
 When a word is found, the definition screen shows the matched headword at the top and the definition text below, with a page counter for long definitions.
+
+HTML dictionaries that declare `sametypesequence=h` use the EPUB text-layout engine for semantic formatting such as headings, bold, italics, lists, and line breaks. Images and CSS styling are ignored. Definitions that are too large or cannot be laid out within the available memory fall back to plain text.
 
 - **Left/Right** or side **Up/Down** — previous / next page
 - **Back** — return to word selection

--- a/src/activities/reader/DictionaryDefinitionActivity.cpp
+++ b/src/activities/reader/DictionaryDefinitionActivity.cpp
@@ -11,6 +11,7 @@
 #include "CrossPointSettings.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/DictHtmlPages.h"
 #include "util/HtmlToPlainText.h"
 
 namespace {
@@ -22,6 +23,13 @@ constexpr size_t MAX_LINE_BYTES = 191;
 // Body text left/right inset, matching the reader's default feel.
 constexpr int SIDE_PADDING = 20;
 
+// Styled-path ceiling: the laid-out Pages keep the whole definition resident
+// (TextBlock arenas ≈ text + ~7 bytes/word plus per-line objects), roughly
+// doubling the string's footprint while this activity is stacked over the
+// reader and word-select. Bigger definitions take the span-based plain-text
+// path, which holds no per-page copies.
+constexpr size_t MAX_STYLED_HTML_BYTES = 16 * 1024;
+
 }  // namespace
 
 void DictionaryDefinitionActivity::onEnter() {
@@ -29,9 +37,41 @@ void DictionaryDefinitionActivity::onEnter() {
   // Normalize StarDict multi-type separators so the wrap loop and the
   // C-string font APIs below both see the whole definition.
   std::replace(definition.begin(), definition.end(), '\0', '\n');
-  definition = htmlToPlainText(definition);
-  wrapText();
+  if (!(htmlDefinition && definition.size() <= MAX_STYLED_HTML_BYTES && layoutHtmlPages())) {
+    definition = htmlToPlainText(definition);
+    wrapText();
+  }
   requestUpdate();
+}
+
+DictionaryDefinitionActivity::BodyArea DictionaryDefinitionActivity::bodyArea() const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const auto orientation = renderer.getOrientation();
+  const bool isLandscape = orientation == GfxRenderer::Orientation::LandscapeClockwise ||
+                           orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
+  const bool isInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
+  const int hintGutterWidth = isLandscape ? metrics.sideButtonHintsWidth : 0;
+  const int topArea = (isInverted ? metrics.buttonHintsHeight : 0) + metrics.topPadding + metrics.headerHeight;
+  const int bottomArea = metrics.buttonHintsHeight + metrics.verticalSpacing;
+  return {renderer.getScreenWidth() - hintGutterWidth - 2 * SIDE_PADDING,
+          renderer.getScreenHeight() - topArea - bottomArea};
+}
+
+// Styled path: lay the HTML definition out through the EPUB chapter parser
+// into reader-identical Pages. Frees `definition` on success (the page arenas
+// own the text); any failure leaves state untouched for the plain-text path.
+bool DictionaryDefinitionActivity::layoutHtmlPages() {
+  const BodyArea body = bodyArea();
+  if (body.width <= 0 || body.height <= 0) return false;
+  if (!buildDictionaryHtmlPages(renderer, definition, static_cast<uint16_t>(body.width),
+                                static_cast<uint16_t>(body.height), pages)) {
+    return false;
+  }
+  definition.clear();
+  definition.shrink_to_fit();
+  totalPages = static_cast<int>(pages.size());
+  currentPage = 0;
+  return true;
 }
 
 int DictionaryDefinitionActivity::measureSpan(const int fontId, const char* text, size_t len) const {
@@ -56,19 +96,11 @@ void DictionaryDefinitionActivity::wrapText() {
   // falls back to an on-demand glyph load from SD (8-slot overflow ring).
   renderer.ensureSdCardFontReady(fontId, definition.c_str(), 0x01 /* REGULAR */);
 
-  const auto& metrics = UITheme::getInstance().getMetrics();
-  const auto orientation = renderer.getOrientation();
-  const bool isLandscape = orientation == GfxRenderer::Orientation::LandscapeClockwise ||
-                           orientation == GfxRenderer::Orientation::LandscapeCounterClockwise;
-  const bool isInverted = orientation == GfxRenderer::Orientation::PortraitInverted;
-  const int hintGutterWidth = isLandscape ? metrics.sideButtonHintsWidth : 0;
-  const int maxWidth = renderer.getScreenWidth() - hintGutterWidth - 2 * SIDE_PADDING;
+  const BodyArea body = bodyArea();
+  const int maxWidth = body.width;
   const int spaceWidth = renderer.getSpaceWidth(fontId, EpdFontFamily::REGULAR);
-
   const int lineHeight = renderer.getLineHeight(fontId);
-  const int topArea = (isInverted ? metrics.buttonHintsHeight : 0) + metrics.topPadding + metrics.headerHeight;
-  const int bottomArea = metrics.buttonHintsHeight + metrics.verticalSpacing;
-  linesPerPage = std::max(1, (renderer.getScreenHeight() - topArea - bottomArea) / lineHeight);
+  linesPerPage = std::max(1, body.height / lineHeight);
 
   const char* text = definition.c_str();
   const uint32_t n = static_cast<uint32_t>(definition.size());
@@ -196,10 +228,15 @@ void DictionaryDefinitionActivity::loop() {
   });
 }
 
-// Draws the current page's line spans (copied into a stack buffer for NUL
+// Draws the current page: a styled Page when the HTML layout succeeded,
+// otherwise the wrapped line spans (copied into a stack buffer for NUL
 // termination). Called twice per render: once in font-cache scan mode, once
 // for the real paint.
 void DictionaryDefinitionActivity::drawBody(const int fontId, const int x, const int startY) const {
+  if (!pages.empty()) {
+    pages[currentPage]->render(renderer, fontId, x, startY);
+    return;
+  }
   const int lineHeight = renderer.getLineHeight(fontId);
   char buf[MAX_LINE_BYTES + 1];
   const int firstLine = currentPage * linesPerPage;

--- a/src/activities/reader/DictionaryDefinitionActivity.h
+++ b/src/activities/reader/DictionaryDefinitionActivity.h
@@ -1,22 +1,27 @@
 #pragma once
 
+#include <Epub/Page.h>
+
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "activities/Activity.h"
 #include "util/ButtonNavigator.h"
 
-// Paged plain-text viewer for one dictionary definition. The definition is
-// word-wrapped once on entry; each page renders spans of the original string,
-// so no per-line copies are held.
+// Paged viewer for one dictionary definition. HTML definitions are laid out
+// through the EPUB chapter parser into styled Pages; anything else (plain
+// text, or HTML too damaged to parse) is word-wrapped once on entry and each
+// page renders spans of the original string, so no per-line copies are held.
 class DictionaryDefinitionActivity final : public Activity {
  public:
   explicit DictionaryDefinitionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, std::string headword,
-                                        std::string definition)
+                                        std::string definition, bool htmlDefinition = false)
       : Activity("DictionaryDefinition", renderer, mappedInput),
         headword(std::move(headword)),
-        definition(std::move(definition)) {}
+        definition(std::move(definition)),
+        htmlDefinition(htmlDefinition) {}
 
   void onEnter() override;
   void loop() override;
@@ -33,6 +38,14 @@ class DictionaryDefinitionActivity final : public Activity {
     uint16_t len;
   };
 
+  // Usable body-text area between the header and the button hints.
+  struct BodyArea {
+    int width;
+    int height;
+  };
+
+  BodyArea bodyArea() const;
+  bool layoutHtmlPages();
   void wrapText();
   int measureSpan(int fontId, const char* text, size_t len) const;
   void drawBody(int fontId, int x, int startY) const;
@@ -41,6 +54,10 @@ class DictionaryDefinitionActivity final : public Activity {
   // Not const: onEnter() normalizes embedded NULs (StarDict multi-type
   // separators) to newlines so C-string APIs see the whole text.
   std::string definition;
+  const bool htmlDefinition;
+  // Styled path: reader-identical Pages laid out from the HTML definition.
+  // Empty means the plain-text span path below is active.
+  std::vector<std::unique_ptr<Page>> pages;
   std::vector<Line> lines;
   int currentPage = 0;
   int totalPages = 1;

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -177,9 +177,10 @@ void DictionaryWordSelectActivity::performLookup() {
 
   if (found) {
     popup = Popup::None;
-    startActivityForResult(std::make_unique<DictionaryDefinitionActivity>(renderer, mappedInput, std::move(headword),
-                                                                          std::move(definition)),
-                           [this](const ActivityResult&) { requestUpdate(); });
+    startActivityForResult(
+        std::make_unique<DictionaryDefinitionActivity>(renderer, mappedInput, std::move(headword),
+                                                       std::move(definition), dict.definitionsAreHtml()),
+        [this](const ActivityResult&) { requestUpdate(); });
     return;
   }
   // Name the failure: a genuine miss is "Not found"; a word that WAS found but

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -1,0 +1,190 @@
+#include "DictHtmlPages.h"
+
+#include <Epub/parsers/ChapterHtmlSlimParser.h>
+#include <HalStorage.h>
+#include <Logging.h>
+#include <Memory.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+#include "CrossPointSettings.h"
+
+namespace {
+
+// Normalized XHTML staged here for the file-driven parser; truncated on each
+// use, removed after the parse.
+constexpr const char* TMP_HTML_PATH = "/.crosspoint/dicthtml.tmp";
+
+// HTML void elements: legal without a closing tag in HTML, but must be
+// self-closed to be well-formed XML.
+bool isVoidElement(const char* name, const size_t len) {
+  static constexpr const char* VOID_ELEMENTS[] = {"area",  "base", "br",   "col",   "embed",  "hr",    "img",
+                                                  "input", "link", "meta", "param", "source", "track", "wbr"};
+  return std::any_of(std::begin(VOID_ELEMENTS), std::end(VOID_ELEMENTS),
+                     [name, len](const char* v) { return strlen(v) == len && strncmp(v, name, len) == 0; });
+}
+
+// True for a well-formed entity reference at html[pos] ('&'): &name; &#123;
+// or &#x1F;. On success *end is the index of the ';'.
+bool isEntityRef(const std::string& html, const size_t pos, size_t* end) {
+  size_t j = pos + 1;
+  const size_t n = html.size();
+  if (j < n && html[j] == '#') {
+    j++;
+    if (j < n && (html[j] == 'x' || html[j] == 'X')) j++;
+    const size_t digits = j;
+    while (j < n && std::isxdigit(static_cast<unsigned char>(html[j]))) j++;
+    if (j == digits) return false;
+  } else {
+    const size_t letters = j;
+    while (j < n && std::isalnum(static_cast<unsigned char>(html[j]))) j++;
+    if (j == letters) return false;
+  }
+  if (j >= n || html[j] != ';') return false;
+  *end = j;
+  return true;
+}
+
+// StarDict HTML is tag soup; expat is a strict XML parser. Produce a
+// well-formed XHTML document from the fragment: wrap it in a root element,
+// lowercase tag names (XML is case-sensitive and the parser matches
+// lowercase), self-close void elements (<br> → <br/>), drop stray void
+// closers (</br>) and <!…>/<?…> constructs, and escape '&'/'<' characters
+// that are not part of markup. Structural damage this cannot repair
+// (mismatched tags, unquoted attribute values) surfaces as a parse error and
+// the caller falls back to the plain-text path.
+std::string normalizeToXhtml(const std::string& html) {
+  std::string out;
+  out.reserve(html.size() + html.size() / 8 + 32);
+  out += "<html><body>";
+
+  const size_t n = html.size();
+  size_t i = 0;
+  while (i < n) {
+    const char c = html[i];
+    if (c == '<' && i + 1 < n && (html[i + 1] == '!' || html[i + 1] == '?')) {
+      // Comment, doctype or processing instruction: drop it entirely.
+      const bool isComment = html.compare(i, 4, "<!--") == 0;
+      const size_t j = isComment ? html.find("-->", i + 4) : html.find('>', i);
+      i = (j == std::string::npos) ? n : j + (isComment ? 3 : 1);
+      continue;
+    }
+    if (c == '<' && i + 1 < n && (html[i + 1] == '/' || std::isalpha(static_cast<unsigned char>(html[i + 1])))) {
+      // Find the tag end, honouring quoted attribute values.
+      size_t j = i + 1;
+      char quote = 0;
+      while (j < n) {
+        const char d = html[j];
+        if (quote) {
+          if (d == quote) quote = 0;
+        } else if (d == '"' || d == '\'') {
+          quote = d;
+        } else if (d == '>') {
+          break;
+        }
+        j++;
+      }
+      if (j == n) {  // unterminated tag: treat the '<' as literal text
+        out += "&lt;";
+        i++;
+        continue;
+      }
+
+      const bool closing = html[i + 1] == '/';
+      const size_t nameStart = i + (closing ? 2 : 1);
+      size_t nameEnd = nameStart;
+      char nameBuf[16];
+      size_t nameLen = 0;
+      while (nameEnd < j && std::isalnum(static_cast<unsigned char>(html[nameEnd]))) {
+        if (nameLen < sizeof(nameBuf) - 1) {
+          nameBuf[nameLen++] = static_cast<char>(std::tolower(static_cast<unsigned char>(html[nameEnd])));
+        }
+        nameEnd++;
+      }
+      const bool isVoid = isVoidElement(nameBuf, nameLen);
+      if (closing && isVoid) {  // "</br>" — no XML equivalent, drop it
+        i = j + 1;
+        continue;
+      }
+      out += '<';
+      if (closing) out += '/';
+      out.append(nameBuf, nameLen);
+      out.append(html, nameEnd, j - nameEnd);  // attributes verbatim
+      if (!closing && isVoid && html[j - 1] != '/') out += '/';
+      out += '>';
+      i = j + 1;
+      continue;
+    }
+    if (c == '<') {  // stray '<' in text ("x < y")
+      out += "&lt;";
+      i++;
+      continue;
+    }
+    if (c == '&') {
+      size_t entityEnd = 0;
+      if (isEntityRef(html, i, &entityEnd)) {
+        out.append(html, i, entityEnd - i + 1);
+        i = entityEnd + 1;
+      } else {  // bare ampersand ("Tom & Jerry")
+        out += "&amp;";
+        i++;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+
+  out += "</body></html>";
+  return out;
+}
+
+}  // namespace
+
+bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definition, const uint16_t viewportWidth,
+                              const uint16_t viewportHeight, std::vector<std::unique_ptr<Page>>& pagesOut) {
+  const std::string xhtml = normalizeToXhtml(definition);
+
+  {
+    HalFile tmp = Storage.open(TMP_HTML_PATH, O_WRITE | O_CREAT | O_TRUNC);
+    if (!tmp) {
+      LOG_ERR("DHTML", "Cannot create %s", TMP_HTML_PATH);
+      return false;
+    }
+    if (tmp.write(xhtml.data(), xhtml.size()) != static_cast<int>(xhtml.size())) {
+      LOG_ERR("DHTML", "Short write to %s", TMP_HTML_PATH);
+      return false;
+    }
+  }  // destructor closes the file before the parser reopens the same path
+
+  pagesOut.clear();
+  pagesOut.reserve(definition.size() / 800 + 4);  // ~a screenful of body text per page
+
+  bool ok = false;
+  {
+    const std::string tmpPath = TMP_HTML_PATH;  // the parser stores a reference
+    // Heap-allocated as Section does — the parser object is far too large for
+    // a stack local. Null epub is safe: imageRendering=2 suppresses <img>
+    // handling, the only path that dereferences it.
+    auto parser = makeUniqueNoThrow<ChapterHtmlSlimParser>(
+        nullptr, tmpPath, renderer, SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
+        SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth, viewportHeight,
+        SETTINGS.hyphenationEnabled, SETTINGS.focusReadingEnabled,
+        [&pagesOut](std::unique_ptr<Page> page, uint16_t, uint16_t, uint32_t) { pagesOut.push_back(std::move(page)); },
+        /*embeddedStyle=*/false, /*contentBase=*/"", /*imageBasePath=*/"", /*imageRendering=*/2);
+    if (!parser) {
+      LOG_ERR("DHTML", "OOM: ChapterHtmlSlimParser");
+    } else {
+      ok = parser->parseAndBuildPages();  // closes the file on both outcomes
+    }
+  }
+  Storage.remove(TMP_HTML_PATH);
+
+  if (!ok || pagesOut.empty()) {
+    pagesOut.clear();
+    return false;
+  }
+  return true;
+}

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -1,5 +1,6 @@
 #include "DictHtmlPages.h"
 
+#include <Arduino.h>
 #include <Epub/parsers/ChapterHtmlSlimParser.h>
 #include <HalStorage.h>
 #include <Logging.h>
@@ -16,6 +17,52 @@ namespace {
 // Normalized XHTML staged here for the file-driven parser; truncated on each
 // use, removed after the parse.
 constexpr const char* TMP_HTML_PATH = "/.crosspoint/dicthtml.tmp";
+
+// Keep enough contiguous heap for the parser's 16KB SD-font advance scratch
+// plus page/layout allocations. Falling back to plain text is cheaper than
+// entering a throwing allocation path under pressure.
+constexpr size_t MIN_STYLED_FREE_HEAP = 40 * 1024;
+constexpr size_t MIN_STYLED_MAX_ALLOC = 20 * 1024;
+
+// Bound retained layout independently of input bytes: compact markup can emit
+// far more objects than its source size suggests.
+constexpr size_t MAX_STYLED_PAGES = 64;
+constexpr size_t MAX_STYLED_PAGE_ELEMENTS = 512;
+
+class BufferedFileWriter {
+ public:
+  explicit BufferedFileWriter(HalFile& file) : file(file) {}
+
+  bool append(const char c) { return append(&c, 1); }
+
+  bool append(const char* data, size_t len) {
+    while (len > 0) {
+      const size_t available = sizeof(buffer) - used;
+      const size_t chunk = std::min(available, len);
+      memcpy(buffer + used, data, chunk);
+      used += chunk;
+      data += chunk;
+      len -= chunk;
+      if (used == sizeof(buffer) && !flush()) return false;
+    }
+    return true;
+  }
+
+  bool append(const char* text) { return append(text, strlen(text)); }
+
+  bool flush() {
+    if (used == 0) return true;
+    if (file.write(buffer, used) != used) return false;
+    used = 0;
+    return true;
+  }
+
+ private:
+  HalFile& file;
+  // Fixed stack staging avoids an expansion-sized XHTML heap allocation.
+  char buffer[128] = {};
+  size_t used = 0;
+};
 
 // HTML void elements: legal without a closing tag in HTML, but must be
 // self-closed to be well-formed XML.
@@ -55,10 +102,9 @@ bool isEntityRef(const std::string& html, const size_t pos, size_t* end) {
 // that are not part of markup. Structural damage this cannot repair
 // (mismatched tags, unquoted attribute values) surfaces as a parse error and
 // the caller falls back to the plain-text path.
-std::string normalizeToXhtml(const std::string& html) {
-  std::string out;
-  out.reserve(html.size() + html.size() / 8 + 32);
-  out += "<html><body>";
+bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
+  BufferedFileWriter out(file);
+  if (!out.append("<html><body>")) return false;
 
   const size_t n = html.size();
   size_t i = 0;
@@ -87,7 +133,7 @@ std::string normalizeToXhtml(const std::string& html) {
         j++;
       }
       if (j == n) {  // unterminated tag: treat the '<' as literal text
-        out += "&lt;";
+        if (!out.append("&lt;")) return false;
         i++;
         continue;
       }
@@ -108,44 +154,47 @@ std::string normalizeToXhtml(const std::string& html) {
         i = j + 1;
         continue;
       }
-      out += '<';
-      if (closing) out += '/';
-      out.append(nameBuf, nameLen);
-      out.append(html, nameEnd, j - nameEnd);  // attributes verbatim
-      if (!closing && isVoid && html[j - 1] != '/') out += '/';
-      out += '>';
+      if (!out.append('<')) return false;
+      if (closing && !out.append('/')) return false;
+      if (!out.append(nameBuf, nameLen)) return false;
+      if (!out.append(html.data() + nameEnd, j - nameEnd)) return false;  // attributes verbatim
+      if (!closing && isVoid && html[j - 1] != '/' && !out.append('/')) return false;
+      if (!out.append('>')) return false;
       i = j + 1;
       continue;
     }
     if (c == '<') {  // stray '<' in text ("x < y")
-      out += "&lt;";
+      if (!out.append("&lt;")) return false;
       i++;
       continue;
     }
     if (c == '&') {
       size_t entityEnd = 0;
       if (isEntityRef(html, i, &entityEnd)) {
-        out.append(html, i, entityEnd - i + 1);
+        if (!out.append(html.data() + i, entityEnd - i + 1)) return false;
         i = entityEnd + 1;
       } else {  // bare ampersand ("Tom & Jerry")
-        out += "&amp;";
+        if (!out.append("&amp;")) return false;
         i++;
       }
       continue;
     }
-    out += c;
+    if (!out.append(c)) return false;
     i++;
   }
 
-  out += "</body></html>";
-  return out;
+  return out.append("</body></html>") && out.flush();
 }
 
 }  // namespace
 
 bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definition, const uint16_t viewportWidth,
                               const uint16_t viewportHeight, std::vector<std::unique_ptr<Page>>& pagesOut) {
-  const std::string xhtml = normalizeToXhtml(definition);
+  if (ESP.getFreeHeap() < MIN_STYLED_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_STYLED_MAX_ALLOC) {
+    LOG_ERR("DHTML", "Low heap for styled definition (%u free, %u max block)", ESP.getFreeHeap(),
+            ESP.getMaxAllocHeap());
+    return false;
+  }
 
   {
     HalFile tmp = Storage.open(TMP_HTML_PATH, O_WRITE | O_CREAT | O_TRUNC);
@@ -153,16 +202,19 @@ bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definiti
       LOG_ERR("DHTML", "Cannot create %s", TMP_HTML_PATH);
       return false;
     }
-    if (tmp.write(xhtml.data(), xhtml.size()) != static_cast<int>(xhtml.size())) {
+    if (!writeNormalizedXhtml(definition, tmp)) {
       LOG_ERR("DHTML", "Short write to %s", TMP_HTML_PATH);
       return false;
     }
   }  // destructor closes the file before the parser reopens the same path
 
   pagesOut.clear();
-  pagesOut.reserve(definition.size() / 800 + 4);  // ~a screenful of body text per page
+  // One fixed allocation (256 bytes on C3); pages must outlive the parser.
+  pagesOut.reserve(MAX_STYLED_PAGES);
 
   bool ok = false;
+  bool resourceLimitHit = false;
+  size_t retainedElements = 0;
   {
     const std::string tmpPath = TMP_HTML_PATH;  // the parser stores a reference
     // Heap-allocated as Section does — the parser object is far too large for
@@ -172,7 +224,18 @@ bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definiti
         nullptr, tmpPath, renderer, SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
         SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth, viewportHeight,
         SETTINGS.hyphenationEnabled, SETTINGS.focusReadingEnabled,
-        [&pagesOut](std::unique_ptr<Page> page, uint16_t, uint16_t, uint32_t) { pagesOut.push_back(std::move(page)); },
+        [&pagesOut, &resourceLimitHit, &retainedElements](std::unique_ptr<Page> page, uint16_t, uint16_t, uint32_t) {
+          if (resourceLimitHit) return;
+          const size_t pageElements = page->elements.size();
+          if (pagesOut.size() >= MAX_STYLED_PAGES || pageElements > MAX_STYLED_PAGE_ELEMENTS - retainedElements ||
+              ESP.getFreeHeap() < MIN_STYLED_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_STYLED_MAX_ALLOC) {
+            resourceLimitHit = true;
+            pagesOut.clear();
+            return;
+          }
+          retainedElements += pageElements;
+          pagesOut.push_back(std::move(page));
+        },
         /*embeddedStyle=*/false, /*contentBase=*/"", /*imageBasePath=*/"", /*imageRendering=*/2);
     if (!parser) {
       LOG_ERR("DHTML", "OOM: ChapterHtmlSlimParser");
@@ -182,7 +245,10 @@ bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definiti
   }
   Storage.remove(TMP_HTML_PATH);
 
-  if (!ok || pagesOut.empty()) {
+  if (resourceLimitHit) {
+    LOG_ERR("DHTML", "Styled definition exceeded page heap budget");
+  }
+  if (!ok || resourceLimitHit || pagesOut.empty()) {
     pagesOut.clear();
     return false;
   }

--- a/src/util/DictHtmlPages.h
+++ b/src/util/DictHtmlPages.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Epub/Page.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+class GfxRenderer;
+
+// Lays out a StarDict HTML definition through the EPUB chapter parser,
+// yielding the same styled, paginated Pages the reader renders. Returns false
+// when the fragment cannot be normalized into parseable XHTML (or on OOM) —
+// the caller falls back to the plain-text viewer path.
+bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definition, uint16_t viewportWidth,
+                              uint16_t viewportHeight, std::vector<std::unique_ptr<Page>>& pagesOut);

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -64,19 +64,32 @@ uint32_t readBe32(const uint8_t* p) {
 // continuation/lead byte, so accented words keep their edges.
 bool isWordByte(unsigned char c) { return c >= 0x80 || std::isalnum(c) != 0; }
 
-// True when the .ifo declares 64-bit index offsets, which this reader does not
-// support (only scans the first 2KB — idxoffsetbits always appears early).
-bool ifoDeclares64BitOffsets(const std::string& ifoPath) {
+// Facts read from the .ifo at open time. Only the first 2KB is scanned — .ifo
+// headers are tiny and both keys always appear early when present.
+struct IfoFacts {
+  bool offsets64 = false;        // idxoffsetbits=64 (unsupported)
+  bool htmlDefinitions = false;  // sametypesequence=h (definitions are HTML)
+};
+
+IfoFacts readIfoFacts(const std::string& ifoPath) {
+  IfoFacts facts;
   HalFile ifo;
-  if (!Storage.openFileForRead("DICT", ifoPath, ifo)) return false;
+  if (!Storage.openFileForRead("DICT", ifoPath, ifo)) return facts;
   char buf[2048];
   const int n = ifo.read(buf, sizeof(buf) - 1);
-  if (n <= 0) return false;
+  if (n <= 0) return facts;
   buf[n] = '\0';
   const char* line = strstr(buf, "idxoffsetbits");
-  if (!line) return false;
-  const char* eq = strchr(line, '=');
-  return eq && strtol(eq + 1, nullptr, 10) == 64;
+  const char* eq = line ? strchr(line, '=') : nullptr;
+  facts.offsets64 = eq && strtol(eq + 1, nullptr, 10) == 64;
+  line = strstr(buf, "sametypesequence");
+  eq = line ? strchr(line, '=') : nullptr;
+  if (eq) {
+    // Only the single-field sequence "h" is treated as HTML; multi-type
+    // entries keep the plain-text viewing path.
+    facts.htmlDefinitions = eq[1] == 'h' && (eq[2] == '\0' || eq[2] == '\r' || eq[2] == '\n');
+  }
+  return facts;
 }
 
 }  // namespace
@@ -84,6 +97,7 @@ bool ifoDeclares64BitOffsets(const std::string& ifoPath) {
 bool Dictionary::open(const char* folderName) {
   basePath.clear();
   hasSyn = false;
+  htmlDefinitions = false;
   std::string resolved;
   if (!DictionaryRegistry::resolveBasePath(folderName, resolved)) {
     LOG_ERR("DICT", "No dictionary found in folder '%s'", folderName ? folderName : "");
@@ -99,7 +113,8 @@ bool Dictionary::open(const char* folderName) {
     LOG_ERR("DICT", "%s has no .dict or .dict.dz", resolved.c_str());
     return false;
   }
-  if (ifoDeclares64BitOffsets(resolved + ".ifo")) {
+  const IfoFacts ifo = readIfoFacts(resolved + ".ifo");
+  if (ifo.offsets64) {
     LOG_ERR("DICT", "%s uses 64-bit index offsets (unsupported)", resolved.c_str());
     return false;
   }
@@ -110,6 +125,7 @@ bool Dictionary::open(const char* folderName) {
     return false;
   }
   hasSyn = Storage.exists((resolved + ".syn").c_str());
+  htmlDefinitions = ifo.htmlDefinitions;
 
   basePath = std::move(resolved);
   return true;

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -51,6 +51,11 @@ class Dictionary {
   // True when the .qidx sidecar (or the .sidx sidecar of a present .syn) is
   // missing or stale — call buildIndex() first so the UI can show an
   // "Indexing…" message for the slow first pass.
+
+  // True when the .ifo declares sametypesequence=h — definitions are HTML and
+  // the viewer may lay them out through the EPUB rendering pipeline.
+  bool definitionsAreHtml() const { return htmlDefinitions; }
+
   bool needsIndex();
 
   // Why an index build failed — the scan buffer is a heap allocation, so the
@@ -181,6 +186,7 @@ class Dictionary {
   std::string basePath;  // "/dictionaries/<folder>/<stem>", empty when not open
   bool hasPlainDict = false;
   bool hasSyn = false;  // a <stem>.syn synonym index exists next to the .idx
+  bool htmlDefinitions = false;
 
   // Shared scan buffer: lookups are single-threaded and this avoids a
   // 256-byte array on the stack of every locate() call.


### PR DESCRIPTION
## Summary

**What is the goal of this PR?** 

Some dictionaries store their definitions with rich formatting (bold headwords, italics, line breaks) rather than plain text. This change teaches the reader to recognize those dictionaries and display their definitions using the same layout engine that renders books, so the formatting shows up properly instead of appearing as raw markup or cramped text. Plain-text dictionaries continue to work exactly as before, so nothing changes for readers who don't use formatted ones.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
