### PR TITLE
fix: serialize display and SD on the shared SPI bus

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -1,6 +1,8 @@
 #include <HalDisplay.h>
 #include <HalGPIO.h>
 
+#include "HalSpiBus.h"
+
 // Global HalDisplay instance
 HalDisplay display;
 
@@ -11,6 +13,8 @@ HalDisplay::HalDisplay() : einkDisplay(EPD_SCLK, EPD_MOSI, EPD_CS, EPD_DC, EPD_R
 HalDisplay::~HalDisplay() {}
 
 void HalDisplay::begin(bool seamless) {
+  HalSpiBus::Lock spiLock;
+
   // Set X3-specific panel mode before initializing.
   if (gpio.deviceIsX3()) {
     einkDisplay.setDisplayX3();
@@ -58,6 +62,8 @@ EInkDisplay::RefreshMode convertRefreshMode(HalDisplay::RefreshMode mode) {
 }
 
 void HalDisplay::displayBuffer(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);
   }
@@ -78,6 +84,8 @@ void HalDisplay::waitRefreshComplete() { einkDisplay.waitRefreshComplete(); }
 bool HalDisplay::supportsAsyncRefresh() const { return einkDisplay.supportsAsyncRefresh(); }
 
 void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+
   if (gpio.deviceIsX3() && mode == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);
   }
@@ -85,7 +93,10 @@ void HalDisplay::refreshDisplay(HalDisplay::RefreshMode mode, bool turnOffScreen
   einkDisplay.refreshDisplay(convertRefreshMode(mode), turnOffScreen);
 }
 
-void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
+void HalDisplay::deepSleep() {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.deepSleep();
+}
 
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
@@ -124,9 +135,13 @@ void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay
 
 void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
 
-void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
+void HalDisplay::displayGrayBuffer(bool turnOffScreen) {
+  HalSpiBus::Lock spiLock;
+  einkDisplay.displayGrayBuffer(turnOffScreen);
+}
 
 void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
+  HalSpiBus::Lock spiLock;
   einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,
                                        yStart, numRows);
 }

--- a/lib/hal/HalSpiBus.cpp
+++ b/lib/hal/HalSpiBus.cpp
@@ -1,0 +1,34 @@
+#include "HalSpiBus.h"
+
+#include <Logging.h>
+
+HalSpiBus::HalSpiBus() {
+  mutex = xSemaphoreCreateRecursiveMutex();
+  if (mutex == nullptr) {
+    LOG_ERR("SPI", "Failed to create SPI bus mutex - bus is unusable");
+  }
+}
+
+HalSpiBus& HalSpiBus::getInstance() {
+  static HalSpiBus spiBus;
+  return spiBus;
+}
+
+HalSpiBus::Lock::Lock() {
+  auto& bus = HalSpiBus::getInstance();
+  if (bus.mutex == nullptr) {
+    LOG_ERR("SPI", "SPI bus mutex not initialized, skipping lock");
+    return;
+  }
+  const BaseType_t takeResult = xSemaphoreTakeRecursive(bus.mutex, portMAX_DELAY);
+  if (takeResult != pdTRUE) {
+    LOG_ERR("SPI", "Failed to acquire SPI bus mutex");
+    return;
+  }
+  acquired = true;
+}
+
+HalSpiBus::Lock::~Lock() {
+  if (!acquired) return;
+  xSemaphoreGiveRecursive(HalSpiBus::getInstance().mutex);
+}

--- a/lib/hal/HalSpiBus.h
+++ b/lib/hal/HalSpiBus.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+// Serializes access to the SPI bus shared by the e-ink panel and the SD card.
+// HalStorage already serializes SD access with storageMutex, but the display
+// and storage both drive the same physical SPI bus; without a bus-level lock a
+// display refresh and a concurrent SD transfer can interleave and confuse
+// SdSpiCard's unsynchronised m_spiActive state machine (see CLAUDE.md / SdFat
+// issue #518), manifesting as corrupted reads or a FreeRTOS panic.
+//
+// The mutex is recursive so a storage path that already holds the bus lock (via
+// HalStorage::StorageLock, which takes it as its outermost member) can re-enter
+// without self-deadlock. Lock ordering is SPI-outer, storage-inner: every
+// StorageLock acquires the SPI lock before storageMutex, and display code takes
+// only the SPI lock, so the global order is consistent and deadlock-free.
+class HalSpiBus {
+ public:
+  class Lock {
+   public:
+    Lock();
+    ~Lock();
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+
+   private:
+    bool acquired = false;
+  };
+
+  static HalSpiBus& getInstance();
+
+ private:
+  HalSpiBus();
+
+  SemaphoreHandle_t mutex = nullptr;
+
+  friend class Lock;
+};

--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -6,6 +6,8 @@
 
 #include <cassert>
 
+#include "HalSpiBus.h"
+
 #define SDCard SDCardManager::getInstance()
 
 HalStorage HalStorage::instance;
@@ -23,7 +25,10 @@ HalStorage::HalStorage() {
 
 // begin() and ready() are only called from setup, no need to acquire mutex for them
 
-bool HalStorage::begin() { return SDCard.begin(); }
+bool HalStorage::begin() {
+  HalSpiBus::Lock spiLock;
+  return SDCard.begin();
+}
 
 bool HalStorage::ready() const { return SDCard.ready(); }
 
@@ -31,8 +36,14 @@ bool HalStorage::ready() const { return SDCard.ready(); }
 
 class HalStorage::StorageLock {
  public:
-  StorageLock() { xSemaphoreTakeRecursive(HalStorage::getInstance().storageMutex, portMAX_DELAY); }
+  // spiLock is a member so it is acquired first (SPI-outer, storage-inner) and
+  // released last, keeping the bus locked for the whole SD operation and giving
+  // a consistent lock order with display code, which takes only the SPI lock.
+  StorageLock() : spiLock() { xSemaphoreTakeRecursive(HalStorage::getInstance().storageMutex, portMAX_DELAY); }
   ~StorageLock() { xSemaphoreGiveRecursive(HalStorage::getInstance().storageMutex); }
+
+ private:
+  HalSpiBus::Lock spiLock;
 };
 
 #define HAL_STORAGE_WRAPPED_CALL(method, ...) \


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 
`HalStorage` serialized SD access with `storageMutex`, but `HalDisplay` took no lock. The e-ink panel and the SD card share one physical SPI bus, so a display refresh interleaving with a background SD transfer (indexing, thumbnail generation, OTA) could confuse `SdSpiCard`'s unsynchronised `m_spiActive` state machine and corrupt reads or trigger a FreeRTOS panic.

Add `HalSpiBus`: a recursive-mutex singleton with an RAII Lock. `HalDisplay` acquires it around every panel operation (begin, `displayBuffer`, `refreshDisplay`, `deepSleep`, `displayGrayBuffer`, `writeGrayscalePlaneStrip`). `HalStorage::StorageLock` acquires it as its outermost member so the order is always SPI-outer, storage-inner, giving a single consistent lock order across display and storage code. The mutex is recursive so a storage path that re-enters `StorageLock` (e.g. `HalFile::Impl close`) does not self-deadlock.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
