### PR TITLE
fix: block cursor mangles non-ASCII characters in cursor mode

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -386,7 +386,21 @@ int KeyboardEntryActivity::lineBreakEnd(std::string& s, const int start, const i
       hi = mid - 1;
     }
   }
-  return best;
+
+  // The search runs over byte indices, so `best` can land inside a multi-byte
+  // character — the caller would then slice it in half and hand both fragments
+  // to the renderer as incomplete sequences. Snap back to a code point
+  // boundary. The line must still contain at least one whole character, or the
+  // wrap loop would never advance.
+  const int firstCharEnd = static_cast<int>(utf8Next(s, static_cast<size_t>(start)));
+  while (best > start && (static_cast<uint8_t>(s[best]) & 0xC0) == 0x80) best--;
+  // Widths measured mid-sequence are unreliable (the fragment renders as a
+  // replacement glyph), so the search can overshoot; step back whole
+  // characters until the snapped line fits.
+  while (best > firstCharEnd && measureRange(s, start, best) > maxWidth) {
+    best = static_cast<int>(utf8Prev(s, static_cast<size_t>(best)));
+  }
+  return best < firstCharEnd ? firstCharEnd : best;
 }
 
 bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, size_t& position) const {

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -716,9 +716,16 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   const int maxLineWidth = textAreaWidth;
   const bool centerText = metrics.keyboardCenteredText;
 
+  // The character under the cursor is a whole code point, not a byte: slicing
+  // one byte off a Cyrillic letter hands the renderer an incomplete sequence.
+  // In the masked-password path displayText is all '*', so this is still 1.
+  const size_t cursorCharBytes = (cursorPos < text.length()) ? utf8Next(text, cursorPos) - cursorPos : 0;
+  const size_t displayCursorCharBytes =
+      (cursorPos < displayText.length()) ? utf8Next(displayText, cursorPos) - cursorPos : 0;
+
   int cursorCharWidth = 6;
-  if (cursorPos < text.length()) {
-    int w = renderer.getTextWidth(UI_12_FONT_ID, text.substr(cursorPos, 1).c_str());
+  if (cursorCharBytes > 0) {
+    int w = renderer.getTextWidth(UI_12_FONT_ID, text.substr(cursorPos, cursorCharBytes).c_str());
     if (w > cursorCharWidth) cursorCharWidth = w;
   }
 
@@ -745,12 +752,12 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         }
         int beforeWidth = renderer.getTextAdvanceX(UI_12_FONT_ID, beforeCursor.c_str(), EpdFontFamily::REGULAR);
         int kernOffset = 0;
-        if (cursorPos < displayText.length()) {
-          std::string beforeAndCursor = beforeCursor + displayText.substr(cursorPos, 1);
+        if (displayCursorCharBytes > 0) {
+          const std::string cursorChar = displayText.substr(cursorPos, displayCursorCharBytes);
+          std::string beforeAndCursor = beforeCursor + cursorChar;
           int beforeAndCursorWidth =
               renderer.getTextAdvanceX(UI_12_FONT_ID, beforeAndCursor.c_str(), EpdFontFamily::REGULAR);
-          int charAdvance =
-              renderer.getTextAdvanceX(UI_12_FONT_ID, displayText.substr(cursorPos, 1).c_str(), EpdFontFamily::REGULAR);
+          int charAdvance = renderer.getTextAdvanceX(UI_12_FONT_ID, cursorChar.c_str(), EpdFontFamily::REGULAR);
           kernOffset = beforeAndCursorWidth - beforeWidth - charAdvance;
         }
         if (centerText) {
@@ -772,7 +779,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         renderer.drawText(UI_12_FONT_ID, lineStartX, inputStartY + inputHeight, part1.c_str());
         // Part 2: skip cursor slot (block + actual char drawn later)
         // Part 3: chars after cursor position (skip char under cursor), starting at cursorPixelX + cursorCharWidth
-        const int afterStart = static_cast<int>(cursorPos) + (cursorPos < text.length() ? 1 : 0);
+        const int afterStart = static_cast<int>(cursorPos + displayCursorCharBytes);
         const int afterEnd = lineEndIdx;
         if (afterStart < afterEnd) {
           const std::string part3 = displayText.substr(afterStart, afterEnd - afterStart);
@@ -798,9 +805,10 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   if (cursorMode && !togglePos && cursorPos <= displayText.length()) {
     static constexpr int blockPadding = 1;
     renderer.fillRect(cursorPixelX - blockPadding, cursorLineY, cursorCharWidth + blockPadding * 2, lineHeight, true);
-    if (cursorPos < text.length()) {
-      const char buf[2] = {text[cursorPos], '\0'};
-      renderer.drawText(UI_12_FONT_ID, cursorPixelX, cursorLineY, buf, false);
+    if (cursorCharBytes > 0) {
+      // Whole code point — a lone lead byte would render as a replacement glyph.
+      renderer.drawText(UI_12_FONT_ID, cursorPixelX, cursorLineY, text.substr(cursorPos, cursorCharBytes).c_str(),
+                        false);
     }
   } else if (cursorPos <= displayText.length()) {
     static constexpr int serifW = 3;


### PR DESCRIPTION
## Symptom

In cursor mode, the block cursor over any non-ASCII character is drawn one glyph too narrow and the character underneath is not rendered inside the block. This affects every layout that has accented letters — `é` on AzertyFr, `ü`/`ß` on QwertzDe, `ñ` on SpanishEs — and any text loaded from outside (OPDS server names, download folder names).

**Before** — French UI, server name `Café`, cursor on `é`:

![before](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-before.png)

**After** — same screen, same keypresses:

![after](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-after.png)

The block should be as wide as the character and show it reversed out, which is exactly what it already does for ASCII.

## Steps to reproduce

No special hardware or data needed — this is reproducible on `develop` in the simulator:

1. Set the UI language to French (`Settings → System → Language`).
2. Open any text field, e.g. `Settings → System → OPDS Servers → <server> → Server Name`.
3. Type `é` (bottom letter row on the AZERTY layout).
4. Hold **Up** to enter cursor mode, then press **Left** until the cursor sits on the `é`.

## Cause

`cursorPos` is a byte offset that is always kept on a code point boundary, but four places in `render()` sliced exactly **one byte** at that offset:

| Line | Code | Purpose |
|---|---|---|
| 837 | `text.substr(cursorPos, 1)` | block width |
| 865, 869 | `displayText.substr(cursorPos, 1)` | kerning offset |
| 891 | `cursorPos + 1` | start of the trailing run |
| 918 | `char buf[2] = {text[cursorPos], '\0'}` | drawing the character in the block |

For a two-byte character that single byte is a lone lead byte. `utf8NextCodepoint()` (`lib/Utf8/Utf8.cpp`) validates continuation bytes, finds none, and returns `REPLACEMENT_GLYPH` (`0xFFFD`) — so the width is measured for the replacement glyph and the draw call paints that instead of the letter.

Byte-identical to the old behaviour for ASCII, where one byte *is* one code point.

## Fix

Uses the existing `utf8Next()` helper to take the whole code point in all four places. No new helper, no behaviour change for ASCII.

The masked-password path is unaffected: `displayText` is all `*` there, so the span is still one byte — that is why the fix computes the span separately for `text` and `displayText`.

## Testing

- Verified in the simulator on `develop` (bug) and on this branch (fixed) — the screenshots above are those two runs, same input script, only the branch differs.
- ASCII behaviour unchanged (checked with a Latin server name in the same screen).
- `clang-format` 21 clean.
- Not tested on hardware.

<details>
<summary>Full screenshots</summary>

Before:

![before-full](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-before-full.png)

After:

![after-full](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-after-full.png)

</details>

Split out of #2828 at @Uri-Tauber's request — this fix is independent of where the keyboard layout tables live.



---

## Second commit: line wrapping (from @coderabbitai's review)

CodeRabbit pointed out that `lineBreakEnd()` has the same byte-vs-code-point problem, and it was right — with a worse symptom than the cursor block.

The function binary-searches over **byte** indices, so the wrap point can land inside a multi-byte character. `render()` slices the line there and hands both halves to the renderer as incomplete sequences; each decodes to `U+FFFD`, and since no built-in font carries that glyph, the character is simply not drawn.

A Cyrillic OPDS server name long enough to wrap loses a letter — `литературы` renders as `литера` / `уры`, the `т` is gone:

![line wrap](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-wrap.png)

The fix snaps the wrap point back to a code point boundary. Because widths measured mid-sequence are unreliable, the snapped line is re-measured and stepped back whole characters until it fits, and a line always keeps at least one whole character so the wrap loop still advances. ASCII is unaffected — the snap is a no-op there, verified with a long Latin name that still fills the line to the same edge.

