### PR TITLE
fix: size translated-label buffers for UTF-8, not ASCII

### DIFF
--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -772,7 +772,9 @@ void WifiSelectionActivity::render(RenderLock&&) {
   Rect screen = theme.getScreenSafeArea(renderer, true, false);
 
   // Draw header
-  char countStr[32];
+  // STR_NETWORKS_FOUND is ~37 bytes once the Arabic translation is substituted,
+  // so 32 truncated it. See ClockSyncActivity for the same class of bug.
+  char countStr[64];
   snprintf(countStr, sizeof(countStr), tr(STR_NETWORKS_FOUND), realNetworkCount);
   GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
                  tr(STR_WIFI_NETWORKS), countStr);

--- a/src/activities/settings/ClockOffsetActivity.cpp
+++ b/src/activities/settings/ClockOffsetActivity.cpp
@@ -334,7 +334,9 @@ void ClockOffsetActivity::render(RenderLock&&) {
     char timeBuf[9];
     const uint8_t encoded = encodeOffset(sign, hours, minutesQuarter);
     if (halClock.formatTime(timeBuf, sizeof(timeBuf), encoded, SETTINGS.clockFormat == 1)) {
-      char preview[24];
+      // 24 bytes did not even hold the label itself once translated: STR_CURRENT_TIME
+      // is 26 bytes in Russian, 24 in Arabic and Ukrainian. See ClockSyncActivity.
+      char preview[64];
       snprintf(preview, sizeof(preview), "%s %s", tr(STR_CURRENT_TIME), timeBuf);
       renderer.drawCenteredText(UI_10_FONT_ID, centreY + 60, preview);
     }

--- a/src/activities/settings/ClockSyncActivity.cpp
+++ b/src/activities/settings/ClockSyncActivity.cpp
@@ -118,7 +118,10 @@ void ClockSyncActivity::render(RenderLock&&) {
     case SUCCESS: {
       renderer.drawCenteredText(UI_12_FONT_ID, midY - 20, tr(STR_CLOCK_SYNC_OK), true, EpdFontFamily::BOLD);
       if (syncedTime[0] != '\0') {
-        char line[32];
+        // Sized for the label in any language: STR_CURRENT_TIME is 26 bytes in
+        // Russian (UTF-8 Cyrillic is 2 bytes per letter) versus 13 in English,
+        // plus a separator and up to "08:56 PM".
+        char line[64];
         snprintf(line, sizeof(line), "%s %s", tr(STR_CURRENT_TIME), syncedTime);
         renderer.drawCenteredText(UI_10_FONT_ID, midY + 10, line);
       }


### PR DESCRIPTION
Three `snprintf` buffers are sized against the English strings, so longer translations get silently truncated. The most visible one drops the last digit of the clock.

## What it looks like

Clock sync screen, Russian UI — the time is `08:56`, but the last digit never makes it to the screen:

<img src="https://raw.githubusercontent.com/winst0niuss/crossword/assets/clock-buffer-screenshots/docs-assets/clock-before-truncated.png" width="300" alt="Clock sync screen showing 08:5, last digit cut off" />

Same screen with this PR:

<img src="https://raw.githubusercontent.com/winst0niuss/crossword/assets/clock-buffer-screenshots/docs-assets/clock-after-fixed.png" width="300" alt="Clock sync screen showing the full time 09:04" />

The status bar was never affected — it formats the time separately, which is why the preview row at the bottom of the status-bar settings shows `08:56` correctly while this screen shows `08:5`.

## Why

`STR_CURRENT_TIME` is 13 bytes in English and 26 in Russian, because Cyrillic is two bytes per letter in UTF-8. `ClockSyncActivity` builds `"%s %s"` from it plus the time into a 32-byte buffer:

| | bytes |
|---|---|
| `Текущее время:` | 26 |
| separator | 1 |
| `08:56` | 5 |
| `NUL` | 1 |
| **total** | **33** |

One byte over, so the trailing `6` is cut.

`ClockOffsetActivity` is worse — its 24-byte buffer cannot hold the label alone in Russian (26), Arabic (24), Ukrainian (24), Hebrew (20 + separator + time) or Vietnamese. In 12-hour format (`08:56 PM`, three bytes longer) both buffers overflow for several more languages, including Bosnian, Czech, Norwegian and Slovak.

`WifiSelectionActivity` has the same defect independently: `STR_NETWORKS_FOUND` expands to roughly 37 bytes in Arabic (`تم العثور على %zu شبكة`) against a 32-byte buffer.

Worth noting that `snprintf` truncates on byte boundaries, not UTF-8 ones, so an overflow can leave an incomplete multi-byte sequence at the end of the string. Here the cut happened to land on an ASCII digit.

## Fix

All three buffers go to 64 bytes — enough for the longest current translation plus a 12-hour time string. They are short-lived locals on the stack, so the extra 40/72 bytes are not held across a render.

I checked the other buffers built the same way and left them alone: `macStr[64]`, `labelBuf[128]`, `remotePageStr[64]` and `valueBuffer[32]` all have headroom against every translation in the tree.

## Testing

Verified in the simulator (X4 Pro, Russian UI) on the clock sync screen — before and after are the screenshots above. Not tested on hardware; the change is a local buffer size, and the same code path renders identically in the simulator.

