### PR TITLE
fix(reader): let the end-of-book menu be tapped

### DIFF
--- a/src/activities/reader/EndOfBookOptions.cpp
+++ b/src/activities/reader/EndOfBookOptions.cpp
@@ -44,7 +44,42 @@ std::string EndOfBookOptions::fullPath(const size_t index) const {
   return folder == "/" ? "/" + names[index] : folder + "/" + names[index];
 }
 
-EndOfBookOptions::Action EndOfBookOptions::handleMenuInput(const MappedInputManager& input, std::string* openPath) {
+void EndOfBookOptions::listGeometry(const GfxRenderer& renderer, int& listTop, int& listHeight) const {
+  const auto& metrics = UITheme::getInstance().getMetrics();
+  const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
+  const int titleY = safe.y + safe.height / 8;
+  const int subtitleY = titleY + renderer.getLineHeight(UI_12_FONT_ID) + metrics.verticalSpacing;
+  listTop = subtitleY + renderer.getLineHeight(UI_10_FONT_ID) + metrics.verticalSpacing * 2;
+  listHeight = safe.y + safe.height - listTop - metrics.verticalSpacing;
+}
+
+EndOfBookOptions::Action EndOfBookOptions::handleMenuInput(const MappedInputManager& input, const GfxRenderer& renderer,
+                                                           std::string* openPath) {
+  // Touch first: a tap acts immediately, a touch-down only moves the highlight, which
+  // matches how every other list in the firmware behaves.
+  const int itemCountWithHome = static_cast<int>(names.size()) + 1;
+  int listTop = 0;
+  int listHeight = 0;
+  listGeometry(renderer, listTop, listHeight);
+  int touched = -1;
+  if (input.wasListItemTapped(touched, itemCountWithHome, selector, listTop, listHeight, false)) {
+    selector = touched;
+    if (selector < static_cast<int>(names.size())) {
+      if (openPath) {
+        *openPath = fullPath(selector);
+      }
+      return Action::OpenBook;
+    }
+    return Action::GoHome;
+  }
+  if (input.wasListItemTouchedDown(touched, itemCountWithHome, selector, listTop, listHeight, false)) {
+    if (selector != touched) {
+      selector = touched;
+      return Action::Redraw;
+    }
+    return Action::None;
+  }
+
   if (input.wasReleased(MappedInputManager::Button::Confirm)) {
     if (selector < static_cast<int>(names.size())) {
       if (openPath) {
@@ -102,12 +137,13 @@ void EndOfBookOptions::render(GfxRenderer& renderer, const MappedInputManager& i
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   const int titleY = safe.y + safe.height / 8;
   const int subtitleY = titleY + renderer.getLineHeight(UI_12_FONT_ID) + metrics.verticalSpacing;
-  const int listTop = subtitleY + renderer.getLineHeight(UI_10_FONT_ID) + metrics.verticalSpacing * 2;
+  int listTop = 0;
+  int listHeight = 0;
+  listGeometry(renderer, listTop, listHeight);
 
   UITheme::drawCenteredText(renderer, safe, UI_12_FONT_ID, titleY, tr(STR_END_OF_BOOK), true, EpdFontFamily::BOLD);
   UITheme::drawCenteredText(renderer, safe, UI_10_FONT_ID, subtitleY, tr(STR_EOB_CONTINUE_WITH));
 
-  const int listHeight = safe.y + safe.height - listTop - metrics.verticalSpacing;
   GUI.drawList(renderer, Rect{safe.x, listTop, safe.width, listHeight}, static_cast<int>(names.size()) + 1, selector,
                [this](const int index) {
                  return index < static_cast<int>(names.size()) ? displayName(names[index])

--- a/src/activities/reader/EndOfBookOptions.h
+++ b/src/activities/reader/EndOfBookOptions.h
@@ -31,7 +31,10 @@ class EndOfBookOptions {
   // Back press returns to the last page of the book. Fills openPath when the result is
   // OpenBook. Returns Action::None when nothing relevant was pressed; callers continue
   // their normal input path (keeping long-press Back to the file browser working).
-  Action handleMenuInput(const MappedInputManager& input, std::string* openPath);
+  // Menu input handling as above. Taps need the renderer because the list's geometry
+  // is derived from the panel's safe area, and the same derivation has to be shared
+  // with render() or the hit rects would drift from what is drawn.
+  Action handleMenuInput(const MappedInputManager& input, const GfxRenderer& renderer, std::string* openPath);
 
   // Draws the full end screen (plain title, or the suggestion menu) onto a cleared buffer.
   void render(GfxRenderer& renderer, const MappedInputManager& input) const;
@@ -45,4 +48,6 @@ class EndOfBookOptions {
   std::atomic<bool> isLoaded{false};
 
   std::string fullPath(size_t index) const;
+  // Top edge and height of the list band, in the same terms render() lays it out.
+  void listGeometry(const GfxRenderer& renderer, int& listTop, int& listHeight) const;
 };

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -494,7 +494,7 @@ void EpubReaderActivity::loop() {
   if (atEndOfBook && endOfBookOptions.menuActive() &&
       !(ignoreNextConfirmRelease && mappedInput.wasReleased(MappedInputManager::Button::Confirm))) {
     std::string openPath;
-    switch (endOfBookOptions.handleMenuInput(mappedInput, &openPath)) {
+    switch (endOfBookOptions.handleMenuInput(mappedInput, renderer, &openPath)) {
       case EndOfBookOptions::Action::OpenBook:
         activityManager.goToReader(openPath);
         return;

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -79,7 +79,7 @@ void XtcReaderActivity::loop() {
   // block.
   if (atEndOfBook && endOfBookOptions.menuActive()) {
     std::string openPath;
-    switch (endOfBookOptions.handleMenuInput(mappedInput, &openPath)) {
+    switch (endOfBookOptions.handleMenuInput(mappedInput, renderer, &openPath)) {
       case EndOfBookOptions::Action::OpenBook:
         activityManager.goToReader(openPath);
         return;


### PR DESCRIPTION
The end-of-book menu lists the next books in the folder plus a Home entry, and on a touch device those rows look tappable. They are not: the component has no touch handling at all — no hit test, no reference to `mappedInput`. Only the buttons move the selection.

## What changed

`handleMenuInput` now checks touch before buttons, following the same idiom as every other list in the firmware: a tap acts on the row, a touch-down only moves the highlight.

The list geometry moves out of `render()` into a shared `listGeometry()`. Computing hit rects separately from what is drawn is exactly how the two drift apart, and this menu's layout derives from the safe area, so it is not a constant that can be duplicated safely.

Both callers pass the renderer through — the EPUB reader and the XTC reader.

## Scope

This is the same gap the small-panel work in #2802 describes for lists generally. Of the firmware's list screens, four had no shared hit test: this one, `EpubReaderBookmarksActivity`, `SettingsActivity` (which has its own equivalent) and `ButtonRemapActivity` (which is about physical buttons and correctly has none). Bookmarks can get the same treatment; kept out of this PR to keep it to one screen.

## Testing

Exercised in the desktop simulator on an X4 Pro profile: tapping a suggested book opens it, tapping Home leaves the reader, touch-and-drag moves the highlight without acting, and the buttons behave exactly as before. Host test suite passes (129/129), `pio check` with the CI flags reports no defects.

Not tested on hardware.
