### PR TITLE
feat: add adaptive tone mapping for custom sleep images

### DIFF
--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -1,5 +1,8 @@
 #include "Bitmap.h"
 
+#include <Logging.h>
+#include <Memory.h>
+
 #include <cstdlib>
 #include <cstring>
 
@@ -11,6 +14,11 @@
 // gray levels (0, 85, 170, 255 ±21) are mapped directly without dithering.
 // For cover images, dithering is done in JpegToBmpConverter.cpp instead.
 constexpr bool USE_ATKINSON = true;  // Use Atkinson dithering instead of Floyd-Steinberg
+constexpr uint32_t ADAPTIVE_TONE_LOW_PERCENTILE_PERMILLE = 10;
+constexpr uint32_t ADAPTIVE_TONE_HIGH_PERCENTILE_PERMILLE = 990;
+constexpr int ADAPTIVE_TONE_MIN_RANGE = 96;
+constexpr int ADAPTIVE_TONE_BLEND_NUM = 3;
+constexpr int ADAPTIVE_TONE_BLEND_DEN = 4;
 // ============================================================================
 
 Bitmap::~Bitmap() {
@@ -165,16 +173,165 @@ BmpReaderError Bitmap::parseHeaders() {
   //  - Native palette → direct mapping, no processing needed
   //  - High-color + dithering enabled → error-diffusion dithering (Atkinson or Floyd-Steinberg)
   //  - High-color + dithering disabled → simple quantization (no error diffusion)
+  if (toneMapping == BitmapToneMapping::Adaptive && bpp > 1) {
+    analyzeAdaptiveToneMapping();
+    const BmpReaderError rewindResult = rewindToData();
+    if (rewindResult != BmpReaderError::Ok) {
+      LOG_ERR("BMP", "Failed to rewind after adaptive tone analysis");
+      return rewindResult;
+    }
+  }
+
   const bool highColor = !nativePalette;
   if (highColor && dithering) {
+    const Gray4QuantizationMode quantizationMode =
+        adaptiveToneMapping ? Gray4QuantizationMode::Native : Gray4QuantizationMode::DisplayTuned;
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(width);
+      atkinsonDitherer = new AtkinsonDitherer(width, quantizationMode);
     } else {
-      fsDitherer = new FloydSteinbergDitherer(width);
+      fsDitherer = new FloydSteinbergDitherer(width, quantizationMode);
     }
   }
 
   return BmpReaderError::Ok;
+}
+
+uint8_t Bitmap::applyAdaptiveTone(const uint8_t luminance) const {
+  if (!adaptiveToneMapping || adaptiveWhitePoint <= adaptiveBlackPoint) {
+    return luminance;
+  }
+
+  int leveled;
+  if (luminance <= adaptiveBlackPoint) {
+    leveled = 0;
+  } else if (luminance >= adaptiveWhitePoint) {
+    leveled = 255;
+  } else {
+    leveled = ((static_cast<int>(luminance) - adaptiveBlackPoint) * 255) /
+              (static_cast<int>(adaptiveWhitePoint) - adaptiveBlackPoint);
+  }
+
+  int adjusted = (static_cast<int>(luminance) * (ADAPTIVE_TONE_BLEND_DEN - ADAPTIVE_TONE_BLEND_NUM) +
+                  leveled * ADAPTIVE_TONE_BLEND_NUM) /
+                 ADAPTIVE_TONE_BLEND_DEN;
+  if (luminance > 242 && adjusted < luminance) {
+    adjusted = luminance;
+  }
+  if (adjusted < 0) return 0;
+  if (adjusted > 255) return 255;
+  return static_cast<uint8_t>(adjusted);
+}
+
+bool Bitmap::analyzeAdaptiveToneMapping() {
+  adaptiveToneMapping = false;
+  adaptiveBlackPoint = 0;
+  adaptiveWhitePoint = 255;
+
+  auto histogram = makeUniqueNoThrow<uint32_t[]>(256);
+  if (!histogram) {
+    LOG_ERR("BMP", "Failed to allocate adaptive tone histogram (%u bytes)",
+            static_cast<unsigned>(256u * sizeof(uint32_t)));
+    return false;
+  }
+
+  // A BMP scanline can be up to 8192 bytes at the parser's 2048 px width limit.
+  // Heap storage keeps it off the small task stack and is released after this one-shot analysis.
+  auto rowBuffer = makeUniqueNoThrow<uint8_t[]>(static_cast<size_t>(rowBytes));
+  if (!rowBuffer) {
+    LOG_ERR("BMP", "Failed to allocate adaptive tone row buffer (%d bytes)", rowBytes);
+    return false;
+  }
+
+  if (!file.seek(bfOffBits)) {
+    LOG_ERR("BMP", "Failed to seek for adaptive tone analysis");
+    return false;
+  }
+
+  uint64_t total = 0;
+  for (int y = 0; y < height; y++) {
+    if (file.read(rowBuffer.get(), rowBytes) != rowBytes) {
+      LOG_ERR("BMP", "Short read during adaptive tone analysis at row %d", y);
+      return false;
+    }
+
+    switch (bpp) {
+      case 32: {
+        const uint8_t* pixel = rowBuffer.get();
+        for (int x = 0; x < width; x++) {
+          const uint8_t luminance = (77u * pixel[2] + 150u * pixel[1] + 29u * pixel[0]) >> 8;
+          histogram[luminance]++;
+          pixel += 4;
+        }
+        break;
+      }
+      case 24: {
+        const uint8_t* pixel = rowBuffer.get();
+        for (int x = 0; x < width; x++) {
+          const uint8_t luminance = (77u * pixel[2] + 150u * pixel[1] + 29u * pixel[0]) >> 8;
+          histogram[luminance]++;
+          pixel += 3;
+        }
+        break;
+      }
+      case 8:
+        for (int x = 0; x < width; x++) {
+          histogram[paletteLum[rowBuffer[x]]]++;
+        }
+        break;
+      case 4:
+        for (int x = 0; x < width; x++) {
+          const uint8_t index = (x & 1) ? (rowBuffer[x >> 1] & 0x0F) : (rowBuffer[x >> 1] >> 4);
+          histogram[paletteLum[index]]++;
+        }
+        break;
+      case 2:
+        for (int x = 0; x < width; x++) {
+          const uint8_t index = (rowBuffer[x >> 2] >> (6 - ((x & 3) * 2))) & 0x03;
+          histogram[paletteLum[index]]++;
+        }
+        break;
+      case 1:
+        for (int x = 0; x < width; x++) {
+          const uint8_t index = (rowBuffer[x >> 3] & (0x80 >> (x & 7))) ? 1 : 0;
+          histogram[paletteLum[index]]++;
+        }
+        break;
+      default:
+        LOG_ERR("BMP", "Unsupported bpp during adaptive tone analysis: %u", static_cast<unsigned>(bpp));
+        return false;
+    }
+    total += static_cast<uint32_t>(width);
+  }
+
+  const uint64_t lowTarget = (total * ADAPTIVE_TONE_LOW_PERCENTILE_PERMILLE) / 1000u;
+  const uint64_t highTarget = (total * ADAPTIVE_TONE_HIGH_PERCENTILE_PERMILLE) / 1000u;
+  uint64_t cumulative = 0;
+  uint8_t low = 0;
+  uint8_t high = 255;
+  bool foundLow = false;
+  for (int i = 0; i < 256; i++) {
+    cumulative += histogram[i];
+    if (!foundLow && cumulative >= lowTarget) {
+      low = static_cast<uint8_t>(i);
+      foundLow = true;
+    }
+    if (cumulative >= highTarget) {
+      high = static_cast<uint8_t>(i);
+      break;
+    }
+  }
+
+  if (static_cast<int>(high) - static_cast<int>(low) < ADAPTIVE_TONE_MIN_RANGE) {
+    LOG_DBG("BMP", "Adaptive tone skipped: black=%u white=%u", static_cast<unsigned>(low), static_cast<unsigned>(high));
+    return false;
+  }
+
+  adaptiveBlackPoint = low;
+  adaptiveWhitePoint = high;
+  adaptiveToneMapping = true;
+  LOG_DBG("BMP", "Adaptive tone enabled: black=%u white=%u", static_cast<unsigned>(adaptiveBlackPoint),
+          static_cast<unsigned>(adaptiveWhitePoint));
+  return true;
 }
 
 // packed 2bpp output, 0 = black, 1 = dark gray, 2 = light gray, 3 = white
@@ -191,18 +348,21 @@ BmpReaderError Bitmap::readNextRow(uint8_t* data, uint8_t* rowBuffer) const {
 
   // Helper lambda to pack 2bpp color into the output stream
   auto packPixel = [&](const uint8_t lum) {
+    const uint8_t toneMappedLum = applyAdaptiveTone(lum);
     uint8_t color;
     if (atkinsonDitherer) {
-      color = atkinsonDitherer->processPixel(adjustPixel(lum), currentX);
+      color = atkinsonDitherer->processPixel(adjustPixel(toneMappedLum), currentX);
     } else if (fsDitherer) {
-      color = fsDitherer->processPixel(adjustPixel(lum), currentX);
+      color = fsDitherer->processPixel(adjustPixel(toneMappedLum), currentX);
     } else {
+      const int adjusted = adjustPixel(toneMappedLum);
       if (nativePalette) {
         // Palette matches native gray levels: direct mapping (still apply brightness/contrast/gamma)
-        color = static_cast<uint8_t>(adjustPixel(lum) >> 6);
+        color = static_cast<uint8_t>(adjusted >> 6);
       } else {
         // Non-native palette with dithering disabled: simple quantization
-        color = quantize(adjustPixel(lum), currentX, prevRowY);
+        color = adaptiveToneMapping ? quantizeGray4(adjusted, Gray4QuantizationMode::Native).index
+                                    : quantize(adjusted, currentX, prevRowY);
       }
     }
     currentOutByte |= (color << bitShift);

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -303,8 +303,8 @@ bool Bitmap::analyzeAdaptiveToneMapping() {
     total += static_cast<uint32_t>(width);
   }
 
-  const uint64_t lowTarget = (total * ADAPTIVE_TONE_LOW_PERCENTILE_PERMILLE) / 1000u;
-  const uint64_t highTarget = (total * ADAPTIVE_TONE_HIGH_PERCENTILE_PERMILLE) / 1000u;
+  const uint64_t lowTarget = (total * ADAPTIVE_TONE_LOW_PERCENTILE_PERMILLE + 999u) / 1000u;
+  const uint64_t highTarget = (total * ADAPTIVE_TONE_HIGH_PERCENTILE_PERMILLE + 999u) / 1000u;
   uint64_t cumulative = 0;
   uint8_t low = 0;
   uint8_t high = 255;

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -60,11 +60,14 @@ enum class BmpReaderError : uint8_t {
   ShortReadRow,
 };
 
+enum class BitmapToneMapping : uint8_t { None, Adaptive };
+
 class Bitmap {
  public:
   static const char* errorToString(BmpReaderError err);
 
-  explicit Bitmap(HalFile& file, bool dithering = false) : file(file), dithering(dithering) {}
+  explicit Bitmap(HalFile& file, bool dithering = false, BitmapToneMapping toneMapping = BitmapToneMapping::None)
+      : file(file), dithering(dithering), toneMapping(toneMapping) {}
   ~Bitmap();
   BmpReaderError parseHeaders();
   BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer) const;
@@ -80,9 +83,12 @@ class Bitmap {
  private:
   static uint16_t readLE16(HalFile& f);
   static uint32_t readLE32(HalFile& f);
+  bool analyzeAdaptiveToneMapping();
+  uint8_t applyAdaptiveTone(uint8_t luminance) const;
 
   HalFile& file;
   bool dithering = false;
+  BitmapToneMapping toneMapping = BitmapToneMapping::None;
   int width = 0;
   int height = 0;
   bool topDown = false;
@@ -92,6 +98,9 @@ class Bitmap {
   bool nativePalette = false;  // true if all palette entries map to native gray levels
   int rowBytes = 0;
   uint8_t paletteLum[256] = {};
+  bool adaptiveToneMapping = false;
+  uint8_t adaptiveBlackPoint = 0;
+  uint8_t adaptiveWhitePoint = 255;
 
   // Dithering state (mutable for const methods)
   mutable int16_t* errorCurRow = nullptr;

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -11,6 +11,32 @@ uint8_t quantizeSimple(int gray);
 uint8_t quantize1bit(int gray, int x, int y);
 int adjustPixel(int gray);
 
+struct QuantizedGray4 {
+  uint8_t index;
+  uint8_t value;
+};
+
+enum class Gray4QuantizationMode : uint8_t { DisplayTuned, Native };
+
+inline QuantizedGray4 quantizeGray4(int gray, const Gray4QuantizationMode mode) {
+  if (gray < 0) gray = 0;
+  if (gray > 255) gray = 255;
+
+  if (mode == Gray4QuantizationMode::Native) {
+    // Midpoints between the display's four logical levels: 0, 85, 170, 255.
+    if (gray < 43) return {0, 0};
+    if (gray < 128) return {1, 85};
+    if (gray < 213) return {2, 170};
+    return {3, 255};
+  }
+
+  // Existing thresholds tuned for the X4 panel.
+  if (gray < 30) return {0, 15};
+  if (gray < 50) return {1, 30};
+  if (gray < 140) return {2, 80};
+  return {3, 210};
+}
+
 enum class BmpRowOrder { BottomUp, TopDown };
 
 // Populates a 1-bit BMP header in the provided memory.
@@ -104,7 +130,8 @@ class Atkinson1BitDitherer {
 // Less error buildup = fewer artifacts than Floyd-Steinberg
 class AtkinsonDitherer {
  public:
-  explicit AtkinsonDitherer(int width) : width(width) {
+  explicit AtkinsonDitherer(int width, Gray4QuantizationMode quantizationMode = Gray4QuantizationMode::DisplayTuned)
+      : width(width), quantizationMode(quantizationMode) {
     errorRow0 = new int16_t[width + 4]();  // Current row
     errorRow1 = new int16_t[width + 4]();  // Next row
     errorRow2 = new int16_t[width + 4]();  // Row after next
@@ -127,41 +154,10 @@ class AtkinsonDitherer {
     if (adjusted < 0) adjusted = 0;
     if (adjusted > 255) adjusted = 255;
 
-    // Quantize to 4 levels
-    uint8_t quantized;
-    int quantizedValue;
-    if (false) {  // original thresholds
-      if (adjusted < 43) {
-        quantized = 0;
-        quantizedValue = 0;
-      } else if (adjusted < 128) {
-        quantized = 1;
-        quantizedValue = 85;
-      } else if (adjusted < 213) {
-        quantized = 2;
-        quantizedValue = 170;
-      } else {
-        quantized = 3;
-        quantizedValue = 255;
-      }
-    } else {  // fine-tuned to X4 eink display
-      if (adjusted < 30) {
-        quantized = 0;
-        quantizedValue = 15;
-      } else if (adjusted < 50) {
-        quantized = 1;
-        quantizedValue = 30;
-      } else if (adjusted < 140) {
-        quantized = 2;
-        quantizedValue = 80;
-      } else {
-        quantized = 3;
-        quantizedValue = 210;
-      }
-    }
+    const QuantizedGray4 quantized = quantizeGray4(adjusted, quantizationMode);
 
     // Calculate error (only distribute 6/8 = 75%)
-    int error = (adjusted - quantizedValue) >> 3;  // error/8
+    int error = (adjusted - quantized.value) >> 3;  // error/8
 
     // Distribute 1/8 to each of 6 neighbors
     errorRow0[x + 3] += error;  // Right
@@ -171,7 +167,7 @@ class AtkinsonDitherer {
     errorRow1[x + 3] += error;  // Bottom-right
     errorRow2[x + 2] += error;  // Two rows down
 
-    return quantized;
+    return quantized.index;
   }
 
   void nextRow() {
@@ -190,6 +186,7 @@ class AtkinsonDitherer {
 
  private:
   int width;
+  Gray4QuantizationMode quantizationMode;
   int16_t* errorRow0;
   int16_t* errorRow1;
   int16_t* errorRow2;
@@ -205,7 +202,9 @@ class AtkinsonDitherer {
 //      7/16  X
 class FloydSteinbergDitherer {
  public:
-  explicit FloydSteinbergDitherer(int width) : width(width), rowCount(0) {
+  explicit FloydSteinbergDitherer(int width,
+                                  Gray4QuantizationMode quantizationMode = Gray4QuantizationMode::DisplayTuned)
+      : width(width), quantizationMode(quantizationMode), rowCount(0) {
     errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
     errorNextRow = new int16_t[width + 2]();
   }
@@ -231,41 +230,10 @@ class FloydSteinbergDitherer {
     if (adjusted < 0) adjusted = 0;
     if (adjusted > 255) adjusted = 255;
 
-    // Quantize to 4 levels (0, 85, 170, 255)
-    uint8_t quantized;
-    int quantizedValue;
-    if (false) {  // original thresholds
-      if (adjusted < 43) {
-        quantized = 0;
-        quantizedValue = 0;
-      } else if (adjusted < 128) {
-        quantized = 1;
-        quantizedValue = 85;
-      } else if (adjusted < 213) {
-        quantized = 2;
-        quantizedValue = 170;
-      } else {
-        quantized = 3;
-        quantizedValue = 255;
-      }
-    } else {  // fine-tuned to X4 eink display
-      if (adjusted < 30) {
-        quantized = 0;
-        quantizedValue = 15;
-      } else if (adjusted < 50) {
-        quantized = 1;
-        quantizedValue = 30;
-      } else if (adjusted < 140) {
-        quantized = 2;
-        quantizedValue = 80;
-      } else {
-        quantized = 3;
-        quantizedValue = 210;
-      }
-    }
+    const QuantizedGray4 quantized = quantizeGray4(adjusted, quantizationMode);
 
     // Calculate error
-    int error = adjusted - quantizedValue;
+    int error = adjusted - quantized.value;
 
     // Distribute error to neighbors (serpentine: direction-aware)
     if (!isReverseRow()) {
@@ -290,7 +258,7 @@ class FloydSteinbergDitherer {
       errorNextRow[x] += (error) >> 4;
     }
 
-    return quantized;
+    return quantized.index;
   }
 
   // Call at the end of each row to swap buffers
@@ -316,6 +284,7 @@ class FloydSteinbergDitherer {
 
  private:
   int width;
+  Gray4QuantizationMode quantizationMode;
   int rowCount;
   int16_t* errorCurRow;
   int16_t* errorNextRow;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -66,7 +66,9 @@ void SleepActivity::renderCustomSleepScreen() const {
   // This takes priority over the /sleep folder.
   HalFile file;
   if (Storage.openFileForRead("SLP", "/sleep.bmp", file)) {
-    Bitmap bitmap(file, true);
+    const bool adaptiveTone =
+        SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+    Bitmap bitmap(file, true, adaptiveTone ? BitmapToneMapping::Adaptive : BitmapToneMapping::None);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
       renderBitmapSleepScreen(bitmap);
@@ -134,7 +136,9 @@ void SleepActivity::renderCustomSleepScreen() const {
       if (Storage.openFileForRead("SLP", filename, randFile)) {
         LOG_DBG("SLP", "Randomly loading: %s/%s", sleepDir, files[randomFileIndex].c_str());
         delay(100);
-        Bitmap bitmap(randFile, true);
+        const bool adaptiveTone =
+            SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+        Bitmap bitmap(randFile, true, adaptiveTone ? BitmapToneMapping::Adaptive : BitmapToneMapping::None);
         if (bitmap.parseHeaders() == BmpReaderError::Ok) {
           renderBitmapSleepScreen(bitmap);
           randFile.close();


### PR DESCRIPTION
## Summary

- Add an explicit adaptive tone-mapping mode to the existing BMP decoder and enable it only for unfiltered custom sleep images.
- Derive black and white points from the image's 1st and 99th luminance percentiles, then blend the correction before the existing four-level dithering pass.
- Preserve the current renderer as the default and automatic fallback. Covers, thumbnails, web code, and filtered black-and-white sleep images are unchanged.

## Scope Check

- [x] I have read `SCOPE.md` and `ROADMAP.md`.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] [PR #302](https://github.com/crosspoint-reader/crosspoint-reader/pull/302) already improved CrossPoint's fixed display-tuned thresholds. This PR preserves those thresholds as the default and addresses the remaining compressed-range cases only for unfiltered custom sleep images. YACP's web preparation and per-book gallery features are intentionally excluded.
- [x] This PR does not touch `freeink-sdk`, `lib/hal`, the bootloader, OTA, or recovery code.

## Additional Context

[PR #302](https://github.com/crosspoint-reader/crosspoint-reader/pull/302) fixed the overly dark BMP output by tuning CrossPoint's four display thresholds. Those fixed thresholds work well for balanced images and remain unchanged by this PR. Images whose useful luminance is concentrated in a smaller range can still lose highlight, shadow, or midtone detail, which is the narrower case addressed here.

Adaptive mode scans the BMP once, builds a 256-bin luminance histogram, and uses its 1st and 99th percentiles as robust black and white points. It requires a minimum 96-level source range, applies a conservative 3/4-strength correction, and keeps near-white highlights above luminance 242 untouched.

If the analysis cannot be enabled—or if the useful range is too narrow—the exact existing quantizer remains in use whenever the input can be rewound. There is no new setting, dependency, task, framebuffer, or steady-state allocation. Peak transient memory is one 1,024-byte histogram plus one scanline buffer (at most 8,192 bytes under the decoder's existing 2,048-pixel/32-bpp limit), allocated with `makeUniqueNoThrow()` and released before dithering. The measured `default` firmware delta is +2,108 bytes of flash and 0 bytes of static RAM.

The runtime cost is one additional sequential SD pass before rendering an adaptive custom sleep image. This work remains synchronous, so it can extend the input-unresponsive interval already discussed in [#1110](https://github.com/crosspoint-reader/crosspoint-reader/issues/1110). No CrossPoint X4/Sticky timing is claimed yet; that measurement is included in the hardware verification below.

### Validation

- `pio run -e default` — passed
- `pio run -e sticky` — passed
- `pio check -e default --fail-on-defect low --fail-on-defect medium --fail-on-defect high` — no defects
- Host CMake/CTest suite — 129/129 tests passed
- `clang-format` 22.1.6 on touched files and `git diff --check` — clean
- `default` size versus `develop` — +2,108 bytes flash, +0 bytes static RAM

### Hardware comparison

Same source images on the same Xteink X3: the existing fixed display-tuned (`Legacy`) mapping on the left, adaptive mapping on the right.

![Adaptive tone-mapping comparison on Xteink X3](https://github.com/Sichroteph/YACP/releases/download/v1.5.0-yacp/adaptive-tone-mapping-before-after-v2.png)

The algorithm was hardware-tested in YACP on X3. The focused CrossPoint port has not yet been timed or visually validated on X4/Sticky.

### Hardware verification

1. Select a custom sleep image and the `No filter` option, using either `/sleep.bmp` or a BMP in `/.sleep` or `/sleep`.
2. Test bright, dark, and midtone-heavy 24-bit BMPs. The log should include `Adaptive tone enabled: black=<n> white=<n>` when analysis succeeds.
3. Confirm that highlights and shadows retain more detail without obvious clipping or a washed-out result.
4. Select another sleep-image filter and confirm that its existing black-and-white output is unchanged.
5. Test a 1-bit BMP and the regular book-cover sleep mode; both should retain their previous rendering path.
6. Measure the time from selecting sleep to the final refresh on X4/Sticky and compare it with the same image rendered without adaptive mapping, with particular attention to the unresponsive interval described in #1110.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools assisted with the implementation port, review, validation, and PR wording. I am a veteran software developer and remain fully responsible for the code I submit. I reviewed the resulting code, scope, fallback behavior, memory lifecycle, and test coverage before proposing it.
