### PR TITLE
fix(reader): leave the chapter slot empty when there is no chapter

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1571,7 +1571,7 @@ void EpubReaderActivity::renderStatusBar() const {
       textYOffset += UITheme::getInstance().getMetrics().statusBarVerticalMargin;
     }
   } else if (sb.titleMode == CrossPointSettings::STATUS_BAR_TITLE::CHAPTER_TITLE) {
-    title = tr(STR_UNNAMED);
+    // Sections outside the ToC have no chapter name: leave the slot empty, not a placeholder.
     if (epub) {
       const int tocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
       if (tocIndex != -1) {

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -89,7 +89,8 @@ XtcReaderActivity::StatusBarInfo XtcReaderActivity::getStatusBarInfo() const {
   }
 
   if (sb.titleMode == CrossPointSettings::STATUS_BAR_TITLE::CHAPTER_TITLE) {
-    title = chapterIt->name.empty() ? tr(STR_UNNAMED) : chapterIt->name;
+    // Unnamed chapters leave the slot empty, as in the EPUB reader.
+    title = chapterIt->name;
   }
 
   return StatusBarInfo{static_cast<int>(currentPage - chapterIt->startPage) + 1,


### PR DESCRIPTION
Covers, title pages and colophons sit outside the table of contents, so the status bar has no chapter to name for them. It filled the slot with "Unnamed", which reads as a fault — as if the title had failed to load — when the honest meaning is that the page belongs to no chapter.

**Before** — title page of an EPUB, English UI:

![before](https://raw.githubusercontent.com/winst0niuss/crossword/assets/unnamed-chapter-screenshots/docs-assets/status-bar-unnamed-before.png)

**After:**

![after](https://raw.githubusercontent.com/winst0niuss/crossword/assets/unnamed-chapter-screenshots/docs-assets/status-bar-unnamed-after.png)

Battery, clock and the page counter are untouched; only the placeholder goes.

## Scope

Both readers do this, so both are changed: `EpubReaderActivity` seeded `title` with the placeholder before looking the section up in the TOC, and `XtcReaderActivity` substituted it for chapters with an empty name.

The chapter list and the bookmark list keep `STR_UNNAMED`. There each entry is a row of its own, and a blank row would look like a rendering glitch rather than an absence — the opposite of the status bar, where blank space reads correctly as "no chapter here".

`STR_UNNAMED` therefore stays in use and no translation changes.

## Testing

Simulator, X4 Pro profile, English UI: title page and cover show an empty slot, ordinary chapters still show their titles, and switching the status bar's title mode to Book still shows the book title. Host test suite passes (129/129).

Not tested on hardware.
