### PR TITLE
fix: trim curly quotes and dashes in dictionary lookup

### DIFF
--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -392,14 +392,20 @@ std::string Dictionary::cleanWord(const char* word) {
   // are all >= 0x80, so isWordByte keeps them; strip those 3-byte codepoints
   // from the edges too, or EPUB text like garage.” never matches a headword.
   while (start < end) {
-    if (!isWordByte(b[start])) start++;
-    else if (end - start >= 3 && b[start] == 0xE2 && (b[start + 1] == 0x80 || b[start + 1] == 0x81)) start += 3;
-    else break;
+    if (!isWordByte(b[start]))
+      start++;
+    else if (end - start >= 3 && b[start] == 0xE2 && (b[start + 1] == 0x80 || b[start + 1] == 0x81))
+      start += 3;
+    else
+      break;
   }
   while (end > start) {
-    if (!isWordByte(b[end - 1])) end--;
-    else if (end - start >= 3 && b[end - 3] == 0xE2 && (b[end - 2] == 0x80 || b[end - 2] == 0x81)) end -= 3;
-    else break;
+    if (!isWordByte(b[end - 1]))
+      end--;
+    else if (end - start >= 3 && b[end - 3] == 0xE2 && (b[end - 2] == 0x80 || b[end - 2] == 0x81))
+      end -= 3;
+    else
+      break;
   }
   if (start >= end) return "";
 

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -385,10 +385,22 @@ bool Dictionary::readDefinition(const DictLocation& location, std::string& out, 
 
 std::string Dictionary::cleanWord(const char* word) {
   if (!word) return "";
+  const auto* b = reinterpret_cast<const unsigned char*>(word);
   size_t start = 0;
   size_t end = strlen(word);
-  while (start < end && !isWordByte(static_cast<unsigned char>(word[start]))) start++;
-  while (end > start && !isWordByte(static_cast<unsigned char>(word[end - 1]))) end--;
+  // Curly quotes and dashes (General Punctuation U+2000-U+206F = E2 80/81 xx)
+  // are all >= 0x80, so isWordByte keeps them; strip those 3-byte codepoints
+  // from the edges too, or EPUB text like garage.” never matches a headword.
+  while (start < end) {
+    if (!isWordByte(b[start])) start++;
+    else if (end - start >= 3 && b[start] == 0xE2 && (b[start + 1] == 0x80 || b[start + 1] == 0x81)) start += 3;
+    else break;
+  }
+  while (end > start) {
+    if (!isWordByte(b[end - 1])) end--;
+    else if (end - start >= 3 && b[end - 3] == 0xE2 && (b[end - 2] == 0x80 || b[end - 2] == 0x81)) end -= 3;
+    else break;
+  }
   if (start >= end) return "";
 
   std::string result(word + start, end - start);


### PR DESCRIPTION
# Summary

`cleanWord` treated any byte >= 0x80 as a word byte to preserve accented letters, but General Punctuation (U+2000-U+206F: curly quotes, dashes) is UTF-8 E2 80/81 xx, all >= 0x80. Trailing/leading quotes were kept, so EPUB text like `garage."` or `possible,"` failed to match a headword.

Extend the edge-trim loops to step over leading/trailing 3-byte General Punctuation codepoints, matching the range `isSelectableToken` already special-cases in `DictionaryWordSelectActivity`.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
