### PR TITLE
feat: Chunked allocation for glyph bitmaps

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -99,8 +99,11 @@ void SdCardFont::freeStyleMiniData(PerStyle& s) {
   s.miniIntervals = nullptr;
   delete[] s.miniGlyphs;
   s.miniGlyphs = nullptr;
-  delete[] s.miniBitmap;
-  s.miniBitmap = nullptr;
+  for (auto& chunk : s.miniBitmapChunks) {
+    delete[] chunk;
+    chunk = nullptr;
+  }
+  s.miniBitmapChunkCount = 0;
   s.miniIntervalCount = 0;
   s.miniGlyphCount = 0;
   s.miniIntervalCapacity = 0;
@@ -1010,30 +1013,66 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
       totalBitmapSize += s.miniGlyphs[i].dataLength;
     }
 
-    if (!ensureArrayCapacity(s.miniBitmap, s.miniBitmapCapacity, totalBitmapSize)) {
-      LOG_ERR("SDCF", "Failed to allocate mini bitmap (%u bytes) for style %u", totalBitmapSize, styleIdx);
-      delete[] readOrder;
-      delete[] mappings;
-      freeStyleMiniData(s);
-      return static_cast<int>(cpCount);
-    }
-    s.miniBitmapUsed = totalBitmapSize;  // underuse-hysteresis signal for resetStyleMiniData
-
     // Read bitmap data sorted by file offset
     std::sort(readOrder, readOrder + validCount,
               [&](uint32_t a, uint32_t b) { return s.miniGlyphs[a].dataOffset < s.miniGlyphs[b].dataOffset; });
 
-    uint32_t miniBitmapOffset = 0;
+    // Assemble the bitmap arena from on-demand 4 KB chunks (see MINI_BM_CHUNK_*).
+    // `span` is the running virtual offset into the arena; each glyph is placed
+    // wholly within one chunk, skipping past a boundary rather than straddling it.
+    // glyph.dataOffset becomes the virtual offset, decoded at render time by
+    // miniGlyphBitmap(). Chunks are allocated only as span reaches them, so a
+    // sparse page never allocates the full ceiling.
+    uint32_t span = 0;
     uint32_t lastBitmapEnd = UINT32_MAX;
     for (uint32_t i = 0; i < validCount; i++) {
       uint32_t mapIdx = readOrder[i];
       EpdGlyph& glyph = s.miniGlyphs[mapIdx];
+      const uint32_t len = glyph.dataLength;
 
-      if (glyph.dataLength == 0) {
-        glyph.dataOffset = miniBitmapOffset;
+      if (len == 0) {
+        glyph.dataOffset = span;
         continue;
       }
+      if (len > MINI_BM_CHUNK_SIZE) {
+        // A single glyph larger than one chunk cannot be placed. Real fonts never
+        // hit this (a 4 KB 2bpp glyph would be enormous); bail rather than corrupt.
+        LOG_ERR("SDCF", "Prewarm: glyph %u B exceeds chunk %u B (style %u)", len, MINI_BM_CHUNK_SIZE, styleIdx);
+        file.close();
+        delete[] readOrder;
+        delete[] mappings;
+        freeStyleMiniData(s);
+        return static_cast<int>(cpCount);
+      }
 
+      // Skip to the next chunk boundary if this glyph would straddle one.
+      const uint32_t within = span & (MINI_BM_CHUNK_SIZE - 1);
+      if (within != 0 && within + len > MINI_BM_CHUNK_SIZE) {
+        span += MINI_BM_CHUNK_SIZE - within;
+      }
+      const uint32_t chunkIdx = span >> MINI_BM_CHUNK_SHIFT;
+      if (chunkIdx >= MINI_BM_MAX_CHUNKS) {
+        LOG_ERR("SDCF", "Prewarm: mini bitmap needs > %u chunks (style %u)", MINI_BM_MAX_CHUNKS, styleIdx);
+        file.close();
+        delete[] readOrder;
+        delete[] mappings;
+        freeStyleMiniData(s);
+        return static_cast<int>(cpCount);
+      }
+      if (!s.miniBitmapChunks[chunkIdx]) {
+        s.miniBitmapChunks[chunkIdx] = new (std::nothrow) uint8_t[MINI_BM_CHUNK_SIZE];
+        if (!s.miniBitmapChunks[chunkIdx]) {
+          LOG_ERR("SDCF", "Failed to allocate mini bitmap chunk %u (style %u)", chunkIdx, styleIdx);
+          file.close();
+          delete[] readOrder;
+          delete[] mappings;
+          freeStyleMiniData(s);
+          return static_cast<int>(cpCount);
+        }
+        if (chunkIdx + 1 > s.miniBitmapChunkCount) s.miniBitmapChunkCount = chunkIdx + 1;
+      }
+
+      const uint32_t off = span & (MINI_BM_CHUNK_SIZE - 1);
       uint32_t fileOff = s.bitmapFileOffset + glyph.dataOffset;
       if (fileOff != lastBitmapEnd) {
         if (!file.seekSet(fileOff)) {
@@ -1046,18 +1085,21 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
         }
         seekCount++;
       }
-      if (file.read(s.miniBitmap + miniBitmapOffset, glyph.dataLength) != static_cast<int>(glyph.dataLength)) {
+      if (file.read(s.miniBitmapChunks[chunkIdx] + off, len) != static_cast<int>(len)) {
         LOG_ERR("SDCF", "Prewarm: short bitmap read (style %u)", styleIdx);
         delete[] readOrder;
         delete[] mappings;
         freeStyleMiniData(s);
         return static_cast<int>(cpCount);
       }
-      lastBitmapEnd = fileOff + glyph.dataLength;
+      lastBitmapEnd = fileOff + len;
 
-      glyph.dataOffset = miniBitmapOffset;
-      miniBitmapOffset += glyph.dataLength;
+      glyph.dataOffset = span;
+      span += len;
     }
+    // Footprint including inter-chunk padding: the underuse-hysteresis signal.
+    s.miniBitmapUsed = span;
+    s.miniBitmapCapacity = s.miniBitmapChunkCount * MINI_BM_CHUNK_SIZE;
   }
 
   uint32_t sdTime = millis() - sdStart;
@@ -1080,7 +1122,10 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
   s.miniMetadataOnly = metadataOnly;
   s.miniHysteresisPending = !metadataOnly;  // one hysteresis evaluation per rebuild
   memset(&s.miniData, 0, sizeof(s.miniData));
-  s.miniData.bitmap = s.miniBitmap;
+  // The mini bitmap is chunked (non-contiguous), so there is no single base
+  // pointer. Prewarmed SD glyphs are resolved via SdCardFont::miniGlyphBitmap()
+  // in the renderer; leave bitmap null so any stray &bitmap[dataOffset] faults.
+  s.miniData.bitmap = nullptr;
   s.miniData.glyph = s.miniGlyphs;
   s.miniData.intervals = s.miniIntervals;
   s.miniData.intervalCount = s.miniIntervalCount;
@@ -1515,6 +1560,16 @@ const uint8_t* SdCardFont::getOverflowBitmap(const EpdGlyph* glyph) const {
     }
   }
   return nullptr;
+}
+
+const uint8_t* SdCardFont::miniGlyphBitmap(const void* ctx, uint32_t dataOffset) const {
+  const auto* octx = static_cast<const OverflowContext*>(ctx);
+  const PerStyle& s = styles_[octx->styleIdx];
+  const uint32_t chunkIdx = dataOffset >> MINI_BM_CHUNK_SHIFT;
+  if (chunkIdx >= s.miniBitmapChunkCount) return nullptr;
+  const uint8_t* chunk = s.miniBitmapChunks[chunkIdx];
+  if (!chunk) return nullptr;
+  return chunk + (dataOffset & (MINI_BM_CHUNK_SIZE - 1));
 }
 
 SdCardFont* SdCardFont::fromMissCtx(void* ctx) { return static_cast<OverflowContext*>(ctx)->self; }

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -94,6 +94,12 @@ class SdCardFont {
   // Returns the bitmap for an on-demand-loaded (overflow) glyph.
   const uint8_t* getOverflowBitmap(const EpdGlyph* glyph) const;
 
+  // Resolves a prewarmed mini glyph's chunked bitmap. `ctx` is the glyphMissCtx
+  // (an OverflowContext identifying the style); `dataOffset` is the glyph's
+  // virtual offset into the style's chunked arena. Returns nullptr if the chunk
+  // is absent or out of range. Called by GfxRenderer::getGlyphBitmap().
+  const uint8_t* miniGlyphBitmap(const void* ctx, uint32_t dataOffset) const;
+
   // Extract SdCardFont* from an opaque glyphMissCtx pointer.
   // Used by GfxRenderer::getGlyphBitmap() to recover the SdCardFont from EpdFontData::glyphMissCtx.
   static SdCardFont* fromMissCtx(void* ctx);
@@ -128,6 +134,18 @@ class SdCardFont {
     uint8_t kernRightClassCount = 0;
     uint8_t ligaturePairCount = 0;
   };
+
+  // The per-style mini bitmap arena is stored as a list of fixed-size chunks
+  // rather than one contiguous block. A whole page's 2bpp glyph bitmaps can run
+  // tens of KB; on a fragmented heap a single contiguous allocation of that size
+  // fails even when the same bytes are available as several smaller free blocks.
+  // Chunking lets the arena be assembled from blocks the allocator can actually
+  // provide. Each glyph's bitmap is placed wholly within one chunk (never
+  // straddling a boundary), so a glyph is addressed by a virtual offset that
+  // maps to (chunk index, offset-in-chunk) via miniGlyphBitmap().
+  static constexpr uint32_t MINI_BM_CHUNK_SHIFT = 12;  // 4 KB chunks
+  static constexpr uint32_t MINI_BM_CHUNK_SIZE = 1u << MINI_BM_CHUNK_SHIFT;
+  static constexpr uint32_t MINI_BM_MAX_CHUNKS = 24;  // 96 KB ceiling per style/page
 
   // All per-style data: file offsets, intervals, kern/lig, prewarm cache, EpdFont
   struct PerStyle {
@@ -188,7 +206,10 @@ class SdCardFont {
     EpdFontData miniData{};
     EpdUnicodeInterval* miniIntervals = nullptr;
     EpdGlyph* miniGlyphs = nullptr;
-    uint8_t* miniBitmap = nullptr;
+    // Chunked mini bitmap arena (see MINI_BM_CHUNK_* above). Chunks are allocated
+    // on demand during prewarm; miniBitmapChunkCount is how many are live.
+    uint8_t* miniBitmapChunks[MINI_BM_MAX_CHUNKS] = {};
+    uint32_t miniBitmapChunkCount = 0;
     uint32_t miniIntervalCount = 0;
     uint32_t miniGlyphCount = 0;
     uint32_t miniIntervalCapacity = 0;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -81,6 +81,9 @@ const uint8_t* GfxRenderer::getGlyphBitmap(const EpdFontData* fontData, const Ep
     if (sdFont->isOverflowGlyph(glyph)) {
       return sdFont->getOverflowBitmap(glyph);  // may be nullptr for zero-width glyphs
     }
+    // Prewarmed SD glyph: the mini bitmap is chunked (non-contiguous), so there is
+    // no fontData->bitmap base to index. Resolve via the per-style chunk table.
+    return sdFont->miniGlyphBitmap(fontData->glyphMissCtx, glyph->dataOffset);
   }
   return &fontData->bitmap[glyph->dataOffset];
 }


### PR DESCRIPTION
# Chunked mini glyph-bitmap cache

Splits the per-page SD-font glyph-bitmap cache (the "mini bitmap" arena built during prewarm) from a single contiguous allocation into fixed 4 KB chunks.

## Why

A whole page's glyph bitmaps can total tens of KB. The old code allocated that as **one contiguous block** sized to the page.

Chunking assembles the arena from 4 KB blocks the allocator can actually hand out. Each glyph's bitmap is placed wholly within one chunk (never straddling a boundary); a glyph is addressed by a virtual offset that maps to `(chunk index, offset-in-chunk)`.

## Mini glyph-bitmap cache: contiguous (before) vs chunked (after)

Latin figures are grounded in device logs + font geometry.

| Metric | Latin (measured/derived) | CJK (estimated) |
|---|---|---|
| Unique glyphs per page | ~60–100 | ~250–450 (cap 512) |
| Avg glyph bitmap size | ~140 B | ~50–200 B |
| **Per-page arena (per style)** | **~12–17 KB** | **~30–60 KB** |
| Peak single allocation — **before** | up to ~17 KB (one block) | up to ~60 KB (one block) |
| Peak single allocation — **after** | **4 KB** (fixed) | **4 KB** (fixed) |
| Reduction in peak allocation | ~4× | **~8–15×** |
| Largest free block for fast path — **before** | ≥ ~17 KB | ≥ ~30–60 KB |
| Largest free block for fast path — **after** | ≥ 4 KB | ≥ 4 KB |
| Chunks used per page — **after** | 1–5 | ~8–15 |
| On allocation failure (fragmented heap) | falls back to per-glyph SD reads (~60–100 glyphs) | falls back to per-glyph SD reads (**300+ glyphs**) |

## Render-cost impact (same font/page, fast path vs fragmentation fallback)

| | Fast path (RAM cache) | Fallback (per-glyph SD) |
|---|---|---|
| `bw_render`, per page | ~30 ms *(measured)* | ~4,200 ms *(measured, pressured build)* |
| Grayscale plane render | ~1 s | ~13 s *(measured, pressured build)* |
| Relative cost | 1× | **~100×** |

Fallback figures were measured on a memory-pressured build (BLE resident), not
reproduced standalone. 

## Cost of chunking when memory is plentiful (no regression)

| Metric | Value |
|---|---|
| Extra render time at full heap | none — `bw_render` 23–39 ms, identical to contiguous *(measured)* |
| Memory overhead | ≤ one extra 4 KB block per ~4 KB of bitmap |
| Boundary padding | ≤ ~43 B per chunk *(measured: `style3 4648 need → 4691 used`)* |
