### PR TITLE
fix: read platformio.ini as UTF-8 in git_branch.py

### DIFF
--- a/scripts/git_branch.py
+++ b/scripts/git_branch.py
@@ -69,7 +69,7 @@ def get_base_version(project_dir):
         warn(f'platformio.ini not found at {ini_path}; base version will be "0.0.0"')
         return '0.0.0'
     config = configparser.ConfigParser()
-    config.read(ini_path)
+    config.read(ini_path, encoding='utf-8')
     if not config.has_option('crosspoint', 'version'):
         warn('No [crosspoint] version in platformio.ini; base version will be "0.0.0"')
         return '0.0.0'


### PR DESCRIPTION
configparser.read() without an explicit encoding decodes using
locale.getpreferredencoding(), which is the ANSI code page on Windows
(cp932 on Japanese systems). Reading platformio.ini then raises
UnicodeDecodeError on any non-ASCII byte and the pre-build script aborts.
platformio.ini is UTF-8, so decode it as UTF-8 regardless of locale.

## Summary

* **What is the goal of this PR?** Make `pio run` work on Windows systems
  whose default locale is not UTF-8 (Japanese, Chinese, Korean).
* **What changes are included?** One line in `scripts/git_branch.py`:
  pass `encoding='utf-8'` to `config.read()`.

### Error before the fix
```
UnicodeDecodeError: 'cp932' codec can't decode byte 0x94 in position 3011:
illegal multibyte sequence
File "scripts/git_branch.py", line 72: config.read(ini_path)
```

The only workaround is setting `PYTHONUTF8=1` in every terminal session,
and the error gives no hint that locale is the cause.

### Environment

* Windows 11, Japanese locale (cp932)
* Python 3.12.10, PlatformIO Core via the VS Code extension
* Reproduced on tags 1.4.1 and 1.5.0

macOS, Linux and English Windows are unaffected because they default to
UTF-8, which is likely why this has gone unnoticed.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

Build-tooling only; no runtime code is touched. No memory or flash impact.

Verified after the change:
```
CrossPoint build version: 1.5.0-dev-fix/git-branch-encoding-fecb9eb3
```

---

### AI Usage

Did you use AI tools to help write this code? _**< YES >**_

I used Claude to investigate the traceback and to help draft this
description. The change itself is a one-line encoding argument that I
verified by reproducing the failure and confirming the fix on my own
hardware.