### PR TITLE
fix: handle progressive JPEGs with separated component scans

### DIFF
--- a/scripts/jpegdec_patches/0003-fix-skip-absent-progressive-chroma-scans.patch
+++ b/scripts/jpegdec_patches/0003-fix-skip-absent-progressive-chroma-scans.patch
@@ -1,17 +1,17 @@
-From 4be2c0535619b8267e4b7ef172a02da0b3975618 Mon Sep 17 00:00:00 2001
+From d62096bbd7639e70227603eaffe0e38df17c3cf7 Mon Sep 17 00:00:00 2001
 From: Leopoldo Pla <leopoldo.pla@treelogic.com>
 Date: Sat, 8 Aug 2026 11:37:37 +0200
 Subject: [PATCH] fix: skip absent progressive chroma scans
 
 ---
- src/jpeg.inl | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
+ src/jpeg.inl | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/src/jpeg.inl b/src/jpeg.inl
-index 1bd38b2..9be89ac 100644
+index 1bd38b2..147b89e 100644
 --- a/src/jpeg.inl
 +++ b/src/jpeg.inl
-@@ -5235,8 +5235,12 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
+@@ -5235,8 +5235,15 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
                  if (pJPEG->ucPixelType >= EIGHT_BIT_GRAYSCALE) {
                      // We're not going to use the color channels, so avoid as much work as possible
                      if (pJPEG->ucMode == 0xc2) { // progressive
@@ -21,8 +21,11 @@ index 1bd38b2..9be89ac 100644
 +                        // Only consume entropy data for components present in this scan.
 +                        if (pJPEG->JPCI[1].component_needed)
 +                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred1);
-+                        if (pJPEG->JPCI[2].component_needed)
++                        if (pJPEG->JPCI[2].component_needed) {
++                            pJPEG->ucACTable = cACTable2;
++                            pJPEG->ucDCTable = cDCTable2;
 +                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred2);
++                        }
                      } else {
                          iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred1); // decode Cr block
                          iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred2); // decode Cb block

--- a/scripts/jpegdec_patches/0003-fix-skip-absent-progressive-chroma-scans.patch
+++ b/scripts/jpegdec_patches/0003-fix-skip-absent-progressive-chroma-scans.patch
@@ -1,0 +1,28 @@
+From 4be2c0535619b8267e4b7ef172a02da0b3975618 Mon Sep 17 00:00:00 2001
+From: Leopoldo Pla <leopoldo.pla@treelogic.com>
+Date: Sat, 8 Aug 2026 11:37:37 +0200
+Subject: [PATCH] fix: skip absent progressive chroma scans
+
+---
+ src/jpeg.inl | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/src/jpeg.inl b/src/jpeg.inl
+index 1bd38b2..9be89ac 100644
+--- a/src/jpeg.inl
++++ b/src/jpeg.inl
+@@ -5235,8 +5235,12 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
+                 if (pJPEG->ucPixelType >= EIGHT_BIT_GRAYSCALE) {
+                     // We're not going to use the color channels, so avoid as much work as possible
+                     if (pJPEG->ucMode == 0xc2) { // progressive
+-                        iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred1);
+-                        iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred2);
++                        // A progressive scan can contain luma without either chroma component.
++                        // Only consume entropy data for components present in this scan.
++                        if (pJPEG->JPCI[1].component_needed)
++                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred1);
++                        if (pJPEG->JPCI[2].component_needed)
++                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred2);
+                     } else {
+                         iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred1); // decode Cr block
+                         iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred2); // decode Cb block

--- a/scripts/patch_jpegdec.py
+++ b/scripts/patch_jpegdec.py
@@ -1,9 +1,9 @@
 """
 PlatformIO pre-build script: apply CrossPoint's JPEGDEC patches via `git apply`.
 
-The upstream JPEGDEC pin still has the wild-pointer + DC-write bugs in
-JPEGDecodeMCU_P that surface when EIGHT_BIT_GRAYSCALE decodes a 3-component
-progressive JPEG (each Y MCU drags two MCU_SKIP calls behind it for Cb/Cr).
+The upstream JPEGDEC pin still has progressive grayscale bugs in
+JPEGDecodeMCU_P, including unsafe MCU_SKIP writes and attempts to consume
+chroma components that are absent from the current scan.
 The patches in `scripts/jpegdec_patches/` carry the fix; this script applies
 each one against the libdep working tree.
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix valid progressive JPEGs that put luminance and chroma in separate scans, which currently render blank.
* **What changes are included?** Add a JPEGDEC patch that only consumes components present in the current scan, selects the correct chroma Huffman tables, and update the patch-runner documentation.

The pinned decoder was reading absent chroma entropy while producing its grayscale preview. Canonical upstream fix: https://github.com/bitbank2/JPEGDEC/pull/124

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. *(Not applicable: this changes only the JPEGDEC patch stack.)*

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable; this is an EPUB image-rendering bug fix within the current scope.

## Additional Context

### Validation

- Build, unit tests, clang-format, and cppcheck pass.
- Synthetic and real-world separated-scan JPEGs fail before the patch and decode successfully after it; baseline color and grayscale controls are unchanged.
- Fresh-cache emulator and physical ESP32-C3 tests render the 600x900 cover and reopen its cache successfully. The device retained 153,272 bytes free heap. *(The hardware run predates the selector-only follow-up in `426ba71`.)*

### Evidence

The screenshots are emulator-only; physical validation used fresh-cache device logs and a completed e-ink refresh.

| Baseline: blank cover | Fixed: cover renders |
| --- | --- |
| ![Baseline emulator screenshot: blank cover](https://raw.githubusercontent.com/lpla/crosspoint-reader/4b9eeac1183021961466e9893e69459dc9703af5/evidence/baseline.png) | ![Fixed emulator screenshot: rendered cover](https://raw.githubusercontent.com/lpla/crosspoint-reader/4b9eeac1183021961466e9893e69459dc9703af5/evidence/fixed.png) |

### Memory / flash impact

No new heap or stack allocation; the patch adds only component guards and Huffman-table selection.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
