### PR TITLE
fix: accept any 2xx from KOSync-compatible servers

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -95,7 +95,10 @@ KOReaderSyncClient::Error KOReaderSyncClient::authenticate() {
   LOG_DBG("KOSync", "Auth response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200) return OK;
+  // Any 2xx is success. The reference kosync server answers 200, but
+  // KOSync-compatible implementations differ (BookLore/grimmory is a Spring
+  // service and uses the idiomatic codes) — see issue #2876.
+  if (httpCode >= 200 && httpCode < 300) return OK;
   if (httpCode == 401) return AUTH_FAILED;
   return SERVER_ERROR;
 }
@@ -132,7 +135,7 @@ KOReaderSyncClient::Error KOReaderSyncClient::createUser() {
   LOG_DBG("KOSync", "Create user response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200 || httpCode == 201) return OK;
+  if (httpCode >= 200 && httpCode < 300) return OK;  // 2xx: created (see #2876)
   if (httpCode == 402) return USER_EXISTS;
   return SERVER_ERROR;
 }
@@ -166,7 +169,16 @@ KOReaderSyncClient::Error KOReaderSyncClient::getProgress(const std::string& doc
     return NETWORK_ERROR;
   }
 
-  if (httpCode == 200) {
+  // 204 = success with no stored progress for this document (Spring-style
+  // KOSync implementations; the reference server answers 200 with an empty
+  // object instead). Map it to the same graceful no-remote-progress path as
+  // 404 rather than falling through to SERVER_ERROR — see issue #2876.
+  if (httpCode == 204) {
+    http.end();
+    return NOT_FOUND;
+  }
+
+  if (httpCode >= 200 && httpCode < 300) {
     JsonDocument doc;
     const DeserializationError error = deserializeJson(doc, http.getString().c_str());
     http.end();
@@ -269,7 +281,11 @@ KOReaderSyncClient::Error KOReaderSyncClient::updateProgress(const KOReaderProgr
   LOG_DBG("KOSync", "Update progress response: %d", httpCode);
 
   if (httpCode <= 0) return NETWORK_ERROR;
-  if (httpCode == 200 || httpCode == 202) return OK;
+  // Any 2xx accepts the progress. The reference kosync server answers 200,
+  // but Spring-based KOSync implementations (BookLore/grimmory) answer a PUT
+  // with the idiomatic 201/204, which used to land in SERVER_ERROR and made
+  // every sync against them fail after a successful pull — issue #2876.
+  if (httpCode >= 200 && httpCode < 300) return OK;
   if (httpCode == 401) return AUTH_FAILED;
   return SERVER_ERROR;
 }


### PR DESCRIPTION
Previously only HTTP 200 was treated as success. Now any 2xx status code is accepted to support KOSync-compatible implementations that use different success codes (e.g., BookLore/grimmory uses idiomatic Spring codes). Fixes #2876.
