### PR TITLE
fix(epub): serialize page turns with rendering

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -501,12 +501,16 @@ void EpubReaderActivity::loop() {
       case EndOfBookOptions::Action::GoHome:
         onGoHome();
         return;
-      case EndOfBookOptions::Action::LastPage:
-        currentSpineIndex = std::max(epub->getSpineItemsCount() - 1, 0);
-        nextPageNumber = 0;
-        pendingPageJump = std::numeric_limits<uint16_t>::max();
+      case EndOfBookOptions::Action::LastPage: {
+        {
+          RenderLock lock(*this);
+          currentSpineIndex = std::max(epub->getSpineItemsCount() - 1, 0);
+          nextPageNumber = 0;
+          pendingPageJump = std::numeric_limits<uint16_t>::max();
+        }
         requestUpdate();
         return;
+      }
       case EndOfBookOptions::Action::Redraw:
         requestUpdate();
         return;
@@ -610,20 +614,32 @@ void EpubReaderActivity::loop() {
 
   // At end of the book with no suggestion menu, forward button goes home and back
   // button returns to last page
-  if (currentSpineIndex > 0 && currentSpineIndex >= epub->getSpineItemsCount()) {
-    if (endOfBookOptions.menuActive()) {
-      // Selection movement was handled above; absorb leftover page-turn triggers so
-      // e.g. "previous" at the top of the list doesn't jump back into the book
-      return;
+  bool returnHomeFromEndOfBook = false;
+  bool redrawFromEndOfBook = false;
+  {
+    RenderLock lock(*this);
+    if (currentSpineIndex > 0 && currentSpineIndex >= epub->getSpineItemsCount()) {
+      if (endOfBookOptions.menuActive()) {
+        // Selection movement was handled above; absorb leftover page-turn triggers so
+        // e.g. "previous" at the top of the list doesn't jump back into the book
+        return;
+      }
+      if (nextTriggered) {
+        returnHomeFromEndOfBook = true;
+      } else {
+        currentSpineIndex = epub->getSpineItemsCount() - 1;
+        nextPageNumber = 0;
+        pendingPageJump = std::numeric_limits<uint16_t>::max();
+        redrawFromEndOfBook = true;
+      }
     }
-    if (nextTriggered) {
-      onGoHome();
-    } else {
-      currentSpineIndex = epub->getSpineItemsCount() - 1;
-      nextPageNumber = 0;
-      pendingPageJump = std::numeric_limits<uint16_t>::max();
-      requestUpdate();
-    }
+  }
+  if (returnHomeFromEndOfBook) {
+    onGoHome();
+    return;
+  }
+  if (redrawFromEndOfBook) {
+    requestUpdate();
     return;
   }
 
@@ -636,22 +652,20 @@ void EpubReaderActivity::loop() {
   }
 
   if (longPress && SETTINGS.longPressButtonBehavior == SETTINGS.CHAPTER_SKIP) {
-    if (!nextTriggered && section && section->currentPage > 0) {
-      section->currentPage = 0;
-      requestUpdate();
-      return;
-    }
-
     // We don't want to delete the section mid-render, so grab the semaphore
     {
       RenderLock lock(*this);
-      nextPageNumber = 0;
-      if (nextTriggered) {
-        currentSpineIndex++;
-      } else if (currentSpineIndex > 0) {
-        currentSpineIndex--;
+      if (!nextTriggered && section && section->currentPage > 0) {
+        section->currentPage = 0;
+      } else {
+        nextPageNumber = 0;
+        if (nextTriggered) {
+          currentSpineIndex++;
+        } else if (currentSpineIndex > 0) {
+          currentSpineIndex--;
+        }
+        section.reset();
       }
-      section.reset();
     }
     requestUpdate();
     return;
@@ -1038,6 +1052,14 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
+  // render() initializes section->currentPage from nextPageNumber. Taking this
+  // lock before reading section makes a page turn received during initialization
+  // apply after that initialization, instead of being overwritten by it.
+  RenderLock lock(*this);
+  if (!section) {
+    return;
+  }
+
   if (isForwardTurn) {
     // Advance within the section while there are (or may still be) more pages: either a built
     // page ahead, or the section is still building (windowed), in which case more pages exist
@@ -1047,28 +1069,23 @@ void EpubReaderActivity::pageTurn(bool isForwardTurn) {
     if (section->currentPage < section->pageCount - 1 || section->isBuilding()) {
       section->currentPage++;
     } else {
-      // We don't want to delete the section mid-render, so grab the semaphore
-      {
-        RenderLock lock(*this);
-        nextPageNumber = 0;
-        currentSpineIndex++;
-        section.reset();
-      }
+      nextPageNumber = 0;
+      currentSpineIndex++;
+      section.reset();
     }
   } else {
     if (section->currentPage > 0) {
       section->currentPage--;
     } else if (currentSpineIndex > 0) {
-      // We don't want to delete the section mid-render, so grab the semaphore
-      {
-        RenderLock lock(*this);
-        nextPageNumber = 0;
-        pendingPageJump = std::numeric_limits<uint16_t>::max();
-        currentSpineIndex--;
-        section.reset();
-      }
+      nextPageNumber = 0;
+      pendingPageJump = std::numeric_limits<uint16_t>::max();
+      currentSpineIndex--;
+      section.reset();
     }
   }
+
+  // requestUpdate() schedules render(), which needs this mutex.
+  lock.unlock();
   lastPageTurnTime = millis();
   requestUpdate();
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix #2929, where the EPUB reader can jump back to the page at which a reading session started.
* **What changes are included?** Serialize EPUB reader page-navigation state with rendering, including same-chapter turns, chapter transitions, long-press chapter navigation, and end-of-book navigation. The position lock is released before scheduling the subsequent render.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (Not applicable; this PR does not touch those areas.)

## Additional Context

The root cause is a race: `render()` restores `nextPageNumber` into a newly initialized section after an accepted page turn has already modified `section->currentPage`. Holding `RenderLock` across the navigation decision and position update prevents that stale restore from overwriting the accepted turn.

No persistent-data, cache, or indexing-format changes. Firmware was built successfully with `pio run -e default` (ESP32-C3 X3/X4 target). Hardware validation on an affected X3 remains pending.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
