### PR TITLE
feat: add Select option for short power button press

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -7,6 +7,7 @@
 
 #include "CrossPointSettings.h"
 #include "components/UITheme.h"
+#include "util/ShortcutAction.h"
 
 bool MappedInputManager::isNavDirectionSwapped() const {
   // Key the swap on the orientation the screen is *actually* rendered at, not the persisted reader
@@ -361,13 +362,21 @@ bool MappedInputManager::wasHomeGesture() const {
   return false;
 }
 
+bool MappedInputManager::wasShortPowerSelectClick() const {
+  return SETTINGS.shortPwrBtn == shortcutActionRawValue(ShortcutAction::Select) &&
+         mapButton(Button::Power, &HalGPIO::wasReleased) &&
+         gpio.getPowerButtonHeldTime() <= SETTINGS.getPowerButtonDuration();
+}
+
 bool MappedInputManager::wasPressed(const Button button) const {
   if (button == Button::Back && wasBackGesture()) return true;
+  if (button == Button::Confirm && wasShortPowerSelectClick()) return true;
   return mapButton(button, &HalGPIO::wasPressed);
 }
 
 bool MappedInputManager::wasReleased(const Button button) const {
   if (button == Button::Back && wasBackGesture()) return true;
+  if (button == Button::Confirm && wasShortPowerSelectClick()) return true;
   return mapButton(button, &HalGPIO::wasReleased);
 }
 

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -108,6 +108,12 @@ class MappedInputManager {
   Labels mapFrontLabels(const char* back, const char* confirm, const char* left, const char* right) const;
   bool mapButton(Button button, bool (HalGPIO::*fn)(uint8_t) const) const;
   bool wasBackGesture() const;
+  // True exactly once, on the frame Power is released, when shortPwrBtn == ShortcutAction::Select
+  // and the completed press was short enough to not have triggered a long-hold action (same
+  // threshold as CrossPointSettings::getPowerButtonDuration(), the power-management path's own
+  // classification). Long holds never report true here, even mid-press, since press/release
+  // duration is only known for certain once the button comes back up.
+  bool wasShortPowerSelectClick() const;
   // Fetch the pending swipe (if any) and map both endpoints to logical screen coords
   bool decodeSwipe(int& sx, int& sy, int& ex, int& ey) const;
   bool listItemFromPoint(int x, int y, int& index, int itemCount, int selectedIndex, int listTop, int listHeight,

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -169,9 +169,10 @@ inline SettingInfo buildDictionarySetting(const std::vector<DictionaryEntry>& di
 // Power-button shortcut options, shared by the short- and long-press settings.
 //
 // The display order is grouped by usefulness rather than by persisted value.
-// Only actions the reader can execute today are listed; the enum carries no entry we cannot run.
-inline SettingInfo buildPowerButtonActionSetting(StrId nameId, uint8_t CrossPointSettings::* valuePtr,
-                                                 const char* key) {
+// Only actions the reader can execute today are listed, plus Select (short-press only; see
+// includeSelect below) — the enum carries no other entry we cannot run.
+inline SettingInfo buildPowerButtonActionSetting(StrId nameId, uint8_t CrossPointSettings::* valuePtr, const char* key,
+                                                 const bool includeSelect = false) {
   SettingEnumOptions options({{StrId::STR_IGNORE, shortcutActionRawValue(ShortcutAction::None)},
                               {StrId::STR_SLEEP, shortcutActionRawValue(ShortcutAction::Sleep)},
                               {StrId::STR_PAGE_TURN, shortcutActionRawValue(ShortcutAction::PageTurn)},
@@ -183,9 +184,14 @@ inline SettingInfo buildPowerButtonActionSetting(StrId nameId, uint8_t CrossPoin
                               {StrId::STR_BROWSE_FILES, shortcutActionRawValue(ShortcutAction::FileBrowser)},
                               {StrId::STR_FILE_TRANSFER, shortcutActionRawValue(ShortcutAction::FileTransfer)},
                               {StrId::STR_LOOK_UP_WORD, shortcutActionRawValue(ShortcutAction::LookUpWord)}},
-                             1);
+                             2);
   if (halTiltSensor.isAvailable()) {
     options.add(StrId::STR_TOGGLE_TILT_PAGE_TURN, shortcutActionRawValue(ShortcutAction::ToggleTiltPageTurn));
+  }
+  // Select only makes sense as a quick tap: aliasing a long hold risks activating whatever is
+  // highlighted while the user is deliberately mid-hold for the long-press action instead.
+  if (includeSelect) {
+    options.add(StrId::STR_SELECT, shortcutActionRawValue(ShortcutAction::Select));
   }
   return SettingInfo::MappedEnum(nameId, valuePtr, std::move(options), key, StrId::STR_CAT_CONTROLS);
 }
@@ -301,7 +307,8 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
                           {StrId::STR_IMAGES_DISPLAY, StrId::STR_IMAGES_PLACEHOLDER, StrId::STR_IMAGES_SUPPRESS},
                           "imageRendering", StrId::STR_CAT_READER),
         // --- Controls: Power Button ---
-        buildPowerButtonActionSetting(StrId::STR_SHORT_PRESS_ACTION, &CrossPointSettings::shortPwrBtn, "shortPwrBtn"),
+        buildPowerButtonActionSetting(StrId::STR_SHORT_PRESS_ACTION, &CrossPointSettings::shortPwrBtn, "shortPwrBtn",
+                                      /*includeSelect=*/true),
         buildPowerButtonActionSetting(StrId::STR_LONG_PRESS_ACTION, &CrossPointSettings::longPwrBtn, "longPwrBtn"),
         SettingInfo::Toggle(StrId::STR_PWR_BTN_FOOTNOTE_BACK, &CrossPointSettings::pwrBtnFootnoteBack,
                             "pwrBtnFootnoteBack", StrId::STR_CAT_CONTROLS),

--- a/src/util/ShortcutAction.cpp
+++ b/src/util/ShortcutAction.cpp
@@ -32,6 +32,8 @@ ShortcutAction shortcutActionFromRawValue(const uint8_t value) {
       return ShortcutAction::FileTransfer;
     case shortcutActionRawValue(ShortcutAction::ToggleTiltPageTurn):
       return ShortcutAction::ToggleTiltPageTurn;
+    case shortcutActionRawValue(ShortcutAction::Select):
+      return ShortcutAction::Select;
     case shortcutActionRawValue(ShortcutAction::None):
     default:
       return ShortcutAction::None;
@@ -53,6 +55,7 @@ bool isShortcutAvailableOutsideReader(const ShortcutAction action) {
     case ShortcutAction::ToggleBookmark:
     case ShortcutAction::SyncProgress:
     case ShortcutAction::LookUpWord:
+    case ShortcutAction::Select:
       return false;
   }
   return false;
@@ -92,6 +95,7 @@ bool runGlobalShortcut(const ShortcutAction action, GfxRenderer& renderer) {
     case ShortcutAction::ToggleBookmark:
     case ShortcutAction::SyncProgress:
     case ShortcutAction::LookUpWord:
+    case ShortcutAction::Select:
       return false;
   }
   return false;

--- a/src/util/ShortcutAction.h
+++ b/src/util/ShortcutAction.h
@@ -19,6 +19,11 @@ enum class ShortcutAction : uint8_t {
   LookUpWord = 9,
   FileTransfer = 10,
   ToggleTiltPageTurn = 11,
+  // Aliases the button to whatever Confirm currently means on screen. Unlike every other
+  // action, this has no fixed effect to run — it is handled entirely at the input layer
+  // (MappedInputManager::wasShortPowerSelectClick), so it is deliberately excluded from
+  // isShortcutAvailableOutsideReader()/runGlobalShortcut()/runReaderShortcut().
+  Select = 12,
 };
 
 constexpr uint8_t shortcutActionRawValue(const ShortcutAction action) { return static_cast<uint8_t>(action); }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let users configure the power button's short-press action to behave exactly like the Confirm/Select button, so a quick power press activates whatever Confirm would on the current screen.
* **What changes are included?**
  * Adds a `SAME_AS_SELECT` value to `CrossPointSettings::SHORT_PWRBTN` (`src/CrossPointSettings.h`), reusing the existing `STR_SELECT` label for the new "Short Power Button Click" option (`src/SettingsList.h`).
  * Implements the aliasing in `MappedInputManager::wasPressed`/`wasReleased` (`src/MappedInputManager.cpp`), mirroring the existing `Back` touch-gesture alias pattern: when the setting is active, a `Power` press/release is OR'd into `Button::Confirm`. Every screen that already polls `Button::Confirm` (Home, Settings, reader menu, list pickers, etc.) picks this up automatically — no per-activity changes needed.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (N/A — this PR doesn't touch any of those.)

## Additional Context

* No memory/flash impact beyond one new enum value and one new branch in two existing functions (`wasPressed`/`wasReleased`).
* `isPressed(Button::Confirm)` (used for long-press-menu detection) is intentionally **not** aliased — a power short-press is a discrete click, not a holdable state, so only the press/release edges are mirrored.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES**
