### PR TITLE
fix: prevent reader resume position rollback

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -789,6 +789,7 @@ void EpubReaderActivity::jumpToPercent(int percent) {
   // Reset state so render() reloads and repositions on the target spine.
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     currentSpineIndex = targetSpineIndex;
     nextPageNumber = 0;
     pendingPercentJump = true;
@@ -814,6 +815,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       // possibly-different settings.
       if (sync.hasVisibleTextOffset && sync.spineIndex >= 0 && sync.spineIndex < epub->getSpineItemsCount()) {
         RenderLock lock(*this);
+        clearDeferredReposition();
         if (section && currentSpineIndex == sync.spineIndex) {
           // Already in this chapter and laid out: resolve straight away, no reload.
           const auto page = section->getPageForVisibleTextOffset(sync.visibleTextOffset);
@@ -845,14 +847,18 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
       if (currentSpineIndex != targetSpineIndex) {
         RenderLock lock(*this);
+        clearDeferredReposition();
         currentSpineIndex = targetSpineIndex;
         nextPageNumber = targetPage;
         section.reset();
       } else if (section && section->currentPage != targetPage) {
         RenderLock lock(*this);
+        clearDeferredReposition();
         const int clampedTargetPage = std::max(0, targetPage);
         section->currentPage = clampedTargetPage;
       } else if (!section) {
+        RenderLock lock(*this);
+        clearDeferredReposition();
         nextPageNumber = targetPage;
       }
     }
@@ -871,6 +877,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
             const auto& chapterResult = std::get<ChapterResult>(result.data);
             RenderLock lock(*this);
 
+            clearDeferredReposition();
             currentSpineIndex = chapterResult.spineIndex;
 
             // If anchor is not empty, it will be used later to calculate the page number.
@@ -1108,6 +1115,12 @@ void EpubReaderActivity::toggleAutoPageTurn(const uint8_t selectedPageTurnOption
 }
 
 void EpubReaderActivity::pageTurn(bool isForwardTurn) {
+  // A page turn is authoritative: do not let a resume/reflow position captured
+  // at session start snap the reader back after the incremental build completes.
+  {
+    RenderLock lock(*this);
+    clearDeferredReposition();
+  }
   if (isForwardTurn) {
     // Advance within the section while there are (or may still be) more pages: either a built
     // page ahead, or the section is still building (windowed), in which case more pages exist
@@ -1252,8 +1265,9 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     // Otherwise fall back to the settings-change reposition: read after the cache-hit reset above,
     // a spec match means the saved page number still names the same content so there is nothing to
     // reposition, while a page jump or fragment anchor is a deliberate navigation that outranks it.
+    const bool explicitOffsetJump = pendingOffsetJump.has_value();
     const std::optional<uint32_t> offsetJump =
-        pendingOffsetJump.has_value() ? pendingOffsetJump
+        explicitOffsetJump ? pendingOffsetJump
         : (pendingPageJump.has_value() || !pendingAnchor.empty() || currentSpineIndex != cachedSpineIndex)
             ? std::nullopt
             : cachedVisibleTextOffset;
@@ -1411,7 +1425,17 @@ void EpubReaderActivity::render(RenderLock&& lock) {
     if (offsetJump.has_value()) {
       if (const auto offsetPage = section->getPageForVisibleTextOffset(*offsetJump)) {
         section->currentPage = *offsetPage;
+        // This anchor has now established the landing page. It must not be
+        // applied again by applyDeferredReposition() after a background build
+        // finishes, or it would undo page turns made during that build.
+        clearDeferredReposition();
       }
+    }
+    if (explicitOffsetJump) {
+      // An explicit bookmark/sync target supersedes any stale session-start
+      // resume anchor even when its offset cannot be resolved (for example an
+      // empty chapter).
+      clearDeferredReposition();
     }
     pendingOffsetJump.reset();  // one-shot explicit jump: consumed on this render
 
@@ -1618,9 +1642,13 @@ bool EpubReaderActivity::applyDeferredReposition() {
       changed = true;
     }
   }
-  cachedChapterTotalPageCount = 0;  // consumed; don't read cached progress again
-  cachedVisibleTextOffset.reset();
+  clearDeferredReposition();
   return changed;
+}
+
+void EpubReaderActivity::clearDeferredReposition() {
+  cachedChapterTotalPageCount = 0;
+  cachedVisibleTextOffset.reset();
 }
 
 bool EpubReaderActivity::saveProgress(int spineIndex, int currentPage, int pageCount) {
@@ -2002,6 +2030,7 @@ void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool s
 
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     pendingAnchor = std::move(anchor);
     currentSpineIndex = targetSpineIndex;
     nextPageNumber = 0;
@@ -2019,6 +2048,7 @@ void EpubReaderActivity::restoreSavedPosition() {
 
   {
     RenderLock lock(*this);
+    clearDeferredReposition();
     currentSpineIndex = pos.spineIndex;
     nextPageNumber = pos.pageNumber;
     section.reset();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -847,22 +847,17 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
       // Any explicit selection supersedes the session-start resume/reflow anchor,
       // including a selection that is already active.
-      {
-        RenderLock lock(*this);
-        clearDeferredReposition();
-      }
+      RenderLock lock(*this);
+      clearDeferredReposition();
 
       if (currentSpineIndex != targetSpineIndex) {
-        RenderLock lock(*this);
         currentSpineIndex = targetSpineIndex;
         nextPageNumber = targetPage;
         section.reset();
       } else if (section && section->currentPage != targetPage) {
-        RenderLock lock(*this);
         const int clampedTargetPage = std::max(0, targetPage);
         section->currentPage = clampedTargetPage;
       } else if (!section) {
-        RenderLock lock(*this);
         nextPageNumber = targetPage;
       }
     }

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -845,24 +845,25 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         targetPage = fallback.pageNumber;
       }
 
-      if (currentSpineIndex != targetSpineIndex) {
+      // Any explicit selection supersedes the session-start resume/reflow anchor,
+      // including a selection that is already active.
+      {
         RenderLock lock(*this);
         clearDeferredReposition();
+      }
+
+      if (currentSpineIndex != targetSpineIndex) {
+        RenderLock lock(*this);
         currentSpineIndex = targetSpineIndex;
         nextPageNumber = targetPage;
         section.reset();
       } else if (section && section->currentPage != targetPage) {
         RenderLock lock(*this);
-        clearDeferredReposition();
         const int clampedTargetPage = std::max(0, targetPage);
         section->currentPage = clampedTargetPage;
       } else if (!section) {
         RenderLock lock(*this);
-        clearDeferredReposition();
         nextPageNumber = targetPage;
-      } else {
-        RenderLock lock(*this);
-        clearDeferredReposition();
       }
     }
   };

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -860,6 +860,9 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         RenderLock lock(*this);
         clearDeferredReposition();
         nextPageNumber = targetPage;
+      } else {
+        RenderLock lock(*this);
+        clearDeferredReposition();
       }
     }
   };

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -186,6 +186,10 @@ class EpubReaderActivity final : public Activity {
   // settings change re-paginates a chapter). Returns true if currentPage moved.
   // No-op while the section is still building or when the pagination is unchanged (plain resume).
   bool applyDeferredReposition();
+  // The saved resume/reflow anchor is only valid until it has established the
+  // initial landing page. Later user navigation must never be overwritten when
+  // a background section build finishes.
+  void clearDeferredReposition();
   void rememberCurrentContentOffset();
   bool saveProgress(int spineIndex, int currentPage, int pageCount);
   // Jump to a percentage of the book (0-100), mapping it to spine and page.


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Prevent EPUB reading sessions from unexpectedly returning to their opening page while a section is indexed in the background.
* **What changes are included?** Treat the saved resume/reflow anchor as one-shot state, clear it after the initial landing page is resolved, and cancel it when explicit navigation or a page turn takes over.

Fix https://github.com/crosspoint-reader/crosspoint-reader/issues/2929.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable: this is a regression fix in the EPUB reader's existing progress and page-navigation flow.

## Additional Context

Root cause: the initial resume offset was used to establish the first page during incremental section building, but remained pending. Once the background build completed, it was applied a second time and overwrote intervening page turns.

The fix is limited to `EpubReaderActivity`: it consumes the anchor after a successful landing and clears stale deferred state for page turns, bookmark/sync jumps, percent jumps, chapter/footnote navigation, and restored footnote positions. All shared state updates are protected by `RenderLock`.

Validation: `clang-format --dry-run --Werror src/activities/reader/EpubReaderActivity.cpp src/activities/reader/EpubReaderActivity.h` and `pio run -e default` both pass. No expected memory or flash impact.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
