### PR TITLE
fix: ignore empty watchdog reports

### DIFF
--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -11,9 +11,13 @@
 #include "esp_private/panic_internal.h"
 
 #define MAX_PANIC_STACK_DEPTH 32
+#define PANIC_CAPTURE_MAGIC 0x50414E49u
 
 RTC_NOINIT_ATTR char panicMessage[256];
 RTC_NOINIT_ATTR HalSystem::StackFrame panicStack[MAX_PANIC_STACK_DEPTH];
+// RTC_NOINIT is uninitialized on cold boot, so only this exact marker proves a
+// panic diagnostic was captured before the reset.
+RTC_NOINIT_ATTR volatile uint32_t panicCaptureMarker;
 
 extern "C" {
 
@@ -29,6 +33,7 @@ void IRAM_ATTR __wrap_panic_abort(const char* message) {
     panicMessage[i] = message[i];
   }
   panicMessage[i] = '\0';
+  panicCaptureMarker = PANIC_CAPTURE_MAGIC;
 
   __real_panic_abort(message);
 }
@@ -68,6 +73,7 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
       break;
     }
   }
+  panicCaptureMarker = PANIC_CAPTURE_MAGIC;
 
   __real_panic_print_backtrace(frame, core);
 #endif
@@ -108,6 +114,7 @@ void checkPanic() {
 }
 
 void clearPanic() {
+  panicCaptureMarker = 0;
   panicMessage[0] = '\0';
   for (size_t i = 0; i < MAX_PANIC_STACK_DEPTH; i++) {
     panicStack[i].sp = 0;
@@ -148,8 +155,13 @@ std::string getPanicInfo(bool full) {
 
 bool isRebootFromPanic() {
   const auto resetReason = esp_reset_reason();
-  return resetReason == ESP_RST_PANIC || resetReason == ESP_RST_CPU_LOCKUP || resetReason == ESP_RST_INT_WDT ||
-         resetReason == ESP_RST_TASK_WDT || resetReason == ESP_RST_WDT;
+  if (resetReason == ESP_RST_PANIC || resetReason == ESP_RST_CPU_LOCKUP) {
+    return true;
+  }
+
+  const bool watchdogReset =
+      resetReason == ESP_RST_INT_WDT || resetReason == ESP_RST_TASK_WDT || resetReason == ESP_RST_WDT;
+  return watchdogReset && panicCaptureMarker == PANIC_CAPTURE_MAGIC;
 }
 
 }  // namespace HalSystem

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -83,9 +83,8 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
 namespace HalSystem {
 
 void begin() {
-  // This is mostly for the first boot, we need to initialize the panic info and logs to empty state
-  // If we reboot from a panic state, we want to keep the panic info until we successfully dump it to the SD card, use
-  // `clearPanic()` to clear it after dumping
+  // On a panic reboot, preserve diagnostics until checkPanic() has tried to write them to the SD card.
+  // Ordinary boots clear any stale retained diagnostics.
   if (!isRebootFromPanic()) {
     clearPanic();
   } else {
@@ -104,9 +103,16 @@ void checkPanic() {
     auto panicInfo = getPanicInfo(true);
     auto file = Storage.open("/crash_report.txt", O_WRITE | O_CREAT | O_TRUNC);
     if (file) {
-      file.write(panicInfo.c_str(), panicInfo.size());
+      const size_t written = file.write(panicInfo.c_str(), panicInfo.size());
       file.close();
-      LOG_INF("SYS", "Dumped panic info to SD card");
+      if (written == panicInfo.size()) {
+        // Keep the crash data for CrashActivity, but mark it consumed so a
+        // later watchdog reset cannot be mistaken for this panic.
+        panicCaptureMarker = 0;
+        LOG_INF("SYS", "Dumped panic info to SD card");
+      } else {
+        LOG_ERR("SYS", "Failed to write complete crash report (%zu of %zu bytes)", written, panicInfo.size());
+      }
     } else {
       LOG_ERR("SYS", "Failed to open crash_report.txt for writing");
     }

--- a/src/activities/home/CrashActivity.cpp
+++ b/src/activities/home/CrashActivity.cpp
@@ -14,7 +14,6 @@ void CrashActivity::onEnter() {
   if (panicMessage.empty()) {
     panicMessage = tr(STR_CRASH_NO_REASON);
   }
-  HalSystem::clearPanic();
 
   requestUpdateAndWait();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -281,6 +281,9 @@ void setup() {
 #endif
 
   HalSystem::begin();
+  // checkPanic() clears the watchdog capture marker after a successful SD
+  // dump, so retain the boot classification for the later activity route.
+  const bool rebootedFromPanic = HalSystem::isRebootFromPanic();
 
   // Read-and-clear so a panic later in setup() doesn't loop into silent reboot.
   // Bound the target range too — RTC_NOINIT memory is uninitialized on cold boot.
@@ -415,7 +418,7 @@ void setup() {
     // Skip normal home/reader routing: jump straight into the SD firmware picker.
     activityManager.replaceActivity(
         std::make_unique<SdFirmwareUpdateActivity>(renderer, mappedInputManager, /*recoveryMode=*/true));
-  } else if (HalSystem::isRebootFromPanic()) {
+  } else if (rebootedFromPanic) {
     // If we rebooted from a panic, go to crash report screen to show the panic info
     activityManager.goToCrashReport();
   } else if (resume == BootResume::Silent && snapshotTarget == SILENT_REBOOT_TARGET_READER &&


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Prevent reset-only watchdog events from opening the crash-report flow with an empty panic reason.

* **What changes are included?**
  * Record a marker in RTC memory only when panic diagnostics are captured.
  * Continue reporting explicit panics and CPU lockups.
  * Require that marker before treating watchdog resets as crashes, and clear it with the existing panic state.


## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* This is a focused port of CrossInk commit `c96d4275`.
* The change adds 4 bytes of RTC no-init state; it does not affect storage formats, normal boot routing, or real panic reporting.
* Hardware follow-up: on an X3/X4, confirm a reset-only watchdog boots normally without an empty crash report, while a genuine panic still reaches the crash-report screen.
---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**<YES>**_
