### PR TITLE
fix(reader): prevent opening next bookmark after deleting from bookmark list

### DIFF
--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -71,7 +71,24 @@ void EpubReaderBookmarksActivity::loop() {
   };
 
   // Delete confirmation popup
-  if (confirmPopup.handleInput(mappedInput, [this] { requestUpdate(); })) return;
+  if (confirmPopup.handleInput(mappedInput, [this] { requestUpdate(); })) {
+    // The popup acts on button press; if that input closed it, the trailing
+    // release must be swallowed below (Confirm would open the bookmark, Back
+    // would exit the activity).
+    popupClosing = !confirmPopup.isActive();
+    return;
+  }
+  if (popupClosing) {
+    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
+        mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
+      return;  // closing press still held
+    }
+    popupClosing = false;
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
+        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+      return;  // swallow the release that closed the popup
+    }
+  }
   if (confirmingDelete) {
     // Popup dismissed without a selection (Back button or tap outside): cancel delete
     confirmingDelete = false;

--- a/src/activities/reader/EpubReaderBookmarksActivity.h
+++ b/src/activities/reader/EpubReaderBookmarksActivity.h
@@ -15,6 +15,7 @@ class EpubReaderBookmarksActivity final : public Activity {
   int selectorIndex = 0;
   std::vector<BookmarkEntry> bookmarks;
   bool confirmingDelete = false;
+  bool popupClosing = false;
   OptionPopup confirmPopup;
 
  public:


### PR DESCRIPTION
## Summary

Fixes #2934.

* **What is the goal of this PR?** Prevents the bookmark list from exiting and opening the next bookmark immediately after a bookmark is deleted.
* **What changes are included?** Added `popupClosing` state handling to `EpubReaderBookmarksActivity` to swallow trailing `Button::Confirm` release events after dismissing `confirmPopup` (matching the pattern in `EpubReaderMenuActivity`).

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

* **Memory / flash impact:** Negligible (1 byte boolean member, 0 heap allocations).
* Follows the existing button release swallowing idiom from `EpubReaderMenuActivity`.

---

### AI Usage

Did you use AI tools to help write this code? **YES**