### PR TITLE
docs: add M5Paper v1.1 port to community forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ One of the best things about open source is that anyone can take the code in a d
 
 - [crosspoint-reader-papers3](https://github.com/juicecultus/crosspoint-reader-papers3) — Crosspoint port for M5Stack Paper S3. 
 
+- [crosspoint-reader-m5paper](https://github.com/madaerodog/crosspoint-reader-m5paper) — CrossPoint port for the original M5Paper v1.0/v1.1 (classic ESP32 + IT8951).
+
 - [t5s3-reader](https://github.com/ShallowGreen123/t5s3-reader) — Crosspoint port for LilyGo T5 ePaper S3 / T5S3 4.7-inch e-paper device.
 
 **Note:** Many of these features will make their way into CrossPoint over time. We maintain a slower pace to ensure rock-solid stability and squash bugs before they reach your device.


### PR DESCRIPTION
Adds a link to [crosspoint-reader-m5paper](https://github.com/madaerodog/crosspoint-reader-m5paper) — a port of CrossPoint to the original M5Stack M5Paper v1.0/v1.1 (classic ESP32-D0WDQ6 + IT8951 e-ink controller over SPI), based on the M5PaperS3 community port.

Working on hardware: EPUB reading, GT911 touch, the M5Paper's physical wheel (page turns / enter / sleep), true power-off sleep via the power latch, and the IT8951 slept between refreshes for battery life. The README documents the classic-ESP32-specific traps (4MB DROM window forcing OMIT_FONTS, GT911 100kHz/no-INT quirks) for anyone else porting to this hardware family.