### PR TITLE
chore: remove unnesessary swallowing code

### DIFF
--- a/src/activities/UiListActivity.cpp
+++ b/src/activities/UiListActivity.cpp
@@ -42,11 +42,11 @@ void UiListActivity::onRowAction(const fui::ActionEvent& event) {
 }
 
 bool UiListActivity::handleButtons() {
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     onBackButton();
     return true;
   }
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     const int selected = activeNav().selected;
     if (selected >= 0 && selected < listCount()) activateIndex(selected);
     return true;

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -51,8 +51,6 @@ void OpdsBookBrowserActivity::onEnter() {
   searchTemplate = "";
   currentPath = "";
   selectorIndex = 0;
-  consumeConfirm = false;
-  consumeBack = false;
   errorMessage.clear();
   statusMessage = tr(STR_CHECKING_WIFI);
 
@@ -112,15 +110,6 @@ void OpdsBookBrowserActivity::onCancelEvent(const fui::ActionEvent&, void* user)
 
 void OpdsBookBrowserActivity::loop() {
   if (state == BrowserState::WIFI_SELECTION || state == BrowserState::SEARCH_INPUT) {
-    return;
-  }
-
-  if (consumeConfirm && mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    consumeConfirm = false;
-    return;
-  }
-  if (consumeBack && mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    consumeBack = false;
     return;
   }
 
@@ -555,10 +544,6 @@ void OpdsBookBrowserActivity::launchSearch() {
 
   auto keyboard = std::make_unique<KeyboardEntryActivity>(renderer, mappedInput, tr(STR_SEARCH));
   startActivityForResult(std::move(keyboard), [this](const ActivityResult& result) {
-    // Swallow the release of the Confirm press that closed the keyboard only
-    // when that button is actually still held on resume — a blanket flag set
-    // at launch went stale on touch flows and ate the next genuine Confirm.
-    consumeConfirm = mappedInput.isPressed(MappedInputManager::Button::Confirm);
     state = BrowserState::BROWSING;
     if (!result.isCancelled) {
       performSearch(std::get<KeyboardResult>(result.data).text);

--- a/src/activities/browser/OpdsBookBrowserActivity.h
+++ b/src/activities/browser/OpdsBookBrowserActivity.h
@@ -37,8 +37,6 @@ class OpdsBookBrowserActivity final : public Activity, private UiAppHost {
   std::vector<std::string> navigationHistory;
   std::string currentPath;
   std::string searchTemplate;
-  bool consumeConfirm = false;
-  bool consumeBack = false;
   int selectorIndex = 0;
   std::string errorMessage;
   std::string statusMessage;

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -110,17 +110,11 @@ void FileBrowserActivity::onEnter() {
     return;
   }
 
-  // If Confirm was held while this activity opened (typical when launched from a menu), ignore
-  // its release — otherwise we'd immediately auto-open whatever is at index 0.
-  lockNextConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
-
   auto root = Storage.open(basepath.c_str());
   if (!root) {
     basepath = "/";
     loadFiles();
   } else if (!root.isDirectory()) {
-    lockLongPressBack = mappedInput.isPressed(MappedInputManager::Button::Back);
-
     const std::string oldPath = basepath;
     basepath = FsHelpers::extractFolderPath(basepath);
     loadFiles();
@@ -240,11 +234,7 @@ void FileBrowserActivity::onRowLongPress(const int index) {
   activateSelected(/*forceDelete=*/true);
 }
 
-void FileBrowserActivity::activateSelected(const bool forceDelete, const bool fromButton) {
-  if (fromButton && lockNextConfirmRelease) {
-    lockNextConfirmRelease = false;
-    return;
-  }
+void FileBrowserActivity::activateSelected(const bool forceDelete) {
   if (files.empty()) return;
 
   const std::string& entry = files[nav.selected];
@@ -268,11 +258,6 @@ void FileBrowserActivity::activateSelected(const bool forceDelete, const bool fr
     const std::string fullPath = cleanBasePath + entry;
 
     auto handler = [this, fullPath](const ActivityResult& res) {
-      // The confirmation popup acts on button press; if that button is still
-      // held when we resume, swallow its release so it doesn't also act here
-      // (Back would go up a directory, Confirm would open the selection).
-      lockLongPressBack = mappedInput.isPressed(MappedInputManager::Button::Back);
-      lockNextConfirmRelease = mappedInput.isPressed(MappedInputManager::Button::Confirm);
       if (!res.isCancelled) {
         LOG_DBG("FileBrowser", "Attempting to delete: %s", fullPath.c_str());
         if (removeDirFile(fullPath)) {
@@ -319,8 +304,8 @@ void FileBrowserActivity::activateSelected(const bool forceDelete, const bool fr
 bool FileBrowserActivity::handleCustomInput() {
   // Long press BACK (1s+) goes to root folder (Books mode only).
   // In firmware-pick mode we keep navigation simple: short Back = up dir / cancel.
-  if (mode == Mode::Books && mappedInput.isPressed(MappedInputManager::Button::Back) &&
-      mappedInput.getHeldTime() >= GO_HOME_MS && basepath != "/" && !lockLongPressBack) {
+  if (mode == Mode::Books && mappedInput.wasReleased(MappedInputManager::Button::Back) &&
+      mappedInput.getHeldTime() >= GO_HOME_MS && basepath != "/") {
     basepath = "/";
     loadFiles();
     nav.selected = 0;
@@ -329,17 +314,12 @@ bool FileBrowserActivity::handleCustomInput() {
     return true;
   }
 
-  if (lockLongPressBack && mappedInput.wasReleased(MappedInputManager::Button::Back)) {
-    lockLongPressBack = false;
-    return true;
-  }
-
   return false;
 }
 
 bool FileBrowserActivity::handleButtons() {
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-    activateSelected(/*forceDelete=*/false, /*fromButton=*/true);
+    activateSelected();
     return true;
   }
 

--- a/src/activities/home/FileBrowserActivity.h
+++ b/src/activities/home/FileBrowserActivity.h
@@ -15,11 +15,6 @@ class FileBrowserActivity final : public UiListActivity {
   // Deletion
   bool removeDirFile(const std::string& fullPath);
 
-  bool lockLongPressBack = false;
-  // True when this activity was entered while Confirm was already held; we must swallow the next
-  // release so we don't immediately auto-open the first entry.
-  bool lockNextConfirmRelease = false;
-
   Mode mode = Mode::Books;
 
   // Files state
@@ -57,9 +52,7 @@ class FileBrowserActivity final : public UiListActivity {
   void drawFooter() override;
   // forceDelete routes the touch long-press to the delete branch; button
   // navigation leaves it false and relies on getHeldTime() instead.
-  // fromButton: only the physical Confirm path may consume the
-  // lockNextConfirmRelease swallow — a touch tap has no pending release.
-  void activateSelected(bool forceDelete = false, bool fromButton = false);
+  void activateSelected(bool forceDelete = false);
 
   // Data loading
   void loadFiles();

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -220,13 +220,10 @@ void HomeActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) backPressSeen = true;
-
   // Back is otherwise unused on the home menu: open the most recently read
   // book directly (recentBooks is most-recent-first and already pruned of
-  // files missing from the SD card). backPressSeen guards against the stale
-  // release of the Back press that closed the previous activity.
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && backPressSeen && !recentBooks.empty()) {
+  // files missing from the SD card).
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && !recentBooks.empty()) {
     onSelectBook(recentBooks[0].path);
     return;
   }

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -18,9 +18,6 @@ class HomeActivity final : public Activity {
   bool hasOpdsServers = false;
   bool coverRendered = false;      // Track if cover has been rendered once
   bool coverBufferStored = false;  // Track if cover buffer is stored
-  // Home can be entered while Back is still held (e.g. leaving Settings with
-  // Back): ignore that stale release until a fresh press is seen here.
-  bool backPressSeen = false;
   uint8_t* coverBuffer = nullptr;  // HomeActivity's own buffer for cover image
   size_t coverBufferSize = 0;      // Bytes allocated to coverBuffer
   // Logical rect last passed to drawRecentBookCover. The cover snapshot only

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -76,28 +76,13 @@ void RecentBooksActivity::onRowLongPress(const int index) {
 }
 
 bool RecentBooksActivity::handleButtons() {
-  // After a long-press has fired, swallow input until Confirm is physically released
-  // (so the release doesn't also open the book; re-arm only once the button is up).
-  if (longPressFired) {
-    if (!mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      longPressFired = false;
-    }
-    return true;
-  }
-
-  // Long-press Confirm on the selected book: prompt to remove it from the list.
-  // Fires when the hold times out while still held (firmware hold-to-act pattern,
-  // cf. FileBrowserActivity BACK long-press).
-  if (!recentBooks.empty() && nav.selected < listCount() &&
-      mappedInput.isPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() >= LONG_PRESS_MS) {
-    longPressFired = true;
-    promptRemoveBook(recentBooks[nav.selected].path, recentBooks[nav.selected].title);
-    return true;
-  }
-
   if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     if (!recentBooks.empty() && nav.selected < listCount()) {
-      activateIndex(nav.selected);
+      if (mappedInput.getHeldTime() >= LONG_PRESS_MS) {
+        promptRemoveBook(recentBooks[nav.selected].path, recentBooks[nav.selected].title);
+      } else {
+        activateIndex(nav.selected);
+      }
       return true;
     }
   }

--- a/src/activities/home/RecentBooksActivity.h
+++ b/src/activities/home/RecentBooksActivity.h
@@ -24,10 +24,6 @@ class RecentBooksActivity final : public UiListActivity {
   const char* headerTitle() const override { return tr(STR_MENU_RECENT_BOOKS); }
   void drawFooter() override;
 
-  // Set when a long-press has fired; input is swallowed until Confirm is released
-  // again so the release doesn't also open the book.
-  bool longPressFired = false;
-
   std::vector<RecentBook> recentBooks;
   // Row buffer, built in loadRecentBooks() (not buildScreen(), which reuses
   // it on every repaint instead of rebuilding a ListItem vector per render).

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -346,7 +346,7 @@ void CrossPointWebServerActivity::loop() {
           // for back button checking
           mappedInput.update();
           // Check for exit button inside loop for responsiveness
-          if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+          if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
             onGoHome();
             return;
           }
@@ -356,7 +356,7 @@ void CrossPointWebServerActivity::loop() {
     }
 
     // Handle exit on Back button (also check outside loop)
-    if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+    if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
       onGoHome();
       return;
     }

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -235,13 +235,11 @@ void DictionaryWordSelectActivity::loop() {
     return;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) confirmPressSeen = true;
-
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     finish();
     return;
   }
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) && confirmPressSeen && !words.empty()) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) && !words.empty()) {
     performLookup();
     return;
   }

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -83,8 +83,4 @@ class DictionaryWordSelectActivity final : public Activity {
   int16_t snapshotW = 0;
   int16_t snapshotH = 0;
   int snapshotIdx = -1;
-
-  // The activity is entered while Confirm is still held (long-press trigger):
-  // ignore the stale release until a fresh press is seen.
-  bool confirmPressSeen = false;
 };

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -500,13 +500,38 @@ void EpubReaderActivity::loop() {
     requestUpdate();
   }
 
+  const bool confirmReleased = mappedInput.wasReleased(MappedInputManager::Button::Confirm);
+  if (confirmReleased) {
+    switch (SETTINGS.longPressMenuFunction) {
+      case CrossPointSettings::LP_MENU_BOOKMARK:
+        if (mappedInput.getHeldTime() >= ReaderUtils::BOOKMARK_HOLD_MS) {
+          addBookmark();
+          showBookmarkMessage = true;
+          bookmarkMessageTime = millis();
+          requestUpdate();
+          return;
+        }
+        break;
+      case CrossPointSettings::LP_MENU_KOSYNC:
+        if (mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS && launchKOReaderSync()) return;
+        break;
+      case CrossPointSettings::LP_MENU_DICTIONARY:
+        if (mappedInput.getHeldTime() >= ReaderUtils::BOOKMARK_HOLD_MS) {
+          openDictionaryWordSelect();
+          return;
+        }
+        break;
+      case CrossPointSettings::LP_MENU_DISABLED:
+      default:
+        break;
+    }
+  }
+
   // While the end screen suggestion menu is showing it owns Confirm/Back/navigation
   // input. Anything it doesn't handle (e.g. long-press Back to the file browser) falls
   // through to the regular handlers below; page turns are absorbed by the end-of-book
-  // block. A Confirm release after a long-press function (bookmark/sync) fired is left
-  // to the regular Confirm handler below, which consumes it via ignoreNextConfirmRelease.
-  if (atEndOfBook && endOfBookOptionsReady.load(std::memory_order_acquire) && endOfBookOptions->menuActive() &&
-      !(ignoreNextConfirmRelease && mappedInput.wasReleased(MappedInputManager::Button::Confirm))) {
+  // block.
+  if (atEndOfBook && endOfBookOptionsReady.load(std::memory_order_acquire) && endOfBookOptions->menuActive()) {
     std::string openPath;
     switch (endOfBookOptions->handleMenuInput(mappedInput, &openPath)) {
       case EndOfBookOptions::Action::OpenBook:
@@ -529,55 +554,8 @@ void EpubReaderActivity::loop() {
     }
   }
 
-  // Enter reader menu activity on short-press Confirm, the board's menu edge-swipe, or a
-  // middle-third tap (see ReaderUtils::isTouchMenuGesture). A long-press
-  // that fired a bound function (bookmark or KOReader sync) sets ignoreNextConfirmRelease so the release
-  // following the hold does not also open the menu.
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
-      ReaderUtils::isTouchMenuGesture(renderer, mappedInput)) {
-    if (ignoreNextConfirmRelease) {
-      ignoreNextConfirmRelease = false;
-    } else {
-      openReaderMenu();
-    }
-  }
-
-  // Long-press Confirm runs the user-selected function (SETTINGS.longPressMenuFunction).
-  if (mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-    switch (SETTINGS.longPressMenuFunction) {
-      case CrossPointSettings::LP_MENU_BOOKMARK:
-        // Hold ~0.4s drops a bookmark at the current page.
-        if (mappedInput.getHeldTime() >= ReaderUtils::BOOKMARK_HOLD_MS && !showBookmarkMessage) {
-          addBookmark();
-          showBookmarkMessage = true;
-          ignoreNextConfirmRelease = true;  // Prevent accidental menu open after adding bookmark
-          bookmarkMessageTime = millis();
-          requestUpdate();
-        }
-        break;
-      case CrossPointSettings::LP_MENU_KOSYNC:
-        // Hold ~1s launches KOReader sync. If sync can't run (no credentials stored), fall
-        // through so the normal Confirm-release still opens the reader menu.
-        if (mappedInput.getHeldTime() >= ReaderUtils::GO_HOME_MS) {
-          if (launchKOReaderSync()) {
-            ignoreNextConfirmRelease = true;  // sync launched or error shown; suppress menu open
-            return;
-          }
-        }
-        break;
-      case CrossPointSettings::LP_MENU_DICTIONARY:
-        // Hold ~0.4s starts dictionary word selection on the current page.
-        if (mappedInput.getHeldTime() >= ReaderUtils::BOOKMARK_HOLD_MS && !showDictionaryMessage) {
-          ignoreNextConfirmRelease = true;  // Prevent menu open on the release that follows
-          openDictionaryWordSelect();
-          return;
-        }
-        break;
-      case CrossPointSettings::LP_MENU_DISABLED:
-      default:
-        break;
-    }
-  }
+  // Short Confirm opens the reader menu; long Confirm actions returned above.
+  if (confirmReleased || ReaderUtils::isTouchMenuGesture(renderer, mappedInput)) openReaderMenu();
 
   // Short press Back restores position when viewing a footnote (takes priority over navigation)
   if (footnoteDepth > 0 && mappedInput.wasReleased(MappedInputManager::Button::Back) &&

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -60,7 +60,6 @@ class EpubReaderActivity final : public Activity {
   // "No dictionary set" popup, shown when a lookup is triggered without a configured dictionary.
   bool showDictionaryMessage = false;
   unsigned long dictionaryMessageTime = 0UL;
-  bool ignoreNextConfirmRelease = false;
   bool currentPageBookmarked = false;
   // Idle-time glyph prewarm: after a page settles, scan the LIKELY next page
   // (scan mode draws nothing) and load its missing glyphs from SD during idle,

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -115,24 +115,7 @@ void EpubReaderBookmarksActivity::onRowLongPress(const int index) {
 
 bool EpubReaderBookmarksActivity::handleCustomInput() {
   // Delete confirmation popup
-  if (confirmPopup.handleInput(mappedInput, [this] { requestUpdate(); })) {
-    // The popup acts on button press; if that input closed it, the trailing
-    // release must be swallowed below (Back would leave the activity, Confirm
-    // would open the selected bookmark).
-    popupClosing = !confirmPopup.isActive();
-    return true;
-  }
-  if (popupClosing) {
-    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-        mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      return true;  // closing press still held
-    }
-    popupClosing = false;
-    if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-      return true;  // swallow the release that closed the popup
-    }
-  }
+  if (confirmPopup.handleInput(mappedInput, [this] { requestUpdate(); })) return true;
   if (confirmingDelete) {
     // Popup dismissed without a selection (Back button or tap outside): cancel delete
     confirmingDelete = false;
@@ -151,15 +134,13 @@ bool EpubReaderBookmarksActivity::handleButtons() {
     return true;
   }
 
-  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {  // Open
-    openSelectedBookmark();
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
+    if (mappedInput.getHeldTime() > ENTER_DELETE_MODE_MS) {
+      showDeleteConfirmation();
+    } else {
+      openSelectedBookmark();
+    }
     return true;
-  }
-
-  if (mappedInput.isPressed(MappedInputManager::Button::Confirm) && mappedInput.getHeldTime() > ENTER_DELETE_MODE_MS) {
-    // No pass-consumed return here: the legacy loop fell through to swipe and
-    // button navigation after arming the confirmation.
-    showDeleteConfirmation();
   }
 
   return false;

--- a/src/activities/reader/EpubReaderBookmarksActivity.h
+++ b/src/activities/reader/EpubReaderBookmarksActivity.h
@@ -25,9 +25,6 @@ class EpubReaderBookmarksActivity final : public UiListActivity {
   void rebuildBookmarkRowItems();
   bool confirmingDelete = false;
   OptionPopup confirmPopup;
-  // True while the button press that closed the popup is still held; its release
-  // must not fall through to the list's own Back/Confirm handlers.
-  bool popupClosing = false;
 
  public:
   explicit EpubReaderBookmarksActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -111,25 +111,7 @@ void EpubReaderMenuActivity::activateIndex(const int index) {
 }
 
 bool EpubReaderMenuActivity::handleCustomInput() {
-  if (optionPopup.handleInput(mappedInput, [this] { requestUpdate(); })) {
-    // The popup acts on button press; if that input closed it, the trailing
-    // release must be swallowed below (Back would close the menu, Confirm
-    // would re-activate the selected item).
-    popupClosing = !optionPopup.isActive();
-    return true;
-  }
-  if (popupClosing) {
-    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-        mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      return true;  // closing press still held
-    }
-    popupClosing = false;
-    if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-      return true;  // swallow the release that closed the popup
-    }
-  }
-  return false;
+  return optionPopup.handleInput(mappedInput, [this] { requestUpdate(); });
 }
 
 bool EpubReaderMenuActivity::handleButtons() {

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -56,7 +56,7 @@ class EpubReaderMenuActivity final : public UiListActivity {
   int listCount() const override { return static_cast<int>(menuItems.size()); }
   void buildScreen(UiScreen& screen) override;
   void activateIndex(int index) override;
-  // Popup input/close-swallow runs before any button or touch handling.
+  // Popup input runs before any button or touch handling.
   bool handleCustomInput() override;
   // Back closes on RELEASE and Confirm activates on RELEASE; everything else
   // (row navigation, page jumps) falls through to the base handler.
@@ -70,9 +70,6 @@ class EpubReaderMenuActivity final : public UiListActivity {
   const std::vector<MenuItem> menuItems;
 
   OptionPopup optionPopup;
-  // True while the button press that closed the popup is still held; its release
-  // must not fall through to the menu's own Back/Confirm handlers.
-  bool popupClosing = false;
   std::string title = "Reader Menu";
   uint8_t pendingOrientation = 0;
   uint8_t selectedPageTurnOption = 0;

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -196,29 +196,21 @@ inline bool handleBackNavigation(const MappedInputManager& mappedInput, Activity
   // board: the bottom-edge up-swipe already exits, and in swipe page-turn
   // mode a right swipe must page back instead. Back swipes stay available in menus and other activities; only
   // this reader-surface handler ignores them. Physical Back buttons are
-  // unaffected: isPressed() is button-only, and this guard skips just the
+  // unaffected: this guard skips just the
   // gesture's own release frame.
   if (mappedInput.wasBackGesture()) {
     return false;
   }
 
-  if (mappedInput.isPressed(MappedInputManager::Button::Back) && mappedInput.getHeldTime() >= GO_BACK_OR_HOME_MS) {
-    if (SETTINGS.backShortToFileBrowser) {
-      goHome.fn(goHome.ctx);
-    } else {
-      activityManager.goToFileBrowser(filePath);
-    }
-    return true;
+  if (!mappedInput.wasReleased(MappedInputManager::Button::Back)) return false;
+
+  const bool longPress = mappedInput.getHeldTime() >= GO_BACK_OR_HOME_MS;
+  if (longPress != SETTINGS.backShortToFileBrowser) {
+    activityManager.goToFileBrowser(filePath);
+  } else {
+    goHome.fn(goHome.ctx);
   }
-  if (mappedInput.wasReleased(MappedInputManager::Button::Back) && mappedInput.getHeldTime() < GO_BACK_OR_HOME_MS) {
-    if (SETTINGS.backShortToFileBrowser) {
-      activityManager.goToFileBrowser(filePath);
-    } else {
-      goHome.fn(goHome.ctx);
-    }
-    return true;
-  }
-  return false;
+  return true;
 }
 
 }  // namespace ReaderUtils

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -222,7 +222,7 @@ void SettingsActivity::stepTab(const int direction) {
 }
 
 bool SettingsActivity::handleButtons() {
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     if (ringPos() == 0) {
       stepTab(1);
     } else {
@@ -232,7 +232,7 @@ bool SettingsActivity::handleButtons() {
     return true;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     if (ringPos() > 0) {
       activeNav().selected = 0;
       requestUpdate();
@@ -401,7 +401,7 @@ void SettingsActivity::openSleepTimeoutPicker() {
       std::make_unique<IntervalSelectionActivity>(
           renderer, mappedInput, "SleepTimeoutInterval", StrId::STR_TIME_TO_SLEEP, SETTINGS.sleepTimeoutMinutes,
           CrossPointSettings::MIN_SLEEP_TIMEOUT_MINUTES, CrossPointSettings::MAX_SLEEP_TIMEOUT_MINUTES, 1, 5,
-          StrId::STR_SLEEP_TIMER_VALUE_FORMAT, false, true, StrId::STR_SLEEP_NEVER),
+          StrId::STR_SLEEP_TIMER_VALUE_FORMAT, false, StrId::STR_SLEEP_NEVER),
       [this](const ActivityResult& result) {
         if (!result.isCancelled) {
           SETTINGS.sleepTimeoutMinutes = static_cast<uint8_t>(std::get<IntervalResult>(result.data).value);

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -170,25 +170,7 @@ void TextSettingsActivity::activateIndex(const int index) {
 }
 
 bool TextSettingsActivity::handleCustomInput() {
-  if (optionPopup_.handleInput(mappedInput, [this] { requestUpdate(); })) {  // picker owns input while open
-    // The popup acts on button press; if that input closed it, the trailing
-    // release must be swallowed below (Back would close this screen, Confirm
-    // would re-activate the selected row).
-    popupClosing_ = !optionPopup_.isActive();
-    return true;
-  }
-  if (popupClosing_) {
-    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-        mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      return true;  // closing press still held
-    }
-    popupClosing_ = false;
-    if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-      return true;  // swallow the release that closed the popup
-    }
-  }
-  return false;
+  return optionPopup_.handleInput(mappedInput, [this] { requestUpdate(); });
 }
 
 bool TextSettingsActivity::handleButtons() {
@@ -197,7 +179,7 @@ bool TextSettingsActivity::handleButtons() {
     return true;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Confirm)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
     if (ringPos() == 0) {
       switchTab();
     } else {

--- a/src/activities/settings/TextSettingsActivity.h
+++ b/src/activities/settings/TextSettingsActivity.h
@@ -85,9 +85,6 @@ class TextSettingsActivity final : public UiTabListActivity {
 
   const SdCardFontRegistry* registry_;
   OptionPopup optionPopup_;
-  // True while the button press that closed the popup is still held; its release
-  // must not fall through to this screen's own Back/Confirm handlers.
-  bool popupClosing_ = false;
   std::vector<FontEntry> fonts_;
   std::vector<SizeEntry> sizes_;
   textsettings::PreviewLayout previewLayout_;  // cached preview line layout; relaid only on setting/geometry change

--- a/src/activities/util/IntervalSelectionActivity.cpp
+++ b/src/activities/util/IntervalSelectionActivity.cpp
@@ -26,7 +26,6 @@ IntervalSelectionActivity::IntervalSelectionActivity(GfxRenderer& renderer, Mapp
                                                      const int initialValue, const int minValue, const int maxValue,
                                                      const int smallStep, const int largeStep,
                                                      const StrId valueFormatId, const bool readerActivity,
-                                                     const bool ignoreInitialConfirmRelease,
                                                      const StrId maxBoundaryLabelId)
     : Activity(activityName, renderer, mappedInput),
       UiAppHost(renderer),
@@ -38,8 +37,7 @@ IntervalSelectionActivity::IntervalSelectionActivity(GfxRenderer& renderer, Mapp
       maxValue(maxValue),
       smallStep(smallStep),
       largeStep(largeStep),
-      readerActivity(readerActivity),
-      ignoreConfirmRelease(ignoreInitialConfirmRelease) {}
+      readerActivity(readerActivity) {}
 
 int IntervalSelectionActivity::clampedValue(const int candidate) const {
   return std::clamp(candidate, minValue, maxValue);
@@ -106,16 +104,6 @@ void IntervalSelectionActivity::onOkEvent(const fui::ActionEvent&, void* user) {
 }
 
 void IntervalSelectionActivity::loop() {
-  if (ignoreConfirmRelease) {
-    if (mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-      ignoreConfirmRelease = false;
-      return;
-    }
-    if (!mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      ignoreConfirmRelease = false;
-    }
-  }
-
   // Touch goes through the FreeInkApp: render() registered the slider, -/+ zones,
   // and Cancel/OK hit rects; the slider follows the finger via InputDrag. Runs
   // before the Back handler because the release of a drag can also register as a

--- a/src/activities/util/IntervalSelectionActivity.h
+++ b/src/activities/util/IntervalSelectionActivity.h
@@ -16,8 +16,7 @@ class IntervalSelectionActivity final : public Activity, private UiAppHost {
   explicit IntervalSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput, const char* activityName,
                                      StrId titleId, int initialValue, int minValue, int maxValue, int smallStep,
                                      int largeStep, StrId valueFormatId = StrId::STR_NONE_OPT,
-                                     bool readerActivity = false, bool ignoreInitialConfirmRelease = false,
-                                     StrId maxBoundaryLabelId = StrId::STR_NONE_OPT);
+                                     bool readerActivity = false, StrId maxBoundaryLabelId = StrId::STR_NONE_OPT);
 
   void onEnter() override;
   void loop() override;
@@ -43,7 +42,6 @@ class IntervalSelectionActivity final : public Activity, private UiAppHost {
   int smallStep;
   int largeStep;
   bool readerActivity;
-  bool ignoreConfirmRelease;
   ButtonNavigator buttonNavigator;
 
   // Swallow the swipe/tap fallout of a slider drag so its release can't trigger

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -676,7 +676,7 @@ void KeyboardEntryActivity::loop() {
     confirmLongHandled = false;
   }
 
-  if (mappedInput.wasPressed(MappedInputManager::Button::Back)) {
+  if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     onCancel();
   }
 

--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -115,12 +115,12 @@ class OptionPopup {
       selectedIndex = (selectedIndex + 1) % count;
       requestUpdate();
       return true;
-    } else if (input.wasPressed(MappedInputManager::Button::Confirm)) {
+    } else if (input.wasReleased(MappedInputManager::Button::Confirm)) {
       active = false;
       if (onSelectCallback) onSelectCallback(selectedIndex);
       requestUpdate();
       return true;
-    } else if (input.wasPressed(MappedInputManager::Button::Back)) {
+    } else if (input.wasReleased(MappedInputManager::Button::Back)) {
       active = false;
       requestUpdate();
       return true;


### PR DESCRIPTION
## Summary

AI coding agents love piling bloat onto downstream code instead of just fixing the upstream bug.

This PR cleans up one class of that.
The bug is dumb simple. One check does `isPressed`, the one next activity does `wasReleased` — so a single press fires as two events, press then release.

The real fix is one word: `isPressed` → `wasReleased`. Instead, agents (Claude Code, Codex, etc.) bolt on ~20 lines of swallowing logic to eat the stray release. Fragile, and it bloats the firmware for nothing. #2969 is a good example — it patches the symptom with such swallowing logic, but the bug only exists because someone swallowed the release in the reader menu instead of making `popupOption` react to it directly.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
