### PR TITLE
fix(epub): resolve contents entries whose href only matches by filename

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -108,6 +108,10 @@ bool BookMetadataCache::beginTocPass() {
     return false;
   }
 
+  spineFilenameIndex.clear();
+  spineFilenameIndex.shrink_to_fit();
+  spineFilenameIndexBuilt = false;
+
   if (spineCount >= LARGE_SPINE_THRESHOLD) {
     spineHrefIndex.clear();
     spineHrefIndex.resize(spineCount);
@@ -149,6 +153,10 @@ bool BookMetadataCache::endTocPass() {
   spineHrefIndex.clear();
   spineHrefIndex.shrink_to_fit();
   useSpineHrefIndex = false;
+
+  spineFilenameIndex.clear();
+  spineFilenameIndex.shrink_to_fit();
+  spineFilenameIndexBuilt = false;
 
   return flushed;
 }
@@ -403,6 +411,58 @@ void BookMetadataCache::createSpineEntry(const std::string& href) {
   spineCount++;
 }
 
+std::string BookMetadataCache::filenameOf(const std::string& path) {
+  const size_t slash = path.find_last_of('/');
+  return slash != std::string::npos ? path.substr(slash + 1) : path;
+}
+
+// Last-resort match for a TOC href that does not resolve against any spine href.
+// Real books ship nav documents whose links are relative to a directory the nav file
+// does not live in (nav.xhtml at OEBPS/ pointing at "chuong-0001.xhtml" while the spine
+// carries "text/chuong-0001.xhtml"), which would leave every contents row dead. In-book
+// links already accept a filename-only match (Epub::resolveHrefToSpineIndex), so the
+// contents index is no less forgiving.
+//
+// The index is built on the first exact-match miss and reused for the rest of the pass:
+// a well-formed book never builds it, and a book whose nav is off by a directory (where
+// every entry misses) walks the spine once rather than once per entry.
+int16_t BookMetadataCache::findSpineIndexByFilename(const std::string& href) {
+  const std::string filename = filenameOf(href);
+  if (filename.empty() || !spineFile) return -1;
+
+  // spineIndex is part of the ordering so that when two spine items share a filename
+  // (same name in different directories) the lookup lands on the earliest one, matching
+  // the spine-order scan that Epub::resolveHrefToSpineIndex does for in-book links.
+  const auto orderByHash = [](const SpineFilenameIndexEntry& a, const SpineFilenameIndexEntry& b) {
+    if (a.filenameHash != b.filenameHash) return a.filenameHash < b.filenameHash;
+    if (a.filenameLen != b.filenameLen) return a.filenameLen < b.filenameLen;
+    return a.spineIndex < b.spineIndex;
+  };
+
+  if (!spineFilenameIndexBuilt) {
+    spineFilenameIndexBuilt = true;  // one build per TOC pass, whether or not anything matches
+    spineFilenameIndex.clear();
+    spineFilenameIndex.resize(spineCount);
+    spineFile.seek(0);
+    for (int i = 0; i < spineCount; i++) {
+      const std::string name = filenameOf(readSpineEntry(spineFile).href);
+      spineFilenameIndex[i] =
+          SpineFilenameIndexEntry{fnvHash64(name), static_cast<uint16_t>(name.size()), static_cast<int16_t>(i)};
+    }
+    spineFile.seek(0);
+    std::sort(spineFilenameIndex.begin(), spineFilenameIndex.end(), orderByHash);
+    LOG_DBG("BMC", "Built spine filename index for %d spine items", spineCount);
+  }
+
+  const SpineFilenameIndexEntry target{fnvHash64(filename), static_cast<uint16_t>(filename.size()), 0};
+  const auto it = std::lower_bound(spineFilenameIndex.begin(), spineFilenameIndex.end(), target, orderByHash);
+  if (it != spineFilenameIndex.end() && it->filenameHash == target.filenameHash &&
+      it->filenameLen == target.filenameLen) {
+    return it->spineIndex;
+  }
+  return -1;
+}
+
 void BookMetadataCache::createTocEntry(const std::string& title, const std::string& href, const std::string& anchor,
                                        const uint8_t level) {
   if (!buildMode || !tocFile || !spineFile) {
@@ -427,9 +487,6 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
       break;
     }
 
-    if (spineIndex == -1) {
-      LOG_DBG("BMC", "createTocEntry: Could not find spine item for TOC href %s", href.c_str());
-    }
   } else {
     spineFile.seek(0);
     for (int i = 0; i < spineCount; i++) {
@@ -439,9 +496,13 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
         break;
       }
     }
-    if (spineIndex == -1) {
-      LOG_DBG("BMC", "createTocEntry: Could not find spine item for TOC href %s", href.c_str());
-    }
+  }
+
+  if (spineIndex == -1) {
+    spineIndex = findSpineIndexByFilename(href);
+  }
+  if (spineIndex == -1) {
+    LOG_DBG("BMC", "createTocEntry: Could not find spine item for TOC href %s", href.c_str());
   }
 
   // Compose the title to NFC at index time so the cache stores precomposed glyphs;

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -77,6 +77,17 @@ class BookMetadataCache {
   std::deque<SpineHrefIndexEntry> spineHrefIndex;
   bool useSpineHrefIndex = false;
 
+  // Index for the filename-only fallback lookup, built on the first TOC href that no
+  // spine href matches exactly (see findSpineIndexByFilename). Well-formed books never
+  // build it, so it costs them nothing.
+  struct SpineFilenameIndexEntry {
+    uint64_t filenameHash;  // FNV-1a 64-bit hash of the href's last path segment
+    uint16_t filenameLen;   // length for collision reduction
+    int16_t spineIndex;
+  };
+  std::deque<SpineFilenameIndexEntry> spineFilenameIndex;
+  bool spineFilenameIndexBuilt = false;
+
   static constexpr uint16_t LARGE_SPINE_THRESHOLD = 400;
 
   // FNV-1a 64-bit hash function
@@ -88,6 +99,11 @@ class BookMetadataCache {
     }
     return hash;
   }
+
+  // Last path segment of an href ("text/ch1.xhtml" -> "ch1.xhtml").
+  static std::string filenameOf(const std::string& path);
+  // Filename-only spine lookup for TOC hrefs that no spine href matches exactly.
+  int16_t findSpineIndexByFilename(const std::string& href);
 
   uint32_t writeSpineEntry(HalFile& file, const SpineEntry& entry) const;
   uint32_t writeTocEntry(HalFile& file, const TocEntry& entry) const;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

  Make the contents (TOC) list usable in EPUBs whose nav document links are
  relative to a directory the nav file does not sit in.

* **What changes are included?**

  `BookMetadataCache::createTocEntry()` resolves a TOC href to a spine index by
  exact string compare only. Books exist where that never matches — e.g. a book
  with `OEBPS/nav.xhtml` whose links are `chuong-0001.xhtml` while the spine
  carries `text/chuong-0001.xhtml`. Every TOC entry is then written with
  `spineIndex == -1`: the contents list renders its titles, but no row can be
  selected and the reader silently ignores the press.

  In-book links are already forgiving here — `Epub::resolveHrefToSpineIndex()`
  falls back to a filename-only match. This PR gives the contents index the same
  fallback, so a link that resolves from inside the book also resolves from the
  contents list.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — the contents list is inert for these books.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

### When it runs

The fallback runs **only after the exact match has failed**, so a well-formed
book follows exactly the path it follows today.

### Cost

The naive form of this fallback rescans the spine per unmatched entry —
O(entries × spine) — and the books that need it are precisely the ones where
*every* entry misses. So the first miss builds a hashed filename index instead,
in the same shape as the existing `spineHrefIndex` (FNV-1a 64-bit hash + length
+ spine index, sorted, binary-searched):

- Well-formed book: index never built, no cost.
- Book with a mismatched nav: spine walked once, then O(log n) per entry.
- RAM: held only for the duration of the TOC pass, and only for books that need
  it; released in `endTocPass()`.

When two spine items share a filename in different directories, `spineIndex` is
part of the sort key, so the lookup lands on the earliest one — matching the
spine-order scan `Epub::resolveHrefToSpineIndex()` does for in-book links.

### Cache compatibility

No cache format change and no version bump: `spineIndex` is already what gets
stored per TOC entry, this only changes how it is resolved at index time. A book
cached before this change keeps its `-1` entries until its cache is rebuilt.

### Testing

- [x] `clang-format`
- [x] Builds clean, including `-Wall -Wextra` on the touched translation unit
- [x] Verified against a real EPUB3 that shows the problem: `OEBPS/nav.xhtml`
      links `chuong-0001.xhtml`, the spine carries `text/chuong-0001.xhtml`
      (its `toc.ncx` happens to use the full paths, so only the EPUB3 nav path
      is affected)
- [ ] Tested on Xteink X3 hardware
- [x] Tested on Xteink X4 hardware

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools were used for the investigation, the patch, and this PR description.
The result was reviewed, formatted, and built locally by the contributor.
