### PR TITLE
fix(ui): keep the option popup's closing press from reaching its host

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -65,24 +65,10 @@ bool EpubReaderMenuActivity::handleHomeGesture() {
 }
 
 void EpubReaderMenuActivity::loop() {
-  if (optionPopup.handleInput(mappedInput, [this] { requestUpdate(); })) {
-    // The popup acts on button press; if that input closed it, the trailing
-    // release must be swallowed below (Back would close the menu, Confirm
-    // would re-activate the selected item).
-    popupClosing = !optionPopup.isActive();
-    return;
-  }
-  if (popupClosing) {
-    if (mappedInput.isPressed(MappedInputManager::Button::Back) ||
-        mappedInput.isPressed(MappedInputManager::Button::Confirm)) {
-      return;  // closing press still held
-    }
-    popupClosing = false;
-    if (mappedInput.wasReleased(MappedInputManager::Button::Back) ||
-        mappedInput.wasReleased(MappedInputManager::Button::Confirm)) {
-      return;  // swallow the release that closed the popup
-    }
-  }
+  // OptionPopup keeps owning the input until the button that closed it comes back
+  // up, so the trailing release cannot reach this menu (Back would close it, Confirm
+  // would re-activate the selected item).
+  if (optionPopup.handleInput(mappedInput, [this] { requestUpdate(); })) return;
 
   if (mappedInput.wasReleased(MappedInputManager::Button::Back)) {
     closeCancelled();

--- a/src/activities/reader/EpubReaderMenuActivity.h
+++ b/src/activities/reader/EpubReaderMenuActivity.h
@@ -55,9 +55,6 @@ class EpubReaderMenuActivity final : public Activity {
 
   ButtonNavigator buttonNavigator;
   OptionPopup optionPopup;
-  // True while the button press that closed the popup is still held; its release
-  // must not fall through to the menu's own Back/Confirm handlers.
-  bool popupClosing = false;
   std::string title = "Reader Menu";
   uint8_t pendingOrientation = 0;
   uint8_t selectedPageTurnOption = 0;

--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -23,6 +23,7 @@ class OptionPopup {
     selectedIndex = currentIndex;
     onSelectCallback = std::move(onSelect);
     layoutValid = false;
+    awaitingClosingRelease = false;
     active = true;
   }
 
@@ -36,6 +37,7 @@ class OptionPopup {
     selectedIndex = currentIndex;
     onSelectCallback = std::move(onSelect);
     layoutValid = false;
+    awaitingClosingRelease = false;
     active = true;
   }
 
@@ -46,11 +48,12 @@ class OptionPopup {
     selectedIndex = currentIndex;
     onSelectCallback = std::move(onSelect);
     layoutValid = false;
+    awaitingClosingRelease = false;
     active = true;
   }
 
   bool handleInput(MappedInputManager& input, const std::function<void()>& requestUpdate) {
-    if (!active) return false;
+    if (!active) return swallowClosingRelease(input);
 
     const int count = static_cast<int>(ownedStrings.size());
     int tx = 0;
@@ -95,12 +98,12 @@ class OptionPopup {
       requestUpdate();
       return true;
     } else if (input.wasPressed(MappedInputManager::Button::Confirm)) {
-      active = false;
+      closeOn(MappedInputManager::Button::Confirm);
       if (onSelectCallback) onSelectCallback(selectedIndex);
       requestUpdate();
       return true;
     } else if (input.wasPressed(MappedInputManager::Button::Back)) {
-      active = false;
+      closeOn(MappedInputManager::Button::Back);
       requestUpdate();
       return true;
     }
@@ -182,7 +185,27 @@ class OptionPopup {
     return x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height;
   }
 
+  // The popup closes on a button *press*, while the activities hosting it act on the
+  // release edge. Without this, the release that dismissed the popup falls through to
+  // the host: Back would leave the screen (from Settings, straight out to the library)
+  // and Confirm would re-open the popup it just closed. Keep owning the input until
+  // the closing button comes back up. Closing by tap arms nothing.
+  void closeOn(const MappedInputManager::Button button) {
+    active = false;
+    closingButton = button;
+    awaitingClosingRelease = true;
+  }
+
+  bool swallowClosingRelease(const MappedInputManager& input) {
+    if (!awaitingClosingRelease) return false;
+    if (input.isPressed(closingButton)) return true;  // still held down
+    awaitingClosingRelease = false;
+    return input.wasReleased(closingButton);
+  }
+
   bool active = false;
+  bool awaitingClosingRelease = false;
+  MappedInputManager::Button closingButton = MappedInputManager::Button::Back;
   std::string title;
   std::vector<std::string> ownedStrings;
   int selectedIndex = 0;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

  Stop the button press that closes an `OptionPopup` from being handled a second
  time by the activity behind it.

* **What changes are included?**

  `OptionPopup` closes on the button **press** edge, while the activities hosting
  it act on the **release** edge. The release that dismissed the popup therefore
  falls through to the host and gets handled again:

  - **Settings → Text**: closing a picker with Back also leaves the Text settings
    screen (`TextSettingsActivity::loop()` exits on `wasReleased(Back)`).
  - **Reader → Bookmarks**: cancelling the delete confirmation with Back also
    closes the bookmarks list (`EpubReaderBookmarksActivity::loop()` finishes on
    `wasReleased(Back)`).

  `EpubReaderMenuActivity` already worked around exactly this with a local
  `popupClosing` latch. This PR moves that behaviour into `OptionPopup` itself, so
  every host gets it: the popup keeps owning the input until the button that
  closed it comes back up, so one press is handled by one layer. The local latch
  in `EpubReaderMenuActivity` is then redundant and is removed.

  Closing by tap arms nothing — a tap has no split press/release across the two
  layers.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — it handles it in one host and not the others.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

### Behaviour by host

Hosts that already act on the press edge (`SettingsActivity`,
`StatusBarSettingsActivity`, `ClearCacheActivity`, `ConfirmationActivity`) never
saw the trailing release, so nothing changes for them — the guard just makes them
immune if they ever move to release edges.

### Cost

Two extra members on `OptionPopup` (a `bool` and a `Button`), no allocation, no
new dependency. Net −24/+30 lines with the local latch removed.

### Testing

- [x] `clang-format`
- [x] Every `OptionPopup` host compiles clean: `TextSettingsActivity`,
      `StatusBarSettingsActivity`, `SettingsActivity`, `ClearCacheActivity`,
      `ConfirmationActivity`, `EpubReaderMenuActivity`, `EpubReaderBookmarksActivity`
- [ ] Tested on Xteink X3 hardware
- [x] Tested on Xteink X4 hardware

### Reviewer focus

1. `swallowClosingRelease()` returning `true` while the closing button is still
   held — a long hold on Back after closing a popup is swallowed until release,
   which is the intent (it must not become a long-press-to-home in the host).
2. Reopening the popup before the closing button is released: all three `show()`
   overloads clear the latch, so the new popup owns the input from that point.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

AI tools were used for the investigation, the patch, and this PR description.
The result was reviewed, formatted, and built locally by the contributor.
