### PR TITLE
fix: avoid full-clock spin while a section build is parked at its watermark

### DIFF
--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -224,7 +224,17 @@ class EpubReaderActivity final : public Activity {
   // it from page 0. Reverts to normal power behavior the moment the build finishes,
   // and while the build is heap-paused (no work is happening, so spinning at full
   // speed would only burn battery; the paused gate still retries every loop pass).
-  bool skipLoopDelay() override { return section && section->isBuilding() && !buildHeapPaused; }
+  // The watermark window below MUST mirror the background-build gate in loop() (the
+  // isPartial()/BUILD_WINDOW_AHEAD test): once a first-open build has laid out its
+  // look-ahead window it parks (isBuilding() stays true but loop() stops pumping it),
+  // so keying only on isBuilding() would hold the loop at full clock indefinitely while
+  // idle on a page -- doing no build work and defeating loop()'s idle downclock + delay
+  // path. Gate on "a build tick will actually run this pass" instead. Read unlocked like
+  // setPowerSaving(): a stale read costs at most one loop pass either way.
+  bool skipLoopDelay() override {
+    return section && section->isBuilding() && !buildHeapPaused &&
+           (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD);
+  }
   bool isReaderActivity() const override { return true; }
   bool appliesNightMode() const override { return true; }
   bool handleForcedRefresh() override {


### PR DESCRIPTION
## Summary
Cherry-pick of [the fix mentioned here](https://github.com/crosspoint-reader/crosspoint-reader/pull/2525#issuecomment-5274356229) for high power usage in v1.5.0. Just making this PR incase you want a smaller change for an immediate fix.

skipLoopDelay() keyed only on section->isBuilding(), but loop()'s background-build pump also requires the reader to be within BUILD_WINDOW_AHEAD pages of the build watermark (or the section to be a partial). Once a first-open build lays out its look-ahead window it parks: isBuilding() stays true while loop() stops pumping it, so skipLoopDelay() forced full clock + yield() with no delay for the whole time the reader sits on a page mid-chapter -- defeating the loop's idle downclock + delay(50) path and pinning the core at full speed doing no build work.

Gate skipLoopDelay() on the same watermark window as the build pump so it returns full-speed only when a build tick will actually run this pass.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

https://github.com/crosspoint-reader/crosspoint-reader/pull/2525 is still the complete power solution for ~3x more battery life, this fix should just bring v1.5.0 power consumption more inline with what it was on v1.4.0 (9.72mA on an idle page). Without this we were seeing 31.13mA on an idle page.

If we merge this in, we'll have to resolve the trivial merge-conflict in #2525

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
