### PR TITLE
fix: Guard GPIO13 power control for Xteink C3 boards only

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -14,9 +14,10 @@
 
 HalPowerManager powerManager;  // Singleton instance
 
-// GPIO13 is the flash SPIWP pad (unused in this board's DIO flash mode), rewired to the
-// battery-latch MOSFET gate: high keeps the battery connected, low powers the device off.
-static constexpr gpio_num_t GPIO_BATTERY_LATCH = GPIO_NUM_13;
+// GPIO13 must stay high during light sleep on the C3 Xteink boards: it controls
+// the X4 battery latch and the X3 SD power rail. Other boards use it for
+// unrelated signals, including the X4 Pro display chip select.
+static constexpr gpio_num_t XTEINK_C3_GPIO13 = GPIO_NUM_13;
 
 void HalPowerManager::begin() {
   if (BoardConfig::ACTIVE.batteryAdc >= 0) {
@@ -84,10 +85,10 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
     // upstream's X3 relies on never happens here — release the hold and drive
     // the latch low explicitly. The hold_en survives deep sleep via the SDK's
     // deepSleep() (esp_sleep_config_gpio_isolate + gpio_deep_sleep_hold_en).
-    gpio_hold_dis(GPIO_BATTERY_LATCH);
-    gpio_set_direction(GPIO_BATTERY_LATCH, GPIO_MODE_OUTPUT);
-    gpio_set_level(GPIO_BATTERY_LATCH, 0);
-    gpio_hold_en(GPIO_BATTERY_LATCH);
+    gpio_hold_dis(XTEINK_C3_GPIO13);
+    gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
+    gpio_set_level(XTEINK_C3_GPIO13, 0);
+    gpio_hold_en(XTEINK_C3_GPIO13);
   }
 #endif
 
@@ -145,17 +146,14 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     esp_sleep_enable_gpio_wakeup();
   }
 
-  // The IDF flash-leakage workaround (CONFIG_ESP_SLEEP_FLASH_LEAKAGE_WORKAROUND) pulls the
-  // DIO-unused SPIWP pad low on light-sleep entry — on this board that releases the battery
-  // latch and hard-powers-off the device. Drive the latch high and pad-hold it (hold latches
-  // the pad state and overrides both the sleep-time pull and any pad re-muxing on the wake
-  // path). The hold is left enabled permanently while running — the wake path may restore
-  // flash-pad muxing, so even a brief release between slices can drop the latch. It is
-  // released only in startDeepSleep(), which must drive the latch low to power off.
-  // Level is set BEFORE direction so the pad never glitches low on the way to output mode.
-  gpio_set_level(GPIO_BATTERY_LATCH, 1);
-  gpio_set_direction(GPIO_BATTERY_LATCH, GPIO_MODE_OUTPUT);
-  gpio_hold_en(GPIO_BATTERY_LATCH);
+  // The C3 flash-leakage workaround pulls its DIO-unused SPIWP pad low during
+  // light sleep. Hold GPIO13 high only on the X3/X4 boards that use that pad as
+  // a power control; on other boards GPIO13 may be a bus signal.
+  if (gpio.isXteinkDevice()) {
+    gpio_set_level(XTEINK_C3_GPIO13, 1);
+    gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
+    gpio_hold_en(XTEINK_C3_GPIO13);
+  }
 
   const esp_err_t err = esp_light_sleep_start();
 
@@ -215,11 +213,13 @@ bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t bu
   esp_sleep_enable_gpio_wakeup();
   esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(BUSY_SLEEP_SLICE_MS) * 1000ULL);
 
-  // Battery-latch hold: the IDF flash-leakage workaround would drop the latch
-  // pad on sleep entry and hard-power-off the device (see lightSleep()).
-  gpio_set_level(GPIO_BATTERY_LATCH, 1);
-  gpio_set_direction(GPIO_BATTERY_LATCH, GPIO_MODE_OUTPUT);
-  gpio_hold_en(GPIO_BATTERY_LATCH);
+  // Preserve the C3 Xteink GPIO13 power control during this sleep slice without
+  // reconfiguring GPIO13 on boards where it is a bus signal.
+  if (gpio.isXteinkDevice()) {
+    gpio_set_level(XTEINK_C3_GPIO13, 1);
+    gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
+    gpio_hold_en(XTEINK_C3_GPIO13);
+  }
 
   const esp_err_t err = esp_light_sleep_start();
 


### PR DESCRIPTION
GPIO13 has different functions on different boards. On C3 Xteink X3/X4 it controls power (battery latch and SD rail), but on other boards like X4 Pro it's a bus signal (display CS). Add runtime check to only apply GPIO13 hold logic on Xteink devices to prevent interfering with GPIO13 usage on other hardware.