### PR TITLE
fix: narrow pr-formatting-check.yml to pull_request_target only

### DIFF
--- a/.github/workflows/pr-formatting-check.yml
+++ b/.github/workflows/pr-formatting-check.yml
@@ -1,7 +1,6 @@
 name: "PR Formatting"
 
 on:
-  pull_request:
   pull_request_target:
     types:
       - opened
@@ -9,7 +8,7 @@ on:
       - edited
 
 permissions:
-  statuses: write
+  pull-requests: read
 
 jobs:
   title-check:


### PR DESCRIPTION
`pr-formatting-check.yml` currently triggers on both `pull_request` and `pull_request_target`, sharing a workflow-level `statuses: write` permission. The `pull_request` trigger is fully PR-controlled (a PR defines and runs its own copy of that trigger's job), so combining it with `statuses: write` gives PR-controlled code broader permission than a title-format check needs.

This PR removes the `pull_request` trigger (the existing `pull_request_target` trigger on `opened`/`reopened`/`edited` already covers everything a title check needs — title changes don't require re-running on `synchronize`) and narrows `permissions` to `pull-requests: read`, which is all `amannn/action-semantic-pull-request` needs to read the PR title — it reports failure via the job's own exit code, not by writing a commit status.

No behavior change to the check itself; verified with `actionlint` (0 findings) and by applying the identical change in a downstream fork, where Title Check continues to run and report correctly with this permission shape on real PRs.