### PR TITLE
fix: request a clean grayscale base on X4 sleep screens

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -108,14 +108,18 @@ void HalDisplay::copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* m
 }
 
 void HalDisplay::displayGrayscaleBase(RefreshMode fallback, bool turnOffScreen) {
-  // X3: a HALF fallback means the caller wants a clean base (e.g. the sleep
-  // cover, a full-screen swap from arbitrary prior content). Without this, the
-  // X3 grayscale base takes its gentle differential happy path and the prior
-  // home/reader frame ghosts through the soft aa_pre_bw_mid waveform. Forcing a
-  // resync makes displayGrayscaleBase clear first, matching displayBuffer(HALF).
+  // A HALF fallback means the caller wants a clean base (e.g. the sleep cover,
+  // a full-screen swap from arbitrary prior content), so request a resync on
+  // every panel; drivers with no differential baseline no-op the request.
+  // Without it the base takes the differential happy path: on X3 the prior
+  // home/reader frame ghosts through the soft aa_pre_bw_mid waveform, and on X4
+  // the base runs as a DU partial diff, leaving pixels in a charge state the
+  // AA nudge LUTs are not calibrated for — the LSB/MSB planes then land
+  // invisibly and greys stay at their black base. The resync makes
+  // displayGrayscaleBase clear first, matching displayBuffer(HALF).
   // The reader's FAST path is deliberately left on the differential path so
   // per-page grayscale stays cheap.
-  if (gpio.deviceIsX3() && fallback == RefreshMode::HALF_REFRESH) {
+  if (fallback == RefreshMode::HALF_REFRESH) {
     einkDisplay.requestResync(1);
   }
 


### PR DESCRIPTION
Fixes the X4 half of #2879: a sleep screen whose image contains grey renders every grey level as solid black.

## Cause

The sleep grayscale pipeline paints a B/W base, writes the LSB/MSB planes, then fires the AA nudge refresh (`SleepActivity::renderBitmapSleepScreen`). The planes are built correctly — decoding the repro BMP through `Bitmap::parseHeaders`/`readNextRow` yields all four levels (`nativePalette == true`, ~108k level-1 and ~108k level-2 pixels on a 480x800 test card), so `drawBitmap()` in `GRAYSCALE_LSB`/`GRAYSCALE_MSB` is not at fault.

The base is. `HalDisplay::displayGrayscaleBase()` gated its "a HALF fallback means the caller wants a clean base" resync on `gpio.deviceIsX3()`:

```cpp
if (gpio.deviceIsX3() && fallback == RefreshMode::HALF_REFRESH) {
  einkDisplay.requestResync(1);
}
```

On X4 the base therefore ran as a differential DU partial against whatever the panel last showed (home or reader). The UC8279 AA LUTs are calibrated against a GC-conditioned pixel state, so the nudge refresh lands invisibly and every grey stays at the black the base pass painted it.

This matches the history: the grayscale branch here used `FULL_REFRESH` only between #2471 and #2588, and that window is the last one in which X4 greys rendered.

## Fix

Drop the X3 gate so the clean-base request is panel-agnostic. On X4 this produces the same waveform `FULL_REFRESH` did — `Uc8279X4Driver::displayStart` takes the identical `!fast` branch (white-seeded DTM1 + GC absolute waveform) for `mode == Full` and for `_needFullClear`, which is what `requestResync()` sets:

```cpp
const bool fast = (mode != RefreshMode::Full) && !_needFullClear && _oldPlaneValid;
```

X3 behaviour is unchanged (it already made this call), and drivers with no differential baseline no-op `requestResync()`.

Scope is limited to the grayscale base. The single-pass B/W sleep and boot paints keep the HALF stock-parity waveform from #2588, and the reader's `FAST` grayscale base stays on the cheap differential path, so per-page AA is untouched.

## Testing

- `pio run` (default env) — SUCCESS. RAM 16.5%, Flash 86.6%. No RAM cost: the change is one condition.
- Xteink X4, flashed from this branch. A 4-level test card (palette `#000000/#555555/#AAAAAA/#FFFFFF`) as `/sleep.bmp` with Sleep Screen Cover Filter = None now renders black / dark grey / light grey / white, and persists through deep sleep. Before this change the same card rendered black / black / black / white.
- Non-grey sleep images take the `hasGreyscale == false` branch and are unaffected.

Tradeoff worth calling out: a sleep image containing grey now costs one GC base flash where it previously ran a silent DU partial. That is the #2471/#2588 tension, but it only applies to images that actually enter the grayscale branch, and without it those images do not render at all.

## Not covered

The X3 symptom in #2879 (grey sleep images wipe to solid white) is a separate fault. X3 already requested the resync, so its base is already clean; the failure is downstream in the gc nudge bank, in the SDK submodule. Unchanged here.
