### PR TITLE
fix: honor CSS border visibility when rendering <hr> in EPUBs

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -305,6 +305,31 @@ bool CssParser::tryInterpretLength(std::string_view val, CssLength& out) {
   return true;
 }
 
+CssBorderStyle CssParser::interpretBorderVisibility(std::string_view val) {
+  val = trimCssWhitespace(stripTrailingImportant(val));
+
+  bool sawNone = false;
+  bool sawAnyWidthToken = false;
+  bool sawNonZeroWidth = false;
+  forEachDelimitedToken(val, isCssWhitespace, [&](std::string_view token) {
+    if (iequalsAscii(token, "none") || iequalsAscii(token, "hidden")) {
+      sawNone = true;
+      return;
+    }
+    CssLength len;
+    if (tryInterpretLength(token, len)) {
+      sawAnyWidthToken = true;
+      if (len.value != 0.0f) sawNonZeroWidth = true;
+    }
+  });
+
+  if (sawNone) return CssBorderStyle::None;
+  // A width-only declaration (e.g. "border: 0", "border-width: 0 0") with every
+  // token resolving to zero is as invisible as "none".
+  if (sawAnyWidthToken && !sawNonZeroWidth) return CssBorderStyle::None;
+  return CssBorderStyle::Visible;
+}
+
 // Declaration parsing
 
 void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style) {
@@ -401,6 +426,10 @@ void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style
       style.direction = CssTextDirection::Ltr;
       style.defined.direction = 1;
     }
+  } else if (iequalsAscii(name, "border") || iequalsAscii(name, "border-style") ||
+             iequalsAscii(name, "border-width")) {
+    style.borderStyle = interpretBorderVisibility(value);
+    style.defined.borderStyle = 1;
   } else if (iequalsAscii(name, "vertical-align")) {
     if (iequalsAscii(value, "super")) {
       style.verticalAlign = CssVerticalAlign::Super;
@@ -744,6 +773,7 @@ bool CssParser::saveToCache() const {
     writeLength(style.imageWidth);
     file.write(static_cast<uint8_t>(style.display));
     file.write(static_cast<uint8_t>(style.verticalAlign));
+    file.write(static_cast<uint8_t>(style.borderStyle));
 
     // Write defined flags as uint32_t
     uint32_t definedBits = 0;
@@ -765,6 +795,7 @@ bool CssParser::saveToCache() const {
     if (style.defined.display) definedBits |= 1 << 15;
     if (style.defined.direction) definedBits |= 1 << 16;
     if (style.defined.verticalAlign) definedBits |= 1 << 17;
+    if (style.defined.borderStyle) definedBits |= 1 << 18;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
   }
 
@@ -817,8 +848,10 @@ bool CssParser::loadFromCache() {
 
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
+  // 8 single-byte enums: textAlign, fontStyle, fontWeight, textDecoration, direction,
+  // display, verticalAlign, borderStyle.
   constexpr size_t CSS_FIXED_STYLE_BYTES =
-      5 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint8_t) + sizeof(uint32_t);
+      8 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint32_t);
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
@@ -923,6 +956,14 @@ bool CssParser::loadFromCache() {
     }
     style.verticalAlign = static_cast<CssVerticalAlign>(verticalAlignVal);
 
+    // Read borderStyle value
+    uint8_t borderStyleVal;
+    if (file.read(&borderStyleVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderStyle = static_cast<CssBorderStyle>(borderStyleVal);
+
     // Read defined flags
     uint32_t definedBits = 0;
     if (file.read(&definedBits, sizeof(definedBits)) != sizeof(definedBits)) {
@@ -947,6 +988,7 @@ bool CssParser::loadFromCache() {
     style.defined.display = (definedBits & 1 << 15) != 0;
     style.defined.direction = (definedBits & 1 << 16) != 0;
     style.defined.verticalAlign = (definedBits & 1 << 17) != 0;
+    style.defined.borderStyle = (definedBits & 1 << 18) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -309,13 +309,23 @@ void CssParser::applyBorderDeclaration(std::string_view val, const bool touchesS
                                        CssStyle& style) {
   val = trimCssWhitespace(stripTrailingImportant(val));
 
-  bool sawNoneKeyword = false;
+  // The CSS border-style keywords that actually render a line. "none"/"hidden" (and
+  // anything else, including an omitted style in the "border" shorthand) render nothing.
+  constexpr std::string_view kVisibleStyleKeywords[] = {"solid",  "dashed", "dotted", "double",
+                                                        "groove", "ridge",  "inset",  "outset"};
+
+  bool sawVisibleStyleKeyword = false;
   bool sawWidthToken = false;
   bool sawNonZeroWidth = false;
   forEachDelimitedToken(val, isCssWhitespace, [&](std::string_view token) {
     if (iequalsAscii(token, "none") || iequalsAscii(token, "hidden")) {
-      sawNoneKeyword = true;
       return;
+    }
+    for (const std::string_view keyword : kVisibleStyleKeywords) {
+      if (iequalsAscii(token, keyword)) {
+        sawVisibleStyleKeyword = true;
+        return;
+      }
     }
     CssLength len;
     if (tryInterpretLength(token, len)) {
@@ -326,9 +336,11 @@ void CssParser::applyBorderDeclaration(std::string_view val, const bool touchesS
 
   // border-style (and the style slot of the "border" shorthand) is only set when this
   // declaration actually speaks to it, so an earlier explicit style survives a later
-  // border-width-only declaration untouched.
+  // border-width-only declaration untouched. A shorthand with a width but no style
+  // keyword (e.g. "border: 1px;") leaves the style at its CSS-initial value of none, so
+  // require an explicit visible-style keyword rather than merely the absence of "none".
   if (touchesStyle) {
-    style.borderStyle = sawNoneKeyword ? CssBorderStyle::None : CssBorderStyle::Visible;
+    style.borderStyle = sawVisibleStyleKeyword ? CssBorderStyle::Visible : CssBorderStyle::None;
     style.defined.borderStyle = 1;
   }
   // border-width only carries meaning when a length token was actually present — a bare

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -305,29 +305,39 @@ bool CssParser::tryInterpretLength(std::string_view val, CssLength& out) {
   return true;
 }
 
-CssBorderStyle CssParser::interpretBorderVisibility(std::string_view val) {
+void CssParser::applyBorderDeclaration(std::string_view val, const bool touchesStyle, const bool touchesWidth,
+                                       CssStyle& style) {
   val = trimCssWhitespace(stripTrailingImportant(val));
 
-  bool sawNone = false;
-  bool sawAnyWidthToken = false;
+  bool sawNoneKeyword = false;
+  bool sawWidthToken = false;
   bool sawNonZeroWidth = false;
   forEachDelimitedToken(val, isCssWhitespace, [&](std::string_view token) {
     if (iequalsAscii(token, "none") || iequalsAscii(token, "hidden")) {
-      sawNone = true;
+      sawNoneKeyword = true;
       return;
     }
     CssLength len;
     if (tryInterpretLength(token, len)) {
-      sawAnyWidthToken = true;
+      sawWidthToken = true;
       if (len.value != 0.0f) sawNonZeroWidth = true;
     }
   });
 
-  if (sawNone) return CssBorderStyle::None;
-  // A width-only declaration (e.g. "border: 0", "border-width: 0 0") with every
-  // token resolving to zero is as invisible as "none".
-  if (sawAnyWidthToken && !sawNonZeroWidth) return CssBorderStyle::None;
-  return CssBorderStyle::Visible;
+  // border-style (and the style slot of the "border" shorthand) is only set when this
+  // declaration actually speaks to it, so an earlier explicit style survives a later
+  // border-width-only declaration untouched.
+  if (touchesStyle) {
+    style.borderStyle = sawNoneKeyword ? CssBorderStyle::None : CssBorderStyle::Visible;
+    style.defined.borderStyle = 1;
+  }
+  // border-width only carries meaning when a length token was actually present — a bare
+  // "border: solid" shorthand says nothing about width and must not clobber a width set
+  // by a separate declaration.
+  if (touchesWidth && sawWidthToken) {
+    style.borderWidthZero = !sawNonZeroWidth;
+    style.defined.borderWidthZero = 1;
+  }
 }
 
 // Declaration parsing
@@ -426,9 +436,12 @@ void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style
       style.direction = CssTextDirection::Ltr;
       style.defined.direction = 1;
     }
-  } else if (iequalsAscii(name, "border") || iequalsAscii(name, "border-style") || iequalsAscii(name, "border-width")) {
-    style.borderStyle = interpretBorderVisibility(value);
-    style.defined.borderStyle = 1;
+  } else if (iequalsAscii(name, "border")) {
+    applyBorderDeclaration(value, /*touchesStyle=*/true, /*touchesWidth=*/true, style);
+  } else if (iequalsAscii(name, "border-style")) {
+    applyBorderDeclaration(value, /*touchesStyle=*/true, /*touchesWidth=*/false, style);
+  } else if (iequalsAscii(name, "border-width")) {
+    applyBorderDeclaration(value, /*touchesStyle=*/false, /*touchesWidth=*/true, style);
   } else if (iequalsAscii(name, "vertical-align")) {
     if (iequalsAscii(value, "super")) {
       style.verticalAlign = CssVerticalAlign::Super;
@@ -773,6 +786,7 @@ bool CssParser::saveToCache() const {
     file.write(static_cast<uint8_t>(style.display));
     file.write(static_cast<uint8_t>(style.verticalAlign));
     file.write(static_cast<uint8_t>(style.borderStyle));
+    file.write(static_cast<uint8_t>(style.borderWidthZero ? 1 : 0));
 
     // Write defined flags as uint32_t
     uint32_t definedBits = 0;
@@ -795,6 +809,7 @@ bool CssParser::saveToCache() const {
     if (style.defined.direction) definedBits |= 1 << 16;
     if (style.defined.verticalAlign) definedBits |= 1 << 17;
     if (style.defined.borderStyle) definedBits |= 1 << 18;
+    if (style.defined.borderWidthZero) definedBits |= 1 << 19;
     file.write(reinterpret_cast<const uint8_t*>(&definedBits), sizeof(definedBits));
   }
 
@@ -847,10 +862,10 @@ bool CssParser::loadFromCache() {
 
   constexpr size_t CSS_LENGTH_FIELD_COUNT = 11;
   constexpr size_t CSS_LENGTH_BYTES = sizeof(float) + sizeof(uint8_t);
-  // 8 single-byte enums: textAlign, fontStyle, fontWeight, textDecoration, direction,
-  // display, verticalAlign, borderStyle.
+  // 9 single-byte fields: textAlign, fontStyle, fontWeight, textDecoration, direction,
+  // display, verticalAlign, borderStyle, borderWidthZero.
   constexpr size_t CSS_FIXED_STYLE_BYTES =
-      8 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint32_t);
+      9 * sizeof(uint8_t) + (CSS_LENGTH_FIELD_COUNT * CSS_LENGTH_BYTES) + sizeof(uint32_t);
 
   // Read each rule
   for (uint16_t i = 0; i < ruleCount; ++i) {
@@ -963,6 +978,14 @@ bool CssParser::loadFromCache() {
     }
     style.borderStyle = static_cast<CssBorderStyle>(borderStyleVal);
 
+    // Read borderWidthZero value
+    uint8_t borderWidthZeroVal;
+    if (file.read(&borderWidthZeroVal, 1) != 1) {
+      rulesBySelector_.clear();
+      return false;
+    }
+    style.borderWidthZero = borderWidthZeroVal != 0;
+
     // Read defined flags
     uint32_t definedBits = 0;
     if (file.read(&definedBits, sizeof(definedBits)) != sizeof(definedBits)) {
@@ -988,6 +1011,7 @@ bool CssParser::loadFromCache() {
     style.defined.direction = (definedBits & 1 << 16) != 0;
     style.defined.verticalAlign = (definedBits & 1 << 17) != 0;
     style.defined.borderStyle = (definedBits & 1 << 18) != 0;
+    style.defined.borderWidthZero = (definedBits & 1 << 19) != 0;
 
     rulesBySelector_[selector] = style;
   }

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -426,8 +426,7 @@ void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style
       style.direction = CssTextDirection::Ltr;
       style.defined.direction = 1;
     }
-  } else if (iequalsAscii(name, "border") || iequalsAscii(name, "border-style") ||
-             iequalsAscii(name, "border-width")) {
+  } else if (iequalsAscii(name, "border") || iequalsAscii(name, "border-style") || iequalsAscii(name, "border-width")) {
     style.borderStyle = interpretBorderVisibility(value);
     style.defined.borderStyle = 1;
   } else if (iequalsAscii(name, "vertical-align")) {

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -33,7 +33,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 8;
+  static constexpr uint8_t CSS_CACHE_VERSION = 9;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;
@@ -155,4 +155,12 @@ class CssParser {
   static CssLength interpretLength(std::string_view val);
   /** Returns true only when a numeric length was parsed (e.g. 2em, 50%). False for auto/inherit/initial. */
   static bool tryInterpretLength(std::string_view val, CssLength& out);
+  /**
+   * Interprets border/border-style/border-width values. Detects "none"/"hidden"
+   * keywords and all-zero widths (e.g. "border: 0") as CssBorderStyle::None;
+   * any other explicit value (a named style, a nonzero width, a color) as Visible.
+   * Per-edge overrides (border-top, etc.) are not parsed — a plain "border"/
+   * "border-style"/"border-width" declaration is the common case for <hr>.
+   */
+  static CssBorderStyle interpretBorderVisibility(std::string_view val);
 };

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -33,7 +33,7 @@
 class CssParser {
  public:
   // Bump when CSS cache format or rules change; section caches are invalidated when this changes
-  static constexpr uint8_t CSS_CACHE_VERSION = 9;
+  static constexpr uint8_t CSS_CACHE_VERSION = 10;
 
   explicit CssParser(std::string cachePath) : cachePath(std::move(cachePath)) {}
   ~CssParser() = default;
@@ -156,11 +156,15 @@ class CssParser {
   /** Returns true only when a numeric length was parsed (e.g. 2em, 50%). False for auto/inherit/initial. */
   static bool tryInterpretLength(std::string_view val, CssLength& out);
   /**
-   * Interprets border/border-style/border-width values. Detects "none"/"hidden"
-   * keywords and all-zero widths (e.g. "border: 0") as CssBorderStyle::None;
-   * any other explicit value (a named style, a nonzero width, a color) as Visible.
+   * Applies a border/border-style/border-width declaration to style. border-style and
+   * border-width are independent CSS longhands that can be declared separately (or
+   * together via the "border" shorthand) and combine with AND-of-visibility semantics —
+   * e.g. "border: none" followed by a later "border-width: 1px" must stay invisible,
+   * since border-width alone never overrides an explicit style of none. touchesStyle/
+   * touchesWidth select which axis (or axes, for the shorthand) this declaration sets;
+   * an axis that isn't touched is left as whatever a prior declaration set it to.
    * Per-edge overrides (border-top, etc.) are not parsed — a plain "border"/
    * "border-style"/"border-width" declaration is the common case for <hr>.
    */
-  static CssBorderStyle interpretBorderVisibility(std::string_view val);
+  static void applyBorderDeclaration(std::string_view val, bool touchesStyle, bool touchesWidth, CssStyle& style);
 };

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -97,6 +97,7 @@ struct CssPropertyFlags {
   uint16_t direction : 1;
   uint16_t verticalAlign : 1;
   uint16_t borderStyle : 1;
+  uint16_t borderWidthZero : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -117,23 +118,24 @@ struct CssPropertyFlags {
         display(0),
         direction(0),
         verticalAlign(0),
-        borderStyle(0) {}
+        borderStyle(0),
+        borderWidthZero(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display || direction || verticalAlign || borderStyle;
+           imageWidth || display || direction || verticalAlign || borderStyle || borderWidthZero;
   }
 
   void clearAll() {
     textAlign = fontStyle = fontWeight = textDecoration = textIndent = 0;
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
-    imageHeight = imageWidth = display = direction = verticalAlign = borderStyle = 0;
+    imageHeight = imageWidth = display = direction = verticalAlign = borderStyle = borderWidthZero = 0;
   }
 };
 
-// Cache serializes defined flags as uint32_t with bit indices 0..18.
+// Cache serializes defined flags as uint32_t with bit indices 0..19.
 static_assert(sizeof(CssPropertyFlags) <= sizeof(uint32_t),
               "CssPropertyFlags exceeds 32 bits; update cache read/write in CssParser.cpp");
 
@@ -160,7 +162,12 @@ struct CssStyle {
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;                       // display property (Block or None)
   CssVerticalAlign verticalAlign = CssVerticalAlign::Baseline;  // vertical-align (super/sub positioning)
-  CssBorderStyle borderStyle = CssBorderStyle::Visible;         // border/border-style/border-width (Visible or None)
+  // border-style component (or the style keyword within a "border" shorthand). Tracked
+  // separately from borderWidthZero below since they're independent CSS longhands that
+  // can be set by different declarations — an element is only visibly bordered when
+  // NEITHER says "invisible". Use isBorderHidden() rather than reading these directly.
+  CssBorderStyle borderStyle = CssBorderStyle::Visible;
+  bool borderWidthZero = false;  // true when border-width (or the shorthand's width token) resolved to all zeros
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -243,6 +250,10 @@ struct CssStyle {
       borderStyle = base.borderStyle;
       defined.borderStyle = 1;
     }
+    if (base.hasBorderWidthZero()) {
+      borderWidthZero = base.borderWidthZero;
+      defined.borderWidthZero = 1;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -264,6 +275,16 @@ struct CssStyle {
   [[nodiscard]] bool hasDirection() const { return defined.direction; }
   [[nodiscard]] bool hasVerticalAlign() const { return defined.verticalAlign; }
   [[nodiscard]] bool hasBorderStyle() const { return defined.borderStyle; }
+  [[nodiscard]] bool hasBorderWidthZero() const { return defined.borderWidthZero; }
+
+  // An element's border is invisible if either independent longhand says so: an
+  // explicit "none"/"hidden" style, or a width that resolved to all zeros. Either
+  // one alone is enough to hide it, regardless of which was declared more recently.
+  [[nodiscard]] bool isBorderHidden() const {
+    const bool styleHidesIt = hasBorderStyle() && borderStyle == CssBorderStyle::None;
+    const bool widthHidesIt = hasBorderWidthZero() && borderWidthZero;
+    return styleHidesIt || widthHidesIt;
+  }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -278,6 +299,7 @@ struct CssStyle {
     display = CssDisplay::Block;
     verticalAlign = CssVerticalAlign::Baseline;
     borderStyle = CssBorderStyle::Visible;
+    borderWidthZero = false;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -160,7 +160,7 @@ struct CssStyle {
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;                       // display property (Block or None)
   CssVerticalAlign verticalAlign = CssVerticalAlign::Baseline;  // vertical-align (super/sub positioning)
-  CssBorderStyle borderStyle = CssBorderStyle::Visible;  // border/border-style/border-width (Visible or None)
+  CssBorderStyle borderStyle = CssBorderStyle::Visible;         // border/border-style/border-width (Visible or None)
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -72,6 +72,10 @@ enum class CssDisplay : uint8_t { Block = 0, None = 1 };
 // Vertical alignment options for inline elements (e.g. superscript/subscript)
 enum class CssVerticalAlign : uint8_t { Baseline = 0, Super = 1, Sub = 2 };
 
+// Border visibility - only whether a border renders at all matters for e-ink
+// rendering (used to decide whether <hr> draws a visible line)
+enum class CssBorderStyle : uint8_t { Visible = 0, None = 1 };
+
 // Bitmask for tracking which properties have been explicitly set
 struct CssPropertyFlags {
   uint16_t textAlign : 1;
@@ -92,6 +96,7 @@ struct CssPropertyFlags {
   uint16_t display : 1;
   uint16_t direction : 1;
   uint16_t verticalAlign : 1;
+  uint16_t borderStyle : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -111,23 +116,24 @@ struct CssPropertyFlags {
         imageWidth(0),
         display(0),
         direction(0),
-        verticalAlign(0) {}
+        verticalAlign(0),
+        borderStyle(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display || direction || verticalAlign;
+           imageWidth || display || direction || verticalAlign || borderStyle;
   }
 
   void clearAll() {
     textAlign = fontStyle = fontWeight = textDecoration = textIndent = 0;
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
-    imageHeight = imageWidth = display = direction = verticalAlign = 0;
+    imageHeight = imageWidth = display = direction = verticalAlign = borderStyle = 0;
   }
 };
 
-// Cache serializes defined flags as uint32_t with bit indices 0..17.
+// Cache serializes defined flags as uint32_t with bit indices 0..18.
 static_assert(sizeof(CssPropertyFlags) <= sizeof(uint32_t),
               "CssPropertyFlags exceeds 32 bits; update cache read/write in CssParser.cpp");
 
@@ -154,6 +160,7 @@ struct CssStyle {
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;                       // display property (Block or None)
   CssVerticalAlign verticalAlign = CssVerticalAlign::Baseline;  // vertical-align (super/sub positioning)
+  CssBorderStyle borderStyle = CssBorderStyle::Visible;  // border/border-style/border-width (Visible or None)
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -232,6 +239,10 @@ struct CssStyle {
       verticalAlign = base.verticalAlign;
       defined.verticalAlign = 1;
     }
+    if (base.hasBorderStyle()) {
+      borderStyle = base.borderStyle;
+      defined.borderStyle = 1;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -252,6 +263,7 @@ struct CssStyle {
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
   [[nodiscard]] bool hasDirection() const { return defined.direction; }
   [[nodiscard]] bool hasVerticalAlign() const { return defined.verticalAlign; }
+  [[nodiscard]] bool hasBorderStyle() const { return defined.borderStyle; }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -265,6 +277,7 @@ struct CssStyle {
     imageHeight = imageWidth = CssLength{};
     display = CssDisplay::Block;
     verticalAlign = CssVerticalAlign::Baseline;
+    borderStyle = CssBorderStyle::Visible;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -327,7 +327,7 @@ void ChapterHtmlSlimParser::startNewTextBlock(const BlockStyle& blockStyle) {
   listItemBulletOnly = false;
 }
 
-void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
+void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle, const bool drawLine) {
   if (partWordBufferIndex > 0) {
     flushPartWordBuffer();
   }
@@ -354,7 +354,8 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   const int16_t bottomSpacing =
       static_cast<int16_t>((blockStyle.marginBottom > 0 ? blockStyle.marginBottom : defaultVerticalSpacing) +
                            (blockStyle.paddingBottom > 0 ? blockStyle.paddingBottom : 0));
-  constexpr uint8_t ruleThickness = 2;
+  // A CSS-hidden border occupies no height, matching browsers — only margin/padding remain.
+  const uint8_t ruleThickness = drawLine ? 2 : 0;
   const int16_t availableWidth =
       std::max<int16_t>(1, static_cast<int16_t>(viewportWidth - blockStyle.totalHorizontalInset()));
   const int16_t width = std::max<int16_t>(1, static_cast<int16_t>(availableWidth / 4));
@@ -376,13 +377,15 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 
   currentPageNextY += topSpacing;
 
-  auto pageRule = std::shared_ptr<PageHorizontalRule>(
-      new (std::nothrow) PageHorizontalRule(width, ruleThickness, xPos, currentPageNextY));
-  if (!pageRule) {
-    LOG_ERR("EHP", "Failed to create PageHorizontalRule");
-    return;
+  if (drawLine) {
+    auto pageRule = std::shared_ptr<PageHorizontalRule>(
+        new (std::nothrow) PageHorizontalRule(width, ruleThickness, xPos, currentPageNextY));
+    if (!pageRule) {
+      LOG_ERR("EHP", "Failed to create PageHorizontalRule");
+      return;
+    }
+    currentPage->elements.push_back(pageRule);
   }
-  currentPage->elements.push_back(pageRule);
   setCurrentPageVisibleOffset(visibleTextOffset);
   currentPageNextY = static_cast<int16_t>(currentPageNextY + ruleThickness + bottomSpacing);
 
@@ -969,7 +972,10 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       hrBlockStyle.textIndentDefined = false;
       hrBlockStyle.textIndent = 0;
     }
-    self->emitHorizontalRule(hrBlockStyle);
+    // A book's own CSS can define <hr> as a purely semantic marker with no visible
+    // line (e.g. "border: none"); only its margin/padding should still occupy space.
+    const bool hrDrawsLine = !(cssStyle.hasBorderStyle() && cssStyle.borderStyle == CssBorderStyle::None);
+    self->emitHorizontalRule(hrBlockStyle, hrDrawsLine);
     self->depth += 1;
     return;
   }

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -362,7 +362,12 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle, con
   const int16_t xPos = static_cast<int16_t>(blockStyle.leftInset() + ((availableWidth - width) / 2));
   const int16_t totalHeight = static_cast<int16_t>(topSpacing + ruleThickness + bottomSpacing);
 
-  if (!currentPage->elements.empty() && currentPageNextY + totalHeight > viewportHeight) {
+  // Gate on consumed Y rather than currentPage->elements.empty(): a run of CSS-hidden
+  // <hr>s (drawLine false) never pushes a page element but still advances
+  // currentPageNextY via margin/padding, so elements.empty() would stay true and this
+  // check would never fire — silently growing past viewportHeight until whatever real
+  // content follows gets flushed onto (or past) an already-overflowed, all-blank page.
+  if (currentPageNextY > 0 && currentPageNextY + totalHeight > viewportHeight) {
     setCurrentPageVisibleOffset(visibleTextOffset);
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
     completedPageCount++;
@@ -974,7 +979,7 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
     }
     // A book's own CSS can define <hr> as a purely semantic marker with no visible
     // line (e.g. "border: none"); only its margin/padding should still occupy space.
-    const bool hrDrawsLine = !(cssStyle.hasBorderStyle() && cssStyle.borderStyle == CssBorderStyle::None);
+    const bool hrDrawsLine = !cssStyle.isBorderHidden();
     self->emitHorizontalRule(hrBlockStyle, hrDrawsLine);
     self->depth += 1;
     return;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -134,7 +134,7 @@ class ChapterHtmlSlimParser {
   static void applyDirectionToEntry(StyleStackEntry& entry, const CssStyle& css);
   static void applyTextDecorationToEntry(StyleStackEntry& entry, const CssStyle& css);
   void pushDecorationStyleEntry(CssTextDecoration defaultDecoration, const CssStyle& cssStyle);
-  void emitHorizontalRule(const BlockStyle& blockStyle);
+  void emitHorizontalRule(const BlockStyle& blockStyle, bool drawLine);
   // XML callbacks
   static void XMLCALL startElement(void* userData, const XML_Char* name, const XML_Char** atts);
   static void XMLCALL characterData(void* userData, const XML_Char* s, int len);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix EPUB `<hr>` rendering to respect CSS border visibility instead of always drawing a solid line.
* **What changes are included?**
  Some EPUBs style `<hr>` as `border: none; margin: 0;`, using it as a purely semantic/structural marker, with a separately-styled visible divider (e.g. a centered "—" glyph) following it. This is a common pattern in professionally produced EPUBs (observed in a Penguin Random House title). CrossPoint's renderer ignored CSS `border` entirely and always drew a solid 2px line for every `<hr>`, producing a visible line the publisher never intended to show, crowding against the actual divider content beneath it.

  This adds minimal CSS parsing for `border`/`border-style`/`border-width` (detects `none`/`hidden` keywords or an all-zero-width value as invisible) and wires it into `<hr>` handling: when CSS marks the border invisible, no line is drawn and no line-thickness space is reserved for it, matching browser behavior. Margin/padding spacing around the `<hr>` is still respected either way.

  Also bumps `CSS_CACHE_VERSION` (8 → 9) since the cached `CssStyle` record gained a field, so old on-disk CSS caches are invalidated cleanly instead of being misread.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* This is a straightforward EPUB-rendering correctness fix affecting the shared CSS/pagination path (`lib/Epub/Epub/css/`, `lib/Epub/Epub/parsers/ChapterHtmlSlimParser.*`), not tied to any device-specific behavior.
* Memory/flash impact: negligible — one new `uint8_t`-backed enum field on `CssStyle`, one new bitfield flag, one new `bool` parameter. No new allocations.
* Only the plain `border`/`border-style`/`border-width` shorthand/longhand properties are parsed; per-edge overrides (`border-top`, etc.) are not, since a plain declaration is the common real-world pattern for `<hr>`.
* Existing on-disk CSS rule caches are automatically invalidated and rebuilt due to the cache version bump — no migration needed.

---

### AI Usage

Did you use AI tools to help write this code? **YES** — diagnosed via Claude Code by extracting and inspecting the actual EPUB source that exhibited the bug (CSS + markup), then implementing and self-reviewing the fix. Reviewed and directed by me throughout.