### PR TITLE
feat: Using factory lut for less fizzy cover image

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -13,6 +13,11 @@
 #include "Epub/parsers/TocNavParser.h"
 #include "Epub/parsers/TocNcxParser.h"
 
+namespace {
+// Needs to be increased if an update needs to regenerate the cover bmp
+constexpr char coverBmpVersion[] = "_v2";
+}  // namespace
+
 bool Epub::findContentOpfFile(std::string* contentOpfFile) const {
   const auto containerPath = "META-INF/container.xml";
   size_t containerSize;
@@ -556,7 +561,7 @@ const std::string& Epub::getLanguage() const {
 }
 
 std::string Epub::getCoverBmpPath(bool cropped) const {
-  const auto coverFileName = std::string("cover") + (cropped ? "_crop" : "");
+  const auto coverFileName = std::string("cover") + coverBmpVersion + (cropped ? "_crop" : "");
   return cachePath + "/" + coverFileName + ".bmp";
 }
 

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -102,25 +102,25 @@ class Atkinson1BitDitherer {
 // 1/8 1/8 1/8
 //     1/8
 // Less error buildup = fewer artifacts than Floyd-Steinberg
-template <bool useOriginalThresholds>
-class AtkinsonDithererImpl {
+class AtkinsonDitherer {
  public:
-  explicit AtkinsonDithererImpl(int width) : width(width) {
+  explicit AtkinsonDitherer(int width, bool useOriginalThresholds = false)
+      : width(width), useOriginalThresholds(useOriginalThresholds) {
     errorRow0 = new int16_t[width + 4]();  // Current row
     errorRow1 = new int16_t[width + 4]();  // Next row
     errorRow2 = new int16_t[width + 4]();  // Row after next
   }
 
-  ~AtkinsonDithererImpl() {
+  ~AtkinsonDitherer() {
     delete[] errorRow0;
     delete[] errorRow1;
     delete[] errorRow2;
   }
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
-  AtkinsonDithererImpl(const AtkinsonDithererImpl& other) = delete;
+  AtkinsonDitherer(const AtkinsonDitherer& other) = delete;
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
-  AtkinsonDithererImpl& operator=(const AtkinsonDithererImpl& other) = delete;
+  AtkinsonDitherer& operator=(const AtkinsonDitherer& other) = delete;
 
   uint8_t processPixel(int gray, int x) {
     // Add accumulated error
@@ -190,14 +190,12 @@ class AtkinsonDithererImpl {
   }
 
  private:
-  int width;
+  const int width;
   int16_t* errorRow0;
   int16_t* errorRow1;
   int16_t* errorRow2;
+  const bool useOriginalThresholds;
 };
-
-using AtkinsonDitherer = AtkinsonDithererImpl<false>;
-using AtkinsonDithererOriginal = AtkinsonDithererImpl<true>;
 
 // Floyd-Steinberg error diffusion dithering with serpentine scanning
 // Serpentine scanning alternates direction each row to reduce "worm" artifacts
@@ -207,24 +205,24 @@ using AtkinsonDithererOriginal = AtkinsonDithererImpl<true>;
 // Error distribution pattern (right-to-left, mirrored):
 // 1/16 5/16 3/16
 //      7/16  X
-template <bool useOriginalThresholds>
-class FloydSteinbergDithererImpl {
+class FloydSteinbergDitherer {
  public:
-  explicit FloydSteinbergDithererImpl(int width) : width(width), rowCount(0) {
+  explicit FloydSteinbergDitherer(int width, bool useOriginalThresholds = false)
+      : width(width), rowCount(0), useOriginalThresholds(useOriginalThresholds) {
     errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
     errorNextRow = new int16_t[width + 2]();
   }
 
-  ~FloydSteinbergDithererImpl() {
+  ~FloydSteinbergDitherer() {
     delete[] errorCurRow;
     delete[] errorNextRow;
   }
 
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
-  FloydSteinbergDithererImpl(const FloydSteinbergDithererImpl& other) = delete;
+  FloydSteinbergDitherer(const FloydSteinbergDitherer& other) = delete;
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
-  FloydSteinbergDithererImpl& operator=(const FloydSteinbergDithererImpl& other) = delete;
+  FloydSteinbergDitherer& operator=(const FloydSteinbergDitherer& other) = delete;
 
   // Process a single pixel and return quantized 2-bit value
   // x is the logical x position (0 to width-1), direction handled internally
@@ -320,11 +318,9 @@ class FloydSteinbergDithererImpl {
   }
 
  private:
-  int width;
+  const int width;
   int rowCount;
   int16_t* errorCurRow;
   int16_t* errorNextRow;
+  const bool useOriginalThresholds;
 };
-
-using FloydSteinbergDitherer = FloydSteinbergDithererImpl<false>;
-using FloydSteinbergDithererOriginal = FloydSteinbergDithererImpl<true>;

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -102,24 +102,25 @@ class Atkinson1BitDitherer {
 // 1/8 1/8 1/8
 //     1/8
 // Less error buildup = fewer artifacts than Floyd-Steinberg
-class AtkinsonDitherer {
+template <bool useOriginalThresholds>
+class AtkinsonDithererImpl {
  public:
-  explicit AtkinsonDitherer(int width) : width(width) {
+  explicit AtkinsonDithererImpl(int width) : width(width) {
     errorRow0 = new int16_t[width + 4]();  // Current row
     errorRow1 = new int16_t[width + 4]();  // Next row
     errorRow2 = new int16_t[width + 4]();  // Row after next
   }
 
-  ~AtkinsonDitherer() {
+  ~AtkinsonDithererImpl() {
     delete[] errorRow0;
     delete[] errorRow1;
     delete[] errorRow2;
   }
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
-  AtkinsonDitherer(const AtkinsonDitherer& other) = delete;
+  AtkinsonDithererImpl(const AtkinsonDithererImpl& other) = delete;
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
-  AtkinsonDitherer& operator=(const AtkinsonDitherer& other) = delete;
+  AtkinsonDithererImpl& operator=(const AtkinsonDithererImpl& other) = delete;
 
   uint8_t processPixel(int gray, int x) {
     // Add accumulated error
@@ -130,7 +131,7 @@ class AtkinsonDitherer {
     // Quantize to 4 levels
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
+    if (useOriginalThresholds) {  // original thresholds
       if (adjusted < 43) {
         quantized = 0;
         quantizedValue = 0;
@@ -195,6 +196,9 @@ class AtkinsonDitherer {
   int16_t* errorRow2;
 };
 
+using AtkinsonDitherer = AtkinsonDithererImpl<false>;
+using AtkinsonDithererOriginal = AtkinsonDithererImpl<true>;
+
 // Floyd-Steinberg error diffusion dithering with serpentine scanning
 // Serpentine scanning alternates direction each row to reduce "worm" artifacts
 // Error distribution pattern (left-to-right):
@@ -203,23 +207,24 @@ class AtkinsonDitherer {
 // Error distribution pattern (right-to-left, mirrored):
 // 1/16 5/16 3/16
 //      7/16  X
-class FloydSteinbergDitherer {
+template <bool useOriginalThresholds>
+class FloydSteinbergDithererImpl {
  public:
-  explicit FloydSteinbergDitherer(int width) : width(width), rowCount(0) {
+  explicit FloydSteinbergDithererImpl(int width) : width(width), rowCount(0) {
     errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
     errorNextRow = new int16_t[width + 2]();
   }
 
-  ~FloydSteinbergDitherer() {
+  ~FloydSteinbergDithererImpl() {
     delete[] errorCurRow;
     delete[] errorNextRow;
   }
 
   // **1. EXPLICITLY DELETE THE COPY CONSTRUCTOR**
-  FloydSteinbergDitherer(const FloydSteinbergDitherer& other) = delete;
+  FloydSteinbergDithererImpl(const FloydSteinbergDithererImpl& other) = delete;
 
   // **2. EXPLICITLY DELETE THE COPY ASSIGNMENT OPERATOR**
-  FloydSteinbergDitherer& operator=(const FloydSteinbergDitherer& other) = delete;
+  FloydSteinbergDithererImpl& operator=(const FloydSteinbergDithererImpl& other) = delete;
 
   // Process a single pixel and return quantized 2-bit value
   // x is the logical x position (0 to width-1), direction handled internally
@@ -234,7 +239,7 @@ class FloydSteinbergDitherer {
     // Quantize to 4 levels (0, 85, 170, 255)
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
+    if (useOriginalThresholds) {  // original thresholds
       if (adjusted < 43) {
         quantized = 0;
         quantizedValue = 0;
@@ -320,3 +325,6 @@ class FloydSteinbergDitherer {
   int16_t* errorCurRow;
   int16_t* errorNextRow;
 };
+
+using FloydSteinbergDitherer = FloydSteinbergDithererImpl<false>;
+using FloydSteinbergDithererOriginal = FloydSteinbergDithererImpl<true>;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1352,6 +1352,10 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
         drawPixel(screenX, screenY, false);
       } else if (renderMode == GRAYSCALE_LSB && val == 1) {
         drawPixel(screenX, screenY, false);
+      } else if (renderMode == FACTORY_GRAY_LSB && !(val & 1)) {
+        drawPixel(screenX, screenY, false);
+      } else if (renderMode == FACTORY_GRAY_MSB && val < 2) {
+        drawPixel(screenX, screenY, false);
       }
     }
   }
@@ -1391,6 +1395,9 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
     return;
   }
 
+  // Factory grayscale inverts the pixel values
+  const bool full = !(renderMode == FACTORY_GRAY_LSB || renderMode == FACTORY_GRAY_MSB);
+
   for (int bmpY = 0; bmpY < bitmap.getHeight(); bmpY++) {
     // Read rows sequentially using readNextRow
     if (bitmap.readNextRow(outputRow, rowBytes) != BmpReaderError::Ok) {
@@ -1425,7 +1432,7 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
       // For 1-bit source: 0 or 1 -> map to black (0,1,2) or white (3)
       // val < 3 means black pixel (draw it)
       if (val < 3) {
-        drawPixel(screenX, screenY, true);
+        drawPixel(screenX, screenY, full);
       }
       // White pixels (val == 3) are not drawn (leave background)
     }
@@ -1589,7 +1596,14 @@ void GfxRenderer::invertScreen() const {
 void GfxRenderer::displayBuffer(const HalDisplay::RefreshMode refreshMode) const {
   auto elapsed = millis() - start_ms;
   LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBuffer", elapsed);
-  display.displayBuffer(refreshMode, fadingFix);
+  // After a factory LUT render, RED RAM still contains the grayscale MSB plane.
+  // Promote the first normal FAST refresh to HALF so both RAM banks are rebased
+  // before differential updates resume.
+  const bool afterFactoryLut = displayState == DisplayState::FactoryLut;
+  const auto effectiveRefreshMode =
+      afterFactoryLut && refreshMode == HalDisplay::FAST_REFRESH ? HalDisplay::HALF_REFRESH : refreshMode;
+  display.displayBuffer(effectiveRefreshMode, fadingFix);
+  displayState = DisplayState::BW;
 }
 
 void GfxRenderer::displayBufferAsync(const HalDisplay::RefreshMode refreshMode) const {
@@ -2128,7 +2142,14 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
-void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+void GfxRenderer::displayGrayBuffer(const unsigned char* lut, bool factoryMode) const {
+  display.displayGrayBuffer(fadingFix, lut, factoryMode);
+  if (factoryMode) {
+    displayState = DisplayState::FactoryLut;
+  } else {
+    displayState = DisplayState::BW;
+  }
+}
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
   // Guard the uint16_t casts below: a negative would wrap to a huge length.

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -28,7 +28,13 @@ enum Color : uint8_t { Clear = 0x00, White = 0x01, LightGray = 0x05, DarkGray = 
 
 class GfxRenderer {
  public:
-  enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
+  enum RenderMode {
+    BW,                // 1-bit black/white
+    GRAYSCALE_LSB,     // Differential gray: mark pixels for LSB plane (clearScreen(0x00) + drawPixel(false))
+    GRAYSCALE_MSB,     // Differential gray: mark pixels for MSB plane (clearScreen(0x00) + drawPixel(false))
+    FACTORY_GRAY_LSB,  // Factory absolute gray: encode BW RAM = bit0 (clearScreen(0x00) + drawPixel(false))
+    FACTORY_GRAY_MSB,  // Factory absolute gray: encode RED RAM = bit1 (clearScreen(0x00) + drawPixel(false))
+  };
 
   // Logical screen orientation from the perspective of callers
   enum Orientation {
@@ -37,6 +43,12 @@ class GfxRenderer {
     PortraitInverted,          // 480x800 logical coordinates, inverted
     LandscapeCounterClockwise  // 800x480 logical coordinates, native panel orientation
   };
+
+  // Display state — tracks whether the physical display was last updated via a factory LUT render.
+  // BW: frameBuffer mirrors the display (menus, EPUB reader).
+  // FactoryLut: display holds a grayscale image; frameBuffer has been reset to white by
+  // cleanupGrayscaleWithFrameBuffer() and no longer represents what is visually shown.
+  enum class DisplayState { BW, FactoryLut };
 
  private:
   static constexpr size_t BW_BUFFER_CHUNK_SIZE = 8000;  // 8KB chunks to allow for non-contiguous memory
@@ -52,6 +64,7 @@ class GfxRenderer {
   uint32_t frameBufferSize = HalDisplay::BUFFER_SIZE;
   std::vector<uint8_t*> bwBufferChunks;
   std::map<int, EpdFontFamily> fontMap;
+  mutable DisplayState displayState = DisplayState::BW;
   // Mutable because ensureSdCardFontReady() is const (called from layout code
   // that holds a const GfxRenderer&) but triggers SD card reads and heap
   // allocation inside the SdCardFont objects. Same pragmatic compromise as
@@ -271,6 +284,8 @@ class GfxRenderer {
                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   int getTextHeight(int fontId) const;
 
+  DisplayState getDisplayState() const { return displayState; }
+
   // Grayscale functions
   void setRenderMode(const RenderMode mode) { this->renderMode = mode; }
   RenderMode getRenderMode() const { return renderMode; }
@@ -286,7 +301,7 @@ class GfxRenderer {
   void displayGrayscaleBase(HalDisplay::RefreshMode fallback = HalDisplay::HALF_REFRESH) const;
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
-  void displayGrayBuffer() const;
+  void displayGrayBuffer(const unsigned char* lut = nullptr, bool factoryMode = false) const;
 
   // Tiled grayscale (X4): stream one band of a plane straight to controller RAM
   // from `scratch` (panelWidthBytes * numRows, physical rows [yStart, yStart+

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -247,8 +247,8 @@ struct BmpConvertCtx {
 
   std::unique_ptr<uint8_t[]> bmpRow;
 
-  std::unique_ptr<AtkinsonDithererOriginal> atkinsonDitherer;
-  std::unique_ptr<FloydSteinbergDithererOriginal> fsDitherer;
+  std::unique_ptr<AtkinsonDitherer> atkinsonDitherer;
+  std::unique_ptr<FloydSteinbergDitherer> fsDitherer;
   std::unique_ptr<Atkinson1BitDitherer> atkinson1BitDitherer;
 
   uint8_t rowsSinceYield;
@@ -679,14 +679,19 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
       return false;
     }
   } else if (!USE_8BIT_OUTPUT) {
+#if FREEINK_DRIVER_SSD1677
+    constexpr bool useOriginalThresholds = true;
+#else
+    constexpr bool useOriginalThresholds = false;
+#endif
     if (USE_ATKINSON) {
-      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDithererOriginal>(outWidth);
+      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth, useOriginalThresholds);
       if (!ctx.atkinsonDitherer) {
         LOG_ERR("JPG", "OOM: AtkinsonDitherer");
         return false;
       }
     } else if (USE_FLOYD_STEINBERG) {
-      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDithererOriginal>(outWidth);
+      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth, useOriginalThresholds);
       if (!ctx.fsDitherer) {
         LOG_ERR("JPG", "OOM: FloydSteinbergDitherer");
         return false;

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -247,8 +247,8 @@ struct BmpConvertCtx {
 
   std::unique_ptr<uint8_t[]> bmpRow;
 
-  std::unique_ptr<AtkinsonDitherer> atkinsonDitherer;
-  std::unique_ptr<FloydSteinbergDitherer> fsDitherer;
+  std::unique_ptr<AtkinsonDithererOriginal> atkinsonDitherer;
+  std::unique_ptr<FloydSteinbergDithererOriginal> fsDitherer;
   std::unique_ptr<Atkinson1BitDitherer> atkinson1BitDitherer;
 
   uint8_t rowsSinceYield;
@@ -680,13 +680,13 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
     }
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth);
+      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDithererOriginal>(outWidth);
       if (!ctx.atkinsonDitherer) {
         LOG_ERR("JPG", "OOM: AtkinsonDitherer");
         return false;
       }
     } else if (USE_FLOYD_STEINBERG) {
-      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth);
+      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDithererOriginal>(outWidth);
       if (!ctx.fsDitherer) {
         LOG_ERR("JPG", "OOM: FloydSteinbergDitherer");
         return false;

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -624,17 +624,23 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   }
 
   // Create ditherers (same as JpegToBmpConverter)
-  AtkinsonDithererOriginal* atkinsonDitherer = nullptr;
-  FloydSteinbergDithererOriginal* fsDitherer = nullptr;
+  AtkinsonDitherer* atkinsonDitherer = nullptr;
+  FloydSteinbergDitherer* fsDitherer = nullptr;
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
+
+#if FREEINK_DRIVER_SSD1677
+  constexpr bool useOriginalThresholds = true;
+#else
+  constexpr bool useOriginalThresholds = false;
+#endif
 
   if (oneBit) {
     atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDithererOriginal(outWidth);
+      atkinsonDitherer = new AtkinsonDitherer(outWidth, useOriginalThresholds);
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDithererOriginal(outWidth);
+      fsDitherer = new FloydSteinbergDitherer(outWidth, useOriginalThresholds);
     }
   }
 

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -624,17 +624,17 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   }
 
   // Create ditherers (same as JpegToBmpConverter)
-  AtkinsonDitherer* atkinsonDitherer = nullptr;
-  FloydSteinbergDitherer* fsDitherer = nullptr;
+  AtkinsonDithererOriginal* atkinsonDitherer = nullptr;
+  FloydSteinbergDithererOriginal* fsDitherer = nullptr;
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
 
   if (oneBit) {
     atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth);
+      atkinsonDitherer = new AtkinsonDithererOriginal(outWidth);
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth);
+      fsDitherer = new FloydSteinbergDithererOriginal(outWidth);
     }
   }
 

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -134,7 +134,9 @@ void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay
 
 void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
 
-void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
+void HalDisplay::displayGrayBuffer(bool turnOffScreen, const unsigned char* lut, bool factoryMode) {
+  einkDisplay.displayGrayBuffer(turnOffScreen, lut, factoryMode);
+}
 
 void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
   einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -94,7 +94,7 @@ class HalDisplay {
   void copyGrayscaleMsbBuffers(const uint8_t* msbBuffer);
   void cleanupGrayscaleBuffers(const uint8_t* bwBuffer);
 
-  void displayGrayBuffer(bool turnOffScreen = false);
+  void displayGrayBuffer(bool turnOffScreen = false, const unsigned char* lut = nullptr, bool factoryMode = false);
 
   // Tiled grayscale: stream one band of a plane (lsbPlane selects LSB/MSB RAM)
   // straight to the controller; supportsStripGrayscale() gates the path. See

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -12,6 +12,9 @@
 #include <PNGdec.h>
 #include <Txt.h>
 #include <Xtc.h>
+#if FREEINK_DRIVER_SSD1677
+#include <lut/Ssd1677Luts.h>
+#endif
 
 #include <algorithm>
 #include <cmath>
@@ -616,7 +619,21 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+#if FREEINK_DRIVER_SSD1677
+  const bool useFactoryGrayscale = hasGreyscale;
+  constexpr auto msbMode = GfxRenderer::FACTORY_GRAY_MSB;
+  constexpr auto lsbMode = GfxRenderer::FACTORY_GRAY_LSB;
+  constexpr const unsigned char* lut = freeink::lut_factory_quality;
+#else
+  constexpr bool useFactoryGrayscale = false;
+  constexpr auto msbMode = GfxRenderer::GRAYSCALE_MSB;
+  constexpr auto lsbMode = GfxRenderer::GRAYSCALE_LSB;
+  constexpr const unsigned char* lut = nullptr;
+#endif
+
+  if (!useFactoryGrayscale) {
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  }
 
   if (!preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
@@ -636,17 +653,17 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
   if (hasGreyscale) {
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    renderer.setRenderMode(lsbMode);
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
     renderer.copyGrayscaleLsbBuffers();
 
     bitmap.rewindToData();
     renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    renderer.setRenderMode(msbMode);
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
     renderer.copyGrayscaleMsbBuffers();
 
-    renderer.displayGrayBuffer();
+    renderer.displayGrayBuffer(lut, useFactoryGrayscale);
     renderer.setRenderMode(GfxRenderer::BW);
   }
 }


### PR DESCRIPTION
## Summary

### Making use of the factory lut grayscale renderings for covers

This PR is based on the work of zgredex, who unfortunately didn't continue his efforts: https://github.com/crosspoint-reader/crosspoint-reader/pull/1614

He added way more stuff, optimized, played around and also added a lot of refactorings.

I tried to boil it down to an as small as possible change request for the most important feature (for me): Nice looking covers.

For me a cover is an essential part of the reading experience, especially as eBook Reader can keep them when turned of. But those changes could of course also be extended to images in the book as well as the image viewer of Crosspoint Reader as zgredex did it.

### comparison pictures

#### develop
<img width="1512" height="2016" alt="strength_before" src="https://github.com/user-attachments/assets/626c9160-7278-41c1-9a72-0c2e13e63281" />

#### my change
<img width="1512" height="2016" alt="strength_after" src="https://github.com/user-attachments/assets/df4f842a-7585-496c-8052-0be526e79997" />

#### develop
<img width="1512" height="2016" alt="jade_before" src="https://github.com/user-attachments/assets/a98de7d2-62b9-44a1-a5b2-228da2cb1e0e" />

#### my change
<img width="1512" height="2016" alt="jade_after" src="https://github.com/user-attachments/assets/fb90c392-c565-4c17-ba67-664713edc908" />


### Open discussion

I had to touch lib/hal, although I just extended the forwarding interface. However, I also had to add driver specific compile time  branching in the Sleep activity. I could move some of the stuff to the freeink repo, however I would still need some knowledge about the used driver as not every display supports the factory lut render mode and the framebuffer handling is inverted in that case.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. -> not yet, see discussion above.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
