### PR TITLE
fix: stop long chapters aborting on the build tables' growth

### DIFF
--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -70,18 +70,36 @@ Section::Section(const std::shared_ptr<Epub>& epub, const int spineIndex, GfxRen
 // (no-op once a build has completed or never started).
 Section::~Section() { suspendBuild(); }
 
-uint32_t Section::onPageComplete(std::unique_ptr<Page> page) {
+void Section::onPageComplete(std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
+                             const uint32_t visibleTextOffset) {
+  // Already stopping (buildSomeMore suspends as soon as it regains control): don't
+  // write pages that can no longer be indexed.
+  if (build_->lutExhausted) return;
+
+  // A zero file offset marks a page that failed to write; commitBuildFile rejects the
+  // build when it sees one, so the entry is still recorded to keep the LUT aligned
+  // with the pages emitted so far.
+  uint32_t position = 0;
   if (!file) {
     LOG_ERR("SCT", "File not open for writing page %d", builtPageCount_);
-    return 0;
+  } else {
+    position = file.position();
+    if (!page->serialize(file)) {
+      LOG_ERR("SCT", "Failed to serialize page %d", builtPageCount_);
+      position = 0;
+    } else {
+      LOG_DBG("SCT", "Page %d processed", builtPageCount_);
+    }
   }
 
-  const uint32_t position = file.position();
-  if (!page->serialize(file)) {
-    LOG_ERR("SCT", "Failed to serialize page %d", builtPageCount_);
-    return 0;
+  if (!build_->lut.push_back({position, paragraphIndex, listItemIndex, visibleTextOffset})) {
+    // Out of memory, or past the LUT's ceiling. builtPageCount_ is deliberately not
+    // advanced: this page is unreachable without an index entry, so the build stops
+    // here and keeps the pages it can still address.
+    LOG_ERR("SCT", "OOM: page LUT at %u pages", build_->lut.size());
+    build_->lutExhausted = true;
+    return;
   }
-  LOG_DBG("SCT", "Page %d processed", builtPageCount_);
 
   builtPageCount_++;
   // pageCount is the pages available to read: a rebuild over a partial only raises it
@@ -89,7 +107,6 @@ uint32_t Section::onPageComplete(std::unique_ptr<Page> page) {
   if (builtPageCount_ > pageCount) {
     pageCount = builtPageCount_;
   }
-  return position;
 }
 
 void Section::writeSectionFileHeader(const ReaderRenderSpec& spec) {
@@ -382,18 +399,17 @@ bool Section::startBuild(const ReaderRenderSpec& spec, const std::function<void(
   }
 
   // The parser stores the path/contentBase/imageBasePath by reference, so they must
-  // live in the BuildContext (which outlives the parser). The page-complete callback
-  // captures the BuildContext pointer to append to its in-RAM LUT; build_ owns the
-  // context for the parser's whole lifetime.
+  // live in the BuildContext (which outlives the parser); build_ owns the context for
+  // the parser's whole lifetime. The page-complete callback runs only from parseStep(),
+  // i.e. after build_ has taken ownership, so it can reach the LUT through build_.
   BuildContext* ctxPtr = ctx.get();
   ctx->parser = makeUniqueNoThrow<ChapterHtmlSlimParser>(
       epub, ctxPtr->parsePath, renderer, spec.fontId, spec.lineCompression, spec.extraParagraphSpacing,
       spec.paragraphAlignment, spec.viewportWidth, spec.viewportHeight, spec.hyphenationEnabled,
       spec.focusReadingEnabled,
-      [this, ctxPtr](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
-                     const uint32_t visibleTextOffset) {
-        ctxPtr->lut.push_back(
-            {this->onPageComplete(std::move(page)), paragraphIndex, listItemIndex, visibleTextOffset});
+      [this](std::unique_ptr<Page> page, const uint16_t paragraphIndex, const uint16_t listItemIndex,
+             const uint32_t visibleTextOffset) {
+        this->onPageComplete(std::move(page), paragraphIndex, listItemIndex, visibleTextOffset);
       },
       spec.embeddedStyle, ctxPtr->contentBase, ctxPtr->imageBasePath, spec.imageRendering, std::move(tocAnchors),
       popupFn, ctxPtr->cssParser);
@@ -436,6 +452,14 @@ bool Section::buildSomeMore(const int maxPages) {
     }
     if (status == ChapterHtmlSlimParser::ParseStatus::Done) {
       return finalizeBuild();
+    }
+    if (build_->lutExhausted) {
+      // The page index could not grow (see onPageComplete). Persist what is indexed as
+      // a partial and report success: the reader keeps the pages it has, and the next
+      // attempt resumes from the watermark rather than losing the chapter.
+      LOG_ERR("SCT", "Stopping build at %u pages: page index exhausted", builtPageCount_);
+      suspendBuild();
+      return true;
     }
     // ParseStatus::More: yield once we've laid out the requested number of pages.
     if (maxPages > 0 && (builtPageCount_ - startCount) >= maxPages) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -624,8 +624,24 @@ bool Section::commitBuildFile(const uint8_t version, const uint32_t bytesConsume
 }
 
 bool Section::finalizeBuild() {
+  // finishParse() closes the parse file before it flushes, and parseBytesConsumed() reads
+  // that file, so the watermark has to be taken now: if the flush below is the write that
+  // exhausts the page index, this build becomes a partial and needs it.
+  build_->bytesConsumed = static_cast<uint32_t>(build_->parser->parseBytesConsumed());
+
   // Flush the trailing page (emits the last page via the completePageFn into the LUT).
   build_->parser->finishParse();
+
+  if (build_->lutExhausted) {
+    // The trailing page could not be indexed (see onPageComplete). Committing a full
+    // section here would cache a chapter that is silently short its last page, with an
+    // anchor map naming a page the LUT has no entry for. Persist the indexed pages as a
+    // partial instead -- the same outcome buildSomeMore produces when the index runs out
+    // mid-parse, rather than a "complete" section that quietly lost content.
+    LOG_ERR("SCT", "Page index exhausted on the final page: persisting %u pages as a partial", builtPageCount_);
+    suspendBuild();
+    return true;
+  }
 
   if (!build_->reusedHtml) {
     // Parse succeeded: promote the freshly unzipped HTML to the persistent cache so future
@@ -666,7 +682,11 @@ void Section::suspendBuild() {
     // Capture the parse watermark and commit before tearing the parser down (the anchor
     // map is read from it). The incomplete trailing page is intentionally not flushed:
     // only fully laid-out pages are persisted, and the rebuild re-derives the rest.
-    const uint32_t consumed = static_cast<uint32_t>(build_->parser->parseBytesConsumed());
+    // parseBytesConsumed() reports the open parse file's position, so it reads 0 once the
+    // parser has closed it -- the case when finalizeBuild suspends after finishParse().
+    // It records the watermark before flushing, so fall back to that.
+    uint32_t consumed = static_cast<uint32_t>(build_->parser->parseBytesConsumed());
+    if (consumed == 0) consumed = build_->bytesConsumed;
     committed = commitBuildFile(SECTION_FILE_PARTIAL_VERSION, consumed, build_->totalBytes);
     if (committed) {
       partial_ = true;

--- a/lib/Epub/Epub/Section.h
+++ b/lib/Epub/Epub/Section.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <ChunkedVector.h>
+
 #include <functional>
 #include <memory>
 #include <optional>
@@ -21,7 +23,8 @@ class Section {
   HalFile file;
 
   void writeSectionFileHeader(const ReaderRenderSpec& spec);
-  uint32_t onPageComplete(std::unique_ptr<Page> page);
+  void onPageComplete(std::unique_ptr<Page> page, uint16_t paragraphIndex, uint16_t listItemIndex,
+                      uint32_t visibleTextOffset);
 
   // Page-offset table entry, kept in RAM while an incremental build is running so
   // already-built pages can be located in the partially-written .bin.
@@ -31,12 +34,25 @@ class Section {
     uint16_t listItemIndex;
     uint32_t visibleTextOffset;
   };
+  // One entry per laid-out page, so the table's length is the length of the chapter:
+  // a single-file book runs to thousands of pages. As a std::vector that meant an
+  // ever-larger contiguous block plus a full copy at every doubling, allocated while
+  // the parse already holds most of the heap -- the allocation that aborts the device
+  // deep into a long chapter. Chunked instead: 128 entries is a 1.5KB chunk, well
+  // inside the largest-free-block floor the reader's build gate enforces, and nothing
+  // is ever copied. 128 chunks cover 16384 pages, far past any real chapter; a build
+  // that somehow exceeds that is suspended rather than aborted.
+  using PageLut = ChunkedVector<PageLutEntry, 128, 128>;
   // Held only while an incremental build is in progress (see startBuild). Carries the
   // live parser plus the strings it references (the parser stores them by reference)
   // and the in-RAM page-offset table.
   struct BuildContext {
     std::unique_ptr<ChapterHtmlSlimParser> parser;
-    std::vector<PageLutEntry> lut;
+    PageLut lut;
+    // Set when the LUT could not take another page. The build stops at the pages it
+    // has (they are still persisted as a partial) instead of continuing to lay out
+    // pages it can no longer index.
+    bool lutExhausted = false;
     std::string parsePath;
     std::string contentBase;
     std::string imageBasePath;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -222,6 +222,19 @@ void ChapterHtmlSlimParser::updateEffectiveInlineStyle() {
   }
 }
 
+// Move the pending id into the anchor map. A full map (or a failed chunk allocation)
+// only costs precision: links to the dropped anchor land at the start of the section
+// instead of on its page. That is the correct trade against aborting the build.
+void ChapterHtmlSlimParser::recordPendingAnchor() {
+  if (pendingAnchorId.empty()) return;
+  if (!anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)}) &&
+      !anchorMapFullLogged) {
+    anchorMapFullLogged = true;
+    LOG_ERR("EHP", "Anchor map full at %u entries, dropping further anchors", anchorData.size());
+  }
+  pendingAnchorId.clear();
+}
+
 void ChapterHtmlSlimParser::flushPendingAnchor() {
   if (pendingAnchorId.empty()) return;
 
@@ -238,8 +251,7 @@ void ChapterHtmlSlimParser::flushPendingAnchor() {
   }
 
   // Record deferred anchor after previous block is flushed (and any TOC page break)
-  anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
-  pendingAnchorId.clear();
+  recordPendingAnchor();
 }
 
 void ChapterHtmlSlimParser::setCurrentPageVisibleOffset(const uint32_t offset) {
@@ -386,10 +398,7 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
   setCurrentPageVisibleOffset(visibleTextOffset);
   currentPageNextY = static_cast<int16_t>(currentPageNextY + ruleThickness + bottomSpacing);
 
-  if (!pendingAnchorId.empty()) {
-    anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
-    pendingAnchorId.clear();
-  }
+  recordPendingAnchor();
 }
 
 void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char* name, const XML_Char** atts) {
@@ -1629,10 +1638,7 @@ bool ChapterHtmlSlimParser::finishParse() {
   // Process last page if there is still text
   if (currentTextBlock) {
     makePages();
-    if (!pendingAnchorId.empty()) {
-      anchorData.push_back({std::move(pendingAnchorId), static_cast<uint16_t>(completedPageCount)});
-      pendingAnchorId.clear();
-    }
+    recordPendingAnchor();
     setCurrentPageVisibleOffset(visibleTextOffset);
     completePageFn(std::move(currentPage), xpathParagraphIndex, xpathListItemIndex, currentPageVisibleOffset);
     completedPageCount++;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ChunkedVector.h>
 #include <HalStorage.h>
 #include <expat.h>
 
@@ -21,6 +22,14 @@ class GfxRenderer;
 class Epub;
 
 #define MAX_WORD_SIZE 200
+
+// Anchor id -> page index, accumulated over a whole chapter parse. Chunked rather
+// than a std::vector because it is appended to while the parse holds most of the
+// heap: a contiguous doubling past ~900 entries is the allocation that fails (and,
+// through the throwing operator new, aborts the device). 64 entries per chunk is
+// 1KB; the 20-chunk directory covers MAX_ANCHORS_PER_CHAPTER plus the TOC anchors
+// that bypass that cap.
+using AnchorMap = ChunkedVector<std::pair<std::string, uint16_t>, 64, 20>;
 
 class ChapterHtmlSlimParser {
   std::shared_ptr<Epub> epub;
@@ -90,7 +99,8 @@ class ChapterHtmlSlimParser {
 
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
-  std::vector<std::pair<std::string, uint16_t>> anchorData;
+  AnchorMap anchorData;
+  bool anchorMapFullLogged = false;     // one LOG_ERR per parse once the map stops accepting anchors
   std::string pendingAnchorId;          // deferred until after previous text block is flushed
   std::vector<std::string> tocAnchors;  // the list of anchors that are TOC chapter boundaries
   uint16_t xpathParagraphIndex = 0;
@@ -126,6 +136,7 @@ class ChapterHtmlSlimParser {
 
   void updateEffectiveInlineStyle();
   void startNewTextBlock(const BlockStyle& blockStyle);
+  void recordPendingAnchor();
   void flushPendingAnchor();
   void flushPartWordBuffer();
   void setCurrentPageVisibleOffset(uint32_t offset);
@@ -189,7 +200,7 @@ class ChapterHtmlSlimParser {
   void abortParse();   // tear down without flushing (error / abandon)
 
   void addLineToPage(std::shared_ptr<TextBlock> line, uint32_t visibleOffset);
-  const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
+  const AnchorMap& getAnchors() const { return anchorData; }
 
   // Byte progress of the in-flight parse, used to estimate a still-building section's total page
   // count (a giant single-spine book never fully lays out, so its real count is unknown). Valid

--- a/lib/Memory/ChunkedVector.h
+++ b/lib/Memory/ChunkedVector.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <new>
+#include <utility>
+
+// Append-only, non-relocating sequence for build-time tables whose length is
+// driven by the document (the section page LUT, the chapter anchor map).
+//
+// std::vector is the wrong shape for these on the ESP32-C3. It grows
+// geometrically into a single contiguous block and must hold the old and the new
+// block at once while it copies, so a 1300-page section demands a ~24KB
+// contiguous allocation on top of the ~12KB it is copying from -- at the exact
+// moment the live parse is holding the heap down. When that allocation fails,
+// std::vector calls the throwing operator new, which with -fno-exceptions is
+// abort(): the device reboots mid-book. See EpubReaderActivity's build heap gate,
+// which admits a build tick at a 16KB largest-free-block floor and so cannot
+// possibly cover a 28KB doubling.
+//
+// ChunkedVector instead allocates fixed-size chunks with nothrow new:
+//   - no reallocation and no copying, so peak usage == live usage;
+//   - the largest single allocation is one chunk, whatever the total length;
+//   - push_back() reports failure so callers can degrade instead of aborting.
+//
+// Elements are value-initialized when a chunk is allocated and assigned on
+// push_back, so T must be default-constructible. Random access is O(1). The
+// chunk directory is a fixed inline array (MaxChunks pointers), which caps the
+// total length at ChunkSize * MaxChunks -- push_back() returns false past that.
+//
+// Each instantiation emits its own code, so keep the number of distinct
+// (T, ChunkSize, MaxChunks) combinations small.
+template <typename T, size_t ChunkSize, size_t MaxChunks>
+class ChunkedVector {
+  static_assert(ChunkSize > 0 && MaxChunks > 0);
+
+ public:
+  size_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
+  static constexpr size_t maxSize() { return ChunkSize * MaxChunks; }
+
+  T& operator[](const size_t i) { return chunks_[i / ChunkSize][i % ChunkSize]; }
+  const T& operator[](const size_t i) const { return chunks_[i / ChunkSize][i % ChunkSize]; }
+  T& back() { return (*this)[size_ - 1]; }
+  const T& back() const { return (*this)[size_ - 1]; }
+
+  // False means the element was not stored: the directory is full, or a chunk
+  // allocation failed. Never aborts.
+  [[nodiscard]] bool push_back(T value) {
+    const size_t chunk = size_ / ChunkSize;
+    if (chunk >= MaxChunks) return false;
+    if (!chunks_[chunk]) {
+      chunks_[chunk].reset(new (std::nothrow) T[ChunkSize]());
+      if (!chunks_[chunk]) return false;
+    }
+    chunks_[chunk][size_ % ChunkSize] = std::move(value);
+    size_++;
+    return true;
+  }
+
+  class const_iterator {
+   public:
+    const_iterator(const ChunkedVector* owner, const size_t index) : owner_(owner), index_(index) {}
+    const T& operator*() const { return (*owner_)[index_]; }
+    const_iterator& operator++() {
+      index_++;
+      return *this;
+    }
+    bool operator!=(const const_iterator& other) const { return index_ != other.index_; }
+
+   private:
+    const ChunkedVector* owner_;
+    size_t index_;
+  };
+
+  const_iterator begin() const { return const_iterator(this, 0); }
+  const_iterator end() const { return const_iterator(this, size_); }
+
+ private:
+  std::unique_ptr<T[]> chunks_[MaxChunks];
+  size_t size_ = 0;
+};


### PR DESCRIPTION
> [!IMPORTANT]
> This entire PR was written by Claude Opus 5

## The bug

A section build keeps two tables in RAM for the whole parse: the per-page LUT in `Section::BuildContext` and the anchor map in `ChapterHtmlSlimParser`. Both were `std::vector`s, so both grew geometrically into a single contiguous block and copied themselves at every doubling — while the live parse was already holding most of the heap.

In a book whose spine is one giant XHTML file, that is fatal. A crash report from a 1300-page section decodes to:

```
operator new(unsigned int)                        <- new_op.cc:55, allocation failed
__cxxabiv1::__terminate                           <- abort()
vector<pair<string,uint16_t>>::_M_realloc_append
ChapterHtmlSlimParser::flushPendingAnchor()       ChapterHtmlSlimParser.cpp:241
```

The allocator arguments are on the stack next to those frames: `0x3800` (14,336) and `0x7000` (28,672) — the anchor map doubling from 896 to 1792 entries of 16 bytes, both blocks live during the copy.

`std::vector` allocates through the *throwing* `operator new`, which under `-fno-exceptions` is `abort()`. So an allocation failure reboots the device rather than returning null. On resume the chapter re-parses from page 0 and dies in the same place, giving a reboot every few pages.

`EpubReaderActivity::buildTickHeapGate()` cannot catch this: it admits a build tick when the largest free block is ≥16KB, and one page inside that tick then demanded 28KB.

## The fix

New `lib/Memory/ChunkedVector.h`: append-only, fixed-size chunks allocated with `new (std::nothrow)`, never reallocated or copied, O(1) random access, `push_back()` returns `false` instead of aborting. Both tables use it — 1.5KB chunks for the LUT, 1KB for the anchor map.

At the crash point this turns a 28,672-byte contiguous demand into 1,024 bytes, and drops steady-state build RAM by ~10KB (no vector slack). On failure it degrades instead of dying: a dropped anchor costs link precision, an exhausted LUT suspends the build and keeps the pages already laid out as a partial.

## Verification

Built clean (no new warnings), `pio check` passes, and the crashing `_M_realloc_append<pair<string,unsigned short>>` instantiation is gone from the ELF.

On device (X3), the chapter that previously aborted at page 1308 now builds to completion:

```
[392786] [DBG] [EHP] Time to parse and build pages: 152771 ms
[392792] [DBG] [SCT] Page 1987 processed
```

1988 pages in one 153-second parse, no `abort`, no panic, no reset. Heap through the deep part of the build:

| uptime | free | max alloc |
|---|---|---|
| 301s (page ~830) | 73,656 | 59,380 |
| 391s (page ~1900) | 42,088 | 32,756 |
| 401s (build freed) | 72,904 | 61,428 |

At the deepest point the largest contiguous block available was 32,756 bytes — under what the old code was asking for.

Not exercised by this run: the OOM fallback paths (the anchor map stayed under its 1024 cap and the LUT under 16384 pages), so those are reasoned-through but untested.