### PR TITLE
fix: strip comments from XHTML in the EPUB optimizer

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -3990,6 +3990,64 @@ function resolvePath(basePath, href) {
   return resolved.replace(/\/+/g, '/');
 }
 
+/** Remove XML comments from XHTML source text. Returns {text, count, bytes}. */
+function stripComments(xml) {
+  const SKIPPED = [
+    { open: '<![CDATA[', close: ']]>' },
+    { open: '<?', close: '?>' },
+  ];
+
+  const encoder = new TextEncoder();
+  const out = [];
+  let i = 0;
+  let count = 0;
+  let bytes = 0;
+
+  const doctypeEnd = (from) => {
+    const gt = xml.indexOf('>', from);
+    const subset = xml.indexOf('[', from);
+    if (subset < 0 || (gt >= 0 && subset > gt)) return gt < 0 ? xml.length : gt + 1;
+    const close = xml.indexOf(']>', subset);
+    return close < 0 ? xml.length : close + 2;
+  };
+
+  while (i < xml.length) {
+    const next = xml.indexOf('<', i);
+    if (next < 0) { out.push(xml.slice(i)); break; }
+    if (next > i) out.push(xml.slice(i, next));
+
+    if (xml.startsWith('<!--', next)) {
+      const close = xml.indexOf('-->', next + 4);
+      const end = close < 0 ? xml.length : close + 3;
+      count++;
+      bytes += encoder.encode(xml.slice(next, end)).length;
+      i = end;
+      continue;
+    }
+
+    if (xml.startsWith('<!DOCTYPE', next)) {
+      const end = doctypeEnd(next + 9);
+      out.push(xml.slice(next, end));
+      i = end;
+      continue;
+    }
+
+    const skipped = SKIPPED.find(s => xml.startsWith(s.open, next));
+    if (skipped) {
+      const close = xml.indexOf(skipped.close, next + skipped.open.length);
+      const end = close < 0 ? xml.length : close + skipped.close.length;
+      out.push(xml.slice(next, end));
+      i = end;
+      continue;
+    }
+
+    out.push('<');
+    i = next + 1;
+  }
+
+  return { text: out.join(''), count, bytes };
+}
+
 /**
  * Serialize an XML doc back to string, preserving the original <?xml?> declaration
  * and cleaning up XMLSerializer namespace prefix noise (xmlns:ns0 etc).
@@ -5024,6 +5082,13 @@ async function convertEpubFile(file, progressCallback) {
   for (const [xhtmlPath, content] of Object.entries(xhtmlFiles)) {
     if (operationCancelled) throw new Error('Cancelled by user');
     let t = content;
+
+    const stripped = stripComments(t);
+    if (stripped.count) {
+      t = stripped.text;
+      logFix(`Comments (${stripped.count}, ${formatBytes(stripped.bytes)})`, xhtmlPath.split('/').pop());
+    }
+
     const r = fixSvgCover(t);
     if (r.fixed) { t = r.c; logFix('SVG cover', xhtmlPath.split('/').pop()); }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This entire PR was written by Claude Opus 5

Moved from the firmware to the optimizer, per @Uri-Tauber's review. The previous firmware-side version is preserved at [`archive/strip-html-comments-firmware`](https://github.com/s4y/crosspoint-reader-fork/tree/archive/strip-html-comments-firmware) but is not proposed for merge.

## The bug

Expat treats a comment as one indivisible token: it cannot report it, and cannot advance its buffer, until it has the closing `-->`. `XML_GetBuffer` therefore grows its buffer to span the whole comment, doubling it and allocating the new block *before* freeing the old (`lib/expat/xmlparse.c:2326-2338`).

Word-exported chapters routinely carry several 34KB `<!--[if gte mso 9]>` blocks of Office boilerplate. One chapter I looked at:

```
comments found: 25
   34043 bytes @  339735  <!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLo...
   34043 bytes @  257663  <!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLo...
   34043 bytes @  196850  <!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLo...
   34043 bytes @  124736  <!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLo...
   34043 bytes @   48188  <!--[if gte mso 9]><xml>\r\n <w:LatentStyles DefLo...
total comment bytes: 180500 (48% of file)
```

48% of the file is Word boilerplate. That drives expat to a 64KB allocation while a 32KB block is still live, which fails on a heap already occupied by a build. `XML_GetBuffer` returns NULL and the chapter stops paginating at the page where the first block appears — here, 41 pages into roughly 170. The first block starts at byte 48,188, right past the content that becomes those 41 pages, which is why the failure is byte-for-byte deterministic.

## The fix

Nothing downstream wants the bytes. Comments reach `ChapterHtmlSlimParser::defaultHandlerExpand`, which discards anything that is not an entity (`lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp:1344-1357`). The parser has no `<style>` element handling at all — only the `style` attribute (`:428`) — and embedded CSS comes only from separate `.css` files via `CssParser`, so no stylesheet hides inside a comment.

So the optimizer drops them, at the top of the second XHTML pass, before anything else looks at the file.

### Why this scans text instead of walking the DOM

The obvious implementation — parse with `DOMParser`, walk a `TreeWalker` over `SHOW_COMMENT`, remove the nodes — does nothing on the files that need it. Word writes `<o:p>` without declaring the `o:` prefix, so `DOMParser` fails with:

```
error on line 22 at column 77: Namespace prefix o on p is not defined
```

and everything inside the optimizer's `if (!parseError)` block is skipped. Those namespace-broken files are exactly the ones carrying the mso boilerplate, so the DOM version removed nothing from the chapter it was written for.

That rejection is a *namespace* rule, not a wellformedness one. `:` is a legal XML name character, and the device creates expat with `XML_ParserCreate(nullptr)` (`ChapterHtmlSlimParser.cpp:1556`), which does no namespace processing — so the device parses these files without complaint. The optimizer exists to feed that parser, so refusing files the device accepts is the wrong behavior.

`stripComments()` therefore scans the source text, mirroring expat's tokenizer over three states — text, `<![CDATA[…]]>`, and `<?…?>` — and removes `<!--…-->` only in the text state. Comments do not nest, cannot open inside CDATA or a processing instruction, and a raw `<` is illegal in an attribute value, so `<!--` in the text state is unambiguously a comment. That last point is a guarantee of well-formed XML rather than an assumption about EPUB content, which is what makes the scan exact instead of heuristic. An unterminated comment runs to EOF, matching how expat would consume it.

Because this runs before `DOMParser`, it is independent of whether that later parse succeeds.

Each file's removal is reported through the existing fix log, e.g. `Comments (25, 176 KB): index_split_003.html`, and the byte savings show up in the optimizer's existing size stats.

## Verification

16 unit cases over `stripComments` extracted from `FilesPage.html` by a brace-matching script — the shipped source, not a copy: CDATA containing `<!--`, a comment following a CDATA section, processing instructions containing `<!--`, unterminated comments, empty comments, comments containing only dashes, markup and dashes inside a comment, multiline comments, a bare `<` in text, a doctype, adjacent comments, and multibyte byte accounting. All pass.

Equivalence against the DOM approach, in headless Chrome: on every parseable chapter of the problem EPUB, and on five mutated variants of a real chapter with comments injected at 1, 2, 727, and trailing positions plus 3KB mso blocks, the scanner's output reparses and serializes **byte-identically** to `TreeWalker`-based comment removal. So on files where the DOM version worked, this is the same result; on files where it silently did nothing, this works.

On the problem chapter itself: 374,599 → 194,099 characters, all 25 comments and 180,500 bytes removed, no `<!--` and no Word markup surviving, body text intact.

`pio run` clean (RAM 16.5%, Flash 87.0%).

## Notes for reviewers

Two adjacent issues this PR deliberately does not address:

1. **Files that fail the XHTML parse also skip every other DOM fixup** — img `width`/`height` removal and split-image rewrites. Word-exported chapters silently receive less optimization across the board. Possibly the block should retry with namespace repair or an HTML-mode parse.
2. **The firmware still fails loudly-but-misleadingly on an unoptimized book.** `XML_GetBuffer` returns NULL for several reasons and `ChapterHtmlSlimParser::parseStep` reports all of them as "Couldn't allocate memory for buffer". Distinguishing that case seems worth doing, but is a separate change.
