### PR TITLE
fix: narrow down use factory lut condition

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -13,11 +13,6 @@
 #include "Epub/parsers/TocNavParser.h"
 #include "Epub/parsers/TocNcxParser.h"
 
-namespace {
-// Needs to be increased if an update needs to regenerate the cover bmp
-constexpr char coverBmpVersion[] = "_v2";
-}  // namespace
-
 bool Epub::findContentOpfFile(std::string* contentOpfFile) const {
   const auto containerPath = "META-INF/container.xml";
   size_t containerSize;
@@ -560,14 +555,14 @@ const std::string& Epub::getLanguage() const {
   return bookMetadataCache->coreMetadata.language;
 }
 
-std::string Epub::getCoverBmpPath(bool cropped) const {
-  const auto coverFileName = std::string("cover") + coverBmpVersion + (cropped ? "_crop" : "");
+std::string Epub::getCoverBmpPath(bool cropped, bool originalThresholds) const {
+  const auto coverFileName = std::string("cover") + (originalThresholds ? "_original" : "") + (cropped ? "_crop" : "");
   return cachePath + "/" + coverFileName + ".bmp";
 }
 
-bool Epub::generateCoverBmp(bool cropped) const {
+bool Epub::generateCoverBmp(bool cropped, bool originalThresholds) const {
   // Already generated, return true
-  if (Storage.exists(getCoverBmpPath(cropped).c_str())) {
+  if (Storage.exists(getCoverBmpPath(cropped, originalThresholds).c_str())) {
     return true;
   }
 
@@ -583,7 +578,8 @@ bool Epub::generateCoverBmp(bool cropped) const {
   }
 
   if (FsHelpers::hasJpgExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverJpgTempPath = getCachePath() + "/.cover.jpg";
 
     HalFile coverJpg;
@@ -599,10 +595,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped);
+    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverJpg.close();
     coverBmp.close();
@@ -610,14 +606,15 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from JPG cover image, success: %s", success ? "yes" : "no");
     return success;
   }
 
   if (FsHelpers::hasPngExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverPngTempPath = getCachePath() + "/.cover.png";
 
     HalFile coverPng;
@@ -633,10 +630,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped);
+    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverPng.close();
     coverBmp.close();
@@ -644,7 +641,7 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from PNG cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from PNG cover image, success: %s", success ? "yes" : "no");
     return success;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -52,8 +52,8 @@ class Epub {
   const std::string& getTitle() const;
   const std::string& getAuthor() const;
   const std::string& getLanguage() const;
-  std::string getCoverBmpPath(bool cropped = false) const;
-  bool generateCoverBmp(bool cropped = false) const;
+  std::string getCoverBmpPath(bool cropped = false, bool originalThresholds = false) const;
+  bool generateCoverBmp(bool cropped = false, bool originalThresholds = false) const;
   std::string getThumbBmpPath() const;
   std::string getThumbBmpPath(int height) const;
   bool generateThumbBmp(int height) const;

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1377,9 +1377,9 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
         drawPixel(screenX, screenY, false);
       } else if (renderMode == GRAYSCALE_LSB && val == 1) {
         drawPixel(screenX, screenY, false);
-      } else if (renderMode == FACTORY_GRAY_LSB && !(val & 1)) {
+      } else if (renderMode == ABSOLUTE_GRAY_LSB && !(val & 1)) {
         drawPixel(screenX, screenY, false);
-      } else if (renderMode == FACTORY_GRAY_MSB && val < 2) {
+      } else if (renderMode == ABSOLUTE_GRAY_MSB && val < 2) {
         drawPixel(screenX, screenY, false);
       }
     }
@@ -1420,8 +1420,8 @@ void GfxRenderer::drawBitmap1Bit(const Bitmap& bitmap, const int x, const int y,
     return;
   }
 
-  // Factory grayscale inverts the pixel values
-  const bool full = !(renderMode == FACTORY_GRAY_LSB || renderMode == FACTORY_GRAY_MSB);
+  // Absolute grayscale inverts the pixel values
+  const bool full = !(renderMode == ABSOLUTE_GRAY_LSB || renderMode == ABSOLUTE_GRAY_MSB);
 
   for (int bmpY = 0; bmpY < bitmap.getHeight(); bmpY++) {
     // Read rows sequentially using readNextRow
@@ -1621,12 +1621,12 @@ void GfxRenderer::invertScreen() const {
 void GfxRenderer::displayBuffer(const HalDisplay::RefreshMode refreshMode) const {
   auto elapsed = millis() - start_ms;
   LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBuffer", elapsed);
-  // After a factory LUT render, RED RAM still contains the grayscale MSB plane.
+  // After an absolute LUT render, RED RAM still contains the grayscale MSB plane.
   // Promote the first normal FAST refresh to HALF so both RAM banks are rebased
   // before differential updates resume.
-  const bool afterFactoryLut = displayState == DisplayState::FactoryLut;
+  const bool afterAbsoluteLut = displayState == DisplayState::AbsoluteLut;
   const auto effectiveRefreshMode =
-      afterFactoryLut && refreshMode == HalDisplay::FAST_REFRESH ? HalDisplay::HALF_REFRESH : refreshMode;
+      afterAbsoluteLut && refreshMode == HalDisplay::FAST_REFRESH ? HalDisplay::HALF_REFRESH : refreshMode;
   display.displayBuffer(effectiveRefreshMode, fadingFix);
   displayState = DisplayState::BW;
 }
@@ -2175,10 +2175,15 @@ void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuff
 void GfxRenderer::displayGrayBuffer(const unsigned char* lut, bool factoryMode) const {
   display.displayGrayBuffer(fadingFix, lut, factoryMode);
   if (factoryMode) {
-    displayState = DisplayState::FactoryLut;
+    displayState = DisplayState::AbsoluteLut;
   } else {
     displayState = DisplayState::BW;
   }
+}
+
+void GfxRenderer::displayAbsoluteGrayBuffer() const {
+  display.displayAbsoluteGrayBuffer(fadingFix);
+  displayState = DisplayState::AbsoluteLut;
 }
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -29,11 +29,11 @@ enum Color : uint8_t { Clear = 0x00, White = 0x01, LightGray = 0x05, DarkGray = 
 class GfxRenderer {
  public:
   enum RenderMode {
-    BW,                // 1-bit black/white
-    GRAYSCALE_LSB,     // Differential gray: mark pixels for LSB plane (clearScreen(0x00) + drawPixel(false))
-    GRAYSCALE_MSB,     // Differential gray: mark pixels for MSB plane (clearScreen(0x00) + drawPixel(false))
-    FACTORY_GRAY_LSB,  // Factory absolute gray: encode BW RAM = bit0 (clearScreen(0x00) + drawPixel(false))
-    FACTORY_GRAY_MSB,  // Factory absolute gray: encode RED RAM = bit1 (clearScreen(0x00) + drawPixel(false))
+    BW,                 // 1-bit black/white
+    GRAYSCALE_LSB,      // Differential gray: mark pixels for LSB plane (clearScreen(0x00) + drawPixel(false))
+    GRAYSCALE_MSB,      // Differential gray: mark pixels for MSB plane (clearScreen(0x00) + drawPixel(false))
+    ABSOLUTE_GRAY_LSB,  // Absolute gray: encode BW RAM = bit0 (clearScreen(0x00) + drawPixel(false))
+    ABSOLUTE_GRAY_MSB,  // Absolute gray: encode RED RAM = bit1 (clearScreen(0x00) + drawPixel(false))
   };
 
   // Logical screen orientation from the perspective of callers
@@ -44,11 +44,11 @@ class GfxRenderer {
     LandscapeCounterClockwise  // 800x480 logical coordinates, native panel orientation
   };
 
-  // Display state — tracks whether the physical display was last updated via a factory LUT render.
+  // Display state — tracks whether the physical display was last updated via a absolute LUT render.
   // BW: frameBuffer mirrors the display (menus, EPUB reader).
-  // FactoryLut: display holds a grayscale image; frameBuffer has been reset to white by
+  // AbsoluteLut: display holds a grayscale image; frameBuffer has been reset to white by
   // cleanupGrayscaleWithFrameBuffer() and no longer represents what is visually shown.
-  enum class DisplayState { BW, FactoryLut };
+  enum class DisplayState { BW, AbsoluteLut };
 
  private:
   static constexpr size_t BW_BUFFER_CHUNK_SIZE = 8000;  // 8KB chunks to allow for non-contiguous memory
@@ -312,6 +312,8 @@ class GfxRenderer {
   void displayGrayscaleBase(HalDisplay::RefreshMode fallback = HalDisplay::HALF_REFRESH) const;
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
+  bool supportsAbsoluteGrayscale() const { return display.supportsAbsoluteGrayscale(); };
+  void displayAbsoluteGrayBuffer() const;
   void displayGrayBuffer(const unsigned char* lut = nullptr, bool factoryMode = false) const;
 
   // Tiled grayscale (X4): stream one band of a plane straight to controller RAM

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -512,7 +512,8 @@ int bmpDrawCallback(JPEGDRAW* pDraw) {
 
 // Internal implementation with configurable target size and bit depth
 bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth,
-                                                     int targetHeight, bool oneBit, bool crop) {
+                                                     int targetHeight, bool oneBit, bool crop,
+                                                     bool originalThresholds) {
   LOG_DBG("JPG", "Converting JPEG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   if (ESP.getFreeHeap() < MIN_FREE_HEAP) {
@@ -679,19 +680,14 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
       return false;
     }
   } else if (!USE_8BIT_OUTPUT) {
-#if FREEINK_DRIVER_SSD1677
-    constexpr bool useOriginalThresholds = true;
-#else
-    constexpr bool useOriginalThresholds = false;
-#endif
     if (USE_ATKINSON) {
-      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth, useOriginalThresholds);
+      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth, originalThresholds);
       if (!ctx.atkinsonDitherer) {
         LOG_ERR("JPG", "OOM: AtkinsonDitherer");
         return false;
       }
     } else if (USE_FLOYD_STEINBERG) {
-      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth, useOriginalThresholds);
+      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth, originalThresholds);
       if (!ctx.fsDitherer) {
         LOG_ERR("JPG", "OOM: FloydSteinbergDitherer");
         return false;
@@ -718,11 +714,11 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
 }
 
 // Core function: Convert JPEG file to 2-bit BMP (uses default target size)
-bool JpegToBmpConverter::jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop) {
+bool JpegToBmpConverter::jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop, bool originalThresholds) {
   // Use runtime display dimensions (swapped for portrait cover sizing)
   const int targetWidth = display.getDisplayHeight();
   const int targetHeight = display.getDisplayWidth();
-  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetWidth, targetHeight, false, crop);
+  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetWidth, targetHeight, false, crop, originalThresholds);
 }
 
 // Convert with custom target size (for thumbnails, 2-bit)

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.h
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.h
@@ -7,10 +7,10 @@ class ZipFile;
 
 class JpegToBmpConverter {
   static bool jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                          bool oneBit, bool crop = true);
+                                          bool oneBit, bool crop = true, bool originalThresholds = false);
 
  public:
-  static bool jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop = true);
+  static bool jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop = true, bool originalThresholds = false);
   // Convert with custom target size (for thumbnails)
   static bool jpegFileToBmpStreamWithSize(HalFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -400,7 +400,7 @@ static void convertScanlineToGray(const PngDecodeContext& ctx, uint8_t* grayRow)
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                                   bool oneBit, bool crop) {
+                                                   bool oneBit, bool crop, bool originalThresholds) {
   LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   // Verify PNG signature
@@ -628,19 +628,13 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   FloydSteinbergDitherer* fsDitherer = nullptr;
   Atkinson1BitDitherer* atkinson1BitDitherer = nullptr;
 
-#if FREEINK_DRIVER_SSD1677
-  constexpr bool useOriginalThresholds = true;
-#else
-  constexpr bool useOriginalThresholds = false;
-#endif
-
   if (oneBit) {
     atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth, useOriginalThresholds);
+      atkinsonDitherer = new AtkinsonDitherer(outWidth, originalThresholds);
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth, useOriginalThresholds);
+      fsDitherer = new FloydSteinbergDitherer(outWidth, originalThresholds);
     }
   }
 
@@ -833,11 +827,11 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   return success;
 }
 
-bool PngToBmpConverter::pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop) {
+bool PngToBmpConverter::pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop, bool originalThresholds) {
   // Use runtime display dimensions (swapped for portrait cover sizing)
   const int targetWidth = display.getDisplayHeight();
   const int targetHeight = display.getDisplayWidth();
-  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop);
+  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop, originalThresholds);
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth,

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -6,10 +6,10 @@ class Print;
 
 class PngToBmpConverter {
   static bool pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                         bool oneBit, bool crop = true);
+                                         bool oneBit, bool crop = true, bool originalThresholds = false);
 
  public:
-  static bool pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop = true);
+  static bool pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop = true, bool originalThresholds = false);
   static bool pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   static bool pngFileTo1BitBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
 };

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -138,6 +138,10 @@ void HalDisplay::displayGrayBuffer(bool turnOffScreen, const unsigned char* lut,
   einkDisplay.displayGrayBuffer(turnOffScreen, lut, factoryMode);
 }
 
+bool HalDisplay::supportsAbsoluteGrayscale() const { return einkDisplay.supportsAbsoluteGrayscale(); }
+
+void HalDisplay::displayAbsoluteGrayBuffer(bool turnOffScreen) { einkDisplay.displayAbsoluteGrayBuffer(turnOffScreen); }
+
 void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
   einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,
                                        yStart, numRows);

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -95,6 +95,8 @@ class HalDisplay {
   void cleanupGrayscaleBuffers(const uint8_t* bwBuffer);
 
   void displayGrayBuffer(bool turnOffScreen = false, const unsigned char* lut = nullptr, bool factoryMode = false);
+  bool supportsAbsoluteGrayscale() const;
+  void displayAbsoluteGrayBuffer(bool turnOffScreen = false);
 
   // Tiled grayscale: stream one band of a plane (lsbPlane selects LSB/MSB RAM)
   // straight to the controller; supportsStripGrayscale() gates the path. See

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -12,9 +12,7 @@
 #include <PNGdec.h>
 #include <Txt.h>
 #include <Xtc.h>
-#if FREEINK_DRIVER_SSD1677
 #include <lut/Ssd1677Luts.h>
-#endif
 
 #include <algorithm>
 #include <cmath>
@@ -620,15 +618,10 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-#if FREEINK_DRIVER_SSD1677
   const bool useFactoryGrayscale =
-      useFactoryLut && hasGreyscale && !preserveBackground &&
+      gpio.deviceIsX4() && useFactoryLut && hasGreyscale && !preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
   const unsigned char* lut = useFactoryGrayscale ? freeink::lut_factory_quality : nullptr;
-#else
-  constexpr bool useFactoryGrayscale = false;
-  constexpr const unsigned char* lut = nullptr;
-#endif
 
   LOG_DBG("SLP", "Using factory lut: %s", useFactoryGrayscale ? "true" : "false");
 
@@ -815,9 +808,8 @@ void SleepActivity::renderCoverSleepScreen() const {
       return (this->*renderNoCoverSleepScreen)();
     }
 
-#if FREEINK_DRIVER_SSD1677
-    useFactoryLut = SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
-#endif
+    useFactoryLut = gpio.deviceIsX4() &&
+                    SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
     if (!lastEpub.generateCoverBmp(cropped, useFactoryLut)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -602,7 +602,8 @@ void SleepActivity::renderDefaultSleepScreen() const {
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
 
-void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool preserveBackground) const {
+void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool preserveBackground,
+                                            const bool useFactoryLut) const {
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
   const auto placement = calculateBitmapPlacement(bitmap.getWidth(), bitmap.getHeight(), renderer);
@@ -620,16 +621,19 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
 #if FREEINK_DRIVER_SSD1677
-  const bool useFactoryGrayscale = hasGreyscale;
-  constexpr auto msbMode = GfxRenderer::FACTORY_GRAY_MSB;
-  constexpr auto lsbMode = GfxRenderer::FACTORY_GRAY_LSB;
-  constexpr const unsigned char* lut = freeink::lut_factory_quality;
+  const bool useFactoryGrayscale =
+      useFactoryLut && hasGreyscale && !preserveBackground &&
+      SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+  const unsigned char* lut = useFactoryGrayscale ? freeink::lut_factory_quality : nullptr;
 #else
   constexpr bool useFactoryGrayscale = false;
-  constexpr auto msbMode = GfxRenderer::GRAYSCALE_MSB;
-  constexpr auto lsbMode = GfxRenderer::GRAYSCALE_LSB;
   constexpr const unsigned char* lut = nullptr;
 #endif
+
+  LOG_DBG("SLP", "Using factory lut: %s", useFactoryGrayscale ? "true" : "false");
+
+  const auto msbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_MSB : GfxRenderer::GRAYSCALE_MSB;
+  const auto lsbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_LSB : GfxRenderer::GRAYSCALE_LSB;
 
   if (!useFactoryGrayscale) {
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
@@ -810,12 +814,18 @@ void SleepActivity::renderCoverSleepScreen() const {
       return (this->*renderNoCoverSleepScreen)();
     }
 
-    if (!lastEpub.generateCoverBmp(cropped)) {
+#if FREEINK_DRIVER_SSD1677
+    const bool originalThresholds =
+        SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+#else
+    constexpr bool originalThresholds = false;
+#endif
+
+    if (!lastEpub.generateCoverBmp(cropped, originalThresholds)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");
       return (this->*renderNoCoverSleepScreen)();
     }
-
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped);
+    coverBmpPath = lastEpub.getCoverBmpPath(cropped, originalThresholds);
   } else {
     return (this->*renderNoCoverSleepScreen)();
   }
@@ -825,7 +835,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false, true);
       return;
     }
   }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -551,7 +551,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false, true);
       file.close();
       return;
     }
@@ -570,7 +570,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       delay(100);
       Bitmap bitmap(randFile, true);
       if (bitmap.parseHeaders() == BmpReaderError::Ok) {
-        renderBitmapSleepScreen(bitmap);
+        renderBitmapSleepScreen(bitmap, false, true);
         randFile.close();
         return;
       }
@@ -775,6 +775,7 @@ void SleepActivity::renderCoverSleepScreen() const {
 
   std::string coverBmpPath;
   bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
+  bool useFactoryLut = false;
 
   // Check if the current book is XTC, TXT, or EPUB
   if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
@@ -815,17 +816,14 @@ void SleepActivity::renderCoverSleepScreen() const {
     }
 
 #if FREEINK_DRIVER_SSD1677
-    const bool originalThresholds =
-        SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
-#else
-    constexpr bool originalThresholds = false;
+    useFactoryLut = SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 #endif
 
-    if (!lastEpub.generateCoverBmp(cropped, originalThresholds)) {
+    if (!lastEpub.generateCoverBmp(cropped, useFactoryLut)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");
       return (this->*renderNoCoverSleepScreen)();
     }
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped, originalThresholds);
+    coverBmpPath = lastEpub.getCoverBmpPath(cropped, useFactoryLut);
   } else {
     return (this->*renderNoCoverSleepScreen)();
   }
@@ -835,7 +833,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap, false, true);
+      renderBitmapSleepScreen(bitmap, false, useFactoryLut);
       return;
     }
   }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -12,7 +12,6 @@
 #include <PNGdec.h>
 #include <Txt.h>
 #include <Xtc.h>
-#include <lut/Ssd1677Luts.h>
 
 #include <algorithm>
 #include <cmath>
@@ -601,7 +600,7 @@ void SleepActivity::renderDefaultSleepScreen() const {
 }
 
 void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool preserveBackground,
-                                            const bool useFactoryLut) const {
+                                            const bool absoluteLut) const {
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
   const auto placement = calculateBitmapPlacement(bitmap.getWidth(), bitmap.getHeight(), renderer);
@@ -618,17 +617,16 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-  const bool useFactoryGrayscale =
-      gpio.deviceIsX4() && useFactoryLut && hasGreyscale && !preserveBackground &&
+  const bool useAbsoluteGrayscale =
+      renderer.supportsAbsoluteGrayscale() && absoluteLut && hasGreyscale && !preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
-  const unsigned char* lut = useFactoryGrayscale ? freeink::lut_factory_quality : nullptr;
 
-  LOG_DBG("SLP", "Using factory lut: %s", useFactoryGrayscale ? "true" : "false");
+  LOG_DBG("SLP", "Using absolute lut: %s", useAbsoluteGrayscale ? "true" : "false");
 
-  const auto msbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_MSB : GfxRenderer::GRAYSCALE_MSB;
-  const auto lsbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_LSB : GfxRenderer::GRAYSCALE_LSB;
+  const auto msbMode = useAbsoluteGrayscale ? GfxRenderer::ABSOLUTE_GRAY_MSB : GfxRenderer::GRAYSCALE_MSB;
+  const auto lsbMode = useAbsoluteGrayscale ? GfxRenderer::ABSOLUTE_GRAY_LSB : GfxRenderer::GRAYSCALE_LSB;
 
-  if (!useFactoryGrayscale) {
+  if (!useAbsoluteGrayscale) {
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
   }
 
@@ -660,7 +658,10 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
     renderer.copyGrayscaleMsbBuffers();
 
-    renderer.displayGrayBuffer(lut, useFactoryGrayscale);
+    if (useAbsoluteGrayscale)
+      renderer.displayAbsoluteGrayBuffer();
+    else
+      renderer.displayGrayBuffer();
     renderer.setRenderMode(GfxRenderer::BW);
   }
 }
@@ -768,7 +769,7 @@ void SleepActivity::renderCoverSleepScreen() const {
 
   std::string coverBmpPath;
   bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
-  bool useFactoryLut = false;
+  bool absoluteLut = false;
 
   // Check if the current book is XTC, TXT, or EPUB
   if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
@@ -808,14 +809,14 @@ void SleepActivity::renderCoverSleepScreen() const {
       return (this->*renderNoCoverSleepScreen)();
     }
 
-    useFactoryLut = gpio.deviceIsX4() &&
-                    SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+    absoluteLut = renderer.supportsAbsoluteGrayscale() &&
+                  SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 
-    if (!lastEpub.generateCoverBmp(cropped, useFactoryLut)) {
+    if (!lastEpub.generateCoverBmp(cropped, absoluteLut)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");
       return (this->*renderNoCoverSleepScreen)();
     }
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped, useFactoryLut);
+    coverBmpPath = lastEpub.getCoverBmpPath(cropped, absoluteLut);
   } else {
     return (this->*renderNoCoverSleepScreen)();
   }
@@ -825,7 +826,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap, false, useFactoryLut);
+      renderBitmapSleepScreen(bitmap, false, absoluteLut);
       return;
     }
   }

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -16,7 +16,8 @@ class SleepActivity final : public Activity {
   void renderDefaultSleepScreen() const;
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
-  void renderBitmapSleepScreen(const Bitmap& bitmap, bool preserveBackground = false) const;
+  void renderBitmapSleepScreen(const Bitmap& bitmap, bool preserveBackground = false,
+                               const bool useFactoryLut = false) const;
   bool renderSleepOverlayFile(HalFile& file, const char* pathForLog) const;
   bool renderTransparentOverlayPng(const std::string& path) const;
   bool renderSleepOverlayPath(const std::string& path) const;

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -17,7 +17,7 @@ class SleepActivity final : public Activity {
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
   void renderBitmapSleepScreen(const Bitmap& bitmap, bool preserveBackground = false,
-                               const bool useFactoryLut = false) const;
+                               const bool AbsoluteLut = false) const;
   bool renderSleepOverlayFile(HalFile& file, const char* pathForLog) const;
   bool renderTransparentOverlayPng(const std::string& path) const;
   bool renderSleepOverlayPath(const std::string& path) const;


### PR DESCRIPTION
## Summary

Thanks for the very fast merge of https://github.com/crosspoint-reader/crosspoint-reader/pull/3018 !
Unfortunately I noticed some bugs while playing around afterwards, especially with non-cover-sleep-screens.

* The feature is not compatible with the recently added transparent cover feature, therefor it must be disabled in that case.
* Same is true for any case of cover filter.
* For the cover filter however we still need the generated cover bmp without original thresholds. So I changed the logic of the epub cover generator slightly. ddependent whether lut factory rendering shall be used, a cover with "_original" (similar to "_crop") as infix is generated.
* This parameter "originalThresholds" is therefor given to the JPG/PNG to BMP converter from the outside and forwarded to the ditherer. Benefit: The device specific `#if FREEINK_DRIVER_SSD1677` is now only left in `SleepActivity.cpp`.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
