### PR TITLE
feat: light-sleep-surviving frontlight for the X4 Pro (FREEINK_FRONTLIGHT_LS)

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -132,9 +132,15 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     return false;
   }
   // Light sleep drops a WiFi association and kills an enumerated USB-CDC link.
+#ifdef FREEINK_FRONTLIGHT_LS
+  // The frontlight PWM runs from RC_FAST with KEEP_ALIVE and survives light
+  // sleep (SDK FREEINK_FRONTLIGHT_LS), so a lit light no longer blocks it.
+  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
+#else
   // It also stops the default LEDC PWM output, visibly flashing ESP-driven
   // frontlights as the idle loop enters repeated sleep slices.
   if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached() || (Frontlight.present() && Frontlight.isOn())) {
+#endif
     return false;
   }
 
@@ -197,9 +203,12 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
 }
 
 bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t busyLevel) {
-  // Same exclusions as lightSleep(): light sleep drops WiFi/USB and suspends
-  // frontlight PWM. No LOG here — this runs ~50x/s mid-refresh.
+  // Same exclusions as lightSleep(). No LOG here — this runs ~50x/s mid-refresh.
+#ifdef FREEINK_FRONTLIGHT_LS
+  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
+#else
   if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached() || (Frontlight.present() && Frontlight.isOn())) {
+#endif
     return false;
   }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -243,6 +243,10 @@ build_flags =
   -DLOG_LEVEL=2
   ; X4 Pro SD is native SDMMC (1-bit), mounted through SdFat's block-device API.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+  ; Frontlight PWM clocked from RC_FAST with KEEP_ALIVE so it survives light
+  ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
+  ; change that stops a lit frontlight from blocking sleep.
+  -DFREEINK_FRONTLIGHT_LS
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Firmware side of Free-Ink/freeink-sdk#39, opened at @itsthisjustin's request on that PR: let the X4 Pro keep light-sleeping while the frontlight is lit, instead of a lit light blocking sleep entirely.
* **What changes are included?**
  - `[env:x4pro]` enables `FREEINK_FRONTLIGHT_LS`: the SDK clocks the frontlight LEDC from RC_FAST with `KEEP_ALIVE`, so the PWM survives light sleep, blink-free — the visible-flashing problem the current guard exists to avoid no longer occurs.
  - `lib/hal/HalPowerManager.cpp`: the `Frontlight.present() && Frontlight.isOn()` exclusion in `lightSleep()` and `onEinkBusyWaitSlice()` compiles out under `FREEINK_FRONTLIGHT_LS`. Boards without the define (papermono, C3) keep the guard byte-identically.
  - `freeink-sdk` submodule pin → head of Free-Ink/freeink-sdk#39 (`e458e6e`, which is current SDK `main` + that PR's two commits). If you prefer to merge #39 first and pin to the resulting merge commit instead, happy to rebase — the app changes themselves are pin-agnostic.

The SDK side also pays the RC_FAST keep-on cost **only while the light is actually lit** (refcounted sleep sub-mode toggle on 0↔nonzero duty edges), so dark idle still sleeps at full depth — details and rationale in Free-Ink/freeink-sdk#39.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does.
- [x] This PR touches `freeink-sdk/` and `lib/hal/` — opened by request of @itsthisjustin (maintainer) on Free-Ink/freeink-sdk#39 for integration ahead of this weekend's release.

## Additional Context

* **Tested working on X4 Pro hardware** (SSD1677 batch): night-reading sessions with the light on at low brightness through repeated sleep windows — no blinking, no flashes, brightness steps behave normally. Under an `esp_pm`/tickless test firmware on the same hardware, `CONFIG_PM_PROFILING` measured **92 % light-sleep residency over a ~31.5 min session (34,492 sleep entries, 0 rejects, ~50 ms average window)** with this frontlight path active — the frontlight configuration neither blocks nor destabilizes sleep. Measurement dump and interpretation are in the SDK PR.
* With the guard compiled out, night reading (light on) regains the full light-sleep saving instead of running the chip awake for the whole session.
* Memory/flash impact: negligible (a few hundred bytes of SDK code under the define; two booleans of state in `FrontlightManager`).
* Risk areas for review: the SDK PR's `esp_private/esp_sleep_internal.h` usage (refcounted RC_FAST sleep sub-mode — no public API exists; it's the same header the LEDC driver manages this through), and the `EpdBus` 20 ms BUSY-assert grace in the polled slice path (covers a BUSY edge taken while sleeping).

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — implementation and analysis with Claude Code; all hardware testing and measurements done by the submitter on a physical X4 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
