### PR TITLE
fix: guard file list against render-task race in FileBrowserActivity

### DIFF
--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -262,14 +262,18 @@ void FileBrowserActivity::activateSelected(const bool forceDelete) {
         LOG_DBG("FileBrowser", "Attempting to delete: %s", fullPath.c_str());
         if (removeDirFile(fullPath)) {
           LOG_DBG("FileBrowser", "Deleted successfully");
-          loadFiles();
-          if (files.empty()) {
-            nav.selected = 0;
-          } else if (nav.selected >= listCount()) {
-            // Move selection to the new "last" item
-            nav.selected = listCount() - 1;
+          {
+            // buildScreen() reads the row caches on the render task; see loop().
+            RenderLock lock(*this);
+            loadFiles();
+            if (files.empty()) {
+              nav.selected = 0;
+            } else if (nav.selected >= listCount()) {
+              // Move selection to the new "last" item
+              nav.selected = listCount() - 1;
+            }
+            nav.follow(listCount());
           }
-          nav.follow(listCount());
 
           requestUpdate(true);
         } else {
@@ -286,6 +290,10 @@ void FileBrowserActivity::activateSelected(const bool forceDelete) {
     return;
   } else {
     // --- SHORT PRESS ACTION: OPEN/NAVIGATE ---
+    // buildScreen() runs on the render task and reads basepath plus the
+    // ListItem label/value pointers into rowNames/rowExtensions that
+    // rebuildRowItems() frees; mutate only under the render lock.
+    RenderLock lock(*this);
     if (basepath.back() != '/') basepath += "/";
 
     if (isDirectory) {
@@ -293,9 +301,12 @@ void FileBrowserActivity::activateSelected(const bool forceDelete) {
       loadFiles();
       nav.selected = 0;
       nav.top = 0;
+      lock.unlock();
       requestUpdate();
     } else {
-      onSelectBook(basepath + entry);
+      const std::string fullPath = basepath + entry;
+      lock.unlock();  // onSelectBook launches an activity; don't hold the lock across it
+      onSelectBook(fullPath);
     }
   }
   return;
@@ -306,10 +317,15 @@ bool FileBrowserActivity::handleCustomInput() {
   // In firmware-pick mode we keep navigation simple: short Back = up dir / cancel.
   if (mode == Mode::Books && mappedInput.wasReleased(MappedInputManager::Button::Back) &&
       mappedInput.getHeldTime() >= GO_HOME_MS && basepath != "/") {
-    basepath = "/";
-    loadFiles();
-    nav.selected = 0;
-    nav.top = 0;
+    {
+      // buildScreen() runs on the render task and reads basepath plus the
+      // row caches rebuildRowItems() frees; mutate only under the render lock.
+      RenderLock lock(*this);
+      basepath = "/";
+      loadFiles();
+      nav.selected = 0;
+      nav.top = 0;
+    }
     requestUpdate();
     return true;
   }
@@ -329,15 +345,20 @@ bool FileBrowserActivity::handleButtons() {
       if (basepath != "/") {
         const std::string oldPath = basepath;
 
-        basepath.replace(basepath.find_last_of('/'), std::string::npos, "");
-        if (basepath.empty()) basepath = "/";
-        loadFiles();
+        {
+          // buildScreen() runs on the render task and reads basepath plus the
+          // row caches rebuildRowItems() frees; mutate only under the render lock.
+          RenderLock lock(*this);
+          basepath.replace(basepath.find_last_of('/'), std::string::npos, "");
+          if (basepath.empty()) basepath = "/";
+          loadFiles();
 
-        const auto pos = oldPath.find_last_of('/');
-        const std::string dirName = oldPath.substr(pos + 1) + "/";
-        nav.selected = static_cast<int>(findEntry(dirName));
-        nav.top = 0;
-        nav.follow(listCount());
+          const auto pos = oldPath.find_last_of('/');
+          const std::string dirName = oldPath.substr(pos + 1) + "/";
+          nav.selected = static_cast<int>(findEntry(dirName));
+          nav.top = 0;
+          nav.follow(listCount());
+        }
 
         requestUpdate();
       } else if (mode == Mode::PickFirmware) {


### PR DESCRIPTION


https://github.com/user-attachments/assets/98dec8f7-0c1c-4410-b236-17907b04ee98



## Summary
I stumbled upon this bug while I was patching 1.5.0 build for Korean support. The race is quite rare (~5%) after using develop tip because there were improvements in Hangul font rendering speed. But I thought this was worth patching upstream as this may bite us in the future. Also this may crash the firmware entirely if the use-after-free memory contains no '.' for filename argument in `getFileExtension()`.

* **What is the goal of this PR?** Fix a use-after-free race in the file browser: `buildScreen()` runs on the ActivityManager render task and reads `basepath` plus the `fui::ListItem` `label`/`value` pointers into the `rowNames`/`rowExtensions` caches, while button handling on the main task navigates via `loadFiles()` → `rebuildRowItems()`, which frees and rebuilds those strings mid-render. `ActivityManager::loop()` intentionally leaves locking to the activity ("the loop() method must be responsible for acquire one if needed"), but `FileBrowserActivity` never takes the `RenderLock`.
* **What changes are included?** Take the `RenderLock` (same idiom as `WifiSelectionActivity`) around every `loop()`-reachable mutation: long-press go-to-root, short-press folder navigation, short-press up-directory, and the post-delete reload. The lock is released before `requestUpdate()` and before launching activities (`onSelectBook`, the delete confirmation) to avoid deadlock with the render task. Single file: `src/activities/home/FileBrowserActivity.cpp`, +41/−20.

**How it manifests**

* On v1.5.0 (pre-#3025 code, same missing lock), confirmed on hardware via a decoded crash report: the render task's row lambda called `getFileExtension()` on a freed `files[]` string; `rfind('.')` over garbage returned `npos` and `substr(npos)` threw → `terminate()` → `abort()`. The decoded stack shows `__throw_out_of_range` with `pos=npos` over a 44-byte dot-less "filename" that no list-construction path can produce (files must match a known extension; directories get a trailing `/`).
* On the current `develop` tip, the same race reproduces as corrupted file-list rows when navigating rapidly while rows are still painting — the `ListItem` pointers dangle into freed heap.
* The race window scales with render duration, which is why slow CJK fallback rendering (#2725) made Korean libraries hit it frequently; #3026 narrowed the window but the race remains.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well (it crashes/corrupts), and this is a fix to stock behavior, not a feature.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** none — no new allocations; the mutex already exists and the added takes are on the navigation path, not the render loop.
* **Risk / review focus:** lock ordering. Every new `RenderLock` scope releases before `requestUpdate()` or any activity launch; worth double-checking no path holds it into `startActivityForResult`.
* **Testing:** X3 hardware, Korean-named library with an SD fallback font (slow rows = wide race window). Rapid Confirm/Back navigation during painting corrupted rows before the patch and is clean after. The v1.5.0 backport was additionally regression-tested with the crash path unguarded: the previously reliable abort recipe no longer fires.
* Other `UiListActivity` subclasses that mutate row data from `loop()` may warrant the same audit.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — investigation (crash-report decoding, race analysis) and the patch were done with Claude Code with Fable 5; hardware reproduction and verification were manual.
