### PR TITLE
fix: release SD font caches before starting WiFi + web server

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -185,6 +185,17 @@ void SdCardFont::freeStyleAll(PerStyle& s) {
 
 // --- Global free/cleanup ---
 
+void SdCardFont::releaseResidentCaches() {
+  clearOverflow();
+  clearPersistentCache();
+  for (uint8_t i = 0; i < MAX_STYLES; i++) {
+    if (!styles_[i].present) continue;
+    freeStyleMiniData(styles_[i]);  // also frees mini kern and restores the stub EpdFontData
+    freeStyleKernLigatureData(styles_[i]);
+    applyGlyphMissCallback(i);  // keep the on-demand miss path alive on the stub
+  }
+}
+
 void SdCardFont::freeAll() {
   clearOverflow();
   clearPersistentCache();

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -71,6 +71,15 @@ class SdCardFont {
   // when font/size/family/glyph-table state changes.
   void clearPersistentCache();
 
+  // Release every rebuildable cache while keeping the font loaded and usable:
+  // mini glyph/kern arenas, kern/ligature class tables, the overflow ring, and
+  // the persistent advance tables. Coverage intervals stay so hasCodepoint()
+  // and reloads keep working; glyphs fault back in on demand and the next
+  // prewarm rebuilds the arenas. For heap-critical transitions (e.g. starting
+  // WiFi + the web server), where retained font data is the difference between
+  // a clean start and an OOM abort.
+  void releaseResidentCaches();
+
   // Returns pointer to the managed EpdFont for a given style.
   // Returns nullptr if the style is not present.
   EpdFont* getEpdFont(uint8_t style = 0);

--- a/lib/GfxRenderer/FontCacheManager.cpp
+++ b/lib/GfxRenderer/FontCacheManager.cpp
@@ -19,6 +19,13 @@ void FontCacheManager::clearCache() {
   }
 }
 
+void FontCacheManager::releaseSdFontCaches() {
+  if (fontDecompressor_) fontDecompressor_->clearCache();
+  for (auto& [id, font] : sdCardFonts_) {
+    font->releaseResidentCaches();
+  }
+}
+
 void FontCacheManager::prewarmCache(int fontId, const char* utf8Text, uint8_t styleMask) {
   // SD card font prewarm path: prewarm all requested styles in one call
   auto it = sdCardFonts_.find(fontId);

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -16,6 +16,11 @@ class FontCacheManager {
   void setFontDecompressor(FontDecompressor* d);
 
   void clearCache();
+  // Release every rebuildable SD-font cache (mini glyph/kern arenas, kern/lig
+  // class tables, overflow rings, advance tables) while keeping the fonts
+  // loaded. Everything faults back in on demand. For heap-critical transitions
+  // (e.g. web-server + WiFi startup); see SdCardFont::releaseResidentCaches().
+  void releaseSdFontCaches();
   void prewarmCache(int fontId, const char* utf8Text, uint8_t styleMask = 0x0F);
   void logStats(const char* label = "render");
   void resetStats();

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -1,6 +1,7 @@
 #include "CalibreConnectActivity.h"
 
 #include <ESPmDNS.h>
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <WiFi.h>
@@ -78,6 +79,15 @@ void CalibreConnectActivity::startWebServer() {
   if (MDNS.begin(HOSTNAME)) {
     // mDNS is optional for the Calibre plugin but still helpful for users.
     LOG_DBG("CAL", "mDNS started: http://%s.local/", HOSTNAME);
+  }
+
+  // Heap-critical allocation: SD-font caches retained for the CJK UI fallback
+  // are rebuildable — release them (again: the WiFi selection screen may have
+  // repopulated them rendering a CJK SSID) so the server object doesn't abort
+  // on OOM. See CrossPointWebServerActivity::startWebServer().
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+    LOG_DBG("CAL", "Free heap before server alloc: %d bytes", ESP.getFreeHeap());
   }
 
   webServer.reset(new CrossPointWebServer());

--- a/src/activities/network/CalibreConnectActivity.cpp
+++ b/src/activities/network/CalibreConnectActivity.cpp
@@ -86,6 +86,7 @@ void CalibreConnectActivity::startWebServer() {
   // repopulated them rendering a CJK SSID) so the server object doesn't abort
   // on OOM. See CrossPointWebServerActivity::startWebServer().
   if (auto* fcm = renderer.getFontCacheManager()) {
+    LOG_DBG("CAL", "Free heap before SD font cache release: %d bytes", ESP.getFreeHeap());
     fcm->releaseSdFontCaches();
     LOG_DBG("CAL", "Free heap before server alloc: %d bytes", ESP.getFreeHeap());
   }

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -256,6 +256,13 @@ void CrossPointWebServerActivity::startAccessPoint() {
 void CrossPointWebServerActivity::startWebServer() {
   LOG_DBG("WEBACT", "Starting web server...");
 
+  // Repeat the release right before the allocation: the WiFi selection screen
+  // rendered since onEnter(), and a CJK SSID repopulates the SD-font caches.
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+    LOG_DBG("WEBACT", "Free heap before server alloc: %d bytes", ESP.getFreeHeap());
+  }
+
   // Create the web server instance
   webServer.reset(new CrossPointWebServer());
   webServer->begin();

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <DNSServer.h>
 #include <ESPmDNS.h>
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <I18n.h>
 #include <WiFi.h>
@@ -64,6 +65,16 @@ void CrossPointWebServerActivity::onEnter() {
   Activity::onEnter();
 
   LOG_DBG("WEBACT", "Free heap at onEnter: %d bytes", ESP.getFreeHeap());
+
+  // Heap-critical transition: WiFi (~45KB) plus the web server have to fit in
+  // what's left of the ~380KB parts. SD-font caches retained for the CJK UI
+  // fallback (mini glyph/kern arenas, kern class tables) are rebuildable on
+  // demand — release them up front instead of aborting in startWebServer()
+  // when the heap comes up short (observed on X3 with a Korean SD font).
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+    LOG_DBG("WEBACT", "Free heap after SD font cache release: %d bytes", ESP.getFreeHeap());
+  }
 
   // Reset state
   state = WebServerActivityState::MODE_SELECTION;

--- a/src/activities/network/CrossPointWebServerActivity.cpp
+++ b/src/activities/network/CrossPointWebServerActivity.cpp
@@ -259,6 +259,7 @@ void CrossPointWebServerActivity::startWebServer() {
   // Repeat the release right before the allocation: the WiFi selection screen
   // rendered since onEnter(), and a CJK SSID repopulates the SD-font caches.
   if (auto* fcm = renderer.getFontCacheManager()) {
+    LOG_DBG("WEBACT", "Free heap before SD font cache release: %d bytes", ESP.getFreeHeap());
     fcm->releaseSdFontCaches();
     LOG_DBG("WEBACT", "Free heap before server alloc: %d bytes", ESP.getFreeHeap());
   }


### PR DESCRIPTION
## Summary
I stumbled upon one more bug when trying to upstream some Korean related patches from 1.5.0 to upstream develop branch. Hangul font optimization seems to have caused regression in file transfer functionality. I've added a patch to clear up heap for web functions to work again.

* **What is the goal of this PR?** Fix a deterministic `abort()` at web-server startup on X3 devices when a CJK SD-card font is the active reader font. Since #3026, UI strings redirected to the CJK SD-font fallback keep fully prewarmed data resident across up to three UI-size font instances — mini glyph/kern arenas plus kern/ligature class tables. With CJK strings on screen this pins tens of KB (a kern-heavy Korean font carries ~53KB of kern data per style on file). Entering the web server then stacks WiFi (~45KB), mDNS, and the server object on top: free heap was down to **16,604 bytes** after WiFi connect (heap log), and the throwing 4KB `vector::resize`s in `CrossPointWebServer`'s constructor hit `bad_alloc` → `terminate()` → `abort()` under `-fno-exceptions`.
* **What changes are included?**
  * `SdCardFont::releaseResidentCaches()` — frees every rebuildable cache (mini glyph/kern arenas, kern/ligature class tables, overflow ring, advance tables) while keeping the font loaded and usable: coverage intervals stay, glyphs fault back in on demand, the next prewarm rebuilds the arenas.
  * `FontCacheManager::releaseSdFontCaches()` — applies it to all registered SD fonts (and clears the built-in decompressor cache).
  * `CrossPointWebServerActivity::onEnter()` — calls it before any network allocation, with free heap logged before/after.

**Evidence / root-causing**

* Decoded crash report (X3, develop tip): `startWebServer()` → `std::vector<unsigned char>::_M_default_append` → `operator new[]` → terminate → abort, with `Free heap at onExit start: 16604 bytes` logged moments earlier.
* Isolation experiment: same firmware, same library — switching **Settings > Reader > Font Family** from a Korean SD font to built-in Noto Serif eliminates the crash completely; switching back restores it. The delta is the resident SD-font data.
* On v1.5.0 the same OOM existed but was intermittent (needed an upload-page request's heap spike — plausibly the mechanism behind #2737); the #3026 residency made it deterministic on entry.

This follows the retention philosophy already stated in `resetStyleMiniData()`: *"Don't hold it when the heap is tight: the arenas are rebuildable."* The web-server transition is the known heap-hostile moment, so the release is explicit and up-front.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well (it aborts), and this is a fix to stock behavior.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** frees memory at the transition (tens of KB with CJK fonts active); no new allocations. Flash: one small function plus two pass-throughs.
* **Cost after leaving the web server:** the first repaint re-faults/re-prewarms glyphs (one-time, bounded by what's on screen). No user-visible issues observed.
* **Verification hooks:** `WEBACT` logs free heap before and after the release, so the reclaimed amount is visible on any serial-enabled unit.
* **Testing:** X3 hardware, Korean library, Korean SD font (kern-heavy build): web-server entry aborted deterministically before this patch; after it, File Transfer starts and runs, and Korean rendering is correct after exiting.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — investigation (crash-report decoding, heap analysis) and the patch were done with Claude Code with Fable 5; hardware reproduction, the font-isolation experiment, and verification were manual.
