### PR TITLE
fix: render NFD Hangul filenames from macOS transfers

### DIFF
--- a/lib/Utf8/Utf8.cpp
+++ b/lib/Utf8/Utf8.cpp
@@ -25,13 +25,15 @@ uint32_t utf8ComposePair(const uint32_t base, const uint32_t mark) {
 
 std::string utf8ComposeNfc(const std::string& in) {
   // Fast path: NFC composition can only change text that contains a combining
-  // diacritical mark U+0300-036F (UTF-8 lead byte 0xCC or 0xCD). Plain ASCII and
+  // diacritical mark U+0300-036F (UTF-8 lead byte 0xCC or 0xCD) or conjoining
+  // Hangul jamo (lead byte 0xE1 for U+1000-1FFF). Plain ASCII and
   // already-precomposed (NFC) text -- the vast majority of words -- have none, so
-  // return them untouched without walking codepoints or allocating. A 0xCD that is
-  // actually a non-combining codepoint just falls through to the full pass below.
+  // return them untouched without walking codepoints or allocating. A 0xCD or
+  // 0xE1 that is actually a non-composing codepoint (e.g. Georgian, Cherokee)
+  // just falls through to the full pass below.
   bool maybeHasMarks = false;
   for (const unsigned char c : in) {
-    if (c == 0xCC || c == 0xCD) {
+    if (c == 0xCC || c == 0xCD || c == 0xE1) {
       maybeHasMarks = true;
       break;
     }
@@ -59,7 +61,23 @@ std::string utf8ComposeNfc(const std::string& in) {
       }
       utf8AppendCodepoint(cp, out);
     } else {
-      if (haveBase) utf8AppendCodepoint(base, out);
+      // Hangul LV / LVT composition (Unicode 3.12, pure arithmetic — no
+      // tables): a modern leading consonant followed by a medial vowel
+      // composes to an LV syllable in the U+AC00 block; an LV syllable
+      // followed by a trailing consonant extends to LVT. macOS stores
+      // filenames in NFD, so Korean names arrive as conjoining jamo, which
+      // the fonts (precomposed syllables only) would miss entirely.
+      if (haveBase) {
+        if (base >= 0x1100 && base <= 0x1112 && cp >= 0x1161 && cp <= 0x1175) {
+          base = 0xAC00 + (base - 0x1100) * 588 + (cp - 0x1161) * 28;
+          continue;
+        }
+        if (base >= 0xAC00 && base <= 0xD7A3 && (base - 0xAC00) % 28 == 0 && cp >= 0x11A8 && cp <= 0x11C2) {
+          base += cp - 0x11A7;
+          continue;
+        }
+        utf8AppendCodepoint(base, out);
+      }
       base = cp;
       haveBase = true;
     }

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -12,10 +12,12 @@ size_t utf8RemoveLastChar(std::string& str);
 // Truncate string by removing N UTF-8 codepoints from the end.
 void utf8TruncateChars(std::string& str, size_t numChars);
 
-// Canonical composition (NFC) for the Latin / Vietnamese range: precomposes a
-// base letter followed by combining diacritical mark(s) into a single codepoint.
-// Needed because the device fonts have no combining-mark positioning, so text
-// stored in NFD (e.g. some EPUB chapter titles) otherwise renders broken.
+// Canonical composition (NFC) for the Latin / Vietnamese range and Hangul:
+// precomposes a base letter followed by combining diacritical mark(s), and
+// conjoining Hangul jamo sequences (L+V[+T]), into single codepoints. Needed
+// because the device fonts have no combining-mark positioning and carry only
+// precomposed Hangul syllables, so NFD text (some EPUB chapter titles; every
+// filename written by macOS) otherwise renders broken or blank.
 std::string utf8ComposeNfc(const std::string& in);
 
 // Truncate a raw char buffer to the last complete UTF-8 codepoint boundary.

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -5,6 +5,7 @@
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Memory.h>
+#include <Utf8.h>
 
 #include <algorithm>
 
@@ -286,7 +287,9 @@ void FileBrowserActivity::activateSelected(const bool forceDelete) {
 
     std::string heading = tr(STR_DELETE) + std::string("? ");
 
-    startActivityForResult(std::make_unique<ConfirmationActivity>(renderer, mappedInput, heading, entry), handler);
+    // Compose the display copy; `entry` stays raw for the delete path itself.
+    startActivityForResult(
+        std::make_unique<ConfirmationActivity>(renderer, mappedInput, heading, utf8ComposeNfc(entry)), handler);
     return;
   } else {
     // --- SHORT PRESS ACTION: OPEN/NAVIGATE ---
@@ -378,6 +381,11 @@ bool FileBrowserActivity::handleButtons() {
 }
 
 std::string getFileName(std::string filename) {
+  // Display copy only — `files[]` keeps the raw directory-entry bytes, because
+  // FAT long-filename lookup is byte-exact: an NFC-normalized path would fail
+  // to open the NFD entry macOS wrote. Composing here fixes rendering (fonts
+  // carry precomposed syllables / letters only) without touching paths.
+  filename = utf8ComposeNfc(filename);
   if (filename.back() == '/') {
     filename.pop_back();
     if (!UITheme::getInstance().getTheme().showsFileIcons()) {

--- a/test/utf8_compose/Utf8ComposeTest.cpp
+++ b/test/utf8_compose/Utf8ComposeTest.cpp
@@ -52,3 +52,68 @@ TEST(Utf8ComposeNfc, ComposesWithinWord) {
   // "Ti" + e+circ+acute + "ng" -> "Tiếng"
   EXPECT_EQ(utf8ComposeNfc("Ti" + std::string("e") + kCombCirc + kCombAcute + "ng"), "Ti\xE1\xBA\xBFng");
 }
+
+// --- Hangul LV / LVT composition (macOS writes filenames in NFD) ---
+
+namespace {
+const std::string kJamoG = "\xE1\x84\x80";   // U+1100 CHOSEONG KIYEOK (leading ㄱ)
+const std::string kJamoH = "\xE1\x84\x92";   // U+1112 CHOSEONG HIEUH (leading ㅎ)
+const std::string kJamoA = "\xE1\x85\xA1";   // U+1161 JUNGSEONG A (medial ㅏ)
+const std::string kJamoN = "\xE1\x86\xAB";   // U+11AB JONGSEONG NIEUN (trailing ㄴ)
+const std::string kJamoNg = "\xE1\x86\xBC";  // U+11BC JONGSEONG IEUNG (trailing ㅇ)
+}  // namespace
+
+// A leading consonant + medial vowel composes to an LV syllable (U+AC00 block).
+TEST(Utf8ComposeNfc, ComposesHangulLv) {
+  EXPECT_EQ(utf8ComposeNfc(kJamoH + kJamoA), "\xED\x95\x98");  // ㅎ(U+1112) + ㅏ(U+1161) -> 하 (U+D558)
+}
+
+// LV + trailing consonant extends to an LVT syllable.
+TEST(Utf8ComposeNfc, ComposesHangulLvt) {
+  // ㅎ(U+1112) + ㅏ(U+1161) + ㄴ(U+11AB) -> 한 (U+D55C)
+  EXPECT_EQ(utf8ComposeNfc(kJamoH + kJamoA + kJamoN), "\xED\x95\x9C");
+}
+
+// Consecutive LVT syllables compose independently within a word.
+TEST(Utf8ComposeNfc, ComposesHangulWord) {
+  // 한 + 강 in NFD -> 한강 (U+D55C U+AC15)
+  const std::string nfd = kJamoH + kJamoA + kJamoN + kJamoG + kJamoA + kJamoNg;
+  EXPECT_EQ(utf8ComposeNfc(nfd), "\xED\x95\x9C\xEA\xB0\x95");
+}
+
+// A real NFD filename: "해커와 화가.epub" (Hackers & Painters) exactly as it
+// appears on a FAT SD card after a Finder copy from macOS -- decomposed
+// conjoining jamo. A run of LV syllables composes while the space and ASCII
+// extension are preserved. Bytes verified against Python unicodedata output.
+TEST(Utf8ComposeNfc, ComposesRealNfdFilename) {
+  const std::string nfd =
+      "\xE1\x84\x92\xE1\x85\xA2\xE1\x84\x8F\xE1\x85\xA5\xE1\x84\x8B\xE1\x85\xAA"  // 해커와 (NFD)
+      " "
+      "\xE1\x84\x92\xE1\x85\xAA\xE1\x84\x80\xE1\x85\xA1"  // 화가 (NFD)
+      ".epub";
+  EXPECT_EQ(utf8ComposeNfc(nfd), "\xED\x95\xB4\xEC\xBB\xA4\xEC\x99\x80 \xED\x99\x94\xEA\xB0\x80.epub");
+}
+
+// Jamo that cannot start a syllable pass through unchanged: a lone leading
+// consonant, a lone medial/trailing, and a leading consonant not followed by a
+// medial vowel.
+TEST(Utf8ComposeNfc, LeavesUncomposableJamoIntact) {
+  EXPECT_EQ(utf8ComposeNfc(kJamoH), kJamoH);
+  EXPECT_EQ(utf8ComposeNfc(kJamoA + kJamoN), kJamoA + kJamoN);
+  EXPECT_EQ(utf8ComposeNfc(kJamoH + "a"), kJamoH + "a");
+}
+
+// Precomposed (NFC) Hangul takes the fast path untouched: syllables encode
+// with lead bytes EA-ED, not the 0xE1 the scan looks for.
+TEST(Utf8ComposeNfc, PassesThroughPrecomposedHangul) {
+  EXPECT_EQ(utf8ComposeNfc("\xED\x95\x9C\xEA\xB0\x95"), "\xED\x95\x9C\xEA\xB0\x95");  // 한강
+}
+
+// Other scripts sharing the 0xE1 lead byte (U+1000-1FFF) fall through the full
+// pass but come out byte-identical.
+TEST(Utf8ComposeNfc, LeavesOtherE1ScriptsIntact) {
+  const std::string georgian = "\xE1\x83\xA5\xE1\x83\x90";  // ქა (U+10E5 U+10D0)
+  EXPECT_EQ(utf8ComposeNfc(georgian), georgian);
+  const std::string cherokee = "\xE1\x8F\xA3";  // Ꮳ (U+13E3)
+  EXPECT_EQ(utf8ComposeNfc(cherokee), cherokee);
+}


### PR DESCRIPTION
## Summary
MacOS stores Korean (Hangul) filenames in decomposed conjoining jamo. (한 → ㅎ + ㅏ + ㄴ) This is different from Windows or Linux environments and need special treatment when rendering using Korean fonts, because normally Korean fonts do not carry font faces for decomposed conjoining jamo. This is solved by NFC normalizing. I've experimented three different kind of patches and I think this patch is the most minimal + well performing patch.

* **What is the goal of this PR?** Render Korean filenames transferred from a Mac. EPUBs that arrive via File Transfer over WiFi or a direct SD-card copy from macOS get **NFD filenames** — decomposed conjoining jamo (U+1100 L + U+1161 V [+ U+11A8 T]) instead of precomposed syllables. Fonts carry only the precomposed U+AC00 block, so these filenames render **blank** in the file browser. Filenames from other sources are typically NFC and unaffected, so a real library accumulates a mix and the bug looks intermittent.
* **What changes are included?** Two small changes — no renderer involvement, no new allocations:
  * `utf8ComposeNfc()` learns Hangul LV/LVT composition (Unicode 3.12, pure arithmetic in the existing accumulate loop; the fast-path byte scan gains `0xE1`). Other scripts sharing that lead byte (Georgian, Cherokee) fall through the full pass byte-identical — covered by tests.
  * `FileBrowserActivity` composes the **display copies only**: `getFileName()` (the `rowNames` cache) and the delete-confirmation heading. `files[]` keeps the raw directory-entry bytes deliberately — **FAT long-filename lookup is byte-exact**, so an NFC-normalized path would fail to open the NFD entry macOS wrote, and the progress-cache hash would change. (This is why the fix composes display strings rather than normalizing at the filesystem layer.)

**Scope of claims, honestly calibrated:**

* The observed bug is filenames. EPUB titles/TOC/content already flow through `utf8ComposeNfc()` at parse time, so hypothetical NFD Hangul *inside* an EPUB would now also compose — but Korean EPUBs use NFC internally in practice; that's a safety net, not an observed fix.
* Composing display copies also fixes NFD **Latin** filenames from macOS (e.g. `café.epub` with a combining acute), which previously rendered with broken combining marks.
* Known limit: filename sinks outside the browser (e.g. a TXT reader title) still show raw NFD; cosmetic, composable the same way as found.

**Interaction with #3026:** without composition, NFD strings reaching the renderer also defeated the batch prewarm — it keys caches on the raw jamo codepoints while drawing needs syllables, so every glyph faulted through `onGlyphMiss` one SD read at a time. With filenames composed before they reach the renderer, the prewarm works as designed.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well (Korean filenames from a Mac are blank), and this is a fix to stock behavior.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code.

## Additional Context

* **Memory / flash impact:** none measurable. The Hangul branch is arithmetic inside an existing loop; composition allocates only when a string actually contains jamo (same policy as the existing Latin path). Display-copy composition happens while the `rowNames` cache is being built anyway.
* **Tests:** seven Hangul cases added to the `Utf8ComposeTest` host suite (runs in CI): LV, LVT, multi-syllable words, a real NFD filename exactly as a Finder copy writes it to a FAT SD card, uncomposable-jamo passthrough, precomposed fast-path passthrough, and byte-identical passthrough for Georgian/Cherokee. Existing Latin/Vietnamese cases pass unchanged.
* **Hardware testing:** X3, Korean library mixing NFC- and NFD-named EPUBs, Korean SD font active: previously-blank NFD filenames render correctly in the file browser and delete dialog; NFC names and non-Korean libraries unaffected.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — investigation and the patch were done with Claude Code with Fable 5; hardware reproduction and verification were manual.
