### PR TITLE
fix: Add runtime check for factory grayscale support

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -145,6 +145,8 @@ void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, ui
 
 bool HalDisplay::supportsStripGrayscale() const { return einkDisplay.supportsStripGrayscale(); }
 
+bool HalDisplay::supportsFactoryGrayscale() const { return einkDisplay.supportsFactoryGrayscale(); }
+
 uint16_t HalDisplay::getDisplayWidth() const { return einkDisplay.getDisplayWidth(); }
 
 uint16_t HalDisplay::getDisplayHeight() const { return einkDisplay.getDisplayHeight(); }

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -101,6 +101,7 @@ class HalDisplay {
   // EInkDisplay::writeGrayscalePlaneStrip.
   void writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows);
   bool supportsStripGrayscale() const;
+  bool supportsFactoryGrayscale() const;
 
   // Runtime geometry passthrough
   uint16_t getDisplayWidth() const;

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -620,10 +620,10 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
 #if FREEINK_DRIVER_SSD1677
-  const bool useFactoryGrayscale = hasGreyscale;
-  constexpr auto msbMode = GfxRenderer::FACTORY_GRAY_MSB;
-  constexpr auto lsbMode = GfxRenderer::FACTORY_GRAY_LSB;
-  constexpr const unsigned char* lut = freeink::lut_factory_quality;
+  const bool useFactoryGrayscale = hasGreyscale && display.supportsFactoryGrayscale();
+  const auto msbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_MSB : GfxRenderer::GRAYSCALE_MSB;
+  const auto lsbMode = useFactoryGrayscale ? GfxRenderer::FACTORY_GRAY_LSB : GfxRenderer::GRAYSCALE_LSB;
+  const unsigned char* lut = useFactoryGrayscale ? freeink::lut_factory_quality : nullptr;
 #else
   constexpr bool useFactoryGrayscale = false;
   constexpr auto msbMode = GfxRenderer::GRAYSCALE_MSB;


### PR DESCRIPTION
Introduce supportsFactoryGrayscale() method to HalDisplay to determine if the device supports factory grayscale mode at runtime. Update SleepActivity to conditionally use factory grayscale settings only when supported, falling back to standard grayscale mode otherwise.

In #3018 we set the sleep covers to run based off a driver availablity but x4pro can have both UC and SSD based controllers so on UC based Pros all sleep covers were failing to generate
