### PR TITLE
feat: PSRAM image cache with one-shot pixel-cache writes for in-book images

### DIFF
--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -12,6 +12,11 @@
 
 #include "Epub/converters/DirectPixelWriter.h"
 #include "Epub/converters/ImageDecoderFactory.h"
+#include "Epub/converters/PxcFormat.h"
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+#include <esp_heap_caps.h>
+#endif
 
 // Cache file format:
 // - uint16_t width
@@ -89,6 +94,278 @@ void rememberImageFailure(const std::string& path) {
   if (failedImageCount == MAX_SESSION_IMAGE_FAILURES || imageFailedThisSession(path)) return;
   failedImageHashes[failedImageCount++] = imagePathHash(path);
 }
+
+// Render the payload straight off SD, a few rows at a time: the fallback for
+// every path that could not hold the image in RAM. `cacheFile` must be
+// positioned just past the header.
+bool renderStreamingFromCache(GfxRenderer& renderer, HalFile& cacheFile, const int x, const int y,
+                              const int cachedWidth, const int cachedHeight, const int bytesPerRow) {
+  // Read several rows per SD access. A one-row-per-read loop here means
+  // cachedHeight (~728) tiny reads through the storage mutex + SdFat; batching
+  // rows into a ~4KB buffer cuts that to ~20 reads per pass without holding the
+  // whole image.
+  int rowsPerRead = 4096 / bytesPerRow;
+  if (rowsPerRead < 1) rowsPerRead = 1;
+  if (rowsPerRead > cachedHeight) rowsPerRead = cachedHeight;
+  uint8_t* readBuffer = (uint8_t*)malloc((size_t)rowsPerRead * bytesPerRow);
+  if (!readBuffer) {
+    // Fall back to a single-row buffer under memory pressure.
+    rowsPerRead = 1;
+    readBuffer = (uint8_t*)malloc(bytesPerRow);
+  }
+  if (!readBuffer) {
+    LOG_ERR("IMG", "Failed to allocate row buffer");
+    return false;
+  }
+
+  DirectPixelWriter pw;
+  pw.init(renderer);
+
+  int rowsInBuffer = 0;
+  int bufferRow = 0;
+  for (int row = 0; row < cachedHeight; row++) {
+    if (bufferRow >= rowsInBuffer) {
+      const int toRead = (cachedHeight - row < rowsPerRead) ? (cachedHeight - row) : rowsPerRead;
+      const size_t bytes = (size_t)toRead * bytesPerRow;
+      if (cacheFile.read(readBuffer, bytes) != static_cast<int>(bytes)) {
+        LOG_ERR("IMG", "Cache read error at row %d", row);
+        free(readBuffer);
+        return false;
+      }
+      rowsInBuffer = toRead;
+      bufferRow = 0;
+    }
+
+    const uint8_t* rowBuffer = readBuffer + (size_t)bufferRow * bytesPerRow;
+    bufferRow++;
+
+    const int destY = y + row;
+    pw.beginRow(destY);
+    // On a grayscale strip pass only a narrow column window of the image is in
+    // the active band; skip the rest instead of unpacking+clipping every pixel.
+    int colStart, colEnd;
+    pw.bandColRange(x, cachedWidth, colStart, colEnd);
+    for (int col = colStart; col < colEnd; col++) {
+      const int byteIdx = col >> 2;            // col / 4
+      const int bitShift = 6 - (col & 3) * 2;  // MSB first within byte
+      uint8_t pixelValue = (rowBuffer[byteIdx] >> bitShift) & 0x03;
+
+      pw.writePixel(x + col, pixelValue);
+    }
+  }
+
+  free(readBuffer);
+  LOG_DBG("IMG", "Cache render complete");
+  return true;
+}
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+// --- Whole-image PSRAM render cache ------------------------------------------
+// Replaces the single per-page-render internal-RAM slot below. The tiled
+// grayscale flow re-renders an image page once for the BW double-refresh and
+// again for every band of both gray planes, and each pass re-read the whole
+// .pxc off SD (~100 ms for a full-page image, ~13 passes). Column clipping
+// cannot reduce that traffic: the row stride (~100 B) is smaller than an SD
+// sector, so every sector is touched regardless of the band window.
+//
+// PSRAM makes the obvious fix affordable. Each slot is one contiguous
+// heap_caps_malloc(MALLOC_CAP_SPIRAM) block holding a whole .pxc image (header
+// + payload), keyed by the hash of its cache path, and the set of slots
+// survives page turns. Three things follow from that:
+//  * every pass of every image on a page hits RAM, not just the first image
+//    (the internal-RAM design could only afford ONE resident image, so a
+//    two-image page re-streamed the second one ~13 times);
+//  * a back-turn, or any re-visit while the image is still resident, costs no
+//    SD access at all;
+//  * a decode can hand its freshly built payload straight over
+//    (adoptPxcImage), so the passes after a first view never read back
+//    the file the decode just wrote.
+//
+// Bounded: 8 slots x at most 96,004 B is ~750 KB of the 8 MB PSRAM, held for as
+// long as the reader is open (clearPxcLru gives it back on the way out).
+// Eviction is LRU, so a new book simply displaces the previous one's images.
+// Failure to allocate is not an error anywhere: the slot stays empty and the
+// caller falls back to the unchanged streaming path.
+//
+// Threading: the cache has no lock of its own. Its invariant is that every
+// access happens on a task holding the RenderLock -- which is true of every
+// render and of every decode, both of which run under it.
+constexpr size_t PXC_LRU_SLOTS = 8;
+
+struct PxcLruSlot {
+  uint8_t* image;   // PXC_HEADER_BYTES + payload, one PSRAM allocation
+  size_t capacity;  // bytes allocated at `image`
+  uint64_t hash;    // imagePathHash(cachePath); 0 (with image == nullptr) = empty
+  uint16_t width;
+  uint16_t height;
+  uint32_t lastUse;
+};
+
+PxcLruSlot pxcLru[PXC_LRU_SLOTS] = {};
+uint32_t pxcLruClock = 0;
+
+void pxcLruDrop(PxcLruSlot& slot) {
+  free(slot.image);  // heap_caps_malloc'd memory is free()-compatible
+  slot = {};
+}
+
+// The slot this image should occupy: its own entry if it already has one, else
+// an empty slot, else the least recently used one. Never null; the returned
+// slot may still hold another image's payload (the caller replaces it).
+PxcLruSlot& pxcLruSlotFor(const uint64_t hash) {
+  PxcLruSlot* victim = &pxcLru[0];
+  for (auto& slot : pxcLru) {
+    if (slot.image && slot.hash == hash) return slot;
+    // An empty slot has lastUse 0, so it always wins this comparison.
+    if (slot.lastUse < victim->lastUse) victim = &slot;
+  }
+  return *victim;
+}
+
+PxcLruSlot* pxcLruFind(const uint64_t hash) {
+  for (auto& slot : pxcLru) {
+    if (slot.image && slot.hash == hash) {
+      slot.lastUse = ++pxcLruClock;
+      return &slot;
+    }
+  }
+  return nullptr;
+}
+
+// True when this image's payload is already resident at the size the caller
+// expects. A peek, deliberately: asking "would this still need decoding?" is
+// not a use, so it leaves lastUse alone and cannot reorder the LRU.
+bool pxcLruHasImage(const std::string& cachePath, const int expectedWidth, const int expectedHeight) {
+  const uint64_t hash = imagePathHash(cachePath);
+  for (const auto& slot : pxcLru) {
+    if (!slot.image || slot.hash != hash) continue;
+    // Same +/-1 tolerance as the on-disk header check (readValidCacheHeader):
+    // re-layout recomputes an image's box without touching its path.
+    return abs(slot.width - expectedWidth) <= 1 && abs(slot.height - expectedHeight) <= 1;
+  }
+  return false;
+}
+
+// Point `slot` at a `bytes`-sized PSRAM block for `hash`, reusing the block it
+// already owns when that is big enough. False leaves the slot empty.
+bool pxcLruReserve(PxcLruSlot& slot, const uint64_t hash, const size_t bytes) {
+  if (slot.capacity < bytes) {
+    pxcLruDrop(slot);
+    auto* block = static_cast<uint8_t*>(heap_caps_malloc(bytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!block) return false;
+    slot.image = block;
+    slot.capacity = bytes;
+  }
+  slot.hash = hash;
+  // The payload for `hash` has not been read in yet, and a reserve that reuses
+  // an oversized block keeps the previous occupant's bytes. Zero the dimensions
+  // so the slot never advertises (new hash, old size) -- pxcLruHasImage and
+  // renderFromCache both trust that pair.
+  slot.width = 0;
+  slot.height = 0;
+  slot.lastUse = ++pxcLruClock;
+  return true;
+}
+
+void renderRowsFromPxcSlot(GfxRenderer& renderer, const PxcLruSlot& slot, const int x, const int y) {
+  const uint8_t* pixels = slot.image + PXC_HEADER_BYTES;
+  const int bytesPerRow = (slot.width + 3) / 4;
+
+  DirectPixelWriter pw;
+  pw.init(renderer);
+
+  for (int row = 0; row < slot.height; row++) {
+    const uint8_t* rowBuffer = pixels + static_cast<size_t>(row) * bytesPerRow;
+    pw.beginRow(y + row);
+    int colStart, colEnd;
+    pw.bandColRange(x, slot.width, colStart, colEnd);
+    for (int col = colStart; col < colEnd; col++) {
+      const int byteIdx = col >> 2;            // col / 4
+      const int bitShift = 6 - (col & 3) * 2;  // MSB first within byte
+      const uint8_t pixelValue = (rowBuffer[byteIdx] >> bitShift) & 0x03;
+      pw.writePixel(x + col, pixelValue);
+    }
+  }
+}
+
+// cacheFile is positioned just past the header. Returns the filled slot, or
+// null when the image is too big for a slot, PSRAM is exhausted, or the read
+// came up short -- all of which fall back to streaming.
+const PxcLruSlot* loadPxcSlot(const uint64_t cacheHash, HalFile& cacheFile, const uint16_t cachedWidth,
+                              const uint16_t cachedHeight, const int bytesPerRow) {
+  const size_t payload = static_cast<size_t>(bytesPerRow) * cachedHeight;
+  if (payload == 0 || payload > PXC_MAX_PAYLOAD_BYTES) return nullptr;
+  const size_t total = PXC_HEADER_BYTES + payload;
+
+  PxcLruSlot& slot = pxcLruSlotFor(cacheHash);
+  if (!pxcLruReserve(slot, cacheHash, total)) return nullptr;
+
+  // Short reads are legal (see the book.bin mirror), so loop to completion.
+  size_t got = 0;
+  while (got < payload) {
+    const int n = cacheFile.read(slot.image + PXC_HEADER_BYTES + got, payload - got);
+    if (n <= 0) break;
+    got += static_cast<size_t>(n);
+  }
+  if (got != payload) {
+    pxcLruDrop(slot);
+    return nullptr;
+  }
+
+  memcpy(slot.image, &cachedWidth, 2);
+  memcpy(slot.image + 2, &cachedHeight, 2);
+  slot.width = cachedWidth;
+  slot.height = cachedHeight;
+  return &slot;
+}
+
+bool renderFromCache(GfxRenderer& renderer, const std::string& cachePath, const int x, const int y,
+                     const int expectedWidth, const int expectedHeight) {
+  const uint64_t cacheHash = imagePathHash(cachePath);
+  if (PxcLruSlot* slot = pxcLruFind(cacheHash)) {
+    // Re-layout (font size, orientation, margins) recomputes an image's box
+    // without touching its path, so a resident payload can name the wrong size.
+    // Same +/-1 tolerance as the on-disk header check; a mismatch drops the
+    // entry and falls through to the file, which is itself about to be rejected
+    // and re-decoded.
+    if (abs(slot->width - expectedWidth) <= 1 && abs(slot->height - expectedHeight) <= 1) {
+      renderRowsFromPxcSlot(renderer, *slot, x, y);
+      return true;
+    }
+    pxcLruDrop(*slot);
+  }
+
+  HalFile cacheFile;
+  if (!Storage.openFileForRead("IMG", cachePath, cacheFile)) {
+    return false;
+  }
+
+  uint16_t cachedWidth, cachedHeight;
+  if (!readValidCacheHeader(cacheFile, expectedWidth, expectedHeight, cachedWidth, cachedHeight)) {
+    LOG_ERR("IMG", "Invalid image cache: %s", cachePath.c_str());
+    return false;
+  }
+
+  LOG_DBG("IMG", "Loading from cache: %s (%dx%d)", cachePath.c_str(), cachedWidth, cachedHeight);
+
+  const int bytesPerRow = (cachedWidth + 3) / 4;  // 2 bits per pixel, 4 pixels per byte
+
+  // First pass after a miss: pull the payload into a slot so this pass and
+  // every later one (this page render, and every re-visit until the slot is
+  // evicted) skip SD entirely.
+  if (const PxcLruSlot* slot = loadPxcSlot(cacheHash, cacheFile, cachedWidth, cachedHeight, bytesPerRow)) {
+    renderRowsFromPxcSlot(renderer, *slot, x, y);
+    LOG_DBG("IMG", "Cache render complete (payload now in PSRAM)");
+    return true;
+  }
+
+  // Streaming fallback (no slot). A failed slot load may have consumed part of
+  // the payload; rewind to just past the header.
+  cacheFile.seek(4);
+  return renderStreamingFromCache(renderer, cacheFile, x, y, cachedWidth, cachedHeight, bytesPerRow);
+}
+
+#else  // !CROSSPOINT_PSRAM_IMAGE_CACHE
 
 // --- Per-page-render RAM slot for the pixel cache ----------------------------
 // The tiled grayscale flow re-renders an image page once for the BW
@@ -232,70 +509,26 @@ bool renderFromCache(GfxRenderer& renderer, const std::string& cachePath, int x,
   // Streaming fallback (slot didn't fit). A failed slot load may have consumed
   // part of the payload; rewind to just past the header.
   cacheFile.seek(4);
-
-  // Read several rows per SD access. A one-row-per-read loop here means
-  // cachedHeight (~728) tiny reads through the storage mutex + SdFat; batching
-  // rows into a ~4KB buffer cuts that to ~20 reads per pass without holding the
-  // whole image.
-  int rowsPerRead = 4096 / bytesPerRow;
-  if (rowsPerRead < 1) rowsPerRead = 1;
-  if (rowsPerRead > cachedHeight) rowsPerRead = cachedHeight;
-  uint8_t* readBuffer = (uint8_t*)malloc((size_t)rowsPerRead * bytesPerRow);
-  if (!readBuffer) {
-    // Fall back to a single-row buffer under memory pressure.
-    rowsPerRead = 1;
-    readBuffer = (uint8_t*)malloc(bytesPerRow);
-  }
-  if (!readBuffer) {
-    LOG_ERR("IMG", "Failed to allocate row buffer");
-    return false;
-  }
-
-  DirectPixelWriter pw;
-  pw.init(renderer);
-
-  int rowsInBuffer = 0;
-  int bufferRow = 0;
-  for (int row = 0; row < cachedHeight; row++) {
-    if (bufferRow >= rowsInBuffer) {
-      const int toRead = (cachedHeight - row < rowsPerRead) ? (cachedHeight - row) : rowsPerRead;
-      const size_t bytes = (size_t)toRead * bytesPerRow;
-      if (cacheFile.read(readBuffer, bytes) != static_cast<int>(bytes)) {
-        LOG_ERR("IMG", "Cache read error at row %d", row);
-        free(readBuffer);
-        return false;
-      }
-      rowsInBuffer = toRead;
-      bufferRow = 0;
-    }
-
-    const uint8_t* rowBuffer = readBuffer + (size_t)bufferRow * bytesPerRow;
-    bufferRow++;
-
-    const int destY = y + row;
-    pw.beginRow(destY);
-    // On a grayscale strip pass only a narrow column window of the image is in
-    // the active band; skip the rest instead of unpacking+clipping every pixel.
-    int colStart, colEnd;
-    pw.bandColRange(x, cachedWidth, colStart, colEnd);
-    for (int col = colStart; col < colEnd; col++) {
-      const int byteIdx = col >> 2;            // col / 4
-      const int bitShift = 6 - (col & 3) * 2;  // MSB first within byte
-      uint8_t pixelValue = (rowBuffer[byteIdx] >> bitShift) & 0x03;
-
-      pw.writePixel(x + col, pixelValue);
-    }
-  }
-
-  free(readBuffer);
-  LOG_DBG("IMG", "Cache render complete");
-  return true;
+  return renderStreamingFromCache(renderer, cacheFile, x, y, cachedWidth, cachedHeight, bytesPerRow);
 }
+
+#endif  // CROSSPOINT_PSRAM_IMAGE_CACHE
 
 }  // namespace
 
 bool ImageBlock::hasValidCache() const {
   const auto cachePath = getCachePath(imagePath);
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // A payload already resident in the render cache is as good as the file, and
+  // answering from RAM costs no SD access at all -- which is the point, because
+  // this runs per image on the page-turn path (renderContents, via
+  // Page::hasImagesNeedingDecode). It also means an image whose file was removed
+  // underneath a live slot (cache cleanup) stops looking like undecoded work.
+  // That caller holds the RenderLock, which is this cache's only
+  // synchronization. The file check below remains the fallback for anything not
+  // (or no longer) resident.
+  if (pxcLruHasImage(cachePath, width, height)) return true;
+#endif
   HalFile cacheFile;
   if (!Storage.openFileForRead("IMG", cachePath, cacheFile)) {
     return false;
@@ -309,7 +542,49 @@ bool ImageBlock::needsDecode() const { return !imageFailedThisSession(imagePath)
 
 void ImageBlock::clearSessionRenderFailures() { failedImageCount = 0; }
 
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+// The PSRAM cache is deliberately not tied to a single page render: its whole
+// point is that a back-turn or a re-visit still hits RAM. Slots are reclaimed
+// by LRU eviction, so the reader's per-page release becomes a no-op.
+void ImageBlock::releaseRenderCache() {}
+
+void ImageBlock::clearPxcLru() {
+  size_t freed = 0;
+  for (auto& slot : pxcLru) {
+    if (!slot.image) continue;
+    freed += slot.capacity;
+    pxcLruDrop(slot);
+  }
+  if (freed) LOG_DBG("IMG", "Released %u bytes of PSRAM image cache", static_cast<unsigned>(freed));
+}
+
+bool adoptPxcImage(const std::string& cachePath, uint8_t* pxcImage, const size_t byteCount) {
+  if (!pxcImage || byteCount <= PXC_HEADER_BYTES) return false;
+  uint16_t width = 0;
+  uint16_t height = 0;
+  memcpy(&width, pxcImage, 2);
+  memcpy(&height, pxcImage + 2, 2);
+  if (width == 0 || height == 0) return false;
+  // The donated block must be exactly one .pxc image, or a render would walk
+  // off the end of it.
+  const size_t payload = static_cast<size_t>((width + 3) / 4) * height;
+  if (payload > PXC_MAX_PAYLOAD_BYTES || PXC_HEADER_BYTES + payload != byteCount) return false;
+
+  const uint64_t hash = imagePathHash(cachePath);
+  PxcLruSlot& slot = pxcLruSlotFor(hash);
+  pxcLruDrop(slot);  // takes ownership of a whole block; never reuses the old one
+  slot.image = pxcImage;
+  slot.capacity = byteCount;
+  slot.hash = hash;
+  slot.width = width;
+  slot.height = height;
+  slot.lastUse = ++pxcLruClock;
+  LOG_DBG("IMG", "Adopted decoded payload: %s (%dx%d)", cachePath.c_str(), width, height);
+  return true;
+}
+#else
 void ImageBlock::releaseRenderCache() { releasePxcSlot(); }
+#endif
 
 void ImageBlock::renderPlaceholder(GfxRenderer& renderer, const int x, const int y) const {
   renderer.fillRect(x, y, width, height, true);

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -26,7 +26,23 @@ class ImageBlock final : public Block {
   // first draw caches the pixel payload in RAM (chunked, heap-gated, falls back
   // to streaming when it doesn't fit); the reader calls this when the page
   // render completes so nothing stays resident between pages.
+  // With CROSSPOINT_PSRAM_IMAGE_CACHE the payload lives in a PSRAM LRU that
+  // deliberately outlives the page render, and this becomes a no-op.
   static void releaseRenderCache();
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // --- Whole-image PSRAM render cache -----------------------------------------
+  // The format itself, and the decode-side donation entry point, live in
+  // converters/PxcFormat.h. What belongs to the block layer is the slot set:
+  //
+  // Free every slot. The cache is bounded (8 x up to ~96 KB = ~750 KB of PSRAM)
+  // and never evicts on its own beyond LRU, because its whole point is
+  // surviving page turns. Leaving the reader ends that: the reader calls this
+  // from onExit to give the PSRAM back, and the next book starts cold rather
+  // than displacing slot by slot. Caller must hold the RenderLock (the cache
+  // has no lock of its own).
+  static void clearPxcLru();
+#endif
 
   // Lazy extraction hook: the section build only header-probes images for their
   // dimensions; the file at imagePath is extracted out of the book on first

--- a/lib/Epub/Epub/converters/PixelCache.h
+++ b/lib/Epub/Epub/converters/PixelCache.h
@@ -8,6 +8,14 @@
 #include <cstring>
 #include <string>
 
+// The .pxc layout this writer produces, plus the hook that hands a whole-image
+// buffer to the render cache on success.
+#include "PxcFormat.h"
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+#include <esp_heap_caps.h>
+#endif
+
 // Streaming cache writer for 2-bit pixels (4 levels). Packs 4 pixels per byte,
 // MSB first.
 //
@@ -40,6 +48,22 @@ struct PixelCache {
   std::string cachePathStr;
   bool ok;
 
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // --- One-shot mode -----------------------------------------------------------
+  // With PSRAM available the band can simply BE the whole image: `whole` is one
+  // heap_caps_malloc(MALLOC_CAP_SPIRAM) block holding a complete .pxc (4-byte
+  // header + payload), `buffer` points at its payload, and the band never
+  // moves. advanceTo() then has nothing to flush and finalize() writes the file
+  // in a SINGLE write instead of the ~40 interleaved 3 KB band flushes a
+  // full-page image costs today -- and hands the block straight to ImageBlock's
+  // render cache, so the ~12 render passes that follow never read it back.
+  //
+  // Everything about this is optional: an image past the cache's payload cap,
+  // or a failed PSRAM allocation, leaves `whole` null and the banded path below
+  // runs exactly as before.
+  uint8_t* whole = nullptr;
+#endif
+
   PixelCache()
       : buffer(nullptr),
         zeroRow(nullptr),
@@ -70,6 +94,47 @@ struct PixelCache {
     flushedRows = 0;
     ok = false;
 
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+    if (!beginWholeBuffer(w, h) && !beginBandBuffer(w, h, maxBlockDstRows)) return false;
+#else
+    if (!beginBandBuffer(w, h, maxBlockDstRows)) return false;
+#endif
+
+    if (!Storage.openFileForWrite("IMG", cachePath, file)) {
+      LOG_ERR("IMG", "Failed to open cache file for writing: %s", cachePath.c_str());
+      freeBuffers();
+      return false;
+    }
+    cachePathStr = cachePath;
+
+    // One-shot mode already carries the header at the head of `whole` and emits
+    // it with the payload in finalize()'s single write; the banded path writes
+    // it to the file now.
+    bool headerInBuffer = false;
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+    headerInBuffer = whole != nullptr;
+#endif
+    if (!headerInBuffer) {
+      uint16_t w16 = (uint16_t)w;
+      uint16_t h16 = (uint16_t)h;
+      if (file.write(&w16, 2) != 2 || file.write(&h16, 2) != 2) {
+        LOG_ERR("IMG", "Failed to write cache header: %s", cachePath.c_str());
+        abort();        // closes the file and removes the stub
+        freeBuffers();  // ...and the band buffer this call allocated above
+        return false;
+      }
+    }
+
+    LOG_DBG("IMG", "Cache stream started: %s (%dx%d, band %d rows)", cachePath.c_str(), w, h, bandRows);
+    ok = true;
+    return true;
+  }
+
+  // Band buffer for the streaming path: enough rows for the tallest single
+  // decode block (maxBlockDstRows output rows), plus a spare zeroed row.
+  // Takes (w, h) like beginWholeBuffer so its diagnostics describe the image it
+  // was asked for rather than whatever the members happen to hold.
+  bool beginBandBuffer(int w, int h, int maxBlockDstRows) {
     int wantRows = maxBlockDstRows + 2;
     if (wantRows < MIN_BAND_ROWS) wantRows = MIN_BAND_ROWS;
     if (wantRows > h) wantRows = h;
@@ -95,33 +160,48 @@ struct PixelCache {
     }
     memset(buffer, 0, bufSize);
     zeroRow = buffer + (size_t)bandRows * bytesPerRow;
-
-    if (!Storage.openFileForWrite("IMG", cachePath, file)) {
-      LOG_ERR("IMG", "Failed to open cache file for writing: %s", cachePath.c_str());
-      free(buffer);
-      buffer = nullptr;
-      return false;
-    }
-    cachePathStr = cachePath;
-
-    uint16_t w16 = (uint16_t)w;
-    uint16_t h16 = (uint16_t)h;
-    if (file.write(&w16, 2) != 2 || file.write(&h16, 2) != 2) {
-      LOG_ERR("IMG", "Failed to write cache header: %s", cachePath.c_str());
-      abort();
-      return false;
-    }
-
-    LOG_DBG("IMG", "Cache stream started: %s (%dx%d, band %d rows)", cachePath.c_str(), w, h, bandRows);
-    ok = true;
     return true;
   }
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // One-shot mode: one PSRAM block holding the complete .pxc. False (with
+  // `whole` left null) whenever the image is past the cache's payload cap or
+  // PSRAM cannot provide the block, which falls back to the banded path.
+  bool beginWholeBuffer(int w, int h) {
+    const size_t payload = (size_t)bytesPerRow * h;
+    if (payload == 0 || payload > PXC_MAX_PAYLOAD_BYTES) return false;
+    const size_t total = PXC_HEADER_BYTES + payload;
+
+    whole = (uint8_t*)heap_caps_malloc(total, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!whole) {
+      LOG_DBG("IMG", "No PSRAM for a %u-byte image buffer; streaming the cache", (unsigned)total);
+      return false;
+    }
+    // Zeroed up front so rows the decode never covers (a clipped image) stay
+    // black, exactly as the banded path's zero-fill leaves them.
+    memset(whole, 0, total);
+    const uint16_t w16 = (uint16_t)w;
+    const uint16_t h16 = (uint16_t)h;
+    memcpy(whole, &w16, 2);
+    memcpy(whole + 2, &h16, 2);
+
+    buffer = whole + PXC_HEADER_BYTES;
+    zeroRow = nullptr;  // the band never moves, so no gap/clip fill is needed
+    bandRows = h;       // the band IS the image: every row is always in range
+    return true;
+  }
+#endif
 
   // Flush every output row below newTopRow (they are final in raster order) and
   // reposition the band to start at newTopRow. Returns false if a write failed,
   // in which case the caller must stop caching for the rest of the decode.
   bool advanceTo(int newTopRow) {
     if (!ok) return false;
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+    // One-shot mode: every row is already in its final place in `whole` and the
+    // band never moves, so there is nothing to flush or reposition.
+    if (whole) return true;
+#endif
     if (newTopRow <= bandStart) return true;
     if (newTopRow > height) newTopRow = height;
 
@@ -147,6 +227,9 @@ struct PixelCache {
       abort();
       return false;
     }
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+    if (whole) return finalizeWhole();
+#endif
     for (int r = flushedRows; r < height; ++r) {
       const int idx = r - bandStart;
       const uint8_t* rowPtr = (idx >= 0 && idx < bandRows) ? (buffer + (size_t)idx * bytesPerRow) : zeroRow;
@@ -163,6 +246,36 @@ struct PixelCache {
     return true;
   }
 
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // One-shot finish: header + payload in a SINGLE write, then hand the block to
+  // the render cache instead of making the passes that follow read it back.
+  //
+  // Donating is only legal from a decode that holds the RenderLock, because
+  // that cache has no lock of its own. It holds here by construction: a
+  // PixelCache exists only for a decode with config.cachePath set, and the sole
+  // producer of those is ImageBlock::render(), which the render task runs under
+  // the lock. Any future off-lock decode that wants a .pxc has to opt out of the
+  // donation before it can use this writer.
+  bool finalizeWhole() {
+    const size_t total = PXC_HEADER_BYTES + (size_t)bytesPerRow * height;
+    if (file.write(whole, total) != total) {
+      LOG_ERR("IMG", "Cache write error: %s", cachePathStr.c_str());
+      abort();
+      return false;
+    }
+    file.close();
+    ok = false;  // file handed off; nothing left to clean up
+    LOG_DBG("IMG", "Cache written in one pass: %s (%dx%d, %u bytes)", cachePathStr.c_str(), width, height,
+            (unsigned)total);
+
+    if (adoptPxcImage(cachePathStr, whole, total)) {
+      whole = nullptr;  // ownership transferred to the render cache
+      buffer = nullptr;
+    }
+    return true;
+  }
+#endif
+
   // Drop a partial/failed cache so a later decode re-creates it cleanly.
   void abort() {
     if (file.isOpen()) file.close();
@@ -172,6 +285,24 @@ struct PixelCache {
     ok = false;
   }
 
+  // Release whichever buffer this cache owns. Safe to call repeatedly.
+  void freeBuffers() {
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+    if (whole) {
+      free(whole);  // heap_caps_malloc'd memory is free()-compatible
+      whole = nullptr;
+      buffer = nullptr;
+      zeroRow = nullptr;
+      return;
+    }
+#endif
+    if (buffer) {
+      free(buffer);
+      buffer = nullptr;
+      zeroRow = nullptr;
+    }
+  }
+
   ~PixelCache() {
     if (file.isOpen()) {
       // The file is still open, so neither finalize() nor abort() ran, or a
@@ -179,9 +310,6 @@ struct PixelCache {
       // Drop the partial cache so we leave no corrupt file behind.
       abort();
     }
-    if (buffer) {
-      free(buffer);
-      buffer = nullptr;
-    }
+    freeBuffers();
   }
 };

--- a/lib/Epub/Epub/converters/PxcFormat.h
+++ b/lib/Epub/Epub/converters/PxcFormat.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <string>
+
+// The on-disk .pxc pixel-cache format, shared by the writer (PixelCache, in
+// converters/) and the reader (ImageBlock, in blocks/). It lives in neither:
+// the converter would otherwise include the block header just for these two
+// constants, which points the dependency backwards for what is only a file
+// format.
+//
+// A cached image, in the .pxc file and in a PSRAM render-cache slot alike:
+// uint16 width, uint16 height, then ((width + 3) / 4) * height bytes of 2-bpp
+// pixels, packed 4 per byte, MSB first, row-major.
+constexpr size_t PXC_HEADER_BYTES = 4;
+// 96,000 B of payload is a full-screen 800x480 image at 2 bpp. Anything larger
+// cannot be a page image on this hardware and stays on the streaming path
+// rather than sizing the cache for it.
+constexpr size_t PXC_MAX_PAYLOAD_BYTES = 96000;
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+// One-shot .pxc donation, called by PixelCache when a decode buffered the whole
+// image in PSRAM: rather than have the ~12 render passes that follow re-read the
+// file the decode just wrote, the buffer is handed straight to the render cache.
+// `pxcImage` must be one heap_caps_malloc block (MALLOC_CAP_SPIRAM) holding
+// exactly `byteCount` bytes in the format above. On true the cache takes
+// ownership and frees the block when the slot is evicted; on false the caller
+// keeps it. Caller must hold the RenderLock (see the cache's threading note in
+// ImageBlock.cpp, which is where this is implemented).
+bool adoptPxcImage(const std::string& cachePath, uint8_t* pxcImage, size_t byteCount);
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -238,6 +238,9 @@ build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4PRO=1
   -DBOARD_HAS_PSRAM
+  ; Whole in-book images live in a PSRAM LRU across page turns instead of the
+  ; internal-RAM slot that only survives one page render. Needs PSRAM.
+  -DCROSSPOINT_PSRAM_IMAGE_CACHE
   -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4pro\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=2

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -3,6 +3,9 @@
 #include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Memory.h>
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+#include <Epub/blocks/ImageBlock.h>  // PSRAM render cache, released below
+#endif
 
 #include <algorithm>
 
@@ -71,6 +74,13 @@ void ReaderActivity::onEnter() {
 
 void ReaderActivity::onExit() {
   Activity::onExit();
+
+#ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
+  // ~750 KB of PSRAM at full occupancy, holding decoded pages of a book nothing
+  // outside the reader will draw again. onExit runs with the RenderLock held
+  // (ActivityManager::exitActivity), which is the cache's access rule.
+  ImageBlock::clearPxcLru();
+#endif
 
   renderer.setOrientation(GfxRenderer::Orientation::Portrait);
   APP_STATE.readerActivityLoadCount = 0;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop in-book images re-streaming their `.pxc` off SD on every render pass. An anti-aliased image page renders ~13 times (BW double-refresh plus every band of both gray planes), and today each pass re-reads the whole pixel cache from the card. Column clipping can't help — the row stride (~100 B) is smaller than an SD sector, so a strip pass touches every sector anyway. The current mitigation is a single per-page-render slot in internal RAM, chunked into 6×16 KB because a contiguous 96 KB rarely fits a fragmented mid-render heap, and dropped when the page render ends. It only ever holds **one** image, so the second image on a page re-streams itself ~13 times, and a back-turn re-streams everything.

* **What changes are included?**
  - New flag `CROSSPOINT_PSRAM_IMAGE_CACHE`, **default off**, enabled in `[env:x4pro]` only (PSRAM board — same precedent as #3032 enabling `FREEINK_FRONTLIGHT_LS` there). Every other env compiles and behaves exactly as today.
  - `lib/Epub/Epub/blocks/ImageBlock.{h,cpp}`: under the flag, the single internal-RAM slot becomes an **8-entry LRU of whole `.pxc` images** in PSRAM (one contiguous `heap_caps_malloc(MALLOC_CAP_SPIRAM)` block each, keyed by the hash of the cache path, storing width/height) that **outlives the page render**. Every pass of every image on a page hits RAM, and a back-turn or re-visit while an image is resident costs no SD access at all. Eviction is LRU (own entry → empty slot → least recently used); a slot reuses its block when the new image fits. `hasValidCache()` consults the LRU before the file, so the page-turn decode probe costs no SD access for resident images. Without the flag the chunked internal-RAM slot is compiled in unchanged.
  - `lib/Epub/Epub/converters/PixelCache.h`: **one-shot `.pxc` writes**. With the payload cap in reach, the band can simply *be* the whole image — one PSRAM block holds a complete `.pxc` (4-byte header + payload), `advanceTo()` has nothing to flush, and `finalize()` emits the file in a **single write** instead of the ~40 interleaved 3 KB band flushes a full-page image costs today. The block is pre-zeroed so rows a clipped image never covers stay black, matching the banded path's zero-fill exactly.
  - **Donation**: on a successful one-shot finalize the block is handed straight to the render cache instead of making the ~12 passes that follow read back the file the decode just wrote. Ownership transfers only on success; the callee re-derives width/height from the block's own header and rejects anything whose size is not exactly `4 + ((w+3)/4)*h`.
  - `lib/Epub/Epub/converters/PxcFormat.h` (new): the on-disk `.pxc` constants and the donation hook, so the converter no longer has to include the block layer for what is only a file format.
  - `src/activities/reader/ReaderActivity.cpp`: one line in `onExit()` — `ImageBlock::clearPxcLru()` gives the PSRAM back when leaving the reader, where the slots can no longer be hit. `onExit` runs with the RenderLock held (`ActivityManager::exitActivity`), which is the cache's access rule.

Memory budget: 8 slots × at most 96,004 B ≈ **750 KB of the 8 MB PSRAM**, held only while the reader is open. Internal RAM use goes *down* on the flagged build (the 96 KB chunked slot is gone). The 96,000 B payload cap is a full-screen 800×480 image at 2 bpp; anything larger is refused and takes the streaming path.

Staleness is handled the same way the on-disk header check does it: a hit is only used when the slot's width/height match the block's expected size within ±1, because re-layout (font size, orientation, margins) recomputes an image's box without changing its path. A mismatch drops the entry and falls through to the file, which is itself about to be rejected and re-decoded.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does. This is a pure performance change to the existing image path — no new user-facing surface, no new setting.
- [x] This PR touches neither `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, nor recovery code.

## Additional Context

* **Tested working on X4 Pro hardware by the submitter.** Multi-image pages, back-turns, AA rendering on image pages, and multi-day reading — including a combined build that also runs light sleep. Image pages no longer stall re-reading the card on every grayscale band, and the second image on a page is now as fast as the first.
* **Adversarially reviewed** before submission, with the findings folded in: LRU lock discipline (every access is on a task holding the RenderLock — verified for both the render path and the decode path; the cache has no lock of its own by design), donation validation (the donated block must be exactly one `.pxc` image or it is refused and the caller keeps it), and eviction safety (a reserve that reuses an oversized block zeroes the slot dimensions first, so a slot can never advertise a new hash with the previous occupant's size).
* **Memory impact**: ~750 KB of PSRAM at full occupancy on the 8 MB part, freed on reader exit. Internal RAM is *reduced* on the flagged build — the 6×16 KB chunked slot no longer exists. Flash delta is small (the two paths are mutually exclusive at compile time). Flag-off builds are byte-for-byte the same design as today.
* **Graceful fallback everywhere.** An image past the payload cap, a failed PSRAM allocation, a short read while filling a slot, or a refused donation all land silently on today's streaming behavior. Nothing here is load-bearing for correctness — worst case is the current performance.
* **Areas to focus review on**: the RenderLock invariant on the LRU (`ImageBlock.cpp`'s threading note), the size validation in `adoptPxcImage`, and the `#else` branch of `ImageBlock.cpp` — the only shared edit outside the flag is that the streaming render loop moved into a helper both branches call.
* **Builds**: `pio run -e x4pro` (flag on) and `pio run -e default` (ESP32-C3, flag off) — both SUCCESS.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — implementation and review with Claude Code (Opus subagents under orchestration); all hardware testing done by the submitter on a physical X4 Pro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
