### PR TITLE
feat: page-turn and chapter-build SD elimination for the X4 Pro

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -10,6 +10,63 @@
 
 #include "FsHelpers.h"
 
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+#include <esp_heap_caps.h>
+
+namespace serialization {
+// Cursor over the whole-file PSRAM mirror of book.bin, shaped like HalFile /
+// BufferedFileReader so the entry decoders below run over it unchanged -- the
+// only seam the mirror needs is the reader type handed to them.
+// Every access is clamped to the mirror: a short/corrupt mirror must degrade to
+// truncated reads (empty strings), never an out-of-bounds walk.
+class BookBinMirrorReader {
+ public:
+  BookBinMirrorReader(const uint8_t* base, const size_t size) : base(base), size(size) {}
+
+  size_t read(void* dst, const size_t len) {
+    const size_t n = std::min(len, remaining());
+    memcpy(dst, base + pos, n);
+    pos += n;
+    return n;
+  }
+  size_t remaining() const { return pos < size ? size - pos : 0; }
+  bool seek(const size_t target) {
+    if (target > size) return false;
+    pos = target;
+    return true;
+  }
+
+ private:
+  const uint8_t* base;
+  size_t size;
+  size_t pos = 0;
+};
+
+// serialization:: overloads mirroring the HalFile ones in Serialization.h. These
+// must precede the entry decoders in the anonymous namespace below:
+// readSpineEntryFrom/readTocEntryFrom call serialization::readString by qualified
+// name, which is not subject to ADL, so the overload set is fixed at the point
+// where those templates are defined rather than where they are instantiated.
+template <typename T>
+void readPod(BookBinMirrorReader& in, T& value) {
+  in.read(&value, sizeof(T));
+}
+
+inline void readString(BookBinMirrorReader& in, std::string& s) {
+  uint32_t len = 0;
+  readPod(in, len);
+  // Clamp before resize(): a garbage length out of a corrupt mirror would
+  // otherwise ask for a multi-MB allocation, where the file path is bounded by
+  // what the file can actually supply.
+  const size_t n = std::min(static_cast<size_t>(len), in.remaining());
+  s.resize(n);
+  if (n > 0) {
+    in.read(&s[0], n);
+  }
+}
+}  // namespace serialization
+#endif  // CROSSPOINT_BOOKBIN_PSRAM
+
 namespace {
 constexpr uint8_t BOOK_CACHE_VERSION = 10;  // v10: ignore ambiguous guide text references
 constexpr char bookBinFile[] = "/book.bin";
@@ -165,6 +222,12 @@ bool BookMetadataCache::endWrite() {
 }
 
 bool BookMetadataCache::buildBookBin(const std::string& epubPath, const BookMetadata& metadata) {
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  // book.bin is about to be rewritten, so any mirror of it is stale. (In practice
+  // the build always runs on a freshly constructed cache that was never loaded;
+  // this keeps the invariant local to the one function that invalidates the file.)
+  releaseMirror();
+#endif
   // Open all three files, writing to meta, reading from spine and toc
   if (!Storage.openFileForWrite("BMC", cachePath + bookBinFile, bookFile)) {
     return false;
@@ -458,6 +521,12 @@ void BookMetadataCache::createTocEntry(const std::string& title, const std::stri
 /* ============= READING / LOADING FUNCTIONS ================ */
 
 bool BookMetadataCache::load() {
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  // A second load() on the same object (re-open after a rebuild) must not serve
+  // the previous file's bytes, and must be allowed to mirror the new one.
+  releaseMirror();
+  mirrorLoadAttempted = false;
+#endif
   if (!Storage.openFileForRead("BMC", cachePath + bookBinFile, bookFile)) {
     return false;
   }
@@ -505,6 +574,78 @@ uint32_t BookMetadataCache::getCumulativeSize(const int index) const {
   return cumulativeSizes[index];
 }
 
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+// Mirror the finalized book.bin into PSRAM so spine/TOC lookups become memory
+// reads. Today each getSpineEntry/getTocEntry below costs two SD seeks plus the
+// entry read: the status-bar chapter title pays one on EVERY page render (via
+// Epub::getTocIndexForSpineIndex + getTocItem), and Epub::resolveHrefToSpineIndex
+// (footnote and TOC href resolution) pays an O(n) scan of the whole spine. The
+// file is small -- a few KB to ~200KB on a 1,732-spine omnibus -- and, once
+// written, immutable for the life of the cache: buildBookBin is the only thing
+// that replaces it, and every rewrite is followed by a fresh BookMetadataCache +
+// load().
+//
+// Silent fallback: an oversized file or a failed allocation simply leaves
+// mirror == nullptr, and every read stays on bookFile exactly as before.
+//
+// Filled lazily, on the first spine/TOC lookup, NOT from load(): Epub::load()
+// also runs for cover-thumbnail generation and for metadata probes (title,
+// author, language -- all read straight out of the header), and those never call
+// a getter. Mirroring in load() made every one of them pay a whole-file PSRAM
+// alloc + read + free for a mirror nothing would read.
+void BookMetadataCache::ensureMirror() {
+  if (mirrorLoadAttempted) return;
+  mirrorLoadAttempted = true;  // one attempt per load(), success or not
+  loadMirror();
+}
+
+void BookMetadataCache::loadMirror() {
+  releaseMirror();
+  const size_t size = bookFile.size();
+  if (size == 0) return;
+  if (size > MAX_MIRROR_BYTES) {
+    LOG_DBG("BMC", "book.bin is %u bytes, past the mirror cap; serving from SD", static_cast<unsigned>(size));
+    return;
+  }
+  auto* buf = static_cast<uint8_t*>(heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!buf) {
+    LOG_DBG("BMC", "No PSRAM for a %u-byte book.bin mirror; serving from SD", static_cast<unsigned>(size));
+    return;
+  }
+
+  // The Epub hands this one bookFile handle to every consumer, so borrow it and
+  // put the cursor back: the fallback path and any future writer must see the
+  // handle exactly as the caller left it.
+  const size_t resume = bookFile.position();
+  size_t got = 0;
+  if (bookFile.seek(0)) {
+    while (got < size) {
+      const int n = bookFile.read(buf + got, size - got);
+      if (n <= 0) break;
+      got += static_cast<size_t>(n);
+    }
+  }
+  bookFile.seek(resume);
+
+  if (got != size) {
+    heap_caps_free(buf);
+    LOG_ERR("BMC", "Short read mirroring book.bin (%u/%u); serving from SD", static_cast<unsigned>(got),
+            static_cast<unsigned>(size));
+    return;
+  }
+  mirror = buf;
+  mirrorSize = static_cast<uint32_t>(size);
+  LOG_DBG("BMC", "Mirrored book.bin (%u bytes) into PSRAM", static_cast<unsigned>(mirrorSize));
+}
+
+void BookMetadataCache::releaseMirror() {
+  if (!mirror) return;
+  heap_caps_free(mirror);
+  mirror = nullptr;
+  mirrorSize = 0;
+}
+#endif  // CROSSPOINT_BOOKBIN_PSRAM
+
 BookMetadataCache::SpineEntry BookMetadataCache::getSpineEntry(const int index) {
   if (!loaded) {
     LOG_ERR("BMC", "getSpineEntry called but cache not loaded");
@@ -515,6 +656,27 @@ BookMetadataCache::SpineEntry BookMetadataCache::getSpineEntry(const int index) 
     LOG_ERR("BMC", "getSpineEntry index %d out of range", index);
     return {};
   }
+
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  // Same LUT walk, served from the mirror. This getter (with getTocEntry below)
+  // is the only place book.bin is seeked in read mode after load(), so it is the
+  // whole seam -- and the only pair of callers that make a mirror worth filling,
+  // hence the lazy fill here rather than in load(). Both branches decode through
+  // the same readSpineEntryFrom template, so the entry format keeps exactly one
+  // implementation.
+  ensureMirror();
+  if (mirror) {
+    serialization::BookBinMirrorReader in(mirror, mirrorSize);
+    // A refused seek means the target is past the mirror (short or corrupt
+    // file). Decoding from wherever the cursor happens to sit would return a
+    // well-formed entry for the wrong spine item; give up instead.
+    if (!in.seek(lutOffset + sizeof(uint32_t) * index)) return {};
+    uint32_t spineEntryPos = 0;
+    serialization::readPod(in, spineEntryPos);
+    if (!in.seek(spineEntryPos)) return {};
+    return readSpineEntryFrom(in);
+  }
+#endif
 
   // Seek to spine LUT item, read from LUT and get out data
   bookFile.seek(lutOffset + sizeof(uint32_t) * index);
@@ -534,6 +696,19 @@ BookMetadataCache::TocEntry BookMetadataCache::getTocEntry(const int index) {
     LOG_ERR("BMC", "getTocEntry index %d out of range", index);
     return {};
   }
+
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  // Same lazy fill and same out-of-bounds handling as getSpineEntry above.
+  ensureMirror();
+  if (mirror) {
+    serialization::BookBinMirrorReader in(mirror, mirrorSize);
+    if (!in.seek(lutOffset + sizeof(uint32_t) * spineCount + sizeof(uint32_t) * index)) return {};
+    uint32_t tocEntryPos = 0;
+    serialization::readPod(in, tocEntryPos);
+    if (!in.seek(tocEntryPos)) return {};
+    return readTocEntryFrom(in);
+  }
+#endif
 
   // Seek to TOC LUT item, read from LUT and get out data
   bookFile.seek(lutOffset + sizeof(uint32_t) * spineCount + sizeof(uint32_t) * index);

--- a/lib/Epub/Epub/BookMetadataCache.h
+++ b/lib/Epub/Epub/BookMetadataCache.h
@@ -94,12 +94,45 @@ class BookMetadataCache {
   SpineEntry readSpineEntry(HalFile& file) const;
   TocEntry readTocEntry(HalFile& file) const;
 
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  // Whole-file PSRAM mirror of the finalized book.bin. nullptr = not mirrored,
+  // which is byte-for-byte the historical file path. See loadMirror().
+  uint8_t* mirror = nullptr;
+  uint32_t mirrorSize = 0;
+  // Set by the first ensureMirror(), whether or not it produced a mirror, so a
+  // book.bin that is too big (or a PSRAM refusal) is not re-probed on every
+  // lookup. Cleared only by load(), which is the one path that can make a
+  // previous verdict stale.
+  bool mirrorLoadAttempted = false;
+  // Sanity cap on what gets mirrored. Real book.bin files run from a few KB to
+  // ~200KB (measured on a 1,732-spine omnibus); anything past this is absurd or
+  // corrupt and stays on SD. Sized just past the worst case observed rather than
+  // "surely enough": the cap's job is to refuse a corrupt length before it turns
+  // into a multi-MB PSRAM allocation.
+  static constexpr uint32_t MAX_MIRROR_BYTES = 512u * 1024;
+  // Fill/free the mirror. Both are no-ops that leave bookFile untouched when the
+  // allocation is refused, so every caller keeps working off the file handle.
+  // ensureMirror() is the lazy one-shot entry point the getters call.
+  void ensureMirror();
+  void loadMirror();
+  void releaseMirror();
+#endif
+
  public:
   BookMetadata coreMetadata;
 
   explicit BookMetadataCache(std::string cachePath)
       : cachePath(std::move(cachePath)), lutOffset(0), spineCount(0), tocCount(0), loaded(false), buildMode(false) {}
+#ifdef CROSSPOINT_BOOKBIN_PSRAM
+  ~BookMetadataCache() { releaseMirror(); }
+  // The mirror is a raw owning pointer; the class was never copied (HalFile
+  // members are already move-only), this makes that a compile error rather than
+  // a double free.
+  BookMetadataCache(const BookMetadataCache&) = delete;
+  BookMetadataCache& operator=(const BookMetadataCache&) = delete;
+#else
   ~BookMetadataCache() = default;
+#endif
 
   // Building phase (stream to disk immediately)
   bool beginWrite();

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -23,7 +23,22 @@
 
 // Minimum file size (in bytes) to show indexing popup - smaller chapters don't benefit from it
 constexpr size_t MIN_SIZE_FOR_POPUP = 10 * 1024;  // 10KB
-constexpr size_t PARSE_BUFFER_SIZE = 1024;
+// Bytes handed to expat per parseStep(), i.e. one SD read per step. The 1KB default is
+// sized for the 380KB-RAM C3; boards with headroom can raise it (build flag) to cut the
+// per-chapter SD read count proportionally. XML_GetBuffer owns the allocation, so the
+// cost is one buffer of this size for the lifetime of a build's parser.
+// Constraint: the incremental build's page budget is only checked BETWEEN parse steps
+// (Section::buildSomeMore), so a larger step can overshoot a tick by whatever a single
+// buffer lays out. Acceptable on the S3, the only target that raises it -- but it is
+// also why this should not go much above ~16KB: buildSomeMore runs with the RenderLock
+// held, so the overshoot is added directly to the lock hold time, and that lock is on
+// the page-turn critical path (a turn cannot render until the running tick releases it).
+// Bigger steps buy fewer SD reads and cost page-turn latency during a build; 16KB is
+// where that trade still favors the reader.
+#ifndef CROSSPOINT_PARSE_BUFFER_SIZE
+#define CROSSPOINT_PARSE_BUFFER_SIZE 1024
+#endif
+constexpr size_t PARSE_BUFFER_SIZE = CROSSPOINT_PARSE_BUFFER_SIZE;
 
 // This number comes from PR #73
 // If we have > 750 words buffered up, perform the layout and consume out all but the last line

--- a/platformio.ini
+++ b/platformio.ini
@@ -247,6 +247,14 @@ build_flags =
   ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
   ; change that stops a lit frontlight from blocking sleep.
   -DFREEINK_FRONTLIGHT_LS
+  ; Page-turn and chapter-build SD elimination, all three PSRAM-funded:
+  ; 16KB expat chunks instead of 1KB (16x fewer SD reads per chapter build),
+  ; the idle prewarm's deserialized page kept for the forward turn that wants
+  ; it, and a lazy whole-file PSRAM mirror of book.bin so spine/TOC lookups
+  ; stop seeking the card.
+  -DCROSSPOINT_PARSE_BUFFER_SIZE=16384
+  -DCROSSPOINT_PAGE_CACHE
+  -DCROSSPOINT_BOOKBIN_PSRAM
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -146,6 +146,14 @@ EpubReaderActivity::~EpubReaderActivity() {
     saveProgress(origin.spineIndex, origin.pageNumber, 0);
   }
 
+#ifdef CROSSPOINT_PAGE_CACHE
+  // ActivityManager destroys the current activity from exitActivity(), which its
+  // callers reach with the RenderLock held, so this teardown is locked exactly as
+  // the fill and consume paths are. Freed here, ahead of the section/epub teardown
+  // and the read-folder move below, rather than left to the member's own
+  // destructor after all of that has run with its heap still pinned.
+  dropCachedPage();
+#endif
   section.reset();
   if (pendingReadFolderMove && epub) {
     const std::string srcPath = epub->getPath();
@@ -288,6 +296,64 @@ void EpubReaderActivity::openDictionaryWordSelect() {
                          [this](const ActivityResult&) { requestUpdate(); });
 }
 
+#ifdef CROSSPOINT_PAGE_CACHE
+void EpubReaderActivity::storeCachedPage(const int pageNumber, std::unique_ptr<Page> page) {
+  // A still-building section re-numbers pages under the entry, so it is never cached.
+  if (!page || !section || section->isBuilding()) return;
+  cachedPage = std::move(page);
+  cachedPageSpine = currentSpineIndex;
+  cachedPageNumber = pageNumber;
+  cachedPageGeneration = sectionGeneration;
+  cachedPagePageCount = section->pageCount;
+  cachedPagePartial = section->isPartial();
+}
+
+std::unique_ptr<Page> EpubReaderActivity::takeCachedPage(const int pageNumber) {
+  if (!cachedPage) return nullptr;
+  if (!section || section->isBuilding() || cachedPageGeneration != sectionGeneration ||
+      cachedPageSpine != currentSpineIndex || cachedPageNumber != pageNumber ||
+      cachedPagePageCount != section->pageCount || cachedPagePartial != section->isPartial()) {
+    // ANY mismatch drops the entry, the page number included (a backward turn, a
+    // menu/bookmark re-render). Keeping it "valid for its own page" instead is
+    // what would let two deserialized Pages be live at once: the render loads
+    // the page it actually wants while the entry still holds the old one, and
+    // the idle prewarm that follows allocates its replacement before the
+    // assignment frees it. One retained Page is the whole heap budget here.
+    dropCachedPage();
+    return nullptr;
+  }
+  auto page = std::move(cachedPage);
+  dropCachedPage();  // consumed: clear the key with it, never leave half an entry
+  return page;
+}
+
+void EpubReaderActivity::dropCachedPage() {
+  cachedPage.reset();
+  cachedPageSpine = -1;
+  cachedPageNumber = -1;
+  // The rest of the key too: a stale generation/pageCount/isPartial left behind
+  // could match a later section by accident. cachedPage == nullptr is the guard
+  // that makes it moot, but a half-cleared key is not a state worth reasoning
+  // about every time one of these fields gains a reader.
+  cachedPageGeneration = 0;
+  cachedPagePageCount = 0;
+  cachedPagePartial = false;
+}
+
+void EpubReaderActivity::onForcedRefreshLocked() {
+  // A forced refresh re-renders the CURRENT page, and the cache entry names the
+  // NEXT one, so takeCachedPage() will miss and drop it -- while the prewarm
+  // markers still name this position, so loop() would never refill it and the
+  // next forward turn would pay a full SD deserialize. Re-arm the prewarm
+  // (markers are only ever read as a pair against the live position, so clearing
+  // the page number alone is enough). Called by ReaderActivity::handleForcedRefresh
+  // under the same RenderLock that loop() takes to move them. The cost of the
+  // re-run is one glyph scan whose fonts are already cached; the point is the
+  // refill.
+  idlePrewarmPage = -1;
+}
+#endif  // CROSSPOINT_PAGE_CACHE
+
 void EpubReaderActivity::loop() {
   if (!epub) {
     finish();
@@ -306,7 +372,8 @@ void EpubReaderActivity::loop() {
       idlePrewarmPage = section->currentPage;
       const int nextPage = section->currentPage + 1;
       if (nextPage < static_cast<int>(section->pageCount)) {
-        if (const auto p = section->loadPage(nextPage)) {
+        auto p = section->loadPage(nextPage);
+        if (p) {
           if (auto* fcm = renderer.getFontCacheManager()) {
             const auto t0 = millis();
             auto scope = fcm->createPrewarmScope();
@@ -314,6 +381,14 @@ void EpubReaderActivity::loop() {
             scope.endScanAndPrewarm();
             LOG_DBG("ERS", "Idle prewarm: page %d in %lums", nextPage, millis() - t0);
           }
+#ifdef CROSSPOINT_PAGE_CACHE
+          // Keep the deserialized page instead of discarding it: the next forward
+          // turn is the render that asks for exactly this (spine, page). The scan
+          // pass does not mutate it (Page::render is const, and the only render-time
+          // state is ImageBlock's static payload cache), so the retained object is
+          // equivalent to a fresh load. Still under the prewarm's RenderLock.
+          storeCachedPage(nextPage, std::move(p));
+#endif
         }
       }
     }
@@ -845,6 +920,12 @@ bool EpubReaderActivity::launchKOReaderSync() {
       nextPageNumber = section->currentPage;
     }
     ImageBlock::setExtractor(nullptr, nullptr);
+#ifdef CROSSPOINT_PAGE_CACHE
+    // Freeing RAM for the handshake is the entire point of this block, and a
+    // retained Page is tens of KB of it. Dropping it here also keeps the
+    // "heap after" log below honest.
+    dropCachedPage();
+#endif
     section.reset();
     epub.reset();
   }
@@ -1028,6 +1109,15 @@ void EpubReaderActivity::renderBook() {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
     section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
+#ifdef CROSSPOINT_PAGE_CACHE
+    // New Section object: anything cached against the old one names a pagination
+    // that no longer exists. This is the ONLY site that installs a `section`, so
+    // it is the single funnel for every reset path (settings, spine, orientation,
+    // footnote nav, jumps, auto-turn toggle, error recovery) -- all of them
+    // section.reset() and come back through here.
+    sectionGeneration++;
+    dropCachedPage();
+#endif
     partialRebuildStartFailed = false;
 
     const bool cacheLoaded = section->loadSectionFile(renderSpec);
@@ -1225,7 +1315,24 @@ void EpubReaderActivity::renderBook() {
   updateBookmarkFlag();
 
   {
+#ifdef CROSSPOINT_PAGE_CACHE
+    // First, the idle prewarm's already-deserialized page, when it names this exact
+    // (spine, page) under an unchanged section -- the forward turn then touches SD
+    // not at all. Consumed here and nowhere else, under the RenderLock that the fill
+    // and every build tick also take: that lock is what keeps the KEY FIELDS
+    // (generation, spine, pageCount, isPartial) from moving between the check and the
+    // use. It does not cover section->currentPage, which pageTurn() moves from the
+    // loop task unlocked -- but that only selects which page is asked for, so a stale
+    // read costs a miss, never a wrong page. A miss falls through.
+    // Note this is a consume, not a fill: renderContents() below moves the Page (and
+    // currentPageFootnotes steals its footnotes first), so the render path cannot
+    // hand a copy back to the cache without a second deserialize. The prewarm is the
+    // only fill site, which is what keeps the cost at one retained Page.
+    auto p = takeCachedPage(section->currentPage);
+    if (!p) p = section->loadPage(section->currentPage);
+#else
     auto p = section->loadPage(section->currentPage);
+#endif
     if (!p) {
       LOG_ERR("ERS", "Failed to load page from SD - clearing section cache");
       automaticPageTurnActive = false;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -4,6 +4,11 @@
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
 
+#ifdef CROSSPOINT_PAGE_CACHE
+// Section.h only forward-declares Page; the cache holds one by value-owning pointer.
+#include <Epub/Page.h>
+#endif
+
 #include <atomic>
 #include <memory>
 #include <optional>
@@ -44,6 +49,61 @@ class EpubReaderActivity final : public ReaderActivity {
   int idlePrewarmSpine = -1;
   int idlePrewarmPage = -1;
   unsigned long lastRenderCompleteMs = 0;
+#ifdef CROSSPOINT_PAGE_CACHE
+  // One-entry deserialized-page cache, filled by the idle prewarm above. That
+  // prewarm already reads (spine, currentPage+1) off SD and deserializes it just
+  // to scan its glyphs, then throws the Page away -- and the very next forward
+  // turn re-opens section.bin, seeks the page LUT and deserializes the same
+  // bytes again, on the page-turn critical path. Keeping the Page instead makes
+  // the forward turn SD-free. Owned here rather than by Section because Section
+  // objects are destroyed and rebuilt constantly, which is exactly what the
+  // cache has to outlive. Owned by EpubReaderActivity rather than ReaderActivity
+  // because the prewarm that fills it is EPUB-only; the TXT and XTC readers that
+  // share the base have no Section and no prewarm.
+  //
+  // Steady-state cost: ONE retained Page (tens of KB of text blocks), live from
+  // the prewarm that fills the entry until the render that consumes it. Never
+  // two: ANY key mismatch, page number included, drops the entry on the spot, so
+  // the next prewarm can't allocate a second Page beside a resident one -- which
+  // is also why a hit-for-its-own-page-later policy is deliberately not offered.
+  //
+  // A hit requires ALL of: same section generation, same spine, same page
+  // number, same pageCount, same isPartial(), and a section that is not
+  // building. Invalidation triggers, enumerated:
+  //  * Section replaced -- settings change, spine change, orientation change,
+  //    footnote navigation (navigateToHref / restoreSavedPosition), page-load
+  //    error recovery, percent/TOC/sync/bookmark jumps, auto-page-turn toggle.
+  //    Every one funnels through section.reset() (24 call sites) plus the ONE
+  //    site that assigns `section` -- renderBook()'s construction path -- which
+  //    bumps sectionGeneration and drops the entry. A reset with no reinstall
+  //    yet is covered too: takeCachedPage() drops on !section.
+  //  * Section re-paginated in place -- only a build does that, so a fill
+  //    requires !isBuilding() and a hit re-checks it. A partial's extension
+  //    build starting (loop() or renderBook()) invalidates immediately, as does
+  //    build progress that re-numbers pages.
+  //  * pageCount / isPartial() moving under an otherwise unchanged Section
+  //    (a build finalizing) -- both are part of the key.
+  // Fill and consume both run under the RenderLock, which is what makes those
+  // key fields coherent. The lock covers the KEY only -- the page number handed
+  // to takeCachedPage comes from section->currentPage, which pageTurn() moves
+  // from the loop task unlocked, so a stale read there can cost a miss and
+  // nothing else.
+  std::unique_ptr<Page> cachedPage;
+  int cachedPageSpine = -1;
+  int cachedPageNumber = -1;
+  uint32_t cachedPageGeneration = 0;
+  uint16_t cachedPagePageCount = 0;
+  bool cachedPagePartial = false;
+  // Bumped every time `section` is installed, so an entry can never be matched
+  // against a different Section object -- a fresh Section can land on the freed
+  // address of the old one, so a pointer alone is not a usable key.
+  uint32_t sectionGeneration = 0;
+  // All three require the RenderLock (see above).
+  void storeCachedPage(int pageNumber, std::unique_ptr<Page> page);
+  std::unique_ptr<Page> takeCachedPage(int pageNumber);
+  void dropCachedPage();
+  void onForcedRefreshLocked() override;
+#endif
   bool bookmarkRemoved = false;
   std::vector<BookmarkEntry> cachedBookmarks;
   bool recentsEntryRemoved = false;

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -196,6 +196,9 @@ bool ReaderActivity::handleForcedRefresh() {
     RenderLock lock(*this);
     pagesUntilFullRefresh = 1;
     forcedRefreshPending = true;
+#ifdef CROSSPOINT_PAGE_CACHE
+    onForcedRefreshLocked();
+#endif
   }
   requestUpdate();
   return true;

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -35,6 +35,14 @@ class ReaderActivity : public Activity {
   virtual void applyInitialOrientation();
   virtual void onEndOfBookRendered() {}
 
+#ifdef CROSSPOINT_PAGE_CACHE
+  // Called from handleForcedRefresh() with the RenderLock already held, before the
+  // re-render is requested. handleForcedRefresh() is final here, so this is how the
+  // EPUB reader (the only subclass with an idle prewarm) re-arms it -- see
+  // EpubReaderActivity::onForcedRefreshLocked().
+  virtual void onForcedRefreshLocked() {}
+#endif
+
   bool handleBackNavigation();
   bool handleEndOfBookMenu(bool suppressConfirmRelease = false);
   bool handleEndOfBookPageTurn(bool prevTriggered, bool nextTriggered);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Take the SD card off the X4 Pro's page-turn and chapter-build hot paths. Three
  independent, flag-gated changes, each of which removes a different class of SD access; the flags are enabled together
  on `[env:x4pro]` in the last commit, and every other environment (the C3 `default` included) is byte-identical to
  before.
* **What changes are included?**

1. **`CROSSPOINT_PARSE_BUFFER_SIZE`** (`ChapterHtmlSlimParser.cpp`) — the expat chunk size was hard-wired to 1024 bytes,
   sized for the 380KB-RAM C3, and each chunk is one SD read, so a 512KB spine costs ~512 SD reads before a single page
   can be laid out. The constant becomes overridable at compile time; `#ifndef` keeps the 1024 default. **Removes ~15/16
   of the SD reads in a chapter build** (16KB chunks on the X4 Pro). `XML_GetBuffer` owns the allocation, so the cost is
   one buffer for the lifetime of a build's parser.

2. **`CROSSPOINT_PAGE_CACHE`** (`EpubReaderActivity`) — the reader's idle glyph prewarm already deserializes
   `(spine, currentPage + 1)` to scan its glyphs, then throws the `Page` away; the very next forward turn re-opens
   `section.bin`, seeks the page LUT and the visible-offset LUT, and deserializes the same bytes again, on the critical
   path. This keeps the prewarmed `Page` in a one-entry cache and hands it to the render that asks for it.
   **Removes the entire page-body SD read from a forward page turn.**

3. **`CROSSPOINT_BOOKBIN_PSRAM`** (`BookMetadataCache`) — every spine/TOC entry costs two SD seeks plus the entry read.
   The status-bar chapter title pays one on *every* page render (`getTocIndexForSpineIndex` + `getTocItem`), and
   `Epub::resolveHrefToSpineIndex` (footnote and TOC href resolution) is an O(n) scan over the whole spine. A lazy
   whole-file PSRAM mirror of `book.bin`, served through the `getSpineEntry`/`getTocEntry` seam, makes those memcpy
   walks. **Removes the per-render and per-href-resolution SD seeks from metadata lookup.**

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — **N/A: this PR touches none of them.** No submodule bump, no HAL change, no
      bootloader/OTA/recovery code. The diff is three source files, two headers, and the `[env:x4pro]` flag list.

## Additional Context

**Tested working on X4 Pro hardware by the submitter**, over multi-day reading — including a combined build with all
three flags on together — across chapter builds, forward and backward turns, footnote jumps, TOC/percent/bookmark
jumps, settings and orientation changes, and KOReader sync.

**Adversarially reviewed.** The two changes with real invalidation surface were re-derived against this branch's
consolidated reader (#3025) rather than ported blind:

* *Page cache invalidation funnel, enumerated exhaustively.* A hit requires **all** of: same section generation, same
  spine, same page number, same `pageCount`, same `isPartial()`, and a section that is not building. `section` is
  assigned at exactly **one** site in `EpubReaderActivity` — `renderBook()`'s construction path — so all 24
  `section.reset()` paths (settings, spine, orientation, footnote nav, error recovery, auto-turn toggle, and every jump)
  funnel back through it; that site bumps a generation counter (not a pointer — a fresh `Section` can land on the freed
  address of the old one) and drops the entry. A reset with no reinstall yet is caught by the `!section` check.
  Re-pagination in place only happens during a build, so a fill requires `!isBuilding()` and a hit re-checks it.
  Beyond the key, the entry is dropped explicitly in the destructor (which `ActivityManager` runs from `exitActivity()`
  with the `RenderLock` held, ahead of the section/epub teardown) and in `launchKOReaderSync()`'s pre-handshake release,
  where freeing RAM is the entire point of the block. `handleForcedRefresh()` is `final` on the base, so it calls a
  flag-gated virtual hook under its existing lock to re-arm the prewarm — otherwise a full-refresh re-render would drop
  the entry with the prewarm markers still naming the current position, and it would never refill.
* *Mirror bounds-checked with fail-soft fallbacks.* Every mirror access is clamped; a refused seek returns `{}` rather
  than decoding a well-formed entry for the wrong item out of a short or corrupt file; string lengths are clamped before
  `resize()`. An empty file, a file past the 512KB sanity cap, a failed PSRAM allocation, or a short read all leave
  `mirror == nullptr` and fall back silently to today's file path. `heap_caps_malloc` is paired with `heap_caps_free`,
  the mirror is released at the top of `load()`, in `buildBookBin()` (the only writer), and in the destructor, and a
  latch means a refused fill is never re-probed. The shared `bookFile` handle is borrowed for the one-time fill with the
  cursor restored, and left open and untouched otherwise.

**Memory.** Both additions are bounded and both are PSRAM-funded on the only board that enables them:

* Page cache: **one** retained `Page` (tens of KB of text blocks), live from the prewarm that fills the entry to the
  render that consumes it — never two. Any key mismatch, the page number included, drops the entry on the spot, so the
  next prewarm cannot allocate a second `Page` beside a resident one. The render path deliberately consumes but never
  fills (`renderContents()` moves the `Page`, and `currentPageFootnotes` steals its footnotes first, so a fill there
  would mean a second deserialize).
* `book.bin` mirror: **≤512 KB** of PSRAM, and in practice a few KB to ~200KB. Filled lazily on the first spine/TOC
  lookup, so cover-thumbnail generation and metadata probes — which read only the header strings — pay nothing.
* Parse buffer: one 16KB buffer for the lifetime of a build's parser, owned by `XML_GetBuffer`. Documented at the
  constant is why it should not go much above that: `buildSomeMore` holds the `RenderLock` across a parse step, so the
  page-budget overshoot is added directly to the lock hold time, and that lock is on the page-turn critical path.

**Each commit is independently revertable** and builds standalone with its own flag off elsewhere.

**Builds:** `pio run -e x4pro` after each commit and `pio run -e default` (C3) after the last — all SUCCESS. Flash and
RAM on `default` are unchanged (all three features compile out).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — implementation and adversarial review with Claude Code;
hardware testing on the X4 Pro was done by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
