### PR TITLE
feat: background section builds and next-chapter preload for the X4 Pro

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -247,6 +247,13 @@ build_flags =
   ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
   ; change that stops a lit frontlight from blocking sleep.
   -DFREEINK_FRONTLIGHT_LS
+  ; Chapter pagination moves off the reader's loop and onto the idle second
+  ; core, in exact page-count ticks under the same RenderLock, with a
+  ; notification-driven idle wait so the task does not hold off light sleep;
+  ; near a chapter end it also pre-loads the next spine's CACHED section so the
+  ; forward boundary turn swaps it in instead of loading synchronously.
+  -DCROSSPOINT_BG_BUILD_TASK
+  -DCROSSPOINT_NEXT_SECTION_PREBUILD
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -370,6 +370,10 @@ RenderLock::RenderLock([[maybe_unused]] Activity&) {
   isLocked = true;
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+RenderLock::RenderLock(TryAcquire) { isLocked = xSemaphoreTake(activityManager.renderingMutex, 0) == pdTRUE; }
+#endif
+
 RenderLock::~RenderLock() {
   if (isLocked) {
     xSemaphoreGive(activityManager.renderingMutex);

--- a/src/activities/RenderLock.h
+++ b/src/activities/RenderLock.h
@@ -9,6 +9,17 @@ class RenderLock {
  public:
   explicit RenderLock();
   explicit RenderLock(Activity&);  // unused for now, but keep for compatibility
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // Non-blocking acquisition for background tasks. A background task must
+  // NEVER park on the rendering mutex: ActivityManager calls onExit() while
+  // holding the RenderLock, and onExit joins the background build task — a
+  // task blocked inside the blocking ctor at that moment would deadlock the
+  // exit. Check locked() before touching guarded state; on false, back off
+  // and retry the whole iteration (the stop flag is re-read each pass).
+  struct TryAcquire {};
+  explicit RenderLock(TryAcquire);
+  bool locked() const { return isLocked; }
+#endif
   RenderLock(const RenderLock&) = delete;
   RenderLock& operator=(const RenderLock&) = delete;
   ~RenderLock();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -158,6 +158,23 @@ EpubReaderActivity::~EpubReaderActivity() {
   }
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+void EpubReaderActivity::onEnter() {
+  ReaderActivity::onEnter();
+  // Only with a book: a failed load has already called finish(), and the task
+  // has nothing to drive.
+  if (epub) startBgBuildTask();
+}
+
+void EpubReaderActivity::onExit() {
+  // Stop the build task before anything else (it dereferences `section` and the
+  // epub, both of which this activity's teardown drops); the join is bounded by
+  // the task's short wait cadence.
+  stopBgBuildTask();
+  ReaderActivity::onExit();
+}
+#endif
+
 bool EpubReaderActivity::loadBook() {
   auto loadedEpub = makeUniqueNoThrow<Epub>(bookPath, "/.crosspoint");
   if (!loadedEpub) {
@@ -288,6 +305,98 @@ void EpubReaderActivity::openDictionaryWordSelect() {
                          [this](const ActivityResult&) { requestUpdate(); });
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+void EpubReaderActivity::bgBuildTaskTrampoline(void* param) {
+  static_cast<EpubReaderActivity*>(param)->bgBuildTaskLoop();
+}
+
+void EpubReaderActivity::startBgBuildTask() {
+  if (bgBuildTaskHandle) return;
+  bgBuildStop.store(false, std::memory_order_relaxed);
+  bgBuildExited.store(false, std::memory_order_relaxed);
+  bgBuildCompleteNotify.store(false, std::memory_order_relaxed);
+  bgBuildFailedNotify.store(false, std::memory_order_relaxed);
+  // Core 0: WiFi's home core, idle while reading (loopTask and the render task
+  // are both pinned to core 1). Priority 1 matches them; the RenderLock is the
+  // ordering authority regardless. Stack: the parse/layout path historically
+  // ran on the 8 KB loop task; 12 KB gives margin for deeper CSS/parser frames.
+  constexpr uint32_t kStack = 12288;
+  if (xTaskCreatePinnedToCore(&bgBuildTaskTrampoline, "ErsBgBuild", kStack, this, 1, &bgBuildTaskHandle, 0) != pdPASS) {
+    bgBuildTaskHandle = nullptr;
+    LOG_ERR("ERS", "Failed to create background build task; falling back to loop ticks");
+  }
+}
+
+void EpubReaderActivity::stopBgBuildTask() {
+  if (!bgBuildTaskHandle) return;
+  // Wake the task out of its (possibly long) idle wait BEFORE raising the stop
+  // flag: at give time the task cannot yet have observed stop=true, so its TCB
+  // is provably alive (give-after-store leaves a theoretical window where the
+  // task polls the flag, self-deletes, and the give hits a freed TCB). Worst
+  // case the woken pass misses the flag and re-sleeps on the short cadence
+  // (this caller holds the RenderLock, so its TryAcquire fails -> ~25 ms),
+  // keeping the join bounded. It cannot start new work either way: everything
+  // it does runs under a TryAcquire this caller's lock defeats.
+  xTaskNotifyGive(bgBuildTaskHandle);
+  bgBuildStop.store(true, std::memory_order_release);
+  while (!bgBuildExited.load(std::memory_order_acquire)) {
+    delay(1);
+  }
+  bgBuildTaskHandle = nullptr;
+}
+
+void EpubReaderActivity::bgBuildTaskLoop() {
+  while (!bgBuildStop.load(std::memory_order_acquire)) {
+    bool didWork = false;
+    // True when this pass could not rule out imminent work (lock contended, or a
+    // build is live but heap-gated this tick) — retry on the short cadence then.
+    bool workPlausible = false;
+    // Active-section build tick: same per-tick RenderLock scope, heap gate, and
+    // page count as the loop pump this replaces — never holds the lock across a
+    // chapter, so pending renders interleave exactly as before. TryAcquire, not
+    // the blocking ctor: parking here would deadlock an exit path that joins
+    // this task while holding the RenderLock (see RenderLock::TryAcquire). All
+    // `section` access happens strictly under the lock: the loop-task idiom of
+    // an unlocked pre-check is a benign stale read there, but this task runs
+    // truly parallel on core 0, where an unlocked deref races ~Section.
+    {
+      RenderLock lock{RenderLock::TryAcquire{}};
+      if (!lock.locked()) {
+        workPlausible = true;
+      } else if (section && section->isBuilding()) {
+        workPlausible = true;
+        if (buildTickHeapGate()) {
+          if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
+            // Reset/redraw belong to the loop task; just report the failure.
+            bgBuildFailedNotify.store(true, std::memory_order_release);
+          } else {
+            didWork = true;
+            if (section->isBuildComplete()) {
+              bgBuildCompleteNotify.store(true, std::memory_order_release);
+            }
+          }
+        }
+      }
+    }
+    if (didWork) {
+      // Back-to-back ticks while there is work; yield one tick so the render
+      // task can take the lock.
+      vTaskDelay(1);
+    } else {
+      // Idle: block on a notification instead of polling, so tickless light
+      // sleep isn't held off by this task all session. renderBook() notifies
+      // after resolving a new render spec (covers build starts, page turns, and
+      // settings changes) and stopBgBuildTask() notifies for exit, so the long
+      // timeout is only a fallback; the short one covers transient lock/heap
+      // declines. Index 0 is this task's own slot — nothing else posts to it.
+      ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(workPlausible ? 25 : 250));
+    }
+  }
+  bgBuildExited.store(true, std::memory_order_release);
+  vTaskDelete(nullptr);
+}
+#endif  // CROSSPOINT_BG_BUILD_TASK
+
 void EpubReaderActivity::loop() {
   if (!epub) {
     finish();
@@ -330,12 +439,40 @@ void EpubReaderActivity::loop() {
     } else {
       LOG_DBG("ERS", "Reader near partial watermark (%d/%d), resuming extension build", section->currentPage,
               section->pageCount);
+#ifdef CROSSPOINT_BG_BUILD_TASK
+      // The one build start that doesn't flow through a render: wake the build
+      // task directly so pickup isn't left to its long idle-wait fallback.
+      if (bgBuildTaskHandle) xTaskNotifyGive(bgBuildTaskHandle);
+#endif
     }
   }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // The core-0 build task owns the pump. Consume its completion/failure
+  // notifications here in the loop task, so section reset, reposition, and
+  // redraw run in their usual context; the loop-tick pump below stays only as
+  // a runtime fallback for the (never observed) case that task creation failed.
+  if (bgBuildFailedNotify.exchange(false, std::memory_order_acq_rel)) {
+    RenderLock lock;
+    LOG_ERR("ERS", "Background section build failed");
+    section.reset();
+    requestUpdate();
+  }
+  if (bgBuildCompleteNotify.exchange(false, std::memory_order_acq_rel)) {
+    RenderLock lock;
+    // cppcheck-suppress knownConditionTrueFalse
+    if (section && section->isBuildComplete() && applyDeferredReposition()) {
+      requestUpdate();
+    }
+  }
+  if (bgBuildTaskHandle == nullptr && section && section->isBuilding() && !RenderLock::peek() &&
+      (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD) &&
+      buildTickHeapGate()) {
+#else
   if (section && section->isBuilding() && !RenderLock::peek() &&
       (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD) &&
       buildTickHeapGate()) {
+#endif
     RenderLock lock;
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
@@ -973,6 +1110,15 @@ void EpubReaderActivity::onReturnFromEndOfBook() {
 }
 
 bool EpubReaderActivity::skipLoopDelay() {
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // With the core-0 build task, loop() no longer needs fast full-clock ticks to
+  // pump the build (the battery cost the loop-driven design paid); only fall
+  // back to loop pacing if the task failed to start. Builds may then run at the
+  // idle CPU clock — slower per page but still seconds per chapter, off-core.
+  // The short-circuit also keeps buildHeapPaused a single-writer field: with the
+  // task alive, only the task calls buildTickHeapGate().
+  if (bgBuildTaskHandle != nullptr) return false;
+#endif
   return section && section->isBuilding() && !buildHeapPaused &&
          (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD);
 }
@@ -1023,6 +1169,15 @@ void EpubReaderActivity::renderBook() {
   buildViewportHeight = viewportHeight;
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // Arm the build task: nearly every state change it cares about (build
+  // started, page turned, spec changed) flows through a render, so one notify
+  // here retires its need to idle-poll — the lazy partial-extension start in
+  // loop() is the exception and notifies directly. The task wakes, fails the
+  // TryAcquire while this render holds the lock, and settles on the short retry
+  // cadence until the lock frees.
+  if (bgBuildTaskHandle) xTaskNotifyGive(bgBuildTaskHandle);
+#endif
 
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -171,6 +171,12 @@ void EpubReaderActivity::onExit() {
   // epub, both of which this activity's teardown drops); the join is bounded by
   // the task's short wait cadence.
   stopBgBuildTask();
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Task is stopped; safe to discard directly. The parked Section never has a
+  // build context, so its destructor touches no shared build state.
+  prebuiltSection.reset();
+  prebuiltSpineIndex = -1;
+#endif
   ReaderActivity::onExit();
 }
 #endif
@@ -378,6 +384,11 @@ void EpubReaderActivity::bgBuildTaskLoop() {
         }
       }
     }
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+    if (!didWork && !bgBuildStop.load(std::memory_order_acquire)) {
+      didWork = prebuildStep();
+    }
+#endif
     if (didWork) {
       // Back-to-back ticks while there is work; yield one tick so the render
       // task can take the lock.
@@ -396,6 +407,61 @@ void EpubReaderActivity::bgBuildTaskLoop() {
   vTaskDelete(nullptr);
 }
 #endif  // CROSSPOINT_BG_BUILD_TASK
+
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+bool EpubReaderActivity::renderSpecEquals(const ReaderRenderSpec& a, const ReaderRenderSpec& b) {
+  return a.fontId == b.fontId && a.lineCompression == b.lineCompression &&
+         a.extraParagraphSpacing == b.extraParagraphSpacing && a.paragraphAlignment == b.paragraphAlignment &&
+         a.viewportWidth == b.viewportWidth && a.viewportHeight == b.viewportHeight &&
+         a.hyphenationEnabled == b.hyphenationEnabled && a.embeddedStyle == b.embeddedStyle &&
+         a.imageRendering == b.imageRendering && a.focusReadingEnabled == b.focusReadingEnabled;
+}
+
+// One prebuild step, run on the background build task when the active section
+// has nothing to build. CACHED-ONLY by design: the prebuild never calls
+// startBuild(), because a second live build context would share the Epub's
+// single CssParser and the html/.bin.part file paths with any build
+// renderBook() starts synchronously — adversarial review found both to be racy.
+// A cache-miss next spine simply falls back to today's boundary behavior. All
+// work — including Section construction and loadSectionFile, which read the
+// shared book.bin metadata handle — happens under the (try-acquired)
+// RenderLock; a cached load is tens of ms, the same order as a build tick.
+// Returns true if it made progress.
+bool EpubReaderActivity::prebuildStep() {
+  RenderLock lock{RenderLock::TryAcquire{}};
+  if (!lock.locked()) return false;
+  // Drop a stale prebuild (reader jumped/paged back, or settings changed). The
+  // parked Section never has a build context, so its destructor touches no
+  // shared build state (no CssParser, no .part commit).
+  if (prebuiltSection && (prebuiltSpineIndex != currentSpineIndex + 1 || !lastRenderSpecValid ||
+                          !renderSpecEquals(prebuiltSpec, lastRenderSpec))) {
+    prebuiltSection.reset();
+    prebuiltSpineIndex = -1;
+    prebuildDeclinedSpine = -1;
+  }
+  if (prebuiltSection) return false;  // parked and ready
+  // Consider prebuilding: current chapter fully built, reader near its end.
+  if (!section || section->isBuilding() || section->isPartial() || !lastRenderSpecValid) return false;
+  if (section->pageCount == 0 || section->currentPage + PREBUILD_NEAR_END_PAGES < static_cast<int>(section->pageCount))
+    return false;
+  if (currentSpineIndex + 1 >= epub->getSpineItemsCount()) return false;
+  const int buildSpine = currentSpineIndex + 1;
+  if (prebuildDeclinedSpine == buildSpine) return false;  // known cache miss; don't re-probe every idle tick
+
+  auto candidate = std::unique_ptr<Section>(new Section(epub, buildSpine, renderer));
+  if (!candidate->loadSectionFile(lastRenderSpec)) {
+    // No usable cache for the next spine. Remember the miss so idle iterations
+    // don't re-open SD files on every wake; cleared when the reader moves on.
+    prebuildDeclinedSpine = buildSpine;
+    return false;
+  }
+  prebuiltSpineIndex = buildSpine;
+  prebuiltSpec = lastRenderSpec;
+  prebuiltSection = std::move(candidate);
+  LOG_DBG("ERS", "Prebuilt next section %d (%s)", buildSpine, prebuiltSection->isPartial() ? "partial" : "ready");
+  return true;
+}
+#endif  // CROSSPOINT_NEXT_SECTION_PREBUILD
 
 void EpubReaderActivity::loop() {
   if (!epub) {
@@ -982,6 +1048,15 @@ bool EpubReaderActivity::launchKOReaderSync() {
       nextPageNumber = section->currentPage;
     }
     ImageBlock::setExtractor(nullptr, nullptr);
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+    // Freeing RAM for the handshake is the entire point of this block, and a
+    // parked prebuild is both a Section of its own and a shared_ptr keeping the
+    // Epub alive past the reset below. Dropping it here also keeps the "heap
+    // after" log honest.
+    prebuiltSection.reset();
+    prebuiltSpineIndex = -1;
+    prebuildDeclinedSpine = -1;
+#endif
     section.reset();
     epub.reset();
   }
@@ -1050,7 +1125,39 @@ bool EpubReaderActivity::pageTurn(bool isForwardTurn) {
       RenderLock lock;
       nextPageNumber = 0;
       currentSpineIndex++;
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+      if (prebuiltSection && prebuiltSpineIndex == currentSpineIndex && lastRenderSpecValid &&
+          renderSpecEquals(prebuiltSpec, lastRenderSpec)) {
+        // Swap the prebuilt Section in: renderBook() sees a loaded section and
+        // skips the synchronous load-or-build entirely. Mirror the cache-hit
+        // side effects of renderBook()'s construction path; a still-building
+        // prebuild continues via the existing incremental machinery.
+        section = std::move(prebuiltSection);
+        prebuiltSpineIndex = -1;
+        prebuildDeclinedSpine = -1;
+        section->currentPage = 0;
+        cachedChapterTotalPageCount = 0;
+        cachedVisibleTextOffset.reset();
+        partialRebuildStartFailed = false;
+#ifdef CROSSPOINT_PAGE_CACHE
+        // Composition hook for PR #3050 (CROSSPOINT_PAGE_CACHE), which keys its
+        // one-entry page cache on sectionGeneration and documents renderBook()
+        // as the only site that installs a `section`. This adoption is the
+        // second such site, and the entry it would leave behind names the
+        // previous chapter's pagination. Undefined on this branch; compiled in
+        // whenever both flags are on, in either merge order.
+        sectionGeneration++;
+        dropCachedPage();
+#endif
+      } else {
+        prebuiltSection.reset();
+        prebuiltSpineIndex = -1;
+        prebuildDeclinedSpine = -1;
+        section.reset();
+      }
+#else
       section.reset();
+#endif
       lastPageTurnTime = millis();
       return true;
     } else {
@@ -1169,6 +1276,13 @@ void EpubReaderActivity::renderBook() {
   buildViewportHeight = viewportHeight;
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Snapshot for the prebuild task (renderBook runs under the RenderLock here;
+  // the task only reads these under the same lock). Also invalidates stale
+  // prebuilds: the task compares its captured spec against this every pass.
+  lastRenderSpec = renderSpec;
+  lastRenderSpecValid = true;
+#endif
 #ifdef CROSSPOINT_BG_BUILD_TASK
   // Arm the build task: nearly every state change it cares about (build
   // started, page turned, spec changed) flows through a render, so one notify

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -3,6 +3,10 @@
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
+#ifdef CROSSPOINT_BG_BUILD_TASK
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#endif
 
 #include <atomic>
 #include <memory>
@@ -74,6 +78,33 @@ class EpubReaderActivity final : public ReaderActivity {
   static constexpr size_t BACKGROUND_BUILD_MIN_MAX_ALLOC = 16 * 1024;
   bool buildTickHeapGate();
   bool buildHeapPaused = false;
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // X4 Pro (dual-core S3): drive section builds from a dedicated task pinned to
+  // core 0 (the Arduino loopTask and the render task both live on core 1)
+  // instead of 2-page ticks stolen from loop(). Same RenderLock discipline and
+  // tick size as the loop pump — the lock is held per 2-page tick, never across
+  // a chapter — but ticks run back-to-back on an otherwise idle core, so a
+  // chapter finalizes in seconds of background time instead of tracking reading
+  // pace, and the BUILD_WINDOW_AHEAD throttle (which exists to ration loop-task
+  // time on a single core) does not apply. Completion/failure are handed back
+  // to the loop task via atomics so reposition/reset/requestUpdate keep running
+  // in their usual task context. If task creation fails, the loop-tick pump
+  // remains as a runtime fallback (gated on bgBuildTaskHandle == nullptr).
+  //
+  // The idle wait is notification-driven, not a poll: a permanent 25 ms tick
+  // would be 40 wakes/s on core 0 for the whole reading session and would hold
+  // the chip out of automatic light sleep, which nothing else about reading
+  // prevents. See bgBuildTaskLoop() for the two cadences and the arming points.
+  TaskHandle_t bgBuildTaskHandle = nullptr;
+  std::atomic<bool> bgBuildStop{false};
+  std::atomic<bool> bgBuildExited{false};
+  std::atomic<bool> bgBuildCompleteNotify{false};
+  std::atomic<bool> bgBuildFailedNotify{false};
+  static void bgBuildTaskTrampoline(void* param);
+  void bgBuildTaskLoop();
+  void startBgBuildTask();
+  void stopBgBuildTask();
+#endif
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr int BUILD_WINDOW_AHEAD = 5;
   static constexpr int PARTIAL_REBUILD_START_MARGIN = 15;
@@ -117,6 +148,10 @@ class EpubReaderActivity final : public ReaderActivity {
       : ReaderActivity("EpubReader", renderer, mappedInput, std::move(bookPath), allowFastInitialRefresh) {}
   ~EpubReaderActivity() override;
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  void onEnter() override;
+  void onExit() override;
+#endif
   void loop() override;
 
   bool pageTurn(bool isForward) override;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -3,6 +3,10 @@
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
+#if defined(CROSSPOINT_NEXT_SECTION_PREBUILD) && !defined(CROSSPOINT_BG_BUILD_TASK)
+#error "CROSSPOINT_NEXT_SECTION_PREBUILD requires CROSSPOINT_BG_BUILD_TASK: the prebuild runs on that task."
+#endif
+
 #ifdef CROSSPOINT_BG_BUILD_TASK
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -104,6 +108,30 @@ class EpubReaderActivity final : public ReaderActivity {
   void bgBuildTaskLoop();
   void startBgBuildTask();
   void stopBgBuildTask();
+#endif
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Prebuild (cache pre-load) of the NEXT spine's Section by the background
+  // build task while the reader sits near the end of a fully-built chapter, so
+  // the forward chapter-boundary turn swaps a ready Section in instead of the
+  // synchronous load. CACHED-ONLY: the prebuild never starts a build — a second
+  // live build context would share the Epub's single CssParser and the
+  // html/.bin.part paths with any build renderBook() starts, both racy.
+  // Everything (construction, loadSectionFile, park, discard, consume) runs
+  // under the try-acquired RenderLock, so the shared book.bin metadata handle
+  // and all reader state are only ever touched serialized. Cache-miss next
+  // spines fall back to today's boundary behavior (remembered in
+  // prebuildDeclinedSpine so idle iterations don't re-probe SD).
+  std::unique_ptr<Section> prebuiltSection;
+  int prebuiltSpineIndex = -1;
+  int prebuildDeclinedSpine = -1;
+  ReaderRenderSpec prebuiltSpec{};
+  // Spec snapshot for the task; written by renderBook() under the RenderLock.
+  ReaderRenderSpec lastRenderSpec{};
+  bool lastRenderSpecValid = false;
+  static bool renderSpecEquals(const ReaderRenderSpec& a, const ReaderRenderSpec& b);
+  bool prebuildStep();
+  // Start prebuilding when the reader is within this many pages of chapter end.
+  static constexpr int PREBUILD_NEAR_END_PAGES = 3;
 #endif
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr int BUILD_WINDOW_AHEAD = 5;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Move chapter pagination off the X4 Pro's reader loop and onto the idle second core,
  and use the time that frees to make the chapter-boundary page turn instant. Two flag-gated commits, both enabled
  together on `[env:x4pro]` in the last commit; every other environment (the C3 `default` included) compiles to today's
  exact behavior.
* **What changes are included?**

1. **`CROSSPOINT_BG_BUILD_TASK`** (`EpubReaderActivity`, `RenderLock`) — today a chapter is paginated in 2-page ticks
   stolen from `loop()`: the reader's own task pauses to parse, the `BUILD_WINDOW_AHEAD` ration keeps the build
   *tracking reading pace* rather than finishing, and `skipLoopDelay()` pins the CPU at full clock for the whole build
   so those ticks come around often enough to matter. On the S3 that work has somewhere better to be — `loopTask` and
   the render task are both on core 1, and core 0 is idle while reading. The flag drives `Section::buildSomeMore` from
   a task pinned to core 0. **Identical per-tick `RenderLock` scope, heap gate, and page count** as the loop pump it
   replaces — the lock is held per 2-page tick, never across a chapter, so pending renders interleave exactly as before
   — but ticks run back-to-back, so a chapter finalizes in seconds of background time, the window ration no longer
   applies, and the full-clock loop spin is retired. Completion and failure hand back to the loop task via atomics, so
   `section` reset, reposition, and redraw keep running in their usual context. **The loop-tick pump stays as a runtime
   fallback**, gated on `bgBuildTaskHandle == nullptr` for the case that task creation fails.

2. **`CROSSPOINT_NEXT_SECTION_PREBUILD`** (requires the task) — a forward turn at a chapter boundary is the slowest
   turn there is: the reader drops the current `Section` and `renderBook()` loads the next spine synchronously, on the
   render task, with the screen already committed. While the reader sits within 3 pages of the end of a fully-built
   chapter, the background task now pre-loads the **next spine's cached `Section`** and parks it; the boundary turn
   adopts it under the `RenderLock` it already takes, and `renderBook()` skips the load-or-build entirely.

**Cached-only by design.** A prebuild-side `startBuild()` would create a second live build context sharing the `Epub`'s
**single `CssParser`** and the `html`/`.bin.part` file paths with any build `renderBook()` starts synchronously —
adversarial review found both to be racy, with no cheap fix that does not amount to a second build context. So the
prebuild only ever *loads a cache*: a cache-miss next spine keeps today's boundary behavior exactly, and the miss is
remembered (`prebuildDeclinedSpine`) so idle passes do not re-probe SD. Everything — construction, `loadSectionFile()`
(which reads the shared `book.bin` metadata handle), park, discard, adopt — happens under the try-acquired
`RenderLock`, so no reader state is ever touched unserialized.

**The idle wait is notification-driven, and that is load-bearing for power.** A permanent 25 ms poll would be 40
wakes/s on core 0 for the whole reading session. Alone that is invisible; combined with automatic light sleep it is
structural sleep denial — nothing about *reading* prevents light sleep, so the poll would hold the chip out of exactly
the state the power work exists to reach. Instead `ulTaskNotifyTake` with two cadences: a **25 ms** retry only while
work is plausible (lock contended, or a live build that was heap-gated this tick), a **250 ms** fallback otherwise.
Arming points: `renderBook()` notifies after resolving the render spec (build starts, page turns, and settings changes
all flow through a render), the lazy partial-extension `startBuild()` in `loop()` notifies directly (the one build
start outside a render), and `stopBgBuildTask()` notifies *before* raising the stop flag. Active builds keep their
back-to-back tick cadence; only the waiting changed.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — **N/A: this PR touches none of them.** No submodule bump, no HAL change, no
      bootloader/OTA/recovery code. `RenderLock.h` / `ActivityManager.cpp` are `src/activities/`, not the SDK or HAL.
      The whole diff is two source files, two headers, and the `[env:x4pro]` flag list.

## Additional Context

**Tested working on X4 Pro hardware by the submitter.** Chapters finalize in the background at exact page counts with
no visible UI-loop stalls; forward boundary turns on cached chapters land with no perceptible boundary pause, and
cache-miss boundaries behave exactly as before. Validated alongside automatic light sleep with PM-profiling data
confirming that the task's idle wait does **not** erode sleep residency — the reason the poll became a notification.
Exercised across chapter builds, forward and backward turns, footnote jumps, TOC/percent/bookmark jumps, settings and
orientation changes, and KOReader sync.

**Adversarially reviewed.** Three findings shaped the final design and are worth reviewer attention:

* *`TryAcquire`, and why the background task must never block on the `RenderLock`.* `ActivityManager::exitActivity()`
  calls `onExit()` **while holding the `RenderLock`**, and `onExit()` joins this task. A task parked in the blocking
  ctor at that moment would deadlock the exit outright. Hence the new non-blocking `RenderLock::TryAcquire` ctor plus
  `locked()`; on a failed acquire the task backs off and retries the whole iteration, re-reading the stop flag. The
  addition is `#ifdef`-guarded, so unflagged builds see the class unchanged. Relatedly, **every** `section` access in
  the task is under the lock: the loop-task idiom of an unlocked pre-check is a benign stale read there, but this task
  is truly parallel, where an unlocked deref races `~Section`.
* *Give-before-store, for TCB liveness.* `stopBgBuildTask()` posts the notification **before** publishing the stop
  flag. At give time the task provably cannot have observed `stop == true`, so it cannot have self-deleted and the give
  cannot land on a freed TCB (the reverse order leaves exactly that window). Worst case the woken pass misses the flag
  and re-sleeps on the short cadence — bounded, because the stopper holds the `RenderLock`, so the woken pass fails its
  `TryAcquire` and settles at ~25 ms. The task cannot start new work in that pass either, for the same reason.
* *Notification index-0 hygiene.* The task uses index 0 as its own private wait slot, and nothing else posts to it —
  the reader never calls `requestUpdate`/`requestUpdateAndWait` from it (completion and failure are atomics consumed by
  the loop task precisely so that reset/reposition/redraw stay on their usual task). `ulTaskNotifyTake(pdTRUE, …)`
  clears the count on every take, so a burst of arming notifies collapses to one pass rather than queueing spins.

**Composes with #3050 (page-turn SD elimination), in either merge order.** #3050's one-entry page cache keys on a
`sectionGeneration` counter bumped at what is currently the *only* site that installs a `section` — `renderBook()`'s
construction path. The prebuild adoption introduces a **second** install site, and the cache entry it would leave
behind names the previous chapter's pagination. The adoption site therefore carries a
`#ifdef CROSSPOINT_PAGE_CACHE` → `sectionGeneration++; dropCachedPage();` hook, naming #3050 in a comment. That flag is
undefined on this branch (so it compiles out here) and compiles in as soon as both are enabled, whichever lands first.
No textual conflict either way — the two hunks are in different functions.

**Memory / flash.** One task: **12 KB stack**, priority 1 (matching `loopTask` and the render task; the `RenderLock` is
the ordering authority regardless), created on reader entry and joined on exit — nothing is allocated when the reader
is not open. 12 KB rather than 8: the parse/layout path historically ran on the 8 KB loop task, and this adds margin
for deeper CSS/parser frames. The prebuild holds at most **one** parked `Section` (a cached page table, not a built
one) and drops it on any spine, spec, or lifecycle change; it is also dropped explicitly in `onExit()` and in
`launchKOReaderSync()`'s pre-handshake release, where freeing RAM is the whole point of the block and the parked
`Section` would otherwise pin the `Epub` past the reset there. Flash on `default` (C3) is unchanged — both features
compile out.

**A follow-up PR** adds background image pre-decode on this same task; this PR is its prerequisite.

**Each commit builds standalone.** `pio run -e x4pro` after commit 1 (flags off) and again with
`PLATFORMIO_BUILD_FLAGS=-DCROSSPOINT_BG_BUILD_TASK` as a compile check; `pio run -e x4pro` (both flags live) and
`pio run -e default` (C3) after commit 2 — all SUCCESS.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — implementation and adversarial review with Claude Code;
hardware testing on the X4 Pro was done by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
