### PR TITLE
feat: background image pre-decode on the build task

### DIFF
--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -13,6 +13,12 @@
 #include "Epub/converters/DirectPixelWriter.h"
 #include "Epub/converters/ImageDecoderFactory.h"
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+#include <Arduino.h>  // millis()/delay() for the background-decode handshake
+
+#include <atomic>
+#endif
+
 // Cache file format:
 // - uint16_t width
 // - uint16_t height
@@ -88,6 +94,68 @@ bool imageFailedThisSession(const std::string& path) {
 void rememberImageFailure(const std::string& path) {
   if (failedImageCount == MAX_SESSION_IMAGE_FAILURES || imageFailedThisSession(path)) return;
   failedImageHashes[failedImageCount++] = imagePathHash(path);
+}
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+// --- Background pre-decode interlock -----------------------------------------
+// AT MOST ONE image decode runs at a time, and the render task always wins.
+//
+// The reader's background task picks its candidates and sets this flag while it
+// still holds the RenderLock, then decodes with the lock released. That
+// ordering is the whole guarantee: a render can only start after the background
+// task released the lock, so it always observes the flag, and the background
+// task can only pick a new candidate while no render is running. Whenever a
+// render is about to decode it therefore stops the background decode first and
+// waits for the acknowledgement.
+//
+// It matters for two independent reasons. (1) Both would be writing the same
+// .pxc if the reader turned onto a page the background task had queued -- and
+// the loser's abort path would delete the winner's file. (2) The PNG decoder
+// object alone is ~44 KB of internal RAM; two live at once can push an
+// allocation over the edge, and a render-path decode that loses that race marks
+// the image failed for the rest of the session.
+//
+// The flag is cleared by the background task wherever its decode ends. A stale
+// `true` is harmless: it costs a render one bounded wait.
+std::atomic<bool> bgDecodeActive{false};
+
+// Which .pxc that decode is producing (imagePathHash of the cache path), so a
+// render can tell "the background task is busy with some other image" from "the
+// background task holds MY file open for write". Only meaningful while
+// bgDecodeActive is true.
+//
+// Plain, not atomic: unlike the flag (cleared with no lock held, wherever the
+// decode ends) this is written only by the background task while it holds the
+// RenderLock and read only by the render task while IT holds the RenderLock, so
+// the lock already serializes the pair -- and a 64-bit atomic on a 32-bit core
+// would be a libatomic call for nothing.
+uint64_t bgDecodeTarget = 0;
+
+// Cap for that wait. The expected cost is one decoder callback (a JPEG MCU row,
+// sub-millisecond to a few ms) plus at most one band flush. The cap only has to
+// cover the one uninterruptible step in a background decode, the ZIP extract of
+// a single image, which is bounded by the image's stored size (typically well
+// under a second). Reaching the cap means something is wrong, and the caller
+// then declines to decode rather than risk a second writer.
+constexpr uint32_t BG_DECODE_CANCEL_TIMEOUT_MS = 5000;
+#endif
+
+// The decode settings for a page image. Single source of truth: render() and
+// the background pre-decode must produce byte-identical cache files, and both
+// the screen clip and the dither phase depend on the absolute position here.
+RenderConfig pageImageDecodeConfig(const std::string& cachePath, const int x, const int y, const int width,
+                                   const int height) {
+  RenderConfig config;
+  config.x = x;
+  config.y = y;
+  config.maxWidth = width;
+  config.maxHeight = height;
+  config.useGrayscale = true;
+  config.useDithering = true;
+  config.performanceMode = false;
+  config.useExactDimensions = true;  // Use pre-calculated dimensions to avoid rounding mismatches
+  config.cachePath = cachePath;      // Enable caching during decode
+  return config;
 }
 
 // --- Per-page-render RAM slot for the pixel cache ----------------------------
@@ -311,6 +379,84 @@ void ImageBlock::clearSessionRenderFailures() { failedImageCount = 0; }
 
 void ImageBlock::releaseRenderCache() { releasePxcSlot(); }
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+ImageToFramebufferDecoder* ImageBlock::backgroundDecoderFor(const std::string& imagePath) {
+  // Called under the RenderLock, which is also what serializes the factory's
+  // lazy singleton creation against the render task and the section build. The
+  // caller keeps the pointer for its unlocked decode rather than calling the
+  // factory again from there, where nothing would serialize that init.
+  return ImageDecoderFactory::getDecoder(imagePath);
+}
+
+void ImageBlock::beginBackgroundDecode(const std::string& imagePath) {
+  // Publish WHICH image before the flag, so a render that observes the flag
+  // observes the matching target with it (both writes happen here, under the
+  // RenderLock; the release store orders them for a reader that somehow sees
+  // the flag first).
+  bgDecodeTarget = imagePathHash(getCachePath(imagePath));
+  bgDecodeActive.store(true, std::memory_order_release);
+}
+
+void ImageBlock::endBackgroundDecode() { bgDecodeActive.store(false, std::memory_order_release); }
+
+bool ImageBlock::backgroundDecodeTargets(const std::string& cachePath) {
+  if (!bgDecodeActive.load(std::memory_order_acquire)) return false;
+  return bgDecodeTarget == imagePathHash(cachePath);
+}
+
+ImageBlock::BgDecodeCancel ImageBlock::cancelBackgroundDecode() {
+  if (!bgDecodeActive.load(std::memory_order_acquire)) return BgDecodeCancel::None;
+
+  ImageToFramebufferDecoder::requestAbort(true);
+  const uint32_t start = millis();
+  while (bgDecodeActive.load(std::memory_order_acquire)) {
+    if (millis() - start >= BG_DECODE_CANCEL_TIMEOUT_MS) {
+      ImageToFramebufferDecoder::requestAbort(false);
+      LOG_ERR("IMG", "Background decode did not stop within %ums", (unsigned)BG_DECODE_CANCEL_TIMEOUT_MS);
+      return BgDecodeCancel::TimedOut;
+    }
+    delay(1);
+  }
+  ImageToFramebufferDecoder::requestAbort(false);
+  LOG_DBG("IMG", "Background decode stopped in %ums", (unsigned)(millis() - start));
+  return BgDecodeCancel::Stopped;
+}
+
+bool ImageBlock::decodeToCacheOnly(GfxRenderer& renderer, ImageToFramebufferDecoder* decoder,
+                                   const std::string& imagePath, const int x, const int y, const int width,
+                                   const int height, const int screenWidth, const int screenHeight) {
+  if (!decoder) return false;
+  // The screen bounds are the ones the caller captured under the RenderLock, and
+  // in cacheOnly mode they are the ONLY ones the converters have: a zero clips
+  // every pixel away, and the all-black .pxc that produces passes every later
+  // header check, so the image would be permanently black until the cache dir is
+  // cleared. Refuse rather than poison the cache.
+  if (screenWidth <= 0 || screenHeight <= 0) {
+    LOG_ERR("IMG", "Pre-decode: bad screen bounds %dx%d for %s", screenWidth, screenHeight, imagePath.c_str());
+    return false;
+  }
+  HalFile file;
+  if (!Storage.openFileForRead("IMG", imagePath, file)) {
+    LOG_DBG("IMG", "Pre-decode: image file not found: %s", imagePath.c_str());
+    return false;
+  }
+  const size_t fileSize = file.size();
+  file.close();
+  if (fileSize == 0) {
+    LOG_DBG("IMG", "Pre-decode: image file is empty: %s", imagePath.c_str());
+    return false;
+  }
+
+  RenderConfig config = pageImageDecodeConfig(getCachePath(imagePath), x, y, width, height);
+  config.cacheOnly = true;
+  config.screenWidth = screenWidth;
+  config.screenHeight = screenHeight;
+  // `renderer` is handed to the decoder interface and never dereferenced in
+  // cacheOnly mode; the converters null out their context pointer up front.
+  return decoder->decodeToFramebuffer(imagePath, renderer, config);
+}
+#endif
+
 void ImageBlock::renderPlaceholder(GfxRenderer& renderer, const int x, const int y) const {
   renderer.fillRect(x, y, width, height, true);
   if (width > 2 && height > 2) {
@@ -356,10 +502,46 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
 
   // Try to render from cache first
   std::string cachePath = getCachePath(imagePath);
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Before the file is even opened for read: if the reader's background
+  // pre-decode is producing THIS .pxc right now, it holds the file open for
+  // write and has only written part of it. Take the image over first, so the
+  // read below sees either the finished file or no usable file at all -- never
+  // a second handle on a half-written one. Only for a matching target: for any
+  // other image the background decode is harmless here and the cancel-and-wait
+  // is pure page-turn latency. Timing out means it is still writing, so decline
+  // the read entirely and draw the placeholder; the next render retries.
+  if (backgroundDecodeTargets(cachePath) && cancelBackgroundDecode() == BgDecodeCancel::TimedOut) {
+    renderPlaceholder(renderer, x, y);
+    return;
+  }
+#endif
+
   if (renderFromCache(renderer, cachePath, x, y, width, height)) {
     renderer.preserveImagePolarity(x, y, width, height);
     return;  // Successfully rendered from cache
   }
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // No cache, so this render is about to extract and decode. Take the image
+  // over from the reader's background pre-decode first: it holds no RenderLock,
+  // so it may be producing this very .pxc, or holding the decoder heap this
+  // decode needs. If it will not stop, draw the placeholder rather than become
+  // a second writer on the same file; the next render retries. (A decode of
+  // this same image was already stopped above; what this catches is one of
+  // another image, whose decoder allocation this decode would fight.)
+  const BgDecodeCancel cancelled = cancelBackgroundDecode();
+  if (cancelled == BgDecodeCancel::TimedOut) {
+    renderPlaceholder(renderer, x, y);
+    return;
+  }
+  // It may have been decoding this very image and finished it on the way out.
+  if (cancelled == BgDecodeCancel::Stopped && renderFromCache(renderer, cachePath, x, y, width, height)) {
+    renderer.preserveImagePolarity(x, y, width, height);
+    return;
+  }
+#endif
 
   // The build only header-probed the image for dimensions; pull the actual
   // file out of the book now, on first visit to the page.
@@ -391,16 +573,7 @@ void ImageBlock::render(GfxRenderer& renderer, const int x, const int y) {
 
   LOG_DBG("IMG", "Decoding and caching: %s", imagePath.c_str());
 
-  RenderConfig config;
-  config.x = x;
-  config.y = y;
-  config.maxWidth = width;
-  config.maxHeight = height;
-  config.useGrayscale = true;
-  config.useDithering = true;
-  config.performanceMode = false;
-  config.useExactDimensions = true;  // Use pre-calculated dimensions to avoid rounding mismatches
-  config.cachePath = cachePath;      // Enable caching during decode
+  const RenderConfig config = pageImageDecodeConfig(cachePath, x, y, width, height);
 
   ImageToFramebufferDecoder* decoder = ImageDecoderFactory::getDecoder(imagePath);
   if (!decoder) {

--- a/lib/Epub/Epub/blocks/ImageBlock.h
+++ b/lib/Epub/Epub/blocks/ImageBlock.h
@@ -6,6 +6,12 @@
 
 #include "Block.h"
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+// Only ever a pointer here: the background pre-decode resolves its decoder
+// under the RenderLock and hands it back for the unlocked decode.
+class ImageToFramebufferDecoder;
+#endif
+
 class ImageBlock final : public Block {
  public:
   ImageBlock(const std::string& imagePath, const std::string& srcPath, int16_t width, int16_t height);
@@ -14,6 +20,11 @@ class ImageBlock final : public Block {
   const std::string& getImagePath() const { return imagePath; }
   int16_t getWidth() const { return width; }
   int16_t getHeight() const { return height; }
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Book-internal href, for a caller that extracts the image itself (see
+  // decodeToCacheOnly). Empty once the file is known to be extracted.
+  const std::string& getSourcePath() const { return srcPath; }
+#endif
 
   bool imageExists() const;
   bool hasValidCache() const;
@@ -27,6 +38,56 @@ class ImageBlock final : public Block {
   // to streaming when it doesn't fit); the reader calls this when the page
   // render completes so nothing stays resident between pages.
   static void releaseRenderCache();
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // --- Background pre-decode ---------------------------------------------------
+  // The reader pre-decodes images on upcoming pages from its background task so
+  // the first view of an image page finds a ready .pxc instead of paying a
+  // multi-second decode on the page-turn critical path. That decode runs with
+  // NO RenderLock held; these statics are what make it safe. The full argument
+  // lives next to their definitions in ImageBlock.cpp.
+
+  // Under the RenderLock: the decoder for this format, or null when there is
+  // none. Resolving it here is not just a capability test -- it is also how
+  // ImageDecoderFactory's lazy singleton creation stays serialized by the lock
+  // (that lazy init is not thread-safe). The caller carries the returned
+  // pointer into its unlocked decode (decodeToCacheOnly) instead of asking the
+  // factory again from there; the singletons are never destroyed, so the
+  // pointer stays valid.
+  static ImageToFramebufferDecoder* backgroundDecoderFor(const std::string& imagePath);
+
+  // Under the RenderLock, immediately before releasing it: publish that a
+  // background decode of `imagePath` is starting. Cleared by the background
+  // task when the decode ends, wherever it ends.
+  static void beginBackgroundDecode(const std::string& imagePath);
+  static void endBackgroundDecode();
+
+  // True when a background decode is in flight AND it is producing exactly this
+  // .pxc. Lets a render take the image over before it opens that file for read,
+  // without paying a cancel-and-wait for images the background task is not
+  // touching. Read from the render task (RenderLock held).
+  static bool backgroundDecodeTargets(const std::string& cachePath);
+
+  // Stop any in-flight background decode and wait (bounded) for it to
+  // acknowledge. Used by render() before it decodes, and by the reader before
+  // it joins the background task.
+  enum class BgDecodeCancel {
+    None,      // nothing was running
+    Stopped,   // it stopped (or had just finished) -- its .pxc may now exist
+    TimedOut,  // it did not stop; the caller must NOT start a decode of its own
+  };
+  static BgDecodeCancel cancelBackgroundDecode();
+
+  // With NO RenderLock held: decode straight into this image's .pxc, touching
+  // neither the renderer nor the framebuffer. `renderer` is forwarded to the
+  // decoder interface and never dereferenced. `decoder` is the pointer the
+  // caller resolved under the lock (see backgroundDecoderFor). The geometry
+  // must be the one a render would use -- both the screen clip and the dither
+  // phase depend on absolute position -- so the file this writes is the file a
+  // render wants.
+  static bool decodeToCacheOnly(GfxRenderer& renderer, ImageToFramebufferDecoder* decoder, const std::string& imagePath,
+                                int x, int y, int width, int height, int screenWidth, int screenHeight);
+#endif
 
   // Lazy extraction hook: the section build only header-probes images for their
   // dimensions; the file at imagePath is extracted out of the book on first

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.cpp
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.cpp
@@ -2,6 +2,18 @@
 
 #include <Logging.h>
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+#include <atomic>
+
+namespace {
+std::atomic<bool> decodeAbort{false};
+}  // namespace
+
+void ImageToFramebufferDecoder::requestAbort(const bool abort) { decodeAbort.store(abort, std::memory_order_release); }
+
+bool ImageToFramebufferDecoder::abortRequested() { return decodeAbort.load(std::memory_order_acquire); }
+#endif
+
 bool ImageToFramebufferDecoder::validateImageDimensions(int width, int height, const std::string& format) {
   if (width * height > MAX_SOURCE_PIXELS) {
     LOG_ERR("IMG", "Image too large (%dx%d = %d pixels %s), max supported: %d pixels", width, height, width * height,

--- a/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
+++ b/lib/Epub/Epub/converters/ImageToFramebufferDecoder.h
@@ -22,6 +22,17 @@ struct RenderConfig {
   float sourceCropY = 0.0f;         // Fraction cropped equally from the top and bottom edges
   bool preserveAlpha = false;       // Skip transparent pixels instead of compositing them against white
   std::string cachePath;            // If non-empty, decoder will write pixel cache to this path
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Produce ONLY the pixel cache: no framebuffer writes, and no interaction
+  // with the renderer whatsoever. The background pre-decode runs on the
+  // reader's build task with no RenderLock held, so it may not read renderer
+  // state either -- which is why the screen bounds the decode clips against are
+  // passed here, captured by the caller while it still held the lock. Requires
+  // a cachePath (a cacheOnly decode with nowhere to write produces nothing).
+  bool cacheOnly = false;
+  int screenWidth = 0;
+  int screenHeight = 0;
+#endif
 };
 
 class ImageToFramebufferDecoder {
@@ -33,6 +44,21 @@ class ImageToFramebufferDecoder {
   virtual bool getDimensions(const std::string& imagePath, ImageDimensions& dims) const = 0;
 
   virtual const char* getFormatName() const = 0;
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Cooperative abort, checked in the converters' per-MCU / per-scanline draw
+  // callbacks and in the pixel cache's write path, so a decode in flight gives
+  // up within one callback instead of running to completion. The decode then
+  // reports failure and drops its partial .pxc.
+  //
+  // Deliberately one global flag rather than per-decode state: both users --
+  // the reader's exit join, and the render task taking an image over from the
+  // background task -- raise it while holding the RenderLock and lower it
+  // before releasing, and no render-task decode can be in flight at either
+  // moment, so the two can never overlap.
+  static void requestAbort(bool abort);
+  static bool abortRequested();
+#endif
 
  protected:
   // Size validation helpers

--- a/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/JpegToFramebufferConverter.cpp
@@ -46,6 +46,16 @@ struct JpegContext {
 
   PixelCache cache;
   bool caching{false};
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Cache-only decode: no framebuffer writes and `renderer` deliberately left
+  // null, so a stray renderer access is a null deref instead of a silent
+  // cross-task read.
+  bool cacheOnly{false};
+  bool aborted{false};  // the draw callback saw the abort flag
+#else
+  static constexpr bool cacheOnly = false;
+#endif
 };
 
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
@@ -120,7 +130,18 @@ constexpr int32_t FP_MASK = FP_ONE - 1;
 
 int jpegDrawCallback(JPEGDRAW* pDraw) {
   JpegContext* ctx = reinterpret_cast<JpegContext*>(pDraw->pUser);
-  if (!ctx || !ctx->config || !ctx->renderer) return 0;
+  if (!ctx || !ctx->config) return 0;
+  const bool cacheOnly = ctx->cacheOnly;
+  if (!cacheOnly && !ctx->renderer) return 0;
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // JPEGDEC treats a 0 return as a clean early stop and still reports success,
+  // so record the abort for decodeToFramebuffer to act on.
+  if (ImageToFramebufferDecoder::abortRequested()) {
+    ctx->aborted = true;
+    return 0;
+  }
+#endif
 
   // In EIGHT_BIT_GRAYSCALE mode, pPixels contains 8-bit grayscale values
   // Buffer is densely packed: stride = pDraw->iWidth, valid columns = pDraw->iWidthUsed
@@ -137,7 +158,6 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   const int32_t invScaleFPX = ctx->invScaleFPX;
   const int32_t fineScaleFPY = ctx->fineScaleFPY;
   const int32_t invScaleFPY = ctx->invScaleFPY;
-  GfxRenderer& renderer = *ctx->renderer;
   const int cfgX = ctx->config->x;
   const int cfgY = ctx->config->y;
   const int blockX = pDraw->x;
@@ -165,9 +185,11 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
 
   if (dstYStart >= dstYEnd || dstXStart >= dstXEnd) return 1;
 
-  // Pre-compute orientation and render-mode state once per callback invocation
+  // Pre-compute orientation and render-mode state once per callback invocation.
+  // A cacheOnly decode never initializes (or uses) the writer: it holds no
+  // RenderLock, so every one of these reads would race the render task.
   DirectPixelWriter pw;
-  pw.init(renderer);
+  if (!cacheOnly) pw.init(*ctx->renderer);
 
   // The cache streams to disk one MCU-row band at a time. Flushing rows below
   // this block (raster order guarantees they are final) repositions the band;
@@ -190,7 +212,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   if (fineScaleFPX == FP_ONE && fineScaleFPY == FP_ONE) {
     for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
       const int outY = cfgY + dstY;
-      pw.beginRow(outY);
+      if (!cacheOnly) pw.beginRow(outY);
       if (caching) cw.beginRow(outY, cacheOriginY);
       const uint8_t* row = &pixels[(dstY - blockY) * stride];
       for (int dstX = dstXStart; dstX < dstXEnd; dstX++) {
@@ -203,7 +225,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
     }
@@ -224,7 +246,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
 
     for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
       const int outY = cfgY + dstY;
-      pw.beginRow(outY);
+      if (!cacheOnly) pw.beginRow(outY);
       if (caching) cw.beginRow(outY, cacheOriginY);
       const int32_t srcFyFP = dstY * invScaleFPY;
       const int32_t fy = srcFyFP & FP_MASK;
@@ -262,7 +284,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
 
@@ -285,7 +307,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
 
@@ -311,7 +333,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
           dithered = gray / 85;
           if (dithered > 3) dithered = 3;
         }
-        pw.writePixel(outX, dithered);
+        if (!cacheOnly) pw.writePixel(outX, dithered);
         if (caching) cw.writePixel(outX, dithered);
       }
     }
@@ -321,7 +343,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
   // === Nearest-neighbor (downscale: fineScale < 1.0) ===
   for (int dstY = dstYStart; dstY < dstYEnd; dstY++) {
     const int outY = cfgY + dstY;
-    pw.beginRow(outY);
+    if (!cacheOnly) pw.beginRow(outY);
     if (caching) cw.beginRow(outY, cacheOriginY);
     const int32_t srcFyFP = dstY * invScaleFPY;
     int ly = (srcFyFP >> FP_SHIFT) - blockY;
@@ -344,7 +366,7 @@ int jpegDrawCallback(JPEGDRAW* pDraw) {
         dithered = gray / 85;
         if (dithered > 3) dithered = 3;
       }
-      pw.writePixel(outX, dithered);
+      if (!cacheOnly) pw.writePixel(outX, dithered);
       if (caching) cw.writePixel(outX, dithered);
     }
   }
@@ -398,10 +420,23 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
   }
 
   JpegContext ctx;
-  ctx.renderer = &renderer;
   ctx.config = &config;
-  ctx.screenWidth = renderer.getScreenWidth();
-  ctx.screenHeight = renderer.getScreenHeight();
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Lock-free background decode: `renderer` is the render task's, so it is not
+  // read at all -- not even for the screen size, which the caller captured
+  // under the RenderLock and passed in the config. Leaving ctx.renderer null
+  // makes any stray access below a null deref instead of a data race.
+  ctx.cacheOnly = config.cacheOnly;
+  if (ctx.cacheOnly) {
+    ctx.screenWidth = config.screenWidth;
+    ctx.screenHeight = config.screenHeight;
+  }
+#endif
+  if (!ctx.cacheOnly) {
+    ctx.renderer = &renderer;
+    ctx.screenWidth = renderer.getScreenWidth();
+    ctx.screenHeight = renderer.getScreenHeight();
+  }
 
   int rc = jpeg->open(imagePath.c_str(), jpegOpen, jpegClose, jpegRead, jpegSeek, jpegDrawCallback);
   const ScopedCleanup cleanup{[&jpeg]() { jpeg->close(); }};
@@ -492,6 +527,11 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
       ctx.caching = false;
     }
   }
+  if (ctx.cacheOnly && !ctx.caching) {
+    // Nothing would come of this decode: it draws nothing and has nowhere to
+    // write. Don't spend seconds finding that out.
+    return false;
+  }
 
   unsigned long decodeStart = millis();
   rc = jpeg->decode(0, 0, jpegScaleOption);
@@ -502,6 +542,17 @@ bool JpegToFramebufferConverter::decodeToFramebuffer(const std::string& imagePat
     if (ctx.caching) ctx.cache.abort();
     return false;
   }
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // An aborted decode stopped mid-image but JPEGDEC still reports success (a 0
+  // from the draw callback is its clean early-exit path), so fail it here and
+  // drop the partial cache.
+  if (ctx.aborted) {
+    LOG_DBG("JPG", "Decode aborted: %s", imagePath.c_str());
+    if (ctx.caching) ctx.cache.abort();
+    return false;
+  }
+#endif
 
   LOG_DBG("JPG", "JPEG decoding complete - render time: %lu ms", decodeTime);
 

--- a/lib/Epub/Epub/converters/PixelCache.h
+++ b/lib/Epub/Epub/converters/PixelCache.h
@@ -8,6 +8,10 @@
 #include <cstring>
 #include <string>
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+#include "ImageToFramebufferDecoder.h"  // decode abort flag, checked below
+#endif
+
 // Streaming cache writer for 2-bit pixels (4 levels). Packs 4 pixels per byte,
 // MSB first.
 //
@@ -122,6 +126,14 @@ struct PixelCache {
   // in which case the caller must stop caching for the rest of the decode.
   bool advanceTo(int newTopRow) {
     if (!ok) return false;
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+    // A decode being torn down must not keep writing bands to SD. Stopping
+    // caching here leaves the file open, so the destructor drops it.
+    if (ImageToFramebufferDecoder::abortRequested()) {
+      ok = false;
+      return false;
+    }
+#endif
     if (newTopRow <= bandStart) return true;
     if (newTopRow > height) newTopRow = height;
 

--- a/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
+++ b/lib/Epub/Epub/converters/PngToFramebufferConverter.cpp
@@ -44,6 +44,16 @@ struct PngContext {
 
   uint8_t* grayLineBuffer{nullptr};
   uint8_t* alphaLineBuffer{nullptr};
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Cache-only decode: no framebuffer writes and `renderer` deliberately left
+  // null, so a stray renderer access is a null deref instead of a silent
+  // cross-task read.
+  bool cacheOnly{false};
+  bool aborted{false};  // the draw callback saw the abort flag
+#else
+  static constexpr bool cacheOnly = false;
+#endif
 };
 
 // File I/O callbacks use pFile->fHandle to access the HalFile*,
@@ -213,7 +223,19 @@ void convertLineToGray(const uint8_t* pPixels, uint8_t* grayLine, int width, int
 
 int pngDrawCallback(PNGDRAW* pDraw) {
   PngContext* ctx = reinterpret_cast<PngContext*>(pDraw->pUser);
-  if (!ctx || !ctx->config || !ctx->renderer || !ctx->grayLineBuffer) return 0;
+  if (!ctx || !ctx->config || !ctx->grayLineBuffer) return 0;
+  const bool cacheOnly = ctx->cacheOnly;
+  if (!cacheOnly && !ctx->renderer) return 0;
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // PNGdec turns a 0 return into PNG_QUIT_EARLY, which already fails the
+  // decode; the flag makes the reason explicit and covers the callback
+  // contract changing under us.
+  if (ImageToFramebufferDecoder::abortRequested()) {
+    ctx->aborted = true;
+    return 0;
+  }
+#endif
 
   int srcY = pDraw->y;
   int srcWidth = ctx->srcWidth;
@@ -247,16 +269,18 @@ int pngDrawCallback(PNGDRAW* pDraw) {
   int screenWidth = ctx->screenWidth;
   bool useDithering = ctx->config->useDithering;
 
-  // Pre-compute orientation and render-mode state once per callback.
+  // Pre-compute orientation and render-mode state once per callback. A
+  // cacheOnly decode never initializes (or uses) the writer: it holds no
+  // RenderLock, so every one of these reads would race the render task.
   DirectPixelWriter pw;
-  pw.init(*ctx->renderer);
+  if (!cacheOnly) pw.init(*ctx->renderer);
 
   for (int dstY = firstDstY; dstY < endDstY; dstY++) {
     ctx->lastDstY = dstY;
     int outY = ctx->config->y + dstY;
     if (outY >= ctx->screenHeight) continue;
 
-    pw.beginRow(outY);
+    if (!cacheOnly) pw.beginRow(outY);
 
     // The cache streams to disk one row at a time. Flushing rows below this one
     // (PNGdec delivers scanlines top to bottom) repositions the single-row band.
@@ -291,7 +315,7 @@ int pngDrawCallback(PNGDRAW* pDraw) {
             ditheredGray = gray / 85;
             if (ditheredGray > 3) ditheredGray = 3;
           }
-          pw.writePixel(outX, ditheredGray, ctx->alphaLineBuffer != nullptr);
+          if (!cacheOnly) pw.writePixel(outX, ditheredGray, ctx->alphaLineBuffer != nullptr);
           if (caching) cw.writePixel(outX, ditheredGray);
         }
       }
@@ -357,10 +381,23 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
 
   PngContext ctx;
   ctx.decoder = png.get();
-  ctx.renderer = &renderer;
   ctx.config = &config;
-  ctx.screenWidth = renderer.getScreenWidth();
-  ctx.screenHeight = renderer.getScreenHeight();
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Lock-free background decode: `renderer` is the render task's, so it is not
+  // read at all -- not even for the screen size, which the caller captured
+  // under the RenderLock and passed in the config. Leaving ctx.renderer null
+  // makes any stray access below a null deref instead of a data race.
+  ctx.cacheOnly = config.cacheOnly;
+  if (ctx.cacheOnly) {
+    ctx.screenWidth = config.screenWidth;
+    ctx.screenHeight = config.screenHeight;
+  }
+#endif
+  if (!ctx.cacheOnly) {
+    ctx.renderer = &renderer;
+    ctx.screenWidth = renderer.getScreenWidth();
+    ctx.screenHeight = renderer.getScreenHeight();
+  }
 
   int rc = png->open(imagePath.c_str(), pngOpenWithHandle, pngCloseWithHandle, pngReadWithHandle, pngSeekWithHandle,
                      pngDrawCallback);
@@ -461,6 +498,11 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
       ctx.caching = false;
     }
   }
+  if (ctx.cacheOnly && !ctx.caching) {
+    // Nothing would come of this decode: it draws nothing and has nowhere to
+    // write. Don't spend seconds finding that out.
+    return false;
+  }
 
   unsigned long decodeStart = millis();
   rc = png->decode(&ctx, 0);
@@ -474,6 +516,16 @@ bool PngToFramebufferConverter::decodeToFramebuffer(const std::string& imagePath
     if (ctx.caching) ctx.cache.abort();
     return false;
   }
+
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Belt and braces: PNGdec fails the decode itself on an early exit, so this
+  // only fires if that contract ever changes.
+  if (ctx.aborted) {
+    LOG_DBG("PNG", "Decode aborted: %s", imagePath.c_str());
+    if (ctx.caching) ctx.cache.abort();
+    return false;
+  }
+#endif
 
   LOG_DBG("PNG", "PNG decoding complete - render time: %lu ms", decodeTime);
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -254,6 +254,12 @@ build_flags =
   ; forward boundary turn swaps it in instead of loading synchronously.
   -DCROSSPOINT_BG_BUILD_TASK
   -DCROSSPOINT_NEXT_SECTION_PREBUILD
+  ; When that task has nothing left to build, it pre-decodes the images on the
+  ; next few pages into their .pxc cache files, so the first view of an image
+  ; page renders from cache (~100 ms) instead of stalling for a multi-second
+  ; extract-and-decode. Requires CROSSPOINT_BG_BUILD_TASK: it IS that task's
+  ; idle work.
+  -DCROSSPOINT_BG_IMAGE_DECODE
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/platformio.ini
+++ b/platformio.ini
@@ -247,6 +247,13 @@ build_flags =
   ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
   ; change that stops a lit frontlight from blocking sleep.
   -DFREEINK_FRONTLIGHT_LS
+  ; Chapter pagination moves off the reader's loop and onto the idle second
+  ; core, in exact page-count ticks under the same RenderLock, with a
+  ; notification-driven idle wait so the task does not hold off light sleep;
+  ; near a chapter end it also pre-loads the next spine's CACHED section so the
+  ; forward boundary turn swaps it in instead of loading synchronously.
+  -DCROSSPOINT_BG_BUILD_TASK
+  -DCROSSPOINT_NEXT_SECTION_PREBUILD
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -370,6 +370,10 @@ RenderLock::RenderLock([[maybe_unused]] Activity&) {
   isLocked = true;
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+RenderLock::RenderLock(TryAcquire) { isLocked = xSemaphoreTake(activityManager.renderingMutex, 0) == pdTRUE; }
+#endif
+
 RenderLock::~RenderLock() {
   if (isLocked) {
     xSemaphoreGive(activityManager.renderingMutex);

--- a/src/activities/RenderLock.h
+++ b/src/activities/RenderLock.h
@@ -9,6 +9,17 @@ class RenderLock {
  public:
   explicit RenderLock();
   explicit RenderLock(Activity&);  // unused for now, but keep for compatibility
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // Non-blocking acquisition for background tasks. A background task must
+  // NEVER park on the rendering mutex: ActivityManager calls onExit() while
+  // holding the RenderLock, and onExit joins the background build task — a
+  // task blocked inside the blocking ctor at that moment would deadlock the
+  // exit. Check locked() before touching guarded state; on false, back off
+  // and retry the whole iteration (the stop flag is re-read each pass).
+  struct TryAcquire {};
+  explicit RenderLock(TryAcquire);
+  bool locked() const { return isLocked; }
+#endif
   RenderLock(const RenderLock&) = delete;
   RenderLock& operator=(const RenderLock&) = delete;
   ~RenderLock();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -158,6 +158,23 @@ EpubReaderActivity::~EpubReaderActivity() {
   }
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+void EpubReaderActivity::onEnter() {
+  ReaderActivity::onEnter();
+  // Only with a book: a failed load has already called finish(), and the task
+  // has nothing to drive.
+  if (epub) startBgBuildTask();
+}
+
+void EpubReaderActivity::onExit() {
+  // Stop the build task before anything else (it dereferences `section` and the
+  // epub, both of which this activity's teardown drops); the join is bounded by
+  // the task's short wait cadence.
+  stopBgBuildTask();
+  ReaderActivity::onExit();
+}
+#endif
+
 bool EpubReaderActivity::loadBook() {
   auto loadedEpub = makeUniqueNoThrow<Epub>(bookPath, "/.crosspoint");
   if (!loadedEpub) {
@@ -288,6 +305,98 @@ void EpubReaderActivity::openDictionaryWordSelect() {
                          [this](const ActivityResult&) { requestUpdate(); });
 }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+void EpubReaderActivity::bgBuildTaskTrampoline(void* param) {
+  static_cast<EpubReaderActivity*>(param)->bgBuildTaskLoop();
+}
+
+void EpubReaderActivity::startBgBuildTask() {
+  if (bgBuildTaskHandle) return;
+  bgBuildStop.store(false, std::memory_order_relaxed);
+  bgBuildExited.store(false, std::memory_order_relaxed);
+  bgBuildCompleteNotify.store(false, std::memory_order_relaxed);
+  bgBuildFailedNotify.store(false, std::memory_order_relaxed);
+  // Core 0: WiFi's home core, idle while reading (loopTask and the render task
+  // are both pinned to core 1). Priority 1 matches them; the RenderLock is the
+  // ordering authority regardless. Stack: the parse/layout path historically
+  // ran on the 8 KB loop task; 12 KB gives margin for deeper CSS/parser frames.
+  constexpr uint32_t kStack = 12288;
+  if (xTaskCreatePinnedToCore(&bgBuildTaskTrampoline, "ErsBgBuild", kStack, this, 1, &bgBuildTaskHandle, 0) != pdPASS) {
+    bgBuildTaskHandle = nullptr;
+    LOG_ERR("ERS", "Failed to create background build task; falling back to loop ticks");
+  }
+}
+
+void EpubReaderActivity::stopBgBuildTask() {
+  if (!bgBuildTaskHandle) return;
+  // Wake the task out of its (possibly long) idle wait BEFORE raising the stop
+  // flag: at give time the task cannot yet have observed stop=true, so its TCB
+  // is provably alive (give-after-store leaves a theoretical window where the
+  // task polls the flag, self-deletes, and the give hits a freed TCB). Worst
+  // case the woken pass misses the flag and re-sleeps on the short cadence
+  // (this caller holds the RenderLock, so its TryAcquire fails -> ~25 ms),
+  // keeping the join bounded. It cannot start new work either way: everything
+  // it does runs under a TryAcquire this caller's lock defeats.
+  xTaskNotifyGive(bgBuildTaskHandle);
+  bgBuildStop.store(true, std::memory_order_release);
+  while (!bgBuildExited.load(std::memory_order_acquire)) {
+    delay(1);
+  }
+  bgBuildTaskHandle = nullptr;
+}
+
+void EpubReaderActivity::bgBuildTaskLoop() {
+  while (!bgBuildStop.load(std::memory_order_acquire)) {
+    bool didWork = false;
+    // True when this pass could not rule out imminent work (lock contended, or a
+    // build is live but heap-gated this tick) — retry on the short cadence then.
+    bool workPlausible = false;
+    // Active-section build tick: same per-tick RenderLock scope, heap gate, and
+    // page count as the loop pump this replaces — never holds the lock across a
+    // chapter, so pending renders interleave exactly as before. TryAcquire, not
+    // the blocking ctor: parking here would deadlock an exit path that joins
+    // this task while holding the RenderLock (see RenderLock::TryAcquire). All
+    // `section` access happens strictly under the lock: the loop-task idiom of
+    // an unlocked pre-check is a benign stale read there, but this task runs
+    // truly parallel on core 0, where an unlocked deref races ~Section.
+    {
+      RenderLock lock{RenderLock::TryAcquire{}};
+      if (!lock.locked()) {
+        workPlausible = true;
+      } else if (section && section->isBuilding()) {
+        workPlausible = true;
+        if (buildTickHeapGate()) {
+          if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
+            // Reset/redraw belong to the loop task; just report the failure.
+            bgBuildFailedNotify.store(true, std::memory_order_release);
+          } else {
+            didWork = true;
+            if (section->isBuildComplete()) {
+              bgBuildCompleteNotify.store(true, std::memory_order_release);
+            }
+          }
+        }
+      }
+    }
+    if (didWork) {
+      // Back-to-back ticks while there is work; yield one tick so the render
+      // task can take the lock.
+      vTaskDelay(1);
+    } else {
+      // Idle: block on a notification instead of polling, so tickless light
+      // sleep isn't held off by this task all session. renderBook() notifies
+      // after resolving a new render spec (covers build starts, page turns, and
+      // settings changes) and stopBgBuildTask() notifies for exit, so the long
+      // timeout is only a fallback; the short one covers transient lock/heap
+      // declines. Index 0 is this task's own slot — nothing else posts to it.
+      ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(workPlausible ? 25 : 250));
+    }
+  }
+  bgBuildExited.store(true, std::memory_order_release);
+  vTaskDelete(nullptr);
+}
+#endif  // CROSSPOINT_BG_BUILD_TASK
+
 void EpubReaderActivity::loop() {
   if (!epub) {
     finish();
@@ -330,12 +439,40 @@ void EpubReaderActivity::loop() {
     } else {
       LOG_DBG("ERS", "Reader near partial watermark (%d/%d), resuming extension build", section->currentPage,
               section->pageCount);
+#ifdef CROSSPOINT_BG_BUILD_TASK
+      // The one build start that doesn't flow through a render: wake the build
+      // task directly so pickup isn't left to its long idle-wait fallback.
+      if (bgBuildTaskHandle) xTaskNotifyGive(bgBuildTaskHandle);
+#endif
     }
   }
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // The core-0 build task owns the pump. Consume its completion/failure
+  // notifications here in the loop task, so section reset, reposition, and
+  // redraw run in their usual context; the loop-tick pump below stays only as
+  // a runtime fallback for the (never observed) case that task creation failed.
+  if (bgBuildFailedNotify.exchange(false, std::memory_order_acq_rel)) {
+    RenderLock lock;
+    LOG_ERR("ERS", "Background section build failed");
+    section.reset();
+    requestUpdate();
+  }
+  if (bgBuildCompleteNotify.exchange(false, std::memory_order_acq_rel)) {
+    RenderLock lock;
+    // cppcheck-suppress knownConditionTrueFalse
+    if (section && section->isBuildComplete() && applyDeferredReposition()) {
+      requestUpdate();
+    }
+  }
+  if (bgBuildTaskHandle == nullptr && section && section->isBuilding() && !RenderLock::peek() &&
+      (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD) &&
+      buildTickHeapGate()) {
+#else
   if (section && section->isBuilding() && !RenderLock::peek() &&
       (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD) &&
       buildTickHeapGate()) {
+#endif
     RenderLock lock;
     if (section->isBuilding() && buildTickHeapGate()) {
       if (!section->buildSomeMore(BACKGROUND_BUILD_PAGES_PER_TICK)) {
@@ -973,6 +1110,15 @@ void EpubReaderActivity::onReturnFromEndOfBook() {
 }
 
 bool EpubReaderActivity::skipLoopDelay() {
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // With the core-0 build task, loop() no longer needs fast full-clock ticks to
+  // pump the build (the battery cost the loop-driven design paid); only fall
+  // back to loop pacing if the task failed to start. Builds may then run at the
+  // idle CPU clock — slower per page but still seconds per chapter, off-core.
+  // The short-circuit also keeps buildHeapPaused a single-writer field: with the
+  // task alive, only the task calls buildTickHeapGate().
+  if (bgBuildTaskHandle != nullptr) return false;
+#endif
   return section && section->isBuilding() && !buildHeapPaused &&
          (section->isPartial() || static_cast<int>(section->pageCount) < section->currentPage + BUILD_WINDOW_AHEAD);
 }
@@ -1023,6 +1169,15 @@ void EpubReaderActivity::renderBook() {
   buildViewportHeight = viewportHeight;
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // Arm the build task: nearly every state change it cares about (build
+  // started, page turned, spec changed) flows through a render, so one notify
+  // here retires its need to idle-poll — the lazy partial-extension start in
+  // loop() is the exception and notifies directly. The task wakes, fails the
+  // TryAcquire while this render holds the lock, and settles on the short retry
+  // cadence until the lock frees.
+  if (bgBuildTaskHandle) xTaskNotifyGive(bgBuildTaskHandle);
+#endif
 
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -2,6 +2,9 @@
 
 #include <Epub/Page.h>
 #include <Epub/blocks/TextBlock.h>
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+#include <Epub/converters/ImageToFramebufferDecoder.h>  // pre-decode abort flag
+#endif
 #include <FontCacheManager.h>
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
@@ -322,6 +325,17 @@ void EpubReaderActivity::startBgBuildTask() {
   bgBuildExited.store(false, std::memory_order_relaxed);
   bgBuildCompleteNotify.store(false, std::memory_order_relaxed);
   bgBuildFailedNotify.store(false, std::memory_order_relaxed);
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // The pre-decode interlock is process-global, not per-task, and a previous
+  // stop can leave it dirty: a cancel that timed out returns with bgDecodeActive
+  // still true (the decode it gave up on ends by clearing it, but nothing
+  // guarantees that happened before the join), and any path that raised the
+  // abort flag lowers it in its own scope. Clear both here so a restarted task
+  // does not inherit "a decode is running" (every render would then pay a
+  // cancel-and-wait) or "abort" (the first pre-decode would bail instantly).
+  ImageBlock::endBackgroundDecode();
+  ImageToFramebufferDecoder::requestAbort(false);
+#endif
   // Core 0: WiFi's home core, idle while reading (loopTask and the render task
   // are both pinned to core 1). Priority 1 matches them; the RenderLock is the
   // ordering authority regardless. Stack: the parse/layout path historically
@@ -341,10 +355,22 @@ void EpubReaderActivity::stopBgBuildTask() {
   // task polls the flag, self-deletes, and the give hits a freed TCB). Worst
   // case the woken pass misses the flag and re-sleeps on the short cadence
   // (this caller holds the RenderLock, so its TryAcquire fails -> ~25 ms),
-  // keeping the join bounded. It cannot start new work either way: everything
-  // it does runs under a TryAcquire this caller's lock defeats.
+  // keeping the join bounded. It cannot start new work either way: every step
+  // is picked under a TryAcquire this caller's lock defeats.
   xTaskNotifyGive(bgBuildTaskHandle);
   bgBuildStop.store(true, std::memory_order_release);
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // A pre-decode in flight would otherwise hold the join for its whole
+  // remaining runtime (seconds), so cancel it -- but only AFTER the stop flag
+  // is published. The cancel can time out (its 5 s cap covers the un-abortable
+  // ZIP extract), and it lowers the abort flag on the way out; with the store
+  // after the cancel, a task sitting between the extract and the decode saw
+  // neither flag raised and went on to run a full multi-second decode inside
+  // the join. Reusing the same cancel-and-wait the render path uses also means
+  // the abort flag is raised and lowered inside one RenderLock scope, which is
+  // what keeps that global flag from ever touching a render-task decode.
+  ImageBlock::cancelBackgroundDecode();
+#endif
   while (!bgBuildExited.load(std::memory_order_acquire)) {
     delay(1);
   }
@@ -387,6 +413,14 @@ void EpubReaderActivity::bgBuildTaskLoop() {
 #ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
     if (!didWork && !bgBuildStop.load(std::memory_order_acquire)) {
       didWork = prebuildStep();
+    }
+#endif
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+    // Lowest-priority idle work: it is the only step here that runs for seconds
+    // with the lock released, so it goes after everything the reader is
+    // actually waiting on.
+    if (!didWork && !bgBuildStop.load(std::memory_order_acquire)) {
+      didWork = imageDecodeStep(workPlausible);
     }
 #endif
     if (didWork) {
@@ -463,6 +497,201 @@ bool EpubReaderActivity::prebuildStep() {
 }
 #endif  // CROSSPOINT_NEXT_SECTION_PREBUILD
 
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+// One image pre-decode step, run on the background build task when there is
+// nothing left to build or prebuild. First view of an in-book image costs a
+// 0.5-3 s decode today, taken inside the render behind a placeholder pass; this
+// moves it off the page-turn critical path by decoding the images of upcoming
+// pages into their .pxc files ahead of time.
+//
+// Two phases, and the split is the whole design:
+//
+// UNDER the (try-acquired) RenderLock -- everything that touches reader state:
+// pick the nearest lookahead page not already ruled out, deserialize it,
+// find the first image with no usable cache, and capture its path, source
+// href and geometry AS VALUES. Also captured: a shared_ptr copy of the Epub,
+// the decoder pointer (resolving it touches ImageDecoderFactory's non-
+// thread-safe lazy init, which only the lock serializes), and the "a background
+// decode is running" flag plus the image it is running on (published here,
+// before the lock is released, so no render can start without seeing them).
+//
+// WITHOUT the lock: extract the image out of the book if needed, then decode it
+// in cacheOnly mode. Both steps touch only the SD card through Storage (which
+// is mutex'd per operation), the pixel cache, and the heap -- no Section, no
+// Epub member, no renderer.
+//
+// Why a shared_ptr copy of the Epub rather than ImageBlock's extractor hook:
+// that hook's context is a raw Epub*, and launchKOReaderSync() drops the Epub
+// under the RenderLock WITHOUT joining this task, to free RAM for the TLS
+// handshake. (onExit's clear is safe -- it happens after stopBgBuildTask()
+// joins -- but the sync path's is not.) A shared_ptr copy keeps the object
+// alive for the length of this step no matter which path runs.
+//
+// Staleness is a non-issue: a .pxc is keyed by the image, not by the page it
+// appears on, so re-pagination cannot invalidate one. The only correctness
+// requirement is that two decoders never write the same file, which the
+// ImageBlock interlock handles (see the note there).
+bool EpubReaderActivity::imageDecodeStep(bool& workPlausible) {
+  std::shared_ptr<Epub> epubRef;
+  // Resolved under the lock and carried into the unlocked phase: the factory's
+  // lazy singleton init is not thread-safe, so it must not be reached from
+  // there (see ImageBlock::backgroundDecoderFor).
+  ImageToFramebufferDecoder* decoder = nullptr;
+  std::string imagePath;
+  std::string srcPath;
+  int x = 0;
+  int y = 0;
+  int width = 0;
+  int height = 0;
+  int screenWidth = 0;
+  int screenHeight = 0;
+  int offset = 0;
+
+  {
+    RenderLock lock{RenderLock::TryAcquire{}};
+    if (!lock.locked()) {
+      workPlausible = true;
+      return false;
+    }
+    // A building section re-numbers pages under the scan, and the margins
+    // snapshot only exists once a render has happened.
+    if (!epub || !section || section->isBuilding() || !lastRenderMarginsValid) return false;
+
+    // The cursor belongs to one reading position; the reader moving re-arms the
+    // whole window. Only this task touches these three.
+    if (imageDecodeSpine != currentSpineIndex || imageDecodeBasePage != section->currentPage) {
+      imageDecodeSpine = currentSpineIndex;
+      imageDecodeBasePage = section->currentPage;
+      imageDecodeDeclined = 0;
+    }
+    if (ESP.getFreeHeap() < IMAGE_DECODE_MIN_FREE_HEAP || ESP.getMaxAllocHeap() < IMAGE_DECODE_MIN_MAX_ALLOC)
+      return false;
+
+    std::unique_ptr<Page> page;
+    // The page this scan reads: either `page` above, or the resident cache entry
+    // borrowed in place (see below). Valid only inside this locked scope.
+    const Page* scanPage = nullptr;
+    for (int i = 1; i <= IMAGE_DECODE_LOOKAHEAD; i++) {
+      if (imageDecodeDeclined & (1u << i)) continue;
+      const int pageNumber = section->currentPage + i;
+      if (pageNumber >= static_cast<int>(section->pageCount)) {
+        imageDecodeDeclined |= (1u << i);  // past the end of the chapter
+        continue;
+      }
+      offset = i;
+#if defined(CROSSPOINT_PAGE_CACHE) && defined(CROSSPOINT_BG_IMAGE_DECODE)
+      // Composition hook for PR #3050 (CROSSPOINT_PAGE_CACHE), whose one-entry
+      // page cache usually holds exactly this page (currentPage + 1 is the first
+      // lookahead slot); deserializing a second copy of it would cost the SD read
+      // that cache exists to avoid, plus a second live Page. Borrow it instead:
+      // the scan below is read-only (const element access), so nothing here can
+      // disturb the entry the next forward turn is going to consume. Full key
+      // check, same fields and same lock as takeCachedPage -- minus the consume:
+      // the entry is left in place, and any mismatch just falls through to the
+      // deserialize. Undefined on this branch; compiled in whenever both flags
+      // are on, in either merge order.
+      if (cachedPage && cachedPageGeneration == sectionGeneration && cachedPageSpine == currentSpineIndex &&
+          cachedPageNumber == pageNumber && cachedPagePageCount == section->pageCount &&
+          cachedPagePartial == section->isPartial()) {
+        scanPage = cachedPage.get();
+        break;
+      }
+#endif
+      page = section->loadPage(pageNumber);
+      scanPage = page.get();
+      break;
+    }
+    if (offset == 0) return false;  // window exhausted until the reader moves
+    if (!scanPage) {
+      imageDecodeDeclined |= (1u << offset);
+      return false;
+    }
+
+    screenWidth = renderer.getScreenWidth();
+    screenHeight = renderer.getScreenHeight();
+    for (const auto& element : scanPage->elements) {
+      if (element->getTag() != TAG_PageImage) continue;
+      const auto& pageImage = static_cast<const PageImage&>(*element);
+      const ImageBlock& block = pageImage.getImageBlock();
+      if (!block.needsDecode()) continue;
+      // Exactly the geometry ImageBlock::render() would use, including its
+      // bounds check: an image the render would reject is not worth decoding.
+      const int px = pageImage.xPos + lastRenderMarginLeft;
+      const int py = pageImage.yPos + lastRenderMarginTop;
+      if (px < 0 || py < 0 || px + block.getWidth() > screenWidth || py + block.getHeight() > screenHeight) continue;
+      decoder = ImageBlock::backgroundDecoderFor(block.getImagePath());
+      if (!decoder) continue;  // no decoder for this format
+      imagePath = block.getImagePath();
+      srcPath = block.getSourcePath();
+      x = px;
+      y = py;
+      width = block.getWidth();
+      height = block.getHeight();
+      break;
+    }
+    if (imagePath.empty()) {
+      imageDecodeDeclined |= (1u << offset);  // nothing left to decode on this page
+      return false;
+    }
+
+    epubRef = epub;
+    ImageBlock::beginBackgroundDecode(imagePath);
+  }
+
+  // ---- No RenderLock held from here ----------------------------------------
+  if (!srcPath.empty() && !Storage.exists(imagePath.c_str())) {
+    // The one step of this that cannot be aborted; it is bounded by the
+    // image's stored size (see BG_DECODE_CANCEL_TIMEOUT_MS).
+    if (!epubRef->extractItemToFile(srcPath, imagePath)) {
+      LOG_DBG("ERS", "Pre-decode extraction failed: %s", srcPath.c_str());
+    }
+  }
+
+  bool decoded = false;
+  // Whoever wanted this decode stopped raised the abort flag while we were in
+  // the extract above, which is the one step that cannot honor it. Starting the
+  // decode anyway is the bad case: the canceller may give up waiting and lower
+  // the flag (BG_DECODE_CANCEL_TIMEOUT_MS) precisely because the extract took
+  // that long, and the decode would then run to completion -- as a second
+  // writer on the file the render task is about to produce, or for seconds
+  // inside an exit join.
+  bool aborted = ImageToFramebufferDecoder::abortRequested();
+  if (!aborted && !bgBuildStop.load(std::memory_order_acquire)) {
+    const unsigned long t0 = millis();
+    decoded =
+        ImageBlock::decodeToCacheOnly(renderer, decoder, imagePath, x, y, width, height, screenWidth, screenHeight);
+    if (decoded) {
+      LOG_DBG("ERS", "Pre-decoded %s in %lums", imagePath.c_str(), millis() - t0);
+    } else {
+      // Read BEFORE endBackgroundDecode(): a canceller only lowers the flag
+      // once it observes the decode has stopped, so while the "active" flag is
+      // still up the abort flag cannot go back down under this read.
+      aborted = ImageToFramebufferDecoder::abortRequested();
+    }
+  }
+  ImageBlock::endBackgroundDecode();
+
+  if (aborted) {
+    // Not a property of the image: the render task took it over (or the reader
+    // is leaving). Declining here would disarm this lookahead slot until the
+    // reader moves, and on an image-dense chapter the takeover happens on
+    // exactly the pages worth pre-decoding. Leave the cursor alone and retry.
+    LOG_DBG("ERS", "Pre-decode aborted: %s", imagePath.c_str());
+    return false;
+  }
+  if (!decoded) {
+    // Heap, format, or a corrupt file -- a property of this image, so stop
+    // offering this page: the render path still decodes whatever it needs, and
+    // retrying here every 25 ms would not help.
+    imageDecodeDeclined |= (1u << offset);
+    return false;
+  }
+  // Deliberately NOT declined on success: the next pass re-scans the same page
+  // for a second image, and declines it once there is nothing left.
+  return true;
+}
+#endif  // CROSSPOINT_BG_IMAGE_DECODE
+
 void EpubReaderActivity::loop() {
   if (!epub) {
     finish();
@@ -498,6 +727,17 @@ void EpubReaderActivity::loop() {
       !partialRebuildStartFailed &&
       section->currentPage + PARTIAL_REBUILD_START_MARGIN >= static_cast<int>(section->pageCount)) {
     RenderLock lock;
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+    // Same reason as the renderBook()-site cancel: this build's parse pump (the
+    // buildSomeMore ticks that follow, wherever they run) extracts images out of
+    // the book to probe their dimensions, and a pre-decode in flight extracts
+    // too, with no lock -- both derive the same destination path from the
+    // book-internal href, so the two would be writing the SAME file. Stop it
+    // before the build exists. The wait is bounded by the cancel timeout and
+    // this is deferrable background work, not a page turn; on a timeout the
+    // overlap stays open exactly as it does at the render site.
+    ImageBlock::cancelBackgroundDecode();
+#endif
     const ReaderRenderSpec buildSpec = SETTINGS.readerRenderSpec(buildViewportWidth, buildViewportHeight);
     if (!section->startBuild(buildSpec)) {
       partialRebuildStartFailed = true;
@@ -1283,6 +1523,15 @@ void EpubReaderActivity::renderBook() {
   lastRenderSpec = renderSpec;
   lastRenderSpecValid = true;
 #endif
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Snapshot for the image pre-decode (same lock, same reason as above): these
+  // are the offsets renderContents hands to Page::render, so an image's on-page
+  // origin is xPos/yPos plus these. The pre-decode must match them exactly --
+  // the screen clip and the dither phase both key off absolute position.
+  lastRenderMarginLeft = static_cast<int16_t>(orientedMarginLeft);
+  lastRenderMarginTop = static_cast<int16_t>(orientedMarginTop);
+  lastRenderMarginsValid = true;
+#endif
 #ifdef CROSSPOINT_BG_BUILD_TASK
   // Arm the build task: nearly every state change it cares about (build
   // started, page turned, spec changed) flows through a render, so one notify
@@ -1296,6 +1545,18 @@ void EpubReaderActivity::renderBook() {
   if (!section) {
     const auto filepath = epub->getSpineItem(currentSpineIndex).href;
     LOG_DBG("ERS", "Loading file: %s, index: %d", filepath.c_str(), currentSpineIndex);
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+    // Everything below -- the Section, its loadSectionFile, and the build this
+    // may start -- can run the chapter parser, which extracts images out of the
+    // book to probe their dimensions. A pre-decode in flight extracts too, with
+    // no lock, and the two would be writing the SAME file (both derive the path
+    // from the book-internal href). Stop it first; the wait is bounded by the
+    // cancel timeout and this is already the slow path (a chapter load), not a
+    // page turn. On a timeout the overlap stays open exactly as it is today --
+    // there is no useful way for a render to decline loading its chapter -- but
+    // that cap is a liveness backstop, not an expected path.
+    ImageBlock::cancelBackgroundDecode();
+#endif
     section = std::unique_ptr<Section>(new Section(epub, currentSpineIndex, renderer));
     partialRebuildStartFailed = false;
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -171,6 +171,12 @@ void EpubReaderActivity::onExit() {
   // epub, both of which this activity's teardown drops); the join is bounded by
   // the task's short wait cadence.
   stopBgBuildTask();
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Task is stopped; safe to discard directly. The parked Section never has a
+  // build context, so its destructor touches no shared build state.
+  prebuiltSection.reset();
+  prebuiltSpineIndex = -1;
+#endif
   ReaderActivity::onExit();
 }
 #endif
@@ -378,6 +384,11 @@ void EpubReaderActivity::bgBuildTaskLoop() {
         }
       }
     }
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+    if (!didWork && !bgBuildStop.load(std::memory_order_acquire)) {
+      didWork = prebuildStep();
+    }
+#endif
     if (didWork) {
       // Back-to-back ticks while there is work; yield one tick so the render
       // task can take the lock.
@@ -396,6 +407,61 @@ void EpubReaderActivity::bgBuildTaskLoop() {
   vTaskDelete(nullptr);
 }
 #endif  // CROSSPOINT_BG_BUILD_TASK
+
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+bool EpubReaderActivity::renderSpecEquals(const ReaderRenderSpec& a, const ReaderRenderSpec& b) {
+  return a.fontId == b.fontId && a.lineCompression == b.lineCompression &&
+         a.extraParagraphSpacing == b.extraParagraphSpacing && a.paragraphAlignment == b.paragraphAlignment &&
+         a.viewportWidth == b.viewportWidth && a.viewportHeight == b.viewportHeight &&
+         a.hyphenationEnabled == b.hyphenationEnabled && a.embeddedStyle == b.embeddedStyle &&
+         a.imageRendering == b.imageRendering && a.focusReadingEnabled == b.focusReadingEnabled;
+}
+
+// One prebuild step, run on the background build task when the active section
+// has nothing to build. CACHED-ONLY by design: the prebuild never calls
+// startBuild(), because a second live build context would share the Epub's
+// single CssParser and the html/.bin.part file paths with any build
+// renderBook() starts synchronously — adversarial review found both to be racy.
+// A cache-miss next spine simply falls back to today's boundary behavior. All
+// work — including Section construction and loadSectionFile, which read the
+// shared book.bin metadata handle — happens under the (try-acquired)
+// RenderLock; a cached load is tens of ms, the same order as a build tick.
+// Returns true if it made progress.
+bool EpubReaderActivity::prebuildStep() {
+  RenderLock lock{RenderLock::TryAcquire{}};
+  if (!lock.locked()) return false;
+  // Drop a stale prebuild (reader jumped/paged back, or settings changed). The
+  // parked Section never has a build context, so its destructor touches no
+  // shared build state (no CssParser, no .part commit).
+  if (prebuiltSection && (prebuiltSpineIndex != currentSpineIndex + 1 || !lastRenderSpecValid ||
+                          !renderSpecEquals(prebuiltSpec, lastRenderSpec))) {
+    prebuiltSection.reset();
+    prebuiltSpineIndex = -1;
+    prebuildDeclinedSpine = -1;
+  }
+  if (prebuiltSection) return false;  // parked and ready
+  // Consider prebuilding: current chapter fully built, reader near its end.
+  if (!section || section->isBuilding() || section->isPartial() || !lastRenderSpecValid) return false;
+  if (section->pageCount == 0 || section->currentPage + PREBUILD_NEAR_END_PAGES < static_cast<int>(section->pageCount))
+    return false;
+  if (currentSpineIndex + 1 >= epub->getSpineItemsCount()) return false;
+  const int buildSpine = currentSpineIndex + 1;
+  if (prebuildDeclinedSpine == buildSpine) return false;  // known cache miss; don't re-probe every idle tick
+
+  auto candidate = std::unique_ptr<Section>(new Section(epub, buildSpine, renderer));
+  if (!candidate->loadSectionFile(lastRenderSpec)) {
+    // No usable cache for the next spine. Remember the miss so idle iterations
+    // don't re-open SD files on every wake; cleared when the reader moves on.
+    prebuildDeclinedSpine = buildSpine;
+    return false;
+  }
+  prebuiltSpineIndex = buildSpine;
+  prebuiltSpec = lastRenderSpec;
+  prebuiltSection = std::move(candidate);
+  LOG_DBG("ERS", "Prebuilt next section %d (%s)", buildSpine, prebuiltSection->isPartial() ? "partial" : "ready");
+  return true;
+}
+#endif  // CROSSPOINT_NEXT_SECTION_PREBUILD
 
 void EpubReaderActivity::loop() {
   if (!epub) {
@@ -982,6 +1048,15 @@ bool EpubReaderActivity::launchKOReaderSync() {
       nextPageNumber = section->currentPage;
     }
     ImageBlock::setExtractor(nullptr, nullptr);
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+    // Freeing RAM for the handshake is the entire point of this block, and a
+    // parked prebuild is both a Section of its own and a shared_ptr keeping the
+    // Epub alive past the reset below. Dropping it here also keeps the "heap
+    // after" log honest.
+    prebuiltSection.reset();
+    prebuiltSpineIndex = -1;
+    prebuildDeclinedSpine = -1;
+#endif
     section.reset();
     epub.reset();
   }
@@ -1050,7 +1125,39 @@ bool EpubReaderActivity::pageTurn(bool isForwardTurn) {
       RenderLock lock;
       nextPageNumber = 0;
       currentSpineIndex++;
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+      if (prebuiltSection && prebuiltSpineIndex == currentSpineIndex && lastRenderSpecValid &&
+          renderSpecEquals(prebuiltSpec, lastRenderSpec)) {
+        // Swap the prebuilt Section in: renderBook() sees a loaded section and
+        // skips the synchronous load-or-build entirely. Mirror the cache-hit
+        // side effects of renderBook()'s construction path; a still-building
+        // prebuild continues via the existing incremental machinery.
+        section = std::move(prebuiltSection);
+        prebuiltSpineIndex = -1;
+        prebuildDeclinedSpine = -1;
+        section->currentPage = 0;
+        cachedChapterTotalPageCount = 0;
+        cachedVisibleTextOffset.reset();
+        partialRebuildStartFailed = false;
+#ifdef CROSSPOINT_PAGE_CACHE
+        // Composition hook for PR #3050 (CROSSPOINT_PAGE_CACHE), which keys its
+        // one-entry page cache on sectionGeneration and documents renderBook()
+        // as the only site that installs a `section`. This adoption is the
+        // second such site, and the entry it would leave behind names the
+        // previous chapter's pagination. Undefined on this branch; compiled in
+        // whenever both flags are on, in either merge order.
+        sectionGeneration++;
+        dropCachedPage();
+#endif
+      } else {
+        prebuiltSection.reset();
+        prebuiltSpineIndex = -1;
+        prebuildDeclinedSpine = -1;
+        section.reset();
+      }
+#else
       section.reset();
+#endif
       lastPageTurnTime = millis();
       return true;
     } else {
@@ -1169,6 +1276,13 @@ void EpubReaderActivity::renderBook() {
   buildViewportHeight = viewportHeight;
 
   const ReaderRenderSpec renderSpec = SETTINGS.readerRenderSpec(viewportWidth, viewportHeight);
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Snapshot for the prebuild task (renderBook runs under the RenderLock here;
+  // the task only reads these under the same lock). Also invalidates stale
+  // prebuilds: the task compares its captured spec against this every pass.
+  lastRenderSpec = renderSpec;
+  lastRenderSpecValid = true;
+#endif
 #ifdef CROSSPOINT_BG_BUILD_TASK
   // Arm the build task: nearly every state change it cares about (build
   // started, page turned, spec changed) flows through a render, so one notify

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -6,6 +6,9 @@
 #if defined(CROSSPOINT_NEXT_SECTION_PREBUILD) && !defined(CROSSPOINT_BG_BUILD_TASK)
 #error "CROSSPOINT_NEXT_SECTION_PREBUILD requires CROSSPOINT_BG_BUILD_TASK: the prebuild runs on that task."
 #endif
+#if defined(CROSSPOINT_BG_IMAGE_DECODE) && !defined(CROSSPOINT_BG_BUILD_TASK)
+#error "CROSSPOINT_BG_IMAGE_DECODE requires CROSSPOINT_BG_BUILD_TASK: it runs as that task's idle work"
+#endif
 
 #ifdef CROSSPOINT_BG_BUILD_TASK
 #include <freertos/FreeRTOS.h>
@@ -132,6 +135,52 @@ class EpubReaderActivity final : public ReaderActivity {
   bool prebuildStep();
   // Start prebuilding when the reader is within this many pages of chapter end.
   static constexpr int PREBUILD_NEAR_END_PAGES = 3;
+#endif
+#ifdef CROSSPOINT_BG_IMAGE_DECODE
+  // Pre-decode the images on upcoming pages from the background build task's
+  // idle work, so the first view of an image page finds a ready .pxc instead of
+  // paying a 0.5-3 s decode on the page-turn critical path (today that decode
+  // happens inside the render, behind a placeholder pass). One page is examined
+  // and at most one image decoded per idle pass; the decode itself runs with
+  // the RenderLock RELEASED, which is what the ImageBlock interlock and the
+  // cacheOnly decode mode exist to make safe. Returns true when a decode ran.
+  bool imageDecodeStep(bool& workPlausible);
+  // How far ahead to look. Three pages is roughly the runway a decode needs at
+  // reading pace, and keeps the declined mask a byte.
+  static constexpr int IMAGE_DECODE_LOOKAHEAD = 3;
+  // Cursor state, touched only by the background task. The declined mask
+  // records which lookahead offsets have already been examined and have nothing
+  // left to decode, so idle passes stop re-reading their pages; it is reset
+  // whenever the reader moves (which is also what re-arms the window).
+  int imageDecodeSpine = -1;
+  int imageDecodeBasePage = -1;
+  uint8_t imageDecodeDeclined = 0;
+  // Free-heap floor for starting a pre-decode. The PNG decoder object is ~44 KB
+  // (JPEG ~20 KB) and the render task may start its own decode, or a build-time
+  // image header probe, on the other core while this one runs; leave room for
+  // both rather than win a race for the last block. A render-path decode that
+  // loses one marks its image failed for the whole session, so this floor is
+  // deliberately generous -- pre-decoding is pure opportunism.
+  static constexpr size_t IMAGE_DECODE_MIN_FREE_HEAP = 96 * 1024;
+  // The decoder object is a single contiguous allocation.
+  static constexpr size_t IMAGE_DECODE_MIN_MAX_ALLOC = 48 * 1024;
+  // Page origin of the last render, captured under the RenderLock: a
+  // pre-decode must place the image exactly where a render would, because both
+  // the screen clip and the dither phase depend on absolute position.
+  //
+  // Implicit invariant, worth stating because it is load-bearing and unenforced:
+  // these describe the layout the CURRENT `section` was paginated with. It holds
+  // because every path that changes the layout (settings, orientation, margins,
+  // status-bar height, auto-turn indicator) resets `section` in the same lock
+  // scope, so the pre-decode -- which refuses to run without a section -- can
+  // never pair a new page with an old origin. A future re-pagination that
+  // changes the origin WITHOUT resetting the section would break it silently:
+  // the .pxc files written from here would be dithered and clipped for the old
+  // origin, and nothing downstream would notice, because the header check only
+  // compares dimensions. Reset lastRenderMarginsValid in any such path.
+  int16_t lastRenderMarginLeft = 0;
+  int16_t lastRenderMarginTop = 0;
+  bool lastRenderMarginsValid = false;
 #endif
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr int BUILD_WINDOW_AHEAD = 5;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -3,6 +3,10 @@
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
+#ifdef CROSSPOINT_BG_BUILD_TASK
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#endif
 
 #include <atomic>
 #include <memory>
@@ -74,6 +78,33 @@ class EpubReaderActivity final : public ReaderActivity {
   static constexpr size_t BACKGROUND_BUILD_MIN_MAX_ALLOC = 16 * 1024;
   bool buildTickHeapGate();
   bool buildHeapPaused = false;
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  // X4 Pro (dual-core S3): drive section builds from a dedicated task pinned to
+  // core 0 (the Arduino loopTask and the render task both live on core 1)
+  // instead of 2-page ticks stolen from loop(). Same RenderLock discipline and
+  // tick size as the loop pump — the lock is held per 2-page tick, never across
+  // a chapter — but ticks run back-to-back on an otherwise idle core, so a
+  // chapter finalizes in seconds of background time instead of tracking reading
+  // pace, and the BUILD_WINDOW_AHEAD throttle (which exists to ration loop-task
+  // time on a single core) does not apply. Completion/failure are handed back
+  // to the loop task via atomics so reposition/reset/requestUpdate keep running
+  // in their usual task context. If task creation fails, the loop-tick pump
+  // remains as a runtime fallback (gated on bgBuildTaskHandle == nullptr).
+  //
+  // The idle wait is notification-driven, not a poll: a permanent 25 ms tick
+  // would be 40 wakes/s on core 0 for the whole reading session and would hold
+  // the chip out of automatic light sleep, which nothing else about reading
+  // prevents. See bgBuildTaskLoop() for the two cadences and the arming points.
+  TaskHandle_t bgBuildTaskHandle = nullptr;
+  std::atomic<bool> bgBuildStop{false};
+  std::atomic<bool> bgBuildExited{false};
+  std::atomic<bool> bgBuildCompleteNotify{false};
+  std::atomic<bool> bgBuildFailedNotify{false};
+  static void bgBuildTaskTrampoline(void* param);
+  void bgBuildTaskLoop();
+  void startBgBuildTask();
+  void stopBgBuildTask();
+#endif
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr int BUILD_WINDOW_AHEAD = 5;
   static constexpr int PARTIAL_REBUILD_START_MARGIN = 15;
@@ -117,6 +148,10 @@ class EpubReaderActivity final : public ReaderActivity {
       : ReaderActivity("EpubReader", renderer, mappedInput, std::move(bookPath), allowFastInitialRefresh) {}
   ~EpubReaderActivity() override;
 
+#ifdef CROSSPOINT_BG_BUILD_TASK
+  void onEnter() override;
+  void onExit() override;
+#endif
   void loop() override;
 
   bool pageTurn(bool isForward) override;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -3,6 +3,10 @@
 #include <Epub.h>
 #include <Epub/FootnoteEntry.h>
 #include <Epub/Section.h>
+#if defined(CROSSPOINT_NEXT_SECTION_PREBUILD) && !defined(CROSSPOINT_BG_BUILD_TASK)
+#error "CROSSPOINT_NEXT_SECTION_PREBUILD requires CROSSPOINT_BG_BUILD_TASK: the prebuild runs on that task."
+#endif
+
 #ifdef CROSSPOINT_BG_BUILD_TASK
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
@@ -104,6 +108,30 @@ class EpubReaderActivity final : public ReaderActivity {
   void bgBuildTaskLoop();
   void startBgBuildTask();
   void stopBgBuildTask();
+#endif
+#ifdef CROSSPOINT_NEXT_SECTION_PREBUILD
+  // Prebuild (cache pre-load) of the NEXT spine's Section by the background
+  // build task while the reader sits near the end of a fully-built chapter, so
+  // the forward chapter-boundary turn swaps a ready Section in instead of the
+  // synchronous load. CACHED-ONLY: the prebuild never starts a build — a second
+  // live build context would share the Epub's single CssParser and the
+  // html/.bin.part paths with any build renderBook() starts, both racy.
+  // Everything (construction, loadSectionFile, park, discard, consume) runs
+  // under the try-acquired RenderLock, so the shared book.bin metadata handle
+  // and all reader state are only ever touched serialized. Cache-miss next
+  // spines fall back to today's boundary behavior (remembered in
+  // prebuildDeclinedSpine so idle iterations don't re-probe SD).
+  std::unique_ptr<Section> prebuiltSection;
+  int prebuiltSpineIndex = -1;
+  int prebuildDeclinedSpine = -1;
+  ReaderRenderSpec prebuiltSpec{};
+  // Spec snapshot for the task; written by renderBook() under the RenderLock.
+  ReaderRenderSpec lastRenderSpec{};
+  bool lastRenderSpecValid = false;
+  static bool renderSpecEquals(const ReaderRenderSpec& a, const ReaderRenderSpec& b);
+  bool prebuildStep();
+  // Start prebuilding when the reader is within this many pages of chapter end.
+  static constexpr int PREBUILD_NEAR_END_PAGES = 3;
 #endif
   static constexpr size_t RENDER_MIN_FREE_HEAP = 24 * 1024;
   static constexpr int BUILD_WINDOW_AHEAD = 5;


### PR DESCRIPTION
## Summary

> **Stacked on #3051** (`feat/x4pro-background-section-builds`). **Review the last commit only** — the first two are
> #3051's and are already under review there. GitHub will collapse this to a single commit once #3051 merges.

* **What is the goal of this PR?** Take the multi-second stall out of the first view of an in-book image, by pre-decoding
  upcoming pages' images on the background build task #3051 already runs. Flag-gated
  (`CROSSPOINT_BG_IMAGE_DECODE`), enabled on `[env:x4pro]`; every other environment (the C3 `default` included)
  compiles to today's exact behavior.
* **What changes are included?** One commit: a `cacheOnly` decode mode in the two framebuffer converters, a
  small interlock in `ImageBlock`, and `imageDecodeStep()` as the build task's lowest-priority idle work.

**The problem.** The first time the reader reaches a page with an image, the decode happens *inside the render*: the
page draws with a placeholder box, FAST-refreshes so the reader is not staring at a blank, then extracts the image out
of the ZIP, decodes it (JPEG or PNG, scaled and dithered into a `.pxc` pixel-cache file), and re-renders. That is
**0.5–3 s of dead time on the page-turn critical path**, every first visit, and it is the single worst turn in an
illustrated book. Everything needed to do the work early already exists: the background build task idles on core 0
between chapters, and the `.pxc` it would produce is keyed by the *image*, not by the page. `imageDecodeStep()` examines
one upcoming page (`currentPage+1..+3`) per idle pass and decodes at most one of its images into its cache file. The
reader then arrives to a cache hit — **~100 ms of SD read instead of seconds of decode**, and no placeholder pass at
all.

**`cacheOnly` decodes — the safety property that makes this possible.** `RenderConfig` gains a `cacheOnly` mode honored
by **both** converters: no `DirectPixelWriter` is ever initialized, and there is **no renderer interaction whatsoever**
— not even reading the screen size, which the caller captures under the `RenderLock` and passes in the config instead.
The context's `renderer` pointer is deliberately left **null** in that mode, so a stray access is a null deref rather
than a silent cross-task read of the render task's state. `decodeToCacheOnly()` rejects non-positive screen bounds,
because in `cacheOnly` mode those are the only bounds the converters have: a zero clips every pixel away and writes an
all-black `.pxc` that passes every later header check — a permanently valid black image. Every call path was audited
and stays inside SD-through-`Storage` (mutex'd per operation), the pixel cache, and the heap. The decode settings now
come from **one shared helper** used by `ImageBlock::render()` too, so the file the background writes is byte-for-byte
the file a render would have written — both the screen clip and the dither phase key off absolute position, so the
reader snapshots the render's page origin under the lock and hands it over.

**Takeover protocol.** At most one image decode runs at a time and the render task always wins. The background task
picks its candidate and publishes both "a decode is running" and *which* `.pxc` it targets while it still holds the
try-acquired `RenderLock`, then decodes with the lock released; a render can only start after that release, so it
always observes the flag, and the background task can only pick a new candidate while no render is running.
`ImageBlock::render()` therefore cancels a *matching* decode **before it opens the `.pxc` for read** — otherwise it
would hold a reader handle on a file being written — and cancels any *other* in-flight decode before starting its own
(two live decoders are ~88 KB of decoder objects, and the render-path loser of that allocation marks its image failed
for the whole session). Cancellation is a global abort flag checked in the converters' draw callbacks and in
`PixelCache::advanceTo`, with a bounded wait for the acknowledgement; JPEGDEC treats a `0` from the draw callback as a
clean early stop and still reports success, so the converters also record the abort in their context and fail the
decode explicitly, dropping the partial file either way. The flag is only ever raised and lowered inside one
`RenderLock` scope, and no render-task decode can be in flight at either of those moments, so its two users can never
overlap.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — **N/A: this PR touches none of them.** No submodule bump, no HAL change, no
      bootloader/OTA/recovery code.

## Additional Context

**Tested working on X4 Pro hardware by the submitter.** Exercised on image-dense chapters (where the pre-decoder and
the render task contend most often, and where the takeover path actually fires), on mixed text/image books, on forward
and backward turns across image pages, on chapter boundaries, and on the combined build with the light-sleep work —
first views of pre-decoded images land with no placeholder pass and no perceptible pause, and nothing regressed on the
paths where the pre-decode loses the race and the render decodes as it does today.

**Adversarially reviewed, with the takeover protocol proven against interleavings.** The review walked the render
task, the background task, and the exit join against each other at every publish/observe point, and three findings
changed the shape of the code:

* *A takeover abort was indistinguishable from a corrupt image.* The step declined its lookahead slot on **any** decode
  failure, including a render cancelling it — so on an image-dense chapter, where takeovers happen on exactly the pages
  worth pre-decoding, the window disarmed itself until the reader moved. The abort flag is now read **before**
  `endBackgroundDecode()` clears the "active" flag (a canceller only lowers the abort flag once it observes the decode
  stopped, so the read is stable there), and an aborted step leaves the cursor alone to retry.
* *A cancel could be lost across the un-abortable ZIP extract.* `stopBgBuildTask()` keeps its notify-before-store
  ordering — that is what keeps the task's TCB provably alive — but now cancels **after** publishing the stop flag. With
  the cancel first, a cancel that timed out during the extract lowered the abort flag on its way out, and the task then
  ran a full multi-second decode inside the exit join. The step also re-checks `abortRequested()` after the extract,
  before committing to the decode.
* *The render took the image over too late.* The original cancel sat after `renderFromCache()`, so a render could open a
  read handle on a `.pxc` the background task was mid-write on. A published target hash now distinguishes "busy with
  some other image" (no wait) from "holds MY file open for write" (cancel first, before the open).

Also: `ImageDecoderFactory`'s lazy singleton init is not thread-safe, so the decoder pointer is resolved **under** the
lock and carried into the unlocked decode; the step holds a `shared_ptr` copy of the `Epub` rather than using
`ImageBlock`'s extractor hook, because `launchKOReaderSync()` drops the `Epub` under the `RenderLock` **without**
joining this task (verified upstream: it clears the extractor and resets `section`/`epub` to free RAM for the TLS
handshake, and only `onExit()` joins the task) — the hook's raw `Epub*` would dangle mid-extract; both the chapter-load
path in `renderBook()` and `loop()`'s lazy partial-extension `startBuild()` cancel an in-flight pre-decode first,
because the chapter parser extracts images to probe dimensions and derives the same destination path; and
`startBgBuildTask()` resets both interlock flags so a restarted task cannot inherit them.

**Worst-case exit-join latency is single-digit ms**, plus one un-abortable ZIP extract. The abort is honored inside a
decoder callback (a JPEG MCU row: well under a millisecond to a few ms) plus at most one 3 KB band flush. The one step
that cannot honor it is the ZIP extract of a single image, bounded by that image's stored size (typically 50–300 ms;
the extractor takes no abort hook). The 5 s cap on the cancel wait exists to cover that and is a **liveness backstop,
not an expected path** — on a timeout the render path draws the placeholder rather than becoming a second writer, and
the exit join proceeds.

### ⚠️ Semantic merge point with #3049 (PSRAM image cache) — please read before merging both

This is **not** a textual conflict, and it will **not** show up as one. #3049's `PixelCache::finalizeWhole()` donates
its finalized whole-image buffer into the PSRAM LRU **unconditionally**:

```cpp
if (adoptPxcImage(cachePathStr, whole, total)) {
  whole = nullptr;  // ownership transferred to the render cache
  buffer = nullptr;
}
```

That is correct **only** under #3049's stated invariant — that `ImageBlock::render()` is the sole producer of
`cachePath`-bearing decodes, and therefore that every access to the LRU happens under the `RenderLock` (the cache has
no lock of its own). **This PR breaks that invariant**: the background task is a second, lock-free producer of exactly
such decodes. On *this* branch nothing is needed — no donation code exists here, so `PixelCache` is untouched apart
from the abort check. But **if both land, the merged tree must gate the donation**, or a lock-free decode will mutate
the PSRAM LRU concurrently with a render.

The resolution is the reference's shape: `PixelCache::begin()` takes the decode mode, `mayDonate` is derived from it
(and defaults to `false`, so the permission is granted by construction rather than revoked by each caller remembering
to), and both converters pass `ctx.cacheOnly` through:

```diff
   // Donating into the render cache is only legal from a decode that holds the
   // RenderLock, because that cache has no lock of its own.
-  bool mayDonate = true;
+  // CROSSPOINT_BG_IMAGE_DECODE's lock-free background decode may not, and its
+  // .pxc is picked up from the file by whichever render wants it first. Derived
+  // in begin() from the cacheOnly flag it is handed, and false until then: the
+  // permission is granted by construction, never by a caller remembering to
+  // revoke it.
+  bool mayDonate = false;

-  bool begin(const std::string& cachePath, int w, int h, int ox, int oy, int maxBlockDstRows) {
+  // `cacheOnly` is the decode mode: a cacheOnly decode runs without the
+  // RenderLock, which is exactly the decode that may not donate into the render
+  // cache (see mayDonate).
+  bool begin(const std::string& cachePath, int w, int h, int ox, int oy, int maxBlockDstRows,
+             [[maybe_unused]] const bool cacheOnly) {
     ...
 #ifdef CROSSPOINT_PSRAM_IMAGE_CACHE
-    if (!beginWholeBuffer(w, h) && !beginBandBuffer(h, maxBlockDstRows)) return false;
+    mayDonate = !cacheOnly;
+    if (!beginWholeBuffer(w, h) && !beginBandBuffer(w, h, maxBlockDstRows)) return false;
 #endif
     ...
   bool finalizeWhole() {
     ...
-    if (adoptPxcImage(cachePathStr, whole, total)) {
+    if (mayDonate && adoptPxcImage(cachePathStr, whole, total)) {

 // JpegToFramebufferConverter.cpp
-    if (!ctx.cache.begin(config.cachePath, destWidth, destHeight, config.x, config.y, maxBlockDstRows)) {
+    if (!ctx.cache.begin(config.cachePath, destWidth, destHeight, config.x, config.y, maxBlockDstRows, ctx.cacheOnly)) {

 // PngToFramebufferConverter.cpp
-    if (!ctx.cache.begin(config.cachePath, ctx.dstWidth, ctx.dstHeight, config.x, config.y, 1)) {
+    if (!ctx.cache.begin(config.cachePath, ctx.dstWidth, ctx.dstHeight, config.x, config.y, 1, ctx.cacheOnly)) {
```

Losing the donation for background decodes costs nothing that matters: the first view reads the pre-decoded `.pxc` off
SD once (~100 ms) instead of decoding it (seconds), and the render that reads it repopulates the LRU normally.
**Happy to push this follow-up to whichever of #3049 / this PR lands second — just say the word and I'll open it.**

**Composes with #3050 (page-turn SD elimination), in either merge order.** The lookahead scan borrows #3050's resident
cached `Page` in place when the keys match, instead of deserializing a second copy of a page that is already in RAM
(`currentPage + 1` is the first lookahead slot, so the prewarm's entry is usually exactly it). The borrow is read-only
and does not consume the entry. It sits behind
`#if defined(CROSSPOINT_PAGE_CACHE) && defined(CROSSPOINT_BG_IMAGE_DECODE)`, naming #3050 in a comment — the same
pattern #3051 used for its adoption-site hook. `CROSSPOINT_PAGE_CACHE` is undefined on this branch, so every symbol in
the block compiles away entirely here and compiles in as soon as both flags are enabled, whichever lands first. No
textual conflict either way.

**Memory / flash.** No new task, no new persistent allocation: the pre-decode runs on #3051's existing core-0 task, and
the decoder object it allocates is the same one a render-path decode allocates, freed the same way. Starting a
pre-decode is gated on **96 KB free heap and a 48 KB max block** — deliberately far above the decoder's own ~60 KB,
because a build-time image header probe on the other core can want the same memory and a render-path decode that loses
that race marks its image failed for the entire session. Pre-decoding is pure opportunism; it declines rather than
competes. The lookahead cursor is three ints and a byte-wide declined mask. Flash on `default` (C3) is unchanged — the
whole feature compiles out, `cacheOnly` folds to a compile-time `false` in both converters, and the shared decode-config
helper is the only edit visible with the flag off.

**Builds.** `pio run -e x4pro` (flags live) and `pio run -e default` (C3) — both SUCCESS.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — implementation and adversarial review with Claude Code;
hardware testing on the X4 Pro was done by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
