### PR TITLE
feat: GT911 INT and button GPIO wake for longer light-sleep slices

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -8,6 +8,10 @@
 #include <esp_sleep.h>
 #include <soc/usb_serial_jtag_struct.h>
 
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+#include <driver/gpio.h>
+#endif
+
 // Global HalGPIO instance
 HalGPIO gpio;
 
@@ -205,6 +209,8 @@ bool HalGPIO::wasHomeKeyTapped() const { return inputMgr.wasHomeKeyTapped(); }
 
 bool HalGPIO::wasHomeKeyLongPressed() const { return inputMgr.wasHomeKeyLongPressed(); }
 
+bool HalGPIO::isHomeKeyDown() const { return inputMgr.isHomeKeyDown(); }
+
 bool HalGPIO::wasTouchTap(float& nx, float& ny) const { return inputMgr.wasTouchTap(nx, ny); }
 
 bool HalGPIO::wasTouchDown(float& nx, float& ny) const { return inputMgr.wasTouchPressedAt(nx, ny); }
@@ -333,3 +339,110 @@ HalGPIO::WakeupReason HalGPIO::getWakeupReason() const {
   }
   return WakeupReason::Other;
 }
+
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+
+namespace {
+
+struct WakePin {
+  gpio_num_t pin;
+  bool activeLow;
+};
+
+constexpr uint8_t MAX_WAKE_PINS = 8;
+WakePin wakePins[MAX_WAKE_PINS];
+uint8_t wakePinCount = 0;
+bool wakePinOverflow = false;
+bool wakeUsable = false;
+
+void addWakePin(const int8_t pin, const bool activeLow) {
+  if (pin < 0) {
+    return;
+  }
+  for (uint8_t i = 0; i < wakePinCount; ++i) {
+    if (wakePins[i].pin == static_cast<gpio_num_t>(pin)) return;  // shared pin (confirm/power)
+  }
+  if (wakePinCount >= MAX_WAKE_PINS) {
+    // Silently dropping a pin would leave a stretched slice deaf to that input
+    // for up to its full length. Fail the whole mechanism closed instead; the
+    // caller then keeps the stock slice, whose poll cadence sees every button.
+    wakePinOverflow = true;
+    return;
+  }
+  wakePins[wakePinCount++] = {static_cast<gpio_num_t>(pin), activeLow};
+}
+
+// True while the pin sits at the level it would wake on.
+bool wakePinAsserted(const WakePin& p) { return digitalRead(p.pin) == (p.activeLow ? LOW : HIGH); }
+
+}  // namespace
+
+void HalGPIO::beginInputWake() {
+  wakePinCount = 0;
+  wakePinOverflow = false;
+  wakeUsable = false;
+
+  // Button pin modes already belong to InputManager::begin() (INPUT_PULLUP for
+  // the nav keys, powerActiveHigh for power) and the touch INT's to the GT911
+  // driver; this only reads their polarity.
+  const auto& in = BoardConfig::ACTIVE.input;
+  if (BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::XteinkAdcLadder) {
+    for (const int8_t pin : {in.back, in.confirm, in.left, in.right, in.up, in.down}) {
+      addWakePin(pin, true);
+    }
+  }
+  // The power pin is in the table even though lightSleep() arms it on its own:
+  // arming is idempotent, and it has to be here for the held-level test — a
+  // power button held down must keep the slice short like any other held input.
+  addWakePin(in.power, !in.powerActiveHigh);
+
+  const int8_t touchIrq = inputMgr.touchWakeIrqPin();
+  addWakePin(touchIrq, inputMgr.touchWakeIrqActiveLow());
+
+  // Every input the loop can act on has to be something this can arm, or a
+  // stretched slice would be deaf to the rest of them for up to its full
+  // length. Boards that fail that test keep the stock slice:
+  //   * XteinkAdcLadder (X4, X3): the nav keys are resistor steps on a single
+  //     ADC pin, found by sampling — there is no per-key level to wake on;
+  //   * a board button hook (LilyGo T5 S3's user button on its PCA9535): the
+  //     key is behind an I2C expander, invisible to a GPIO wake, and the
+  //     expander's own INT line is not modeled here;
+  //   * a live touch panel with no level-holding INT: a contact would have no
+  //     way to signal during a long slice (see FREEINK_GT911_INT_WAKE, which
+  //     is what makes touchWakeIrqPin() report a pin at all);
+  //   * more wake pins than the table holds (see addWakePin).
+  const bool navKeysAreGpio =
+      BoardConfig::ACTIVE.inputStyle != BoardConfig::InputStyle::XteinkAdcLadder && !InputManager::hasButtonHook();
+  wakeUsable = wakePinCount > 0 && !wakePinOverflow && navKeysAreGpio && (!inputMgr.hasTouch() || touchIrq >= 0);
+  LOG_INF("PWR", "Input wake: %u pin(s), touch INT %d, gpioKeys=%d usable=%d", static_cast<unsigned>(wakePinCount),
+          static_cast<int>(touchIrq), static_cast<int>(navKeysAreGpio), static_cast<int>(wakeUsable));
+  if (!wakeUsable) {
+    wakePinCount = 0;
+  }
+}
+
+bool HalGPIO::inputWakeAvailable() const { return wakeUsable; }
+
+uint8_t HalGPIO::armInputWake(bool& allArmed) const {
+  uint8_t armedCount = 0;
+  for (uint8_t i = 0; i < wakePinCount; ++i) {
+    // Level triggers are the only thing light sleep can wake on: the GPIO edge
+    // detector is clock-gated while asleep, so gpio_wakeup_enable() accepts
+    // nothing else. A pin already at that level would end the sleep the moment
+    // it starts, so leave it out (see the header for why that costs nothing).
+    if (wakePinAsserted(wakePins[i])) continue;
+    gpio_wakeup_enable(wakePins[i].pin, wakePins[i].activeLow ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
+    ++armedCount;
+  }
+  allArmed = armedCount == wakePinCount;
+  return armedCount;
+}
+
+void HalGPIO::disarmInputWake() const {
+  for (uint8_t i = 0; i < wakePinCount; ++i) {
+    gpio_wakeup_disable(wakePins[i].pin);
+    gpio_set_intr_type(wakePins[i].pin, GPIO_INTR_DISABLE);
+  }
+}
+
+#endif  // CROSSPOINT_TOUCH_INT_WAKE

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -118,6 +118,11 @@ class HalGPIO {
   bool hasHomeKey() const;
   bool wasHomeKeyTapped() const;
   bool wasHomeKeyLongPressed() const;
+  // Home key currently held, as a level rather than an edge. A motionless hold
+  // produces no new touch frames, so its long-press threshold is timed by
+  // update() against the wall clock: callers that may stop polling have to
+  // check this or they stretch that threshold by however long they stay away.
+  bool isHomeKeyDown() const;
   bool wasTouchTap(float& nx, float& ny) const;
   bool wasTouchDown(float& nx, float& ny) const;
   // Raw release edge, reported even when the contact was not a tap (swipe end,
@@ -166,6 +171,43 @@ class HalGPIO {
   enum class WakeupReason { PowerButton, AfterFlash, AfterUSBPower, Other };
 
   WakeupReason getWakeupReason() const;
+
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  // --- Input GPIO light-sleep wake -------------------------------------------
+  // The idle loop light-sleeps in LIGHT_SLEEP_SLICE_MS slices whose only wake
+  // source is the timer, so the chip wakes 20x/s whether or not anything
+  // happened. Arming the touch INT and the button GPIOs as level wake sources
+  // lets one slice run much longer and still end the instant the user touches
+  // the panel or presses a key. Nothing here classifies input: the poll at the
+  // top of the loop still reports every press, gesture and debounce as before.
+
+  // Build the wake-pin table from BoardConfig and the touch driver. Call after
+  // begin() has probed the touch controller. Any task may call it: the pins are
+  // wake sources for esp_light_sleep_start() itself, so — unlike an
+  // interrupt-and-notify wait — there is no ISR to install and no task to latch.
+  void beginInputWake();
+
+  // False when no wake source could be armed, or when this board has inputs no
+  // GPIO level can represent: ADC-ladder nav keys, a button behind an I2C
+  // expander, or a live touch panel whose INT cannot hold a level. Callers then
+  // keep the stock slice, whose timer cadence polls every input.
+  bool inputWakeAvailable() const;
+
+  // Arm every wake pin that is currently RELEASED as a light-sleep GPIO wake
+  // and return how many were armed; `allArmed` reports that none had to be
+  // skipped. A pin already sitting at its wake level (a GT911 INT stuck low
+  // after an I2C fault, a button held down in a bag) would end the sleep the
+  // instant it began, so it is left out — the poll right after the sleep is
+  // what consumes its state anyway — and the caller keeps the slice short.
+  // Pair with disarmInputWake() before returning: esp_sleep's GPIO trigger bits
+  // are shared with deep sleep.
+  uint8_t armInputWake(bool& allArmed) const;
+
+  // Clear the wake enable AND the level interrupt type on every wake pin (the
+  // type survives gpio_wakeup_disable() and would be live ammunition for any
+  // later-installed GPIO ISR service).
+  void disarmInputWake() const;
+#endif
 
   // Button indices
   static constexpr uint8_t BTN_BACK = 0;

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -120,7 +120,13 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   freeink::PowerManager::deepSleepUntilPowerButton();
 }
 
-bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+// A slice that ends this much faster than the stock cadence is treated as an
+// instant return rather than a wake: see the busy-loop note in lightSleep().
+static constexpr unsigned long IMMEDIATE_RETURN_MS = 20;
+#endif
+
+bool HalPowerManager::lightSleep(const HalGPIO& gpio, [[maybe_unused]] const unsigned long maxSliceMs) const {
   // A performance Lock means a render (or similar) task is mid-flight; light sleep
   // freezes the whole chip, so it would stall that task.
   // Note: like setPowerSaving(), read without the mutex — stale in either
@@ -160,7 +166,26 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
   // press, so a misread around the sleep transition costs one extra wake
   // blip, never a phantom press. Idle cost is zero — the pin only holds its
   // pressed level while a finger is on it.
-  esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(LIGHT_SLEEP_SLICE_MS) * 1000ULL);
+  unsigned long sliceMs = LIGHT_SLEEP_SLICE_MS;
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  // The same argument, widened to the rest of the inputs: with the touch INT
+  // and every nav key armed as level wakes too, the timer is no longer what
+  // ends an idle slice — the user is. The slice may then run up to the caller's
+  // bound, turning twenty short wakes per second into one long window, without
+  // costing input latency. The bound is only taken when EVERY wake pin got
+  // armed: one that was skipped for sitting at its wake level is input state
+  // the poll after this call has not consumed yet (a GT911 INT still held
+  // because update() skipped its I2C slot, a button mid-press), and sleeping a
+  // full second on it would be a visible stall.
+  bool allWakePinsArmed = false;
+  if (gpio.inputWakeAvailable() && gpio.armInputWake(allWakePinsArmed) > 0) {
+    esp_sleep_enable_gpio_wakeup();
+    if (allWakePinsArmed && maxSliceMs > sliceMs) {
+      sliceMs = maxSliceMs;
+    }
+  }
+#endif
+  esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(sliceMs) * 1000ULL);
   const int8_t powerPin = BoardConfig::ACTIVE.input.power;
   if (powerPin >= 0) {
     gpio_wakeup_enable(static_cast<gpio_num_t>(powerPin),
@@ -177,6 +202,9 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     gpio_hold_en(XTEINK_C3_GPIO13);
   }
 
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  const unsigned long sleepStartMs = millis();
+#endif
   const esp_err_t err = esp_light_sleep_start();
 
   // Disarm immediately: an armed timer wake persists across sleep calls and would
@@ -191,6 +219,13 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
     gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE);
   }
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  // Same reason, for the input pins: they are wake sources for the duration of
+  // one slice only, so nothing here can turn a nav key or the touch INT into a
+  // deep-sleep wake source (startDeepSleep() always runs outside this call and
+  // arms its own).
+  gpio.disarmInputWake();
+#endif
 
   xSemaphoreGive(sleepMutex);
 
@@ -199,6 +234,24 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     LOG_DBG("PWR", "Light sleep rejected: %d", static_cast<int>(err));
     return false;
   }
+
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  // Busy-loop floor. A level wake pin that asserts between armInputWake()'s
+  // released-check and the sleep start — or the power pin, which is armed above
+  // whatever its level — ends the slice immediately. One such round is fine:
+  // the poll right after this call consumes it. A line that keeps re-asserting
+  // (a GT911 INT stuck low behind an I2C fault, a chattering contact) would
+  // otherwise spin the loop at full rate with no sleep at all, the exact
+  // opposite of this feature, so anything shorter than IMMEDIATE_RETURN_MS is
+  // padded back out to the cadence the stock slice would have had. A plain
+  // delay() is safe here: the tick only stops while the chip sleeps, and the
+  // other sleeper (the render task's BUSY slice) implies a Lock, which this
+  // call already declined on.
+  const unsigned long sleptMs = millis() - sleepStartMs;
+  if (sleptMs < IMMEDIATE_RETURN_MS) {
+    delay(LIGHT_SLEEP_SLICE_MS - sleptMs);
+  }
+#endif
   return true;
 }
 

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -74,12 +74,20 @@ class HalPowerManager {
   // Should be called inside main loop() to handle the currentLockMode
   void startDeepSleep(HalGPIO& gpio) const;
 
-  // Light-sleep the CPU for LIGHT_SLEEP_SLICE_MS (timer wake; buttons are polled on
-  // wake at the same cadence as the delay() this replaces). Returns false WITHOUT
+  // Light-sleep the CPU for one slice (timer wake; buttons are polled on wake at
+  // the same cadence as the delay() this replaces). Returns false WITHOUT
   // sleeping when unsafe: a performance Lock is held (render in flight), WiFi is
   // active, or USB is connected (light sleep kills the CDC link). The caller must
   // fall back to delay() in that case.
-  bool lightSleep(const HalGPIO& gpio) const;
+  //
+  // maxSliceMs is an UPPER bound, honoured only when every input the loop must
+  // not miss is armed as a GPIO wake for this slice (CROSSPOINT_TOUCH_INT_WAKE):
+  // the slice then ends the moment the user touches the panel or presses a key
+  // instead of at the next timer tick, so a longer bound costs no responsiveness
+  // — see HalGPIO::armInputWake. It falls back to LIGHT_SLEEP_SLICE_MS whenever
+  // that is not the case (no wake pins on this board or in this build, or one of
+  // them is currently held), because then only the timer ends the slice.
+  bool lightSleep(const HalGPIO& gpio, unsigned long maxSliceMs = LIGHT_SLEEP_SLICE_MS) const;
 
   // BUSY-wait slice hook (EpdBus::setBusyWaitSliceHook): light-sleep the chip
   // for up to BUSY_SLEEP_SLICE_MS while the panel refreshes autonomously,

--- a/platformio.ini
+++ b/platformio.ini
@@ -247,6 +247,12 @@ build_flags =
   ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
   ; change that stops a lit frontlight from blocking sleep.
   -DFREEINK_FRONTLIGHT_LS
+  ; Wake an idle light-sleep slice on the GT911 INT and the nav/power GPIOs
+  ; instead of only on its 50 ms timer, so the slice can run up to ~1 s. Needs
+  ; the SDK flag: it puts the GT911 INT in the low-level hold a light-sleep GPIO
+  ; wake can see (edge pulses are invisible — the detector is clock-gated).
+  -DCROSSPOINT_TOUCH_INT_WAKE
+  -DFREEINK_GT911_INT_WAKE
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -568,6 +568,11 @@ void setup() {
     gpio.update();
   }
 
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  // After gpio.begin() has probed the touch controller, so the GT911 INT is
+  // already either configured as a level hold or reported unusable.
+  gpio.beginInputWake();
+#endif
   allowSleepAt = millis() + 2000;
 }
 
@@ -579,6 +584,40 @@ static void delayWallClock(const unsigned long ms) {
   while (static_cast<long>(millis() - deadline) < 0) {
     vTaskDelay(1);
   }
+}
+
+// Upper bound for the next idle light-sleep slice. The stock
+// LIGHT_SLEEP_SLICE_MS gives the 20 Hz poll cadence a plain delay() would have;
+// with CROSSPOINT_TOUCH_INT_WAKE the touch INT and the button GPIOs are armed
+// as level wake sources, so a longer slice still ends the instant the user does
+// something. That only holds while every input the loop must not miss can raise
+// one, which is what the conditions below check — each keeps the stock slice:
+//   * no usable wake source on this board (HalGPIO::inputWakeAvailable);
+//   * tilt page turn armed — the IMU has no interrupt line here and its flick
+//     detector needs its 20 Hz sampling (HalTiltSensor::POLL_INTERVAL_MS);
+//   * a contact is down — the touch long-press and hold timers are evaluated by
+//     the poll, and a motionless finger produces no new GT911 frame to wake on;
+//   * the capacitive home key is down — same reason, and a separate latch from
+//     the contact one: a held key reports no frames either, so its
+//     HOME_KEY_LONG_PRESS_MS threshold is timed purely by the poll.
+// Without the flag this is a compile-time constant and the loop tail below
+// behaves exactly as before.
+static unsigned long idleLightSleepSliceMs() {
+#ifdef CROSSPOINT_TOUCH_INT_WAKE
+  if (!gpio.inputWakeAvailable()) return HalPowerManager::LIGHT_SLEEP_SLICE_MS;
+  if (SETTINGS.tiltPageTurn != CrossPointTiltPageTurn::TILT_OFF && halTiltSensor.isAvailable()) {
+    return HalPowerManager::LIGHT_SLEEP_SLICE_MS;
+  }
+  float nx = 0.0f;
+  float ny = 0.0f;
+  if (gpio.isTouchHeldAt(nx, ny) || gpio.isHomeKeyDown()) return HalPowerManager::LIGHT_SLEEP_SLICE_MS;
+  // Serial CMD: handling is polled from this loop, so stay responsive while a
+  // host is attached. lightSleep() already declines outright whenever USB is
+  // connected, so this is the floor for a link its cached check has not seen.
+  return Serial ? 250 : 1000;
+#else
+  return HalPowerManager::LIGHT_SLEEP_SLICE_MS;
+#endif
 }
 
 void loop() {
@@ -772,7 +811,7 @@ void loop() {
         // a tap shorter than the 50 ms cadence would otherwise land in a single
         // sample and be dropped, and every press would commit a slice late.
         delayWallClock(10);
-      } else if (!powerManager.lightSleep(gpio)) {
+      } else if (!powerManager.lightSleep(gpio, idleLightSleepSliceMs())) {
         // Light sleep declined = a render Lock, USB, or WiFi is active — the
         // chip is at full clock anyway, so poll at 100 Hz. A 50 ms cadence
         // here dropped sub-slice power taps (a press needs two samples >=5 ms


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Let an idle light-sleep slice be ended by the *user* instead of by its timer, so the X4 Pro sleeps in one long window rather than twenty short ones per second — without costing input latency.
* **What changes are included?**

The idle loop tail sleeps in `LIGHT_SLEEP_SLICE_MS` (50 ms) slices whose only wake source is the timer, so the chip wakes 20x/s whether or not anything happened. Under `CROSSPOINT_TOUCH_INT_WAKE` (default off, enabled for `[env:x4pro]`), `HalPowerManager::lightSleep()` also arms the **GT911 touch INT and the nav/power GPIOs as LEVEL wake sources** inside its existing arm → `esp_light_sleep_start()` → disarm cycle, and the caller may then ask for a longer slice — up to **1000 ms** idle, **250 ms** with a USB host attached. The slice still ends the instant a finger lands on the panel or a key goes down, and nothing here classifies input: the existing `gpio.update()` poll at the top of the loop reports every press, gesture and debounce exactly as before.

Level triggers are the only thing light sleep can wake on (the GPIO edge detector is clock-gated while asleep). That is what the SDK side provides — `FREEINK_GT911_INT_WAKE` puts the GT911 INT in a low-level hold and reports the pin only once the controller has verifiably consumed that config — so both flags are enabled together for `[env:x4pro]`. Pin polarity comes from `BoardConfig`, so other profiles would arm correctly too.

**The slice is only stretched when every input the loop must not miss can raise a level.** Each of these keeps the stock 50 ms slice, byte for byte:

* no usable wake source on this board (`HalGPIO::inputWakeAvailable`);
* tilt page turn armed — the IMU has no interrupt line and its flick detector needs its 20 Hz sampling;
* a touch contact is down, or the capacitive home key is down — both are timed by the poll against the wall clock and produce no frames while motionless;
* a USB host is attached (250 ms cap; `lightSleep()` already declines outright while USB is connected).

**Hardening** (all of it review-driven, and all of it load-bearing):

* a pin already sitting at its wake level — a GT911 INT stuck low after an I2C fault, a button held down in a bag — would end the sleep the instant it began, so it is **not armed**; the poll right after the sleep is what consumes its state. A round that skipped ANY pin keeps the stock slice rather than sitting a full second on unconsumed input state.
* an **elapsed-time floor**: a slice that returns in under 20 ms is treated as that instant-return case and padded back out to the stock cadence, so a re-asserting line can never spin the loop at full rate with no sleep at all. This also bounds the pre-existing case of an idle slice armed on a power button that is being held.
* **board gating** — the wake is used only when every nav input is a real GPIO: not the X4/X3 ADC ladder (resistor steps on one ADC pin, no per-key level), not a board button hook (the LilyGo T5 S3 key behind its PCA9535), and not a live touch panel whose INT cannot hold a level.
* a **wake-pin table overflow** fails the whole mechanism closed instead of silently leaving one input deaf.
* **deep-sleep purity**: the pins are wake sources for the duration of one slice only. `lightSleep()` already disarms everything (and clears the level interrupt types) before it returns, so nothing can turn a nav key or the touch INT into a deep-sleep wake source; `startDeepSleep()` always runs outside the call and arms its own.

The render task's BUSY-wait slice (`onEinkBusyWaitSlice`) is deliberately untouched and keeps its 20 ms cadence — only the idle path stretches.

### Re-derivation note (what changed vs. the prototype)

The mechanism was validated on an `esp_pm`/tickless prototype where the idle loop blocked on `ulTaskNotifyTake` woken by a GPIO ISR. **That machinery is dropped here and is not needed**: this branch's sleep calls `esp_light_sleep_start()` directly, which honours `gpio_wakeup_enable()` level wakes natively — the same way `lightSleep()` already wakes on the power pin. So there is no ISR to install, no notification to post, and therefore none of the prototype's notification hygiene (draining `loopTask` notification index 0, which it shared with `ActivityManager::requestUpdateAndWait()`, and a `CONFIG_ARDUINO_ISR_IRAM` build guard for the flash-resident `gpio_intr_disable()` inside the handler). `beginInputWake()` also no longer has to run on the task that later waits. Kept: the wake-pin table, the polarity/board gating, the held-level skip, the elapsed floor, and the arm-only-for-this-slice discipline — the last one being how `HalPowerManager` already sleeps, which is why the deep-sleep path needed no changes at all.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. — This touches `lib/hal/` (HalGPIO, HalPowerManager) **and** bumps the `freeink-sdk/`
      pin. Continuing the X4 Pro light-sleep integration thread with the maintainer around
      Free-Ink/freeink-sdk#39 and #3032; this is the wake-source half of the same work.

## Additional Context

**Submodule pin.** The gitlink is bumped to the head of the paired SDK PR, **Free-Ink/freeink-sdk#41** (`cdba235`), because `HalGPIO` needs its new `touchWakeIrqPin()` / `touchWakeIrqActiveLow()` / `isHomeKeyDown()` / `hasButtonHook()` accessors. Same convention as #3032 — happy to re-pin to the merge commit once that PR lands (or to hold this PR until then). That commit is SDK `main` plus the two INT-wake commits, so the bump also carries `main`'s intervening merges; both builds below are against it.

**Builds.** `pio run -e x4pro` SUCCESS, `pio run -e default` SUCCESS.

**Memory / flash impact.** Negligible: an 8-entry `{gpio_num_t, bool}` wake-pin table (~24 B of `.bss`) plus a few hundred bytes of flash, all inside `#ifdef CROSSPOINT_TOUCH_INT_WAKE`. `-e default` is bit-for-bit unaffected — every addition is behind the flag, and the one unguarded line (the `lightSleep()` call now passing a slice bound) resolves to the stock `LIGHT_SLEEP_SLICE_MS` constant without it.

**Where to focus review.** The held-level skip and the elapsed floor in `HalPowerManager::lightSleep()` (they are what keep a stuck line from turning this into a busy loop), and the `wakeUsable` board gate in `HalGPIO::beginInputWake()`.

### On-device measurements

On-device PM-profiling comparison by the submitter (X4 Pro hardware; both runs `CONFIG_PM_PROFILING` dumps under an esp_pm/tickless test firmware — the mechanism being upstreamed here is the wake-source plumbing those runs exercised; this branch's timed-slice sleep has the same 50 ms wake cadence bottleneck the measurements target):

| Metric | Light sleep alone (Free-Ink/freeink-sdk#39 baseline) | + touch/button INT wake |
|---|---|---|
| Sleep residency | 92% | 92% (with ~2× the active reading share) |
| Sleep entries/sec | 18.2/s | 4.5/s (4× fewer wakeups) |
| Average sleep window | 50.6 ms | 204 ms (4× longer) |
| Awake-idle time share | ~2% | ~0% (poll idling eliminated) |
| Touch I2C polls/sec | 20.7/s | 6.2/s (polls only while interacting) |
| Rejected sleep attempts | 0 | 0 |

**"The submitter confirmed page-turn and touch responsiveness are not perceptibly different — no added latency was observable in normal reading."** The residual ~4.5 wakes/s in the measured build traces to an unrelated background task's fallback timer, not this mechanism.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — Claude Code implementation and adversarial review (held-level busy-loop, notification hygiene, board gating, and GT911 config-consumption verification were all review-hardened); hardware testing and measurements by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUgQffv7GGVCWQ9gijsVbp
