### PR TITLE
fix: let TxtReaderActivity::skipPages() reach the end-of-book sentinel

### DIFF
--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -361,7 +361,10 @@ bool TxtReaderActivity::skipPages(int amount) {
   }
   int newPage = currentPage + amount;
   if (newPage < 0) newPage = 0;
-  if (newPage >= totalPages) newPage = totalPages - 1;
+  // Clamp to totalPages, not totalPages - 1: pageTurn() lets currentPage reach
+  // totalPages and isAtEndOfBook() treats that as the end-of-book sentinel, so
+  // a forward skip must be able to reach it too.
+  if (newPage > totalPages) newPage = totalPages;
   if (newPage != currentPage) {
     currentPage = newPage;
     return true;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix `TxtReaderActivity::skipPages()` so a forward skip can reach the same end-of-book sentinel that a normal page turn already can.
* **What changes are included?** One-line clamp change in `skipPages()`, plus a comment explaining why.

## Why

`TxtReaderActivity::pageTurn()` allows `currentPage` to reach `totalPages`, and `isAtEndOfBook()` defines `currentPage >= totalPages` as the end-of-book condition. `skipPages()`, used for larger jumps (e.g. a long-press-forward skip), instead clamps to `totalPages - 1` — one short of that same sentinel — so a skip landing at or past the end of the book can never actually trigger the end screen, even though an ordinary single-page forward turn reaches it correctly.

`XtcReaderActivity::skipPages()` already clamps to the equivalent of its own page count (not one short of it):

```cpp
if (newPage > static_cast<int>(xtc->getPageCount())) newPage = static_cast<int>(xtc->getPageCount());
```

This PR brings `TxtReaderActivity` in line with that existing, correct pattern in its sibling reader activity — it's an internal-consistency fix within CrossPoint's own reader code, not something specific to any fork.

## Verification

* `pio run -e default` — success
* `pio run -e sticky` — success
* `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` (CI's exact flags) — 0 defects
* Host unit test suite (`ctest`) — 137/137 passed
* clang-format — clean
* Confirmed no existing open/closed PR or issue addresses this (searched `skipPages` across both); the recent `refactor(reader): consolidate reader activities` (#3025, merged) touched this file but did not change this clamp behavior.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware doesn't already handle this correctly (`TxtReaderActivity` is the outlier vs. its own sibling `XtcReaderActivity`), and this isn't a fork-specific behavior question.
- [ ] N/A — this PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

No memory/flash impact — a single comparison operator change in an existing function, no new allocations or code paths. No behavior change for backward paging or the common single-page-forward case; only affects the specific skip-forward-near-end-of-book case, where it now correctly reaches the end screen instead of stopping one page short.

---

### AI Usage

Did you use AI tools to help write this code? **PARTIALLY** — Claude Code was used to identify the inconsistency, write the one-line fix, and run the verification suite above. The inconsistency itself was independently confirmed by direct code reading (comparing `pageTurn()`/`isAtEndOfBook()`/`skipPages()` against each other and against `XtcReaderActivity`'s equivalent), not just AI-asserted.
