### PR TITLE
fix: pagination to handle wrapped labels in UI lists

### DIFF
--- a/src/activities/UiListActivity.cpp
+++ b/src/activities/UiListActivity.cpp
@@ -82,7 +82,7 @@ void UiListActivity::loop() {
   const auto swipe = mappedInput.wasSwipe();
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
     auto& n = activeNav();
-    const int delta = swipe == MappedInputManager::SwipeDir::Up ? n.visibleRows : -n.visibleRows;
+    const int delta = swipe == MappedInputManager::SwipeDir::Up ? n.pageRows() : -n.pageRows();
     if (n.scrollBy(delta, listCount())) requestUpdate();
     return;
   }
@@ -96,10 +96,13 @@ void UiListActivity::navigateButtons() {
   buttonNavigator.onNextRelease([this, count, &n] { moveSelectionTo(ButtonNavigator::nextIndex(n.selected, count)); });
   buttonNavigator.onPreviousRelease(
       [this, count, &n] { moveSelectionTo(ButtonNavigator::previousIndex(n.selected, count)); });
+  // Page by the rows the last build actually drew (pageRows), not the
+  // fixed-height visibleRows estimate: with wrapped labels the estimate
+  // overshoots and rows between pages would never be shown.
   buttonNavigator.onNextContinuous(
-      [this, count, &n] { moveSelectionTo(ButtonNavigator::nextPageIndex(n.selected, count, n.visibleRows)); });
+      [this, count, &n] { moveSelectionTo(ButtonNavigator::nextPageIndex(n.selected, count, n.pageRows())); });
   buttonNavigator.onPreviousContinuous(
-      [this, count, &n] { moveSelectionTo(ButtonNavigator::previousPageIndex(n.selected, count, n.visibleRows)); });
+      [this, count, &n] { moveSelectionTo(ButtonNavigator::previousPageIndex(n.selected, count, n.pageRows())); });
 }
 
 void UiListActivity::syncListViewport(UiScreen& screen, fui::ListProps& props, const bool hasSubtitle) {
@@ -135,6 +138,16 @@ void UiListActivity::render(RenderLock&&) {
   renderer.clearScreen();
   drawChrome();
   renderUi();
+  // Wrapped labels grow rows, so fewer rows can fit than the fixed-height
+  // estimate ListNav plans with. list() reports the real layout back
+  // (ListNav::onListRendered); when the selection landed past the drawn rows
+  // the nav advanced the viewport and asked for another build. Bounded: top
+  // strictly advances toward the selection each pass.
+  for (int pass = 0; activeNav().consumeRebuildNeeded() && pass < 8; ++pass) {
+    renderer.clearScreen();
+    drawChrome();
+    renderUi();
+  }
   drawFooter();
   renderer.displayBuffer();
 }

--- a/src/activities/UiListActivity.cpp
+++ b/src/activities/UiListActivity.cpp
@@ -66,9 +66,14 @@ bool UiListActivity::routeListTouch() {
 }
 
 void UiListActivity::moveSelectionTo(const int index) {
-  auto& n = activeNav();
-  n.selected = index;
-  n.follow(listCount());
+  {
+    // The render task reads nav mid-build (syncToProps, layout feedback); a
+    // press landing during a render would otherwise tear selection/viewport.
+    RenderLock lock(*this);
+    auto& n = activeNav();
+    n.selected = index;
+    n.follow(listCount());
+  }
   requestUpdate();
 }
 
@@ -81,9 +86,16 @@ void UiListActivity::loop() {
   // off-screen) and button navigation pulls the view back to it.
   const auto swipe = mappedInput.wasSwipe();
   if (swipe == MappedInputManager::SwipeDir::Up || swipe == MappedInputManager::SwipeDir::Down) {
-    auto& n = activeNav();
-    const int delta = swipe == MappedInputManager::SwipeDir::Up ? n.pageRows() : -n.pageRows();
-    if (n.scrollBy(delta, listCount())) requestUpdate();
+    bool moved = false;
+    {
+      // Same nav-vs-render race as moveSelectionTo: the render task writes
+      // pageRows/top mid-build, so read and mutate under one lock.
+      RenderLock lock(*this);
+      auto& n = activeNav();
+      const int delta = swipe == MappedInputManager::SwipeDir::Up ? n.pageRows() : -n.pageRows();
+      moved = n.scrollBy(delta, listCount());
+    }
+    if (moved) requestUpdate();
     return;
   }
 

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -469,6 +469,10 @@ void FileBrowserActivity::buildScreen(UiScreen& screen) {
   // The trailing value here is just the short extension: skip the balanced
   // 60%-band wrap cap and let both name lines run the full width before it.
   props.balanceWrappedLabelWithValue = false;
+  // Wrapped two-line names shrink how many rows fit a page, so the last row
+  // of a page can end up in leftover space: draw it as a partial preview so
+  // files past the fold are visibly present, not silently absent.
+  props.partialTrailingRow = true;
   syncListViewport(screen, props);
   screen.list(props);
 }


### PR DESCRIPTION
fui lists are drawing-virtualized but all viewport math assumed fixed row heights; two-line wrapped filenames make fewer rows fit than listVisibleRows estimates, so the selection could land on a never-drawn row (highlight "lands nowhere", including on wrap-around, since the last row sat past the count visibleRows clamp and was physically unreachable) and page-sized jumps skipped the rows between the real and estimated page boundaries (files unfindable). The SDK now feeds real layout back to the nav and the nav corrects itself before the frame is displayed