### PR TITLE
chore: revert light sleep code but keep battery drain fix

### DIFF
--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -93,10 +93,6 @@ bool HalDisplay::isInverted() const { return einkDisplay.isInverted(); }
 
 void HalDisplay::deepSleep() { einkDisplay.deepSleep(); }
 
-void HalDisplay::setBusyWaitSliceHook(bool (*sliceHook)(int8_t busyPin, uint8_t busyLevel)) {
-  einkDisplay.setBusyWaitSliceHook(sliceHook);
-}
-
 uint8_t* HalDisplay::getFrameBuffer() const { return einkDisplay.getFrameBuffer(); }
 
 uint8_t* HalDisplay::lendFrameBufferStorage(uint32_t* sizeOut) { return einkDisplay.lendBuildStorage(sizeOut); }

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -61,10 +61,6 @@ class HalDisplay {
   // Power management
   void deepSleep();
 
-  // Install the slice hook that replaces the BUSY poll delay on proven-long
-  // waits (see EpdBus::setBusyWaitSliceHook for the contract)
-  void setBusyWaitSliceHook(bool (*sliceHook)(int8_t busyPin, uint8_t busyLevel));
-
   // Access to frame buffer
   uint8_t* getFrameBuffer() const;
 

--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -6,7 +6,6 @@
 #include <Wire.h>
 #include <XteinkDetect.h>
 #include <esp_sleep.h>
-#include <soc/usb_serial_jtag_struct.h>
 
 // Global HalGPIO instance
 HalGPIO gpio;
@@ -141,42 +140,9 @@ void HalGPIO::begin() {
 
 void HalGPIO::update() {
   inputMgr.update();
-  updateUsbState(millis());
-}
-
-void HalGPIO::updateUsbState(const unsigned long now) {
-  // SOF-based host-link sampling (see the member comment). A cheap register
-  // read, so it runs at its own short cadence on both devices and is never
-  // behind the I2C throttle below — a fresh enumeration must cancel light
-  // sleep within a poll or two, or the next slice kills the CDC link again.
-  if (sofLastSampleMs == 0 || now - sofLastSampleMs >= SOF_SAMPLE_MS) {
-    const auto sof = static_cast<uint16_t>(USB_SERIAL_JTAG.fram_num.sof_frame_index);
-    usbSofActive = (sof != lastSofFrameIndex);
-    lastSofFrameIndex = sof;
-    sofLastSampleMs = now;
-  }
-
-  // Throttle the X3's I2C-based USB detection; see USB_POLL_X3_MS. First call
-  // (usbLastPollMs == 0) always polls so boot state is correct. The combined
-  // verdict below is still recomputed every call so a SOF-detected attach is
-  // not held back by the throttle window.
-  if (usbLastPollMs == 0 || !deviceIsX3() || now - usbLastPollMs >= USB_POLL_X3_MS) {
-    usbLastPollMs = now;
-    usbElectricalConnected = isUsbElectricalConnected();
-  }
-  const bool connected = usbSofActive || usbElectricalConnected;
+  const bool connected = isUsbConnected();
   usbStateChanged = (connected != lastUsbConnected);
   lastUsbConnected = connected;
-}
-
-void HalGPIO::pollUsbState() {
-  // Wait out the SOF sample floor so the comparison sees a real frame delta:
-  // two reads inside one USB frame compare equal and read as "no host".
-  const unsigned long elapsed = millis() - sofLastSampleMs;
-  if (sofLastSampleMs != 0 && elapsed < SOF_SAMPLE_MS) {
-    delay(SOF_SAMPLE_MS - elapsed);
-  }
-  updateUsbState(millis());
 }
 
 bool HalGPIO::wasUsbStateChanged() const { return usbStateChanged; }
@@ -190,8 +156,6 @@ bool HalGPIO::wasAnyPressed() const { return inputMgr.wasAnyPressed(); }
 bool HalGPIO::wasReleased(uint8_t buttonIndex) const { return inputMgr.wasReleased(buttonIndex); }
 
 bool HalGPIO::wasAnyReleased() const { return inputMgr.wasAnyReleased(); }
-
-bool HalGPIO::isDebouncePending() const { return inputMgr.isDebouncePending(); }
 
 unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 
@@ -287,16 +251,9 @@ bool HalGPIO::verifyPowerButtonWakeup(uint16_t requiredDurationMs, bool shortPre
 }
 
 bool HalGPIO::isUsbConnected() const {
-  // Recent SOF activity means an enumerated host regardless of what the
-  // electrical check says (false at boot until update() has sampled twice).
-  return usbSofActive || isUsbElectricalConnected();
-}
-
-bool HalGPIO::isUsbElectricalConnected() const {
   if (deviceIsX3()) {
     // X3: infer USB/charging via BQ27220 Current() register (0x0C, signed mA).
-    // Positive current means charging. Misses a data-only cable and a full
-    // battery — the SOF check in update() covers those.
+    // Positive current means charging.
     for (uint8_t attempt = 0; attempt < 2; ++attempt) {
       int16_t currentMa = 0;
       if (X3GPIO::readBQ27220CurrentMA(&currentMa)) {

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -45,35 +45,6 @@ class HalGPIO {
 
   bool lastUsbConnected = false;
   bool usbStateChanged = false;
-  unsigned long usbLastPollMs = 0;
-  bool usbElectricalConnected = false;  // last result of the per-device electrical/charge check
-
-  // X3 USB detection is a BQ27220 I2C read (~0.3-1 ms of awake CPU per call);
-  // polled every loop it costs a few percent of the light-sleep idle floor for
-  // nothing. At >=1 s intervals the energy cost is unmeasurable (~µC/s), so 1 s
-  // is chosen for prompt plug/unplug UX (battery icon, light-sleep USB guard /
-  // CDC recovery). X4 detection is a single digitalRead and stays per-loop.
-  static constexpr unsigned long USB_POLL_X3_MS = 1000;
-
-  // USB-Serial-JTAG SOF activity, sampled by update(): the host sends a SOF
-  // frame every 1 ms while the bus is enumerated, so a frame index that moved
-  // between two samples means a live host link. Catches what the charge-based
-  // X3 check misses: a data-only cable, and any cable once the battery is full
-  // (charge current ~0). Samples must be >SOF_SAMPLE_MS apart — update() can be
-  // called back-to-back (inner input loops), and adjacent reads would compare
-  // equal and flicker the verdict.
-  uint16_t lastSofFrameIndex = 0;
-  unsigned long sofLastSampleMs = 0;
-  bool usbSofActive = false;
-  static constexpr unsigned long SOF_SAMPLE_MS = 10;
-
-  // Per-device electrical/charge-inference USB check (fresh read; X3 = BQ27220
-  // charge current over I2C, X4 = VBUS-driven level on GPIO20).
-  bool isUsbElectricalConnected() const;
-
-  // Shared body of update()/pollUsbState(): SOF sampling + throttled electrical
-  // check + combined-verdict edge tracking.
-  void updateUsbState(unsigned long now);
 
  public:
   enum class DeviceType : uint8_t { X4, X3 };
@@ -105,11 +76,6 @@ class HalGPIO {
   bool wasAnyPressed() const;
   bool wasReleased(uint8_t buttonIndex) const;
   bool wasAnyReleased() const;
-  // True while a raw button-state change is still inside the debounce window.
-  // The idle loop polls fast while this is set so the confirming sample lands
-  // ~10 ms after the first; at the 50 ms light-sleep cadence a short tap can
-  // otherwise appear in a single sample and never commit (dropped press).
-  bool isDebouncePending() const;
   unsigned long getHeldTime() const;
   unsigned long getPowerButtonHeldTime() const;
   bool hasTouch() const;
@@ -146,19 +112,6 @@ class HalGPIO {
 
   // Check if USB is connected
   bool isUsbConnected() const;
-
-  // Sample USB state without a full input update. Called during setup() BEFORE
-  // the first e-ink refresh: the boot paint happens before loop() ever runs
-  // update(), so without this the light-sleep slice guards see the unsampled
-  // default ("no USB") and sleeping through the boot refresh kills a live CDC
-  // link (charge-based X3 detection also reads false whenever the battery is
-  // full). Two calls >=SOF_SAMPLE_MS apart establish the SOF verdict; the
-  // method itself waits out the floor if called too soon after the last sample.
-  void pollUsbState();
-
-  // USB state as sampled by the last update() call.
-  // Prefer this in per-loop polling: isUsbConnected() performs a fresh I2C read on X3.
-  bool isUsbConnectedCached() const { return lastUsbConnected; }
 
   // Returns true once per edge (plug or unplug) since the last update()
   bool wasUsbStateChanged() const;

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -4,13 +4,11 @@
 #include <Logging.h>
 #include <PowerManager.h>
 #include <WiFi.h>
-#include <driver/gpio.h>
 #include <esp_sleep.h>
 #include <soc/soc_caps.h>
 
 #include <cassert>
 
-#include "HalFrontlight.h"
 #include "HalGPIO.h"
 
 #if FREEINK_DEVICE_PAPERMONO
@@ -19,21 +17,18 @@
 
 HalPowerManager powerManager;  // Singleton instance
 
-// GPIO13 must stay high during light sleep on the C3 Xteink boards: it controls
-// the X4 battery latch and the X3 SD power rail. Other boards use it for
-// unrelated signals, including the X4 Pro display chip select.
+// GPIO13 controls the X4 battery latch and the X3 SD power rail on the C3
+// Xteink boards. Other boards use it for unrelated signals, including the
+// X4 Pro display chip select.
 static constexpr gpio_num_t XTEINK_C3_GPIO13 = GPIO_NUM_13;
 
 void HalPowerManager::begin() {
   if (BoardConfig::ACTIVE.batteryAdc >= 0) {
     pinMode(BoardConfig::ACTIVE.batteryAdc, INPUT);
   }
-  mainLoopTask = xTaskGetCurrentTaskHandle();  // Arduino runs setup() on the loop task
   normalFreq = getCpuFrequencyMhz();
   modeMutex = xSemaphoreCreateMutex();
   assert(modeMutex != nullptr);
-  sleepMutex = xSemaphoreCreateMutex();
-  assert(sleepMutex != nullptr);
 }
 
 void HalPowerManager::setPowerSaving(bool enabled) {
@@ -84,12 +79,9 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   if (gpio.isXteinkDevice()) {
     // GPIO13 gates the battery MOSFET on both Xteink C3 boards; driving it low
     // is the battery power-off (the SDK wake source still handles USB power).
-    // Unlike upstream, X3 is included: lightSleep() pad-holds the latch HIGH
-    // persistently while running (the IDF flash-leakage workaround would drop
-    // it mid-slice, hard-powering the device off), so the implicit low that
-    // upstream's X3 relies on never happens here — release the hold and drive
-    // the latch low explicitly. The hold_en survives deep sleep via the SDK's
-    // deepSleep() (esp_sleep_config_gpio_isolate + gpio_deep_sleep_hold_en).
+    // Release any surviving pad hold first: hold_en survives deep sleep via
+    // the SDK's deepSleep() (esp_sleep_config_gpio_isolate +
+    // gpio_deep_sleep_hold_en), and a held pad silently ignores the drive.
     gpio_hold_dis(XTEINK_C3_GPIO13);
     gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
     gpio_set_level(XTEINK_C3_GPIO13, 0);
@@ -118,170 +110,6 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   // Waits for the power button to be physically released (so holding it doesn't
   // immediately wake the device again), then arms the wake source and sleeps.
   freeink::PowerManager::deepSleepUntilPowerButton();
-}
-
-bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
-  // A performance Lock means a render (or similar) task is mid-flight; light sleep
-  // freezes the whole chip, so it would stall that task.
-  // Note: like setPowerSaving(), read without the mutex — stale in either
-  // direction is acceptable: a stale lock delays sleeping by one 50 ms slice;
-  // a Lock acquired after this check freezes that task for at most one slice
-  // (timer wake; RAM/peripheral state retained), which is cheaper than
-  // serializing Lock ctor/dtor against the entire sleep window.
-  if (currentLockMode != None) {
-    return false;
-  }
-  // Light sleep drops a WiFi association and kills an enumerated USB-CDC link.
-#ifdef FREEINK_FRONTLIGHT_LS
-  // The frontlight PWM runs from RC_FAST with KEEP_ALIVE and survives light
-  // sleep (SDK FREEINK_FRONTLIGHT_LS), so a lit light no longer blocks it.
-  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
-#else
-  // It also stops the default LEDC PWM output, visibly flashing ESP-driven
-  // frontlights as the idle loop enters repeated sleep slices.
-  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached() || (Frontlight.present() && Frontlight.isOn())) {
-#endif
-    return false;
-  }
-
-  // Serialize wake-source arming with the render task's BUSY-wait slice (see
-  // sleepMutex declaration for the failure mode this prevents).
-  xSemaphoreTake(sleepMutex, portMAX_DELAY);
-
-  // Timer wake keeps the button/tilt poll cadence identical to the delay() it
-  // replaces: the front/side buttons are ADC resistor-ladder inputs whose
-  // pressed levels sit mid-rail, invisible to a digital GPIO wake, so they
-  // must be polled. The power button (a true GPIO) is ALSO armed, as a level
-  // wake at its pressed level: committing a press needs two update() samples
-  // >=5 ms apart, so at the timer-only 50 ms cadence a tap shorter than a
-  // slice could land in one sample — or none — and be dropped entirely
-  // (field-reported as unreliable short-press sleep). The wake is only an
-  // early poll: update()'s debounce still decides whether it was a real
-  // press, so a misread around the sleep transition costs one extra wake
-  // blip, never a phantom press. Idle cost is zero — the pin only holds its
-  // pressed level while a finger is on it.
-  esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(LIGHT_SLEEP_SLICE_MS) * 1000ULL);
-  const int8_t powerPin = BoardConfig::ACTIVE.input.power;
-  if (powerPin >= 0) {
-    gpio_wakeup_enable(static_cast<gpio_num_t>(powerPin),
-                       BoardConfig::ACTIVE.input.powerActiveHigh ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL);
-    esp_sleep_enable_gpio_wakeup();
-  }
-
-  // The C3 flash-leakage workaround pulls its DIO-unused SPIWP pad low during
-  // light sleep. Hold GPIO13 high only on the X3/X4 boards that use that pad as
-  // a power control; on other boards GPIO13 may be a bus signal.
-  if (gpio.isXteinkDevice()) {
-    gpio_set_level(XTEINK_C3_GPIO13, 1);
-    gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
-    gpio_hold_en(XTEINK_C3_GPIO13);
-  }
-
-  const esp_err_t err = esp_light_sleep_start();
-
-  // Disarm immediately: an armed timer wake persists across sleep calls and would
-  // carry over into startDeepSleep(), waking the device on USB power after 50 ms.
-  // gpio_wakeup_disable() clears only the wake-enable bit — the pin's LEVEL
-  // interrupt type survives it. A leftover level type is live ammunition for
-  // any later-installed GPIO ISR service: an asserted level feeding the
-  // shared service with no per-pin handler registered re-enters the ISR
-  // forever and livelocks the CPU. Clear the type explicitly.
-  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
-  if (powerPin >= 0) {
-    gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
-    gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE);
-  }
-
-  xSemaphoreGive(sleepMutex);
-
-  if (err != ESP_OK) {
-    // e.g. ESP_ERR_SLEEP_REJECT — we did not actually sleep
-    LOG_DBG("PWR", "Light sleep rejected: %d", static_cast<int>(err));
-    return false;
-  }
-  return true;
-}
-
-bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t busyLevel) {
-  // Same exclusions as lightSleep(). No LOG here — this runs ~50x/s mid-refresh.
-#ifdef FREEINK_FRONTLIGHT_LS
-  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached()) {
-#else
-  if (WiFi.getMode() != WIFI_MODE_NULL || gpio.isUsbConnectedCached() || (Frontlight.present() && Frontlight.isOn())) {
-#endif
-    return false;
-  }
-
-  // Mid-debounce: committing needs a second sample, so let the SDK's short poll
-  // delay run instead of halting the chip. Same guard lightSleep() gets in loop().
-  // Unsynchronized like the checks above; stale costs at most one slice.
-  if (gpio.isDebouncePending()) {
-    return false;
-  }
-
-  xSemaphoreTake(sleepMutex, portMAX_DELAY);
-
-  // Wake the instant BUSY leaves its active level (refresh complete). Level
-  // wake (not edge) means an already-completed refresh returns immediately
-  // instead of sleeping a full slice. The timer bound only exists so the main
-  // loop gets scheduling windows to keep sampling the ADC-ladder buttons.
-  const auto pin = static_cast<gpio_num_t>(busyPin);
-  gpio_wakeup_enable(pin, busyLevel == HIGH ? GPIO_INTR_LOW_LEVEL : GPIO_INTR_HIGH_LEVEL);
-  // Also wake the instant the power button is pressed, so the main loop's poll
-  // sees even sub-slice taps mid-refresh (same rationale and safety argument
-  // as lightSleep(): the wake is an early poll, never a synthesized press).
-  const int8_t powerPin = BoardConfig::ACTIVE.input.power;
-  if (powerPin >= 0) {
-    gpio_wakeup_enable(static_cast<gpio_num_t>(powerPin),
-                       BoardConfig::ACTIVE.input.powerActiveHigh ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL);
-  }
-  esp_sleep_enable_gpio_wakeup();
-  esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(BUSY_SLEEP_SLICE_MS) * 1000ULL);
-
-  // Preserve the C3 Xteink GPIO13 power control during this sleep slice without
-  // reconfiguring GPIO13 on boards where it is a bus signal.
-  if (gpio.isXteinkDevice()) {
-    gpio_set_level(XTEINK_C3_GPIO13, 1);
-    gpio_set_direction(XTEINK_C3_GPIO13, GPIO_MODE_OUTPUT);
-    gpio_hold_en(XTEINK_C3_GPIO13);
-  }
-
-  const esp_err_t err = esp_light_sleep_start();
-
-  // Disarm everything armed above; an armed source persisting into
-  // startDeepSleep() would wake the device on USB power (see lightSleep()).
-  // As in lightSleep(): also clear the LEVEL interrupt types, which
-  // gpio_wakeup_disable() leaves behind (see the livelock note there).
-  esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
-  gpio_wakeup_disable(pin);
-  gpio_set_intr_type(pin, GPIO_INTR_DISABLE);
-  if (powerPin >= 0) {
-    gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
-    gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE);
-  }
-
-  xSemaphoreGive(sleepMutex);
-
-  if (err != ESP_OK) {
-    return false;  // e.g. ESP_ERR_SLEEP_REJECT — fall back to the SDK's poll delay
-  }
-
-  // Yield until the equal-priority main loop finishes an iteration, not just one
-  // tick: one tick is less awake CPU than an iteration needs, so we would re-halt
-  // the chip mid-poll. Capped so a loop parked on SD I/O can't hold the panel awake.
-  const uint32_t seenIterations = mainLoopIterations;
-  // Skipped entirely when the loop cannot make progress and the yield would just
-  // burn the cap awake: parked in requestUpdateAndWait() on this very render;
-  // never started (setup-time paints, iterations still 0); or this task IS the
-  // loop task (direct displayBuffer calls from setup()/loop() busy-wait here).
-  const bool loopCanPoll = !mainLoopBlocked && seenIterations != 0 && xTaskGetCurrentTaskHandle() != mainLoopTask;
-  unsigned yieldTicks = 0;
-  if (loopCanPoll) {
-    for (; yieldTicks < SLICE_YIELD_MAX_TICKS && mainLoopIterations == seenIterations; ++yieldTicks) {
-      vTaskDelay(1);
-    }
-  }
-  return true;
 }
 
 uint16_t HalPowerManager::getBatteryPercentage() const {

--- a/lib/hal/HalPowerManager.h
+++ b/lib/hal/HalPowerManager.h
@@ -23,26 +23,6 @@ class HalPowerManager {
   enum LockMode { None, NormalSpeed };
   LockMode currentLockMode = None;
   SemaphoreHandle_t modeMutex = nullptr;  // Protect access to currentLockMode
-  // Bumped by the main loop, read by the render task (see onEinkBusyWaitSlice).
-  // Single writer, naturally aligned: the 32-bit access is atomic on RISC-V.
-  volatile uint32_t mainLoopIterations = 0;
-
-  // Cap on how long one slice may stay awake waiting for that iteration.
-  // Productive yields measure ~0.4 ms, so two ticks is ample headroom.
-  static constexpr unsigned SLICE_YIELD_MAX_TICKS = 2;
-
-  // Set while the main loop is blocked in requestUpdateAndWait(). Captured in
-  // begin(), which Arduino runs on the loop task, so the handle compare below
-  // ignores any other task that might wait on a render.
-  TaskHandle_t mainLoopTask = nullptr;
-  volatile bool mainLoopBlocked = false;
-
-  // Serializes wake-source arm -> esp_light_sleep_start() -> disarm across the
-  // two sleepers (main-loop lightSleep() and the render task's BUSY-wait slice).
-  // Without it, lightSleep()'s deliberately unsynchronized lock-mode read could
-  // let both tasks interleave arming/disarming: the loser's disarm-all can strip
-  // the winner's wake sources and leave it sleeping with none armed.
-  SemaphoreHandle_t sleepMutex = nullptr;
 
  public:
 #if BOARD_HAS_PSRAM
@@ -50,20 +30,8 @@ class HalPowerManager {
 #else
   static constexpr int LOW_POWER_FREQ = 10;  // MHz
 #endif
-
-  // Two-stage idle backoff. Renders re-raise the clock via Lock regardless, so the
-  // full-speed window only needs to cover rapid consecutive input (avoids clock
-  // thrash); polling stays at 100 Hz until light sleep takes over the cadence.
-  static constexpr unsigned long IDLE_DOWNCLOCK_MS = 500;     // full speed -> LOW_POWER_FREQ
-  static constexpr unsigned long IDLE_LIGHT_SLEEP_MS = 1000;  // 100 Hz polling -> light sleep
-
-  static constexpr unsigned long BATTERY_POLL_MS = 1500;     // ms
-  static constexpr unsigned long LIGHT_SLEEP_SLICE_MS = 50;  // ms
-
-  // Timer bound for one BUSY-wait light-sleep slice. The refresh end itself
-  // wakes exactly via GPIO level wake on the BUSY pin; the timer only bounds
-  // how coarse main-loop button sampling gets during a long refresh.
-  static constexpr unsigned long BUSY_SLEEP_SLICE_MS = 20;  // ms
+  static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;  // ms
+  static constexpr unsigned long BATTERY_POLL_MS = 1500;       // ms
 
   void begin();
 
@@ -73,37 +41,6 @@ class HalPowerManager {
   // Setup wake up GPIO and enter deep sleep
   // Should be called inside main loop() to handle the currentLockMode
   void startDeepSleep(HalGPIO& gpio) const;
-
-  // Light-sleep the CPU for LIGHT_SLEEP_SLICE_MS (timer wake; buttons are polled on
-  // wake at the same cadence as the delay() this replaces). Returns false WITHOUT
-  // sleeping when unsafe: a performance Lock is held (render in flight), WiFi is
-  // active, or USB is connected (light sleep kills the CDC link). The caller must
-  // fall back to delay() in that case.
-  bool lightSleep(const HalGPIO& gpio) const;
-
-  // BUSY-wait slice hook (EpdBus::setBusyWaitSliceHook): light-sleep the chip
-  // for up to BUSY_SLEEP_SLICE_MS while the panel refreshes autonomously,
-  // waking early the moment the BUSY pin leaves `busyLevel`. Returns false
-  // WITHOUT sleeping when unsafe (WiFi active, USB connected, or sleep
-  // rejected) — the SDK then falls back to its plain poll delay. Called from
-  // the render task; safe by construction (the waiter IS the locked task).
-  // Leaves the CPU clock alone: the chip is asleep for most of the wait, so a
-  // downclock buys nothing and only slows the main loop's awake windows.
-  bool onEinkBusyWaitSlice(int8_t busyPin, uint8_t busyLevel);
-
-  // Call at the end of every main-loop iteration; paces the slice hook's yield.
-  // Read-then-assign, not ++: C++20 deprecates increment on a volatile lvalue.
-  void noteMainLoopIteration() { mainLoopIterations = mainLoopIterations + 1; }
-
-  // Bracket a blocking wait on the render task (requestUpdateAndWait). While the
-  // main loop is parked there it cannot poll, so the slice hook skips its yield
-  // instead of burning the full cap awake once per slice for nothing.
-  void noteRenderWaitBegin() {
-    if (xTaskGetCurrentTaskHandle() == mainLoopTask) mainLoopBlocked = true;
-  }
-  void noteRenderWaitEnd() {
-    if (xTaskGetCurrentTaskHandle() == mainLoopTask) mainLoopBlocked = false;
-  }
 
   // Get battery percentage (range 0-100)
   uint16_t getBatteryPercentage() const;

--- a/scripts/debugging_monitor.py
+++ b/scripts/debugging_monitor.py
@@ -32,7 +32,6 @@ import re
 import signal
 import sys
 import threading
-import time
 from collections import deque
 from datetime import datetime
 
@@ -66,11 +65,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default="",
         help="Suppress lines containing this keyword (case-insensitive)",
-    )
-    parser.add_argument(
-        "--no-graph",
-        action="store_true",
-        help="Disable the matplotlib memory graph (plain serial console + command prompt only)",
     )
     return parser
 
@@ -126,13 +120,6 @@ data_lock: threading.Lock = threading.Lock()  # Prevent reading while writing
 
 # Global shutdown flag
 shutdown_event = threading.Event()
-
-# Command-ack handshake: the firmware answers every CMD: line with CMDACK:<cmd>
-# (a handler ran) or CMDERR:<reason>:<cmd> (e.g. unknown — includes commands
-# compiled out of the running build). The reader thread sets ack_event when
-# either arrives so input_worker can report success, rejection, or a timeout.
-ACK_TIMEOUT_S = 2.0
-ack_event = threading.Event()
 
 # Initialize colors
 init(autoreset=True)
@@ -245,43 +232,12 @@ def parse_memory_line(line: str) -> tuple[int | None, int | None, int | None]:
     )
 
 
-def reopen_serial(ser_holder: dict) -> bool:
-    """
-    Close the (possibly dead) serial port and retry opening it until it comes back
-    or shutdown is requested. Devices re-enumerate on reboot/deep-sleep, so the
-    monitor must survive the port vanishing and reappearing. Returns True once
-    reconnected, False if shutting down.
-    """
-    try:
-        ser_holder["ser"].close()
-    except (OSError, serial.SerialException):
-        pass
-    print(f"{Fore.YELLOW}Serial disconnected - waiting for device to come back...{Style.RESET_ALL}")
-    while not shutdown_event.is_set():
-        try:
-            # Same no-reset open as the initial connect: deassert DTR/RTS
-            # before open() so the reconnect never reboots the device.
-            ser = serial.Serial(None, ser_holder["baud"], timeout=0.1)
-            ser.port = ser_holder["port"]
-            ser.dtr = False
-            ser.rts = False
-            ser.open()
-            ser_holder["ser"] = ser
-            print(f"{Fore.GREEN}Reconnected to {ser_holder['port']}{Style.RESET_ALL}")
-            return True
-        except (OSError, serial.SerialException):
-            time.sleep(0.25)
-    return False
-
-
-def serial_worker(ser_holder: dict, kwargs: dict[str, str]) -> None:
+def serial_worker(ser, kwargs: dict[str, str]) -> None:
     """
     Runs in a background thread. Handles reading serial data, printing to console,
     updating memory usage data for graphing, and processing screenshot data.
-    Automatically reconnects when the device reboots or is replugged.
     Monitors the global shutdown event for graceful termination.
     """
-    ser = ser_holder["ser"]
     print(f"{Fore.CYAN}--- Opening serial port ---{Style.RESET_ALL}")
     filter_keyword = kwargs.get("filter", "").lower()
     suppress = kwargs.get("suppress", "").lower()
@@ -306,88 +262,73 @@ def serial_worker(ser_holder: dict, kwargs: dict[str, str]) -> None:
 
     try:
         while not shutdown_event.is_set():
-            try:
-                if expecting_screenshot:
-                    data = ser.read(screenshot_size - len(screenshot_data))
-                    if not data:
+            if expecting_screenshot:
+                data = ser.read(screenshot_size - len(screenshot_data))
+                if not data:
+                    continue
+                screenshot_data += data
+                if len(screenshot_data) == screenshot_size:
+                    if Image:
+                        img = Image.frombytes("1", (800, 480), screenshot_data)
+                        # We need to rotate the image because the raw data is in landscape mode
+                        img = img.transpose(Image.ROTATE_270)
+                        img.save("screenshot.bmp")
+                        print(
+                            f"{Fore.GREEN}Screenshot saved to screenshot.bmp{Style.RESET_ALL}"
+                        )
+                    else:
+                        with open("screenshot.raw", "wb") as f:
+                            f.write(screenshot_data)
+                        print(
+                            f"{Fore.GREEN}Screenshot saved to screenshot.raw (PIL not available){Style.RESET_ALL}"
+                        )
+                    expecting_screenshot = False
+                    screenshot_data = b""
+            else:
+                try:
+                    raw_data = ser.readline().decode("utf-8", errors="replace")
+
+                    if not raw_data:
                         continue
-                    screenshot_data += data
-                    if len(screenshot_data) == screenshot_size:
-                        if Image:
-                            img = Image.frombytes("1", (800, 480), screenshot_data)
-                            # We need to rotate the image because the raw data is in landscape mode
-                            img = img.transpose(Image.ROTATE_270)
-                            img.save("screenshot.bmp")
-                            print(
-                                f"{Fore.GREEN}Screenshot saved to screenshot.bmp{Style.RESET_ALL}"
-                            )
-                        else:
-                            with open("screenshot.raw", "wb") as f:
-                                f.write(screenshot_data)
-                            print(
-                                f"{Fore.GREEN}Screenshot saved to screenshot.raw (PIL not available){Style.RESET_ALL}"
-                            )
-                        expecting_screenshot = False
-                        screenshot_data = b""
-                    continue
 
-                raw_data = ser.readline().decode("utf-8", errors="replace")
+                    clean_line = raw_data.strip()
+                    if not clean_line:
+                        continue
 
-                if not raw_data:
-                    continue
+                    if clean_line.startswith("SCREENSHOT_START:"):
+                        screenshot_size = int(clean_line.split(":")[1])
+                        expecting_screenshot = True
+                        continue
+                    elif clean_line == "SCREENSHOT_END":
+                        continue  # ignore
 
-                clean_line = raw_data.strip()
-                if not clean_line:
-                    continue
+                    # Add PC timestamp
+                    pc_time = datetime.now().strftime("%H:%M:%S")
+                    formatted_line = re.sub(r"^\[\d+\]", f"[{pc_time}]", clean_line)
 
-                # Command acks bypass filter/suppress: they are direct feedback
-                # for a command the user just typed, never routine log noise.
-                if clean_line.startswith("CMDACK:"):
-                    print(f"{Fore.GREEN}Command OK: {clean_line[len('CMDACK:'):]}{Style.RESET_ALL}")
-                    ack_event.set()
-                    continue
-                if clean_line.startswith("CMDERR:"):
-                    print(f"{Fore.RED}Command REJECTED: {clean_line[len('CMDERR:'):]}{Style.RESET_ALL}")
-                    ack_event.set()
-                    continue
+                    # Check for Memory Line
+                    if "[MEM]" in formatted_line:
+                        free_val, total_val, max_alloc_val = parse_memory_line(formatted_line)
+                        if free_val is not None and total_val is not None:
+                            with data_lock:
+                                time_data.append(pc_time)
+                                free_mem_data.append(free_val / 1024)
+                                total_mem_data.append(total_val / 1024)
+                                max_alloc_data.append((max_alloc_val or 0) / 1024)
+                    # Apply filters
+                    if filter_keyword and filter_keyword not in formatted_line.lower():
+                        continue
+                    if suppress and suppress in formatted_line.lower():
+                        continue
+                    # Print to console
+                    line_color = get_color_for_line(formatted_line)
+                    print(f"{line_color}{formatted_line}")
 
-                if clean_line.startswith("SCREENSHOT_START:"):
-                    screenshot_size = int(clean_line.split(":")[1])
-                    expecting_screenshot = True
-                    continue
-                elif clean_line == "SCREENSHOT_END":
-                    continue  # ignore
-
-                # Add PC timestamp
-                pc_time = datetime.now().strftime("%H:%M:%S")
-                formatted_line = re.sub(r"^\[\d+\]", f"[{pc_time}]", clean_line)
-
-                # Check for Memory Line
-                if "[MEM]" in formatted_line:
-                    free_val, total_val, max_alloc_val = parse_memory_line(formatted_line)
-                    if free_val is not None and total_val is not None:
-                        with data_lock:
-                            time_data.append(pc_time)
-                            free_mem_data.append(free_val / 1024)
-                            total_mem_data.append(total_val / 1024)
-                            max_alloc_data.append((max_alloc_val or 0) / 1024)
-                # Apply filters
-                if filter_keyword and filter_keyword not in formatted_line.lower():
-                    continue
-                if suppress and suppress in formatted_line.lower():
-                    continue
-                # Print to console
-                line_color = get_color_for_line(formatted_line)
-                print(f"{line_color}{formatted_line}")
-
-            except (OSError, serial.SerialException):
-                # Device rebooted, deep-slept, or was replugged: drop any partial
-                # screenshot transfer and wait for the port to come back.
-                expecting_screenshot = False
-                screenshot_data = b""
-                if not reopen_serial(ser_holder):
+                except (OSError, UnicodeDecodeError):
+                    print(
+                        f"{Fore.RED}Device disconnected or data error.{Style.RESET_ALL}"
+                    )
                     break
-                ser = ser_holder["ser"]
     except KeyboardInterrupt:
         # If thread is killed violently (e.g. main exit), silence errors
         pass
@@ -395,31 +336,17 @@ def serial_worker(ser_holder: dict, kwargs: dict[str, str]) -> None:
         pass  # ser closed in main
 
 
-def input_worker(ser_holder: dict) -> None:
+def input_worker(ser) -> None:
     """
     Runs in a background thread. Handles user input to send commands to the ESP32 device.
     Monitors the global shutdown event for graceful termination on Ctrl-C.
     """
     while not shutdown_event.is_set():
         try:
-            cmd = input("Command: ").strip()
-            if not cmd:
-                continue
-            ack_event.clear()
-            ser_holder["ser"].write(f"CMD:{cmd}\n".encode())
-            # The reader thread prints the ack/rejection line itself; this wait
-            # only exists to catch silence. SCREENSHOT acks after the ~48KB
-            # transfer, which finishes well inside the timeout at 115200 baud
-            # over USB-CDC (native USB, not actually rate-limited).
-            if not ack_event.wait(ACK_TIMEOUT_S):
-                print(
-                    f"{Fore.YELLOW}No response to CMD:{cmd} after {ACK_TIMEOUT_S:g}s - device may be "
-                    f"asleep/rebooting, or running firmware without command acks.{Style.RESET_ALL}"
-                )
+            cmd = input("Command: ")
+            ser.write(f"CMD:{cmd}\n".encode())
         except (EOFError, KeyboardInterrupt):
             break
-        except (OSError, serial.SerialException):
-            print(f"{Fore.YELLOW}Device not connected - command dropped.{Style.RESET_ALL}")
 
 
 def update_graph(frame) -> list:  # pylint: disable=unused-argument
@@ -531,24 +458,12 @@ def main() -> None:
         sys.exit(1)
 
     try:
-        # Deassert DTR/RTS BEFORE opening: passing the port to the constructor
-        # opens immediately with DTR asserted, and the USB-Serial-JTAG
-        # peripheral interprets that as a reset — rebooting the device on every
-        # monitor attach (the `reset=11` bench artifact) and destroying any
-        # wedged state we're trying to observe post-mortem.
-        ser = serial.Serial(None, args.baud, timeout=0.1)
-        ser.port = port
+        ser = serial.Serial(port, args.baud, timeout=0.1)
         ser.dtr = False
         ser.rts = False
-        ser.open()
     except serial.SerialException as e:
         print(f"{Fore.RED}Error opening port: {e}{Style.RESET_ALL}")
         return
-
-    # Shared holder so the reader thread can transparently reconnect (device
-    # reboots / deep sleeps / replugs) and the input thread always writes to
-    # the live port object.
-    ser_holder = {"ser": ser, "port": port, "baud": args.baud}
 
     # Set up signal handler for graceful shutdown
     signal.signal(signal.SIGINT, signal_handler)
@@ -556,24 +471,12 @@ def main() -> None:
     # 1. Start the Serial Reader in a separate thread
     # Daemon=True means this thread dies when the main program closes
     myargs = vars(args)  # Convert Namespace to dict for easier passing
-    t = threading.Thread(target=serial_worker, args=(ser_holder, myargs), daemon=True)
+    t = threading.Thread(target=serial_worker, args=(ser, myargs), daemon=True)
     t.start()
 
     # Start input thread
-    input_thread = threading.Thread(target=input_worker, args=(ser_holder,), daemon=True)
+    input_thread = threading.Thread(target=input_worker, args=(ser,), daemon=True)
     input_thread.start()
-
-    if args.no_graph:
-        # Plain console mode: keep the main thread alive until Ctrl-C
-        print(f"{Fore.YELLOW}Graph disabled (--no-graph). Press Ctrl-C to exit.{Style.RESET_ALL}")
-        try:
-            while not shutdown_event.is_set():
-                time.sleep(0.5)
-        except KeyboardInterrupt:
-            print(f"\n{Fore.YELLOW}Exiting...{Style.RESET_ALL}")
-        finally:
-            shutdown_event.set()
-        return
 
     # 2. Set up the Graph (Main Thread)
     try:

--- a/src/activities/ActivityManager.cpp
+++ b/src/activities/ActivityManager.cpp
@@ -351,11 +351,7 @@ void ActivityManager::requestUpdateAndWait() {
   assert(!holdingRenderLock && "Cannot call requestUpdateAndWait() while holding RenderLock");
 
   xTaskNotify(renderTaskHandle, 1, eIncrement);
-  // Tell the power manager the loop is parked here: it cannot poll input until the
-  // render finishes, so the BUSY-wait slice hook should not yield to it meanwhile.
-  powerManager.noteRenderWaitBegin();
   ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
-  powerManager.noteRenderWaitEnd();
 }
 
 // RenderLock

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -370,13 +370,6 @@ void setup() {
   halTiltSensor.begin();
   halClock.begin();
 
-  // First of two USB samples (second below, before display bring-up): the SOF
-  // verdict needs two samples a frame apart, and it must be settled before the
-  // first refresh — the boot paint's light-sleep slices would otherwise kill a
-  // live CDC link whenever the charge-based check reads false (full battery,
-  // data-only cable). See HalGPIO::pollUsbState().
-  gpio.pollUsbState();
-
   const auto wakeupReason = gpio.getWakeupReason();
 
   // Latch the recovery chord before SD and settings I/O. X4 Pro uses a plain
@@ -398,12 +391,6 @@ void setup() {
     }
   }
 
-  // Light-sleep through the render task's e-ink BUSY wait (0.3-2 s of pure pin
-  // polling) in short slices, waking exactly on the BUSY pin's completion level
-  // (falls back to plain polling when WiFi/USB blocks light sleep)
-  display.setBusyWaitSliceHook(
-      [](int8_t busyPin, uint8_t busyLevel) { return powerManager.onEinkBusyWaitSlice(busyPin, busyLevel); });
-
 #if FREEINK_DEVICE_X4 || FREEINK_DEVICE_X3
   LOG_INF("MAIN", "Hardware detect: %s", gpio.deviceIsX3() ? "X3" : "X4");
 #else
@@ -414,7 +401,6 @@ void setup() {
   // We need 6 open files concurrently when parsing a new chapter
   if (!Storage.begin()) {
     LOG_ERR("MAIN", "SD card initialization failed");
-    gpio.pollUsbState();  // settle the USB verdict before the error paint (see above)
     setupDisplayAndFonts(isSilentReboot);
     activityManager.goToFullScreenMessage("SD card error", EpdFontFamily::BOLD);
     return;
@@ -478,10 +464,6 @@ void setup() {
                             : isSleepWake && !APP_STATE.showBootScreen ? BootResume::SplashlessWake
                                                                        : BootResume::Splash;
   bool allowFastInitialReaderRefresh = false;
-
-  // Second USB sample (first one right after powerManager.begin()): settles the
-  // SOF host-link verdict before the first refresh can slice-sleep.
-  gpio.pollUsbState();
 
   setupDisplayAndFonts(resume != BootResume::Splash);
 
@@ -571,16 +553,6 @@ void setup() {
   allowSleepAt = millis() + 2000;
 }
 
-// delay() counts ticks, and the tick stops while onEinkBusyWaitSlice() light-sleeps
-// the chip (millis() is RTC-corrected on wake; the tick is not). A delay(10) mid-refresh
-// would stretch to ~210 ms and starve button sampling. millis() stays honest.
-static void delayWallClock(const unsigned long ms) {
-  const unsigned long deadline = millis() + ms;
-  while (static_cast<long>(millis() - deadline) < 0) {
-    vTaskDelay(1);
-  }
-}
-
 void loop() {
   static unsigned long maxLoopDuration = 0;
   const unsigned long loopStartTime = millis();
@@ -605,20 +577,13 @@ void loop() {
     if (line.startsWith("CMD:")) {
       String cmd = line.substring(4);
       cmd.trim();
-      bool handled = true;
       if (cmd == "SCREENSHOT") {
         const uint32_t bufferSize = display.getBufferSize();
         logSerial.printf("SCREENSHOT_START:%d\n", bufferSize);
         uint8_t* buf = display.getFrameBuffer();
         logSerial.write(buf, bufferSize);
         logSerial.printf("SCREENSHOT_END\n");
-      } else {
-        handled = false;
       }
-      // Raw print, not LOG_*: debugging_monitor.py keys on this ack to report
-      // command success, so it must survive LOG_LEVEL=0 builds. Commands
-      // compiled out of this build report unknown.
-      logSerial.printf(handled ? "CMDACK:%s\n" : "CMDERR:unknown:%s\n", cmd.c_str());
     }
   }
 
@@ -736,9 +701,6 @@ void loop() {
   activityManager.loop();
   const unsigned long activityDuration = millis() - activityStartTime;
 
-  // Body complete: releases the slice hook's yield (see onEinkBusyWaitSlice).
-  powerManager.noteMainLoopIteration();
-
   const unsigned long loopDuration = millis() - loopStartTime;
   if (loopDuration > maxLoopDuration) {
     maxLoopDuration = loopDuration;
@@ -754,40 +716,13 @@ void loop() {
     powerManager.setPowerSaving(false);  // Make sure we're at full performance when skipLoopDelay is requested
     yield();                             // Give FreeRTOS a chance to run tasks, but return immediately
   } else {
-    const unsigned long idleMs = millis() - lastActivityTime;
-    if (idleMs >= HalPowerManager::IDLE_LIGHT_SLEEP_MS) {
-      // Idle: light-sleep between input polls instead of busy-delaying (same poll cadence).
-      // Race-to-sleep: run the brief wake windows at normal clock, not LOW_POWER_FREQ.
-      // The board's sleep-floor current is paid per-millisecond regardless of CPU
-      // speed, so finishing the per-wake work ~16x faster and returning to sleep
-      // costs less charge than stretching the window at 10 MHz (measured at 10 MHz:
-      // 8.8 mA for 4.5 ms per wake). The downclock below only serves the pre-sleep
-      // 100 Hz delay-poll phase. The lightSleep()-rejected fallback delay() then
-      // also runs at normal clock, but that only happens when USB (externally
-      // powered), WiFi, or a render Lock (full speed wanted anyway) is active.
-      powerManager.setPowerSaving(false);
-      if (gpio.isDebouncePending()) {
-        // A raw button-state change is mid-debounce: commitment needs a second
-        // matching sample, so poll again quickly instead of sleeping a slice —
-        // a tap shorter than the 50 ms cadence would otherwise land in a single
-        // sample and be dropped, and every press would commit a slice late.
-        delayWallClock(10);
-      } else if (!powerManager.lightSleep(gpio)) {
-        // Light sleep declined = a render Lock, USB, or WiFi is active — the
-        // chip is at full clock anyway, so poll at 100 Hz. A 50 ms cadence
-        // here dropped sub-slice power taps (a press needs two samples >=5 ms
-        // apart to commit), which made short-press sleep flaky during renders
-        // — exactly when a render Lock forces this fallback.
-        delayWallClock(10);
-      }
+    if (millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
+      // If we've been inactive for a while, increase the delay to save power
+      powerManager.setPowerSaving(true);  // Lower CPU frequency after extended inactivity
+      delay(50);
     } else {
-      // Response window after recent input: keep 100 Hz polling for snappy interaction,
-      // but downclock once rapid-input bursts have settled — renders re-raise the clock
-      // via HalPowerManager::Lock, so full speed only serves loop bookkeeping here
-      if (idleMs >= HalPowerManager::IDLE_DOWNCLOCK_MS) {
-        powerManager.setPowerSaving(true);
-      }
-      delayWallClock(10);
+      // Short delay to prevent tight loop while still being responsive
+      delay(10);
     }
   }
 }


### PR DESCRIPTION
Simplifies USB connection detection by removing SOF-based sampling and I2C throttling logic. USB state is now determined by a single isUsbConnected() call instead of complex updateUsbState() polling. Also removes the display busy wait slice hook mechanism and associated debounce pending checks.

Reverts #2525 