### PR TITLE
feat: absolute lut sleep screen renderung for more smooth covers and custom bmp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "freeink-sdk"]
 	path = freeink-sdk
-	url = https://github.com/Free-Ink/freeink-sdk.git
-	branch = main
+	url = https://github.com/theZiz/freeink-sdk.git
+	branch = feat/absolute-lut-grayscale

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -555,14 +555,14 @@ const std::string& Epub::getLanguage() const {
   return bookMetadataCache->coreMetadata.language;
 }
 
-std::string Epub::getCoverBmpPath(bool cropped) const {
-  const auto coverFileName = std::string("cover") + (cropped ? "_crop" : "");
+std::string Epub::getCoverBmpPath(bool cropped, bool originalThresholds) const {
+  const auto coverFileName = std::string("cover") + (originalThresholds ? "_original" : "") + (cropped ? "_crop" : "");
   return cachePath + "/" + coverFileName + ".bmp";
 }
 
-bool Epub::generateCoverBmp(bool cropped) const {
+bool Epub::generateCoverBmp(bool cropped, bool originalThresholds) const {
   // Already generated, return true
-  if (Storage.exists(getCoverBmpPath(cropped).c_str())) {
+  if (Storage.exists(getCoverBmpPath(cropped, originalThresholds).c_str())) {
     return true;
   }
 
@@ -578,7 +578,8 @@ bool Epub::generateCoverBmp(bool cropped) const {
   }
 
   if (FsHelpers::hasJpgExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverJpgTempPath = getCachePath() + "/.cover.jpg";
 
     HalFile coverJpg;
@@ -594,10 +595,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped);
+    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverJpg.close();
     coverBmp.close();
@@ -605,14 +606,15 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from JPG cover image, success: %s", success ? "yes" : "no");
     return success;
   }
 
   if (FsHelpers::hasPngExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverPngTempPath = getCachePath() + "/.cover.png";
 
     HalFile coverPng;
@@ -628,10 +630,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped);
+    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverPng.close();
     coverBmp.close();
@@ -639,7 +641,7 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from PNG cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from PNG cover image, success: %s", success ? "yes" : "no");
     return success;

--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -632,14 +632,14 @@ const std::string& Epub::getLanguage() const {
   return bookMetadataCache->coreMetadata.language;
 }
 
-std::string Epub::getCoverBmpPath(bool cropped) const {
-  const auto coverFileName = std::string("cover") + (cropped ? "_crop" : "");
+std::string Epub::getCoverBmpPath(bool cropped, bool originalThresholds) const {
+  const auto coverFileName = std::string("cover") + (originalThresholds ? "_original" : "") + (cropped ? "_crop" : "");
   return cachePath + "/" + coverFileName + ".bmp";
 }
 
-bool Epub::generateCoverBmp(bool cropped) const {
+bool Epub::generateCoverBmp(bool cropped, bool originalThresholds) const {
   // Already generated, return true
-  if (Storage.exists(getCoverBmpPath(cropped).c_str())) {
+  if (Storage.exists(getCoverBmpPath(cropped, originalThresholds).c_str())) {
     return true;
   }
 
@@ -655,7 +655,8 @@ bool Epub::generateCoverBmp(bool cropped) const {
   }
 
   if (FsHelpers::hasJpgExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from JPG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverJpgTempPath = getCachePath() + "/.cover.jpg";
 
     HalFile coverJpg;
@@ -671,10 +672,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped);
+    const bool success = JpegToBmpConverter::jpegFileToBmpStream(coverJpg, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverJpg.close();
     coverBmp.close();
@@ -682,14 +683,15 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from JPG cover image, success: %s", success ? "yes" : "no");
     return success;
   }
 
   if (FsHelpers::hasPngExtension(coverImageHref)) {
-    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode)", cropped ? "cropped" : "fit");
+    LOG_DBG("EBP", "Generating BMP from PNG cover image (%s mode%s)", cropped ? "cropped" : "fit",
+            originalThresholds ? ", original thresholds" : "");
     const auto coverPngTempPath = getCachePath() + "/.cover.png";
 
     HalFile coverPng;
@@ -705,10 +707,10 @@ bool Epub::generateCoverBmp(bool cropped) const {
     }
 
     HalFile coverBmp;
-    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped), coverBmp)) {
+    if (!Storage.openFileForWrite("EBP", getCoverBmpPath(cropped, originalThresholds), coverBmp)) {
       return false;
     }
-    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped);
+    const bool success = PngToBmpConverter::pngFileToBmpStream(coverPng, coverBmp, cropped, originalThresholds);
     // Explicitly close() files before calling Storage.remove()
     coverPng.close();
     coverBmp.close();
@@ -716,7 +718,7 @@ bool Epub::generateCoverBmp(bool cropped) const {
 
     if (!success) {
       LOG_ERR("EBP", "Failed to generate BMP from PNG cover image");
-      Storage.remove(getCoverBmpPath(cropped).c_str());
+      Storage.remove(getCoverBmpPath(cropped, originalThresholds).c_str());
     }
     LOG_DBG("EBP", "Generated BMP from PNG cover image, success: %s", success ? "yes" : "no");
     return success;

--- a/lib/Epub/Epub.h
+++ b/lib/Epub/Epub.h
@@ -52,8 +52,8 @@ class Epub {
   const std::string& getTitle() const;
   const std::string& getAuthor() const;
   const std::string& getLanguage() const;
-  std::string getCoverBmpPath(bool cropped = false) const;
-  bool generateCoverBmp(bool cropped = false) const;
+  std::string getCoverBmpPath(bool cropped = false, bool originalThresholds = false) const;
+  bool generateCoverBmp(bool cropped = false, bool originalThresholds = false) const;
   std::string getThumbBmpPath() const;
   std::string getThumbBmpPath(int height) const;
   bool generateThumbBmp(int height) const;

--- a/lib/Epub/Epub/converters/DirectPixelWriter.h
+++ b/lib/Epub/Epub/converters/DirectPixelWriter.h
@@ -161,6 +161,14 @@ struct DirectPixelWriter {
         draw = (pixelValue == 1);
         state = false;
         break;
+      case GfxRenderer::ABSOLUTE_GRAY_LSB:
+        draw = true;
+        state = (pixelValue & 1);  // 1, 3
+        break;
+      case GfxRenderer::ABSOLUTE_GRAY_MSB:
+        draw = true;
+        state = (pixelValue > 1);  // 2, 3
+        break;
       default:
         return;
     }

--- a/lib/GfxRenderer/Bitmap.cpp
+++ b/lib/GfxRenderer/Bitmap.cpp
@@ -168,9 +168,9 @@ BmpReaderError Bitmap::parseHeaders() {
   const bool highColor = !nativePalette;
   if (highColor && dithering) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(width);
+      atkinsonDitherer = new AtkinsonDitherer(width, originalThresholds);
     } else {
-      fsDitherer = new FloydSteinbergDitherer(width);
+      fsDitherer = new FloydSteinbergDitherer(width, originalThresholds);
     }
   }
 

--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -64,7 +64,8 @@ class Bitmap {
  public:
   static const char* errorToString(BmpReaderError err);
 
-  explicit Bitmap(HalFile& file, bool dithering = false) : file(file), dithering(dithering) {}
+  explicit Bitmap(HalFile& file, bool dithering = false, bool originalThresholds = false)
+      : file(file), dithering(dithering), originalThresholds(originalThresholds) {}
   ~Bitmap();
   BmpReaderError parseHeaders();
   BmpReaderError readNextRow(uint8_t* data, uint8_t* rowBuffer) const;
@@ -83,6 +84,7 @@ class Bitmap {
 
   HalFile& file;
   bool dithering = false;
+  bool originalThresholds = false;
   int width = 0;
   int height = 0;
   bool topDown = false;

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -104,7 +104,8 @@ class Atkinson1BitDitherer {
 // Less error buildup = fewer artifacts than Floyd-Steinberg
 class AtkinsonDitherer {
  public:
-  explicit AtkinsonDitherer(int width) : width(width) {
+  explicit AtkinsonDitherer(int width, bool originalThresholds = false)
+      : width(width), originalThresholds(originalThresholds) {
     errorRow0 = new int16_t[width + 4]();  // Current row
     errorRow1 = new int16_t[width + 4]();  // Next row
     errorRow2 = new int16_t[width + 4]();  // Row after next
@@ -130,7 +131,7 @@ class AtkinsonDitherer {
     // Quantize to 4 levels
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
+    if (originalThresholds) {
       if (adjusted < 43) {
         quantized = 0;
         quantizedValue = 0;
@@ -189,10 +190,11 @@ class AtkinsonDitherer {
   }
 
  private:
-  int width;
+  const int width;
   int16_t* errorRow0;
   int16_t* errorRow1;
   int16_t* errorRow2;
+  const bool originalThresholds;
 };
 
 // Floyd-Steinberg error diffusion dithering with serpentine scanning
@@ -205,7 +207,8 @@ class AtkinsonDitherer {
 //      7/16  X
 class FloydSteinbergDitherer {
  public:
-  explicit FloydSteinbergDitherer(int width) : width(width), rowCount(0) {
+  explicit FloydSteinbergDitherer(int width, bool originalThresholds = false)
+      : width(width), rowCount(0), originalThresholds(originalThresholds) {
     errorCurRow = new int16_t[width + 2]();  // +2 for boundary handling
     errorNextRow = new int16_t[width + 2]();
   }
@@ -234,7 +237,7 @@ class FloydSteinbergDitherer {
     // Quantize to 4 levels (0, 85, 170, 255)
     uint8_t quantized;
     int quantizedValue;
-    if (false) {  // original thresholds
+    if (originalThresholds) {
       if (adjusted < 43) {
         quantized = 0;
         quantizedValue = 0;
@@ -315,8 +318,9 @@ class FloydSteinbergDitherer {
   }
 
  private:
-  int width;
+  const int width;
   int rowCount;
   int16_t* errorCurRow;
   int16_t* errorNextRow;
+  const bool originalThresholds;
 };

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1439,6 +1439,10 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
         drawPixel(screenX, screenY, false);
       } else if (renderMode == GRAYSCALE_LSB && val == 1) {
         drawPixel(screenX, screenY, false);
+      } else if (renderMode == ABSOLUTE_GRAY_LSB) {
+        drawPixel(screenX, screenY, val & 1);  // 1, 3
+      } else if (renderMode == ABSOLUTE_GRAY_MSB) {
+        drawPixel(screenX, screenY, val > 1);  // 2, 3
       }
     }
   }
@@ -1676,7 +1680,14 @@ void GfxRenderer::invertScreen() const {
 void GfxRenderer::displayBuffer(const HalDisplay::RefreshMode refreshMode) const {
   auto elapsed = millis() - start_ms;
   LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBuffer", elapsed);
-  display.displayBuffer(refreshMode, fadingFix);
+  // After an absolute LUT render, RED RAM still contains the grayscale MSB plane.
+  // Promote the first normal FAST refresh to HALF so both RAM banks are rebased
+  // before differential updates resume.
+  const bool afterAbsoluteLut = displayState == DisplayState::AbsoluteLut;
+  const auto effectiveRefreshMode =
+      afterAbsoluteLut && refreshMode == HalDisplay::FAST_REFRESH ? HalDisplay::HALF_REFRESH : refreshMode;
+  display.displayBuffer(effectiveRefreshMode, fadingFix);
+  displayState = DisplayState::BW;
 }
 
 void GfxRenderer::displayBufferAsync(const HalDisplay::RefreshMode refreshMode) const {
@@ -2221,6 +2232,11 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
 void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+
+void GfxRenderer::displayAbsoluteGrayBuffer() const {
+  display.displayAbsoluteGrayBuffer(fadingFix);
+  displayState = DisplayState::AbsoluteLut;
+}
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
   // Guard the uint16_t casts below: a negative would wrap to a huge length.

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1439,6 +1439,10 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
         drawPixel(screenX, screenY, false);
       } else if (renderMode == GRAYSCALE_LSB && val == 1) {
         drawPixel(screenX, screenY, false);
+      } else if (renderMode == ABSOLUTE_GRAY_LSB) {
+        drawPixel(screenX, screenY, val & 1);  // 1, 3
+      } else if (renderMode == ABSOLUTE_GRAY_MSB) {
+        drawPixel(screenX, screenY, val > 1);  // 2, 3
       }
     }
   }
@@ -1683,7 +1687,14 @@ void GfxRenderer::displayBuffer(HalDisplay::RefreshMode refreshMode) const {
   auto elapsed = millis() - start_ms;
   LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBuffer", elapsed);
   refreshMode = applyPromotedRefresh(refreshMode);
-  display.displayBuffer(refreshMode, fadingFix);
+  // After an absolute LUT render, RED RAM still contains the grayscale MSB plane.
+  // Promote the first normal FAST refresh to HALF so both RAM banks are rebased
+  // before differential updates resume.
+  const bool afterAbsoluteLut = displayState == DisplayState::AbsoluteLut;
+  const auto effectiveRefreshMode =
+      afterAbsoluteLut && refreshMode == HalDisplay::FAST_REFRESH ? HalDisplay::HALF_REFRESH : refreshMode;
+  display.displayBuffer(effectiveRefreshMode, fadingFix);
+  displayState = DisplayState::BW;
 }
 
 void GfxRenderer::displayBufferAsync(HalDisplay::RefreshMode refreshMode) const {
@@ -2229,6 +2240,11 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
 void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+
+void GfxRenderer::displayAbsoluteGrayBuffer() const {
+  display.displayAbsoluteGrayBuffer(fadingFix);
+  displayState = DisplayState::AbsoluteLut;
+}
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
   // Guard the uint16_t casts below: a negative would wrap to a huge length.

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -28,7 +28,13 @@ enum Color : uint8_t { Clear = 0x00, White = 0x01, LightGray = 0x05, DarkGray = 
 
 class GfxRenderer {
  public:
-  enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
+  enum RenderMode {
+    BW,                 // 1-bit black/white
+    GRAYSCALE_LSB,      // Differential gray: mark pixels for LSB plane (clearScreen(0x00) + drawPixel(false))
+    GRAYSCALE_MSB,      // Differential gray: mark pixels for MSB plane (clearScreen(0x00) + drawPixel(false))
+    ABSOLUTE_GRAY_LSB,  // Absolute gray: encode BW RAM = bit0 (clearScreen(0x00) + drawPixel(false))
+    ABSOLUTE_GRAY_MSB,  // Absolute gray: encode RED RAM = bit1 (clearScreen(0x00) + drawPixel(false))
+  };
 
   // Logical screen orientation from the perspective of callers
   enum Orientation {
@@ -37,6 +43,12 @@ class GfxRenderer {
     PortraitInverted,          // 480x800 logical coordinates, inverted
     LandscapeCounterClockwise  // 800x480 logical coordinates, native panel orientation
   };
+
+  // Display state — tracks whether the physical display was last updated via a absolute LUT render.
+  // BW: frameBuffer mirrors the display (menus, EPUB reader).
+  // AbsoluteLut: display holds a grayscale image; frameBuffer has been reset to white by
+  // cleanupGrayscaleWithFrameBuffer() and no longer represents what is visually shown.
+  enum class DisplayState { BW, AbsoluteLut };
 
  private:
   static constexpr size_t BW_BUFFER_CHUNK_SIZE = 8000;  // 8KB chunks to allow for non-contiguous memory
@@ -52,6 +64,8 @@ class GfxRenderer {
   uint32_t frameBufferSize = HalDisplay::BUFFER_SIZE;
   std::vector<uint8_t*> bwBufferChunks;
   std::map<int, EpdFontFamily> fontMap;
+  // Mutable becase the displayBuffer* methods are const
+  mutable DisplayState displayState = DisplayState::BW;
   // Mutable because ensureSdCardFontReady() is const (called from layout code
   // that holds a const GfxRenderer&) but triggers SD card reads and heap
   // allocation inside the SdCardFont objects. Same pragmatic compromise as
@@ -297,6 +311,8 @@ class GfxRenderer {
                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   int getTextHeight(int fontId) const;
 
+  DisplayState getDisplayState() const { return displayState; }
+
   // Grayscale functions
   void setRenderMode(const RenderMode mode) { this->renderMode = mode; }
   RenderMode getRenderMode() const { return renderMode; }
@@ -313,6 +329,8 @@ class GfxRenderer {
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer() const;
+  bool supportsAbsoluteGrayscale() const { return display.supportsAbsoluteGrayscale(); };
+  void displayAbsoluteGrayBuffer() const;
 
   // Tiled grayscale (X4): stream one band of a plane straight to controller RAM
   // from `scratch` (panelWidthBytes * numRows, physical rows [yStart, yStart+

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -28,7 +28,13 @@ enum Color : uint8_t { Clear = 0x00, White = 0x01, LightGray = 0x05, DarkGray = 
 
 class GfxRenderer {
  public:
-  enum RenderMode { BW, GRAYSCALE_LSB, GRAYSCALE_MSB };
+  enum RenderMode {
+    BW,                 // 1-bit black/white
+    GRAYSCALE_LSB,      // Differential gray: mark pixels for LSB plane (clearScreen(0x00) + drawPixel(false))
+    GRAYSCALE_MSB,      // Differential gray: mark pixels for MSB plane (clearScreen(0x00) + drawPixel(false))
+    ABSOLUTE_GRAY_LSB,  // Absolute gray: encode BW RAM = bit0 (no clearScreen needed, directly drawPixel)
+    ABSOLUTE_GRAY_MSB,  // Absolute gray: encode RED RAM = bit1 (no clearScreen needed, directly drawPixel)
+  };
 
   // Logical screen orientation from the perspective of callers
   enum Orientation {
@@ -37,6 +43,12 @@ class GfxRenderer {
     PortraitInverted,          // 480x800 logical coordinates, inverted
     LandscapeCounterClockwise  // 800x480 logical coordinates, native panel orientation
   };
+
+  // Display state — tracks whether the physical display was last updated via a absolute LUT render.
+  // BW: frameBuffer mirrors the display (menus, EPUB reader).
+  // AbsoluteLut: display holds a grayscale image; frameBuffer has been reset to white by
+  // cleanupGrayscaleWithFrameBuffer() and no longer represents what is visually shown.
+  enum class DisplayState { BW, AbsoluteLut };
 
  private:
   static constexpr size_t BW_BUFFER_CHUNK_SIZE = 8000;  // 8KB chunks to allow for non-contiguous memory
@@ -52,6 +64,8 @@ class GfxRenderer {
   uint32_t frameBufferSize = HalDisplay::BUFFER_SIZE;
   std::vector<uint8_t*> bwBufferChunks;
   std::map<int, EpdFontFamily> fontMap;
+  // Mutable becase the displayBuffer* methods are const
+  mutable DisplayState displayState = DisplayState::BW;
   // Mutable because ensureSdCardFontReady() is const (called from layout code
   // that holds a const GfxRenderer&) but triggers SD card reads and heap
   // allocation inside the SdCardFont objects. Same pragmatic compromise as
@@ -313,6 +327,8 @@ class GfxRenderer {
                            EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   int getTextHeight(int fontId) const;
 
+  DisplayState getDisplayState() const { return displayState; }
+
   // Grayscale functions
   void setRenderMode(const RenderMode mode) { this->renderMode = mode; }
   RenderMode getRenderMode() const { return renderMode; }
@@ -329,6 +345,8 @@ class GfxRenderer {
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
   void displayGrayBuffer() const;
+  bool supportsAbsoluteGrayscale() const { return display.supportsAbsoluteGrayscale(); };
+  void displayAbsoluteGrayBuffer() const;
 
   // Tiled grayscale (X4): stream one band of a plane straight to controller RAM
   // from `scratch` (panelWidthBytes * numRows, physical rows [yStart, yStart+

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.cpp
@@ -512,7 +512,8 @@ int bmpDrawCallback(JPEGDRAW* pDraw) {
 
 // Internal implementation with configurable target size and bit depth
 bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth,
-                                                     int targetHeight, bool oneBit, bool crop) {
+                                                     int targetHeight, bool oneBit, bool crop,
+                                                     bool originalThresholds) {
   LOG_DBG("JPG", "Converting JPEG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   if (ESP.getFreeHeap() < MIN_FREE_HEAP) {
@@ -680,13 +681,13 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
     }
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth);
+      ctx.atkinsonDitherer = makeUniqueNoThrow<AtkinsonDitherer>(outWidth, originalThresholds);
       if (!ctx.atkinsonDitherer) {
         LOG_ERR("JPG", "OOM: AtkinsonDitherer");
         return false;
       }
     } else if (USE_FLOYD_STEINBERG) {
-      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth);
+      ctx.fsDitherer = makeUniqueNoThrow<FloydSteinbergDitherer>(outWidth, originalThresholds);
       if (!ctx.fsDitherer) {
         LOG_ERR("JPG", "OOM: FloydSteinbergDitherer");
         return false;
@@ -713,11 +714,11 @@ bool JpegToBmpConverter::jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& b
 }
 
 // Core function: Convert JPEG file to 2-bit BMP (uses default target size)
-bool JpegToBmpConverter::jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop) {
+bool JpegToBmpConverter::jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop, bool originalThresholds) {
   // Use runtime display dimensions (swapped for portrait cover sizing)
   const int targetWidth = display.getDisplayHeight();
   const int targetHeight = display.getDisplayWidth();
-  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetWidth, targetHeight, false, crop);
+  return jpegFileToBmpStreamInternal(jpegFile, bmpOut, targetWidth, targetHeight, false, crop, originalThresholds);
 }
 
 // Convert with custom target size (for thumbnails, 2-bit)

--- a/lib/JpegToBmpConverter/JpegToBmpConverter.h
+++ b/lib/JpegToBmpConverter/JpegToBmpConverter.h
@@ -7,10 +7,10 @@ class ZipFile;
 
 class JpegToBmpConverter {
   static bool jpegFileToBmpStreamInternal(HalFile& jpegFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                          bool oneBit, bool crop = true);
+                                          bool oneBit, bool crop = true, bool originalThresholds = false);
 
  public:
-  static bool jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop = true);
+  static bool jpegFileToBmpStream(HalFile& jpegFile, Print& bmpOut, bool crop = true, bool originalThresholds = false);
   // Convert with custom target size (for thumbnails)
   static bool jpegFileToBmpStreamWithSize(HalFile& jpegFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   // Convert to 1-bit BMP (black and white only, no grays) for fast home screen rendering

--- a/lib/PngToBmpConverter/PngToBmpConverter.cpp
+++ b/lib/PngToBmpConverter/PngToBmpConverter.cpp
@@ -400,7 +400,7 @@ static void convertScanlineToGray(const PngDecodeContext& ctx, uint8_t* grayRow)
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                                   bool oneBit, bool crop) {
+                                                   bool oneBit, bool crop, bool originalThresholds) {
   LOG_DBG("PNG", "Converting PNG to %s BMP (target: %dx%d)", oneBit ? "1-bit" : "2-bit", targetWidth, targetHeight);
 
   // Verify PNG signature
@@ -632,9 +632,9 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
     atkinson1BitDitherer = new Atkinson1BitDitherer(outWidth);
   } else if (!USE_8BIT_OUTPUT) {
     if (USE_ATKINSON) {
-      atkinsonDitherer = new AtkinsonDitherer(outWidth);
+      atkinsonDitherer = new AtkinsonDitherer(outWidth, originalThresholds);
     } else if (USE_FLOYD_STEINBERG) {
-      fsDitherer = new FloydSteinbergDitherer(outWidth);
+      fsDitherer = new FloydSteinbergDitherer(outWidth, originalThresholds);
     }
   }
 
@@ -827,11 +827,11 @@ bool PngToBmpConverter::pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpO
   return success;
 }
 
-bool PngToBmpConverter::pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop) {
+bool PngToBmpConverter::pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop, bool originalThresholds) {
   // Use runtime display dimensions (swapped for portrait cover sizing)
   const int targetWidth = display.getDisplayHeight();
   const int targetHeight = display.getDisplayWidth();
-  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop);
+  return pngFileToBmpStreamInternal(pngFile, bmpOut, targetWidth, targetHeight, false, crop, originalThresholds);
 }
 
 bool PngToBmpConverter::pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth,

--- a/lib/PngToBmpConverter/PngToBmpConverter.h
+++ b/lib/PngToBmpConverter/PngToBmpConverter.h
@@ -6,10 +6,10 @@ class Print;
 
 class PngToBmpConverter {
   static bool pngFileToBmpStreamInternal(HalFile& pngFile, Print& bmpOut, int targetWidth, int targetHeight,
-                                         bool oneBit, bool crop = true);
+                                         bool oneBit, bool crop = true, bool originalThresholds = false);
 
  public:
-  static bool pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop = true);
+  static bool pngFileToBmpStream(HalFile& pngFile, Print& bmpOut, bool crop = true, bool originalThresholds = false);
   static bool pngFileToBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
   static bool pngFileTo1BitBmpStreamWithSize(HalFile& pngFile, Print& bmpOut, int targetMaxWidth, int targetMaxHeight);
 };

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -132,6 +132,10 @@ void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.
 
 void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
 
+bool HalDisplay::supportsAbsoluteGrayscale() const { return einkDisplay.supportsAbsoluteGrayscale(); }
+
+void HalDisplay::displayAbsoluteGrayBuffer(bool turnOffScreen) { einkDisplay.displayAbsoluteGrayBuffer(turnOffScreen); }
+
 void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
   einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,
                                        yStart, numRows);

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -91,6 +91,8 @@ class HalDisplay {
   void cleanupGrayscaleBuffers(const uint8_t* bwBuffer);
 
   void displayGrayBuffer(bool turnOffScreen = false);
+  bool supportsAbsoluteGrayscale() const;
+  void displayAbsoluteGrayBuffer(bool turnOffScreen = false);
 
   // Tiled grayscale: stream one band of a plane (lsbPlane selects LSB/MSB RAM)
   // straight to the controller; supportsStripGrayscale() gates the path. See

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -719,27 +719,52 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
   PngToFramebufferConverter converter;
   LOG_DBG("SLP", "Rendering transparent PNG overlay: %s (%dx%d)", path.c_str(), dimensions.width, dimensions.height);
 
-  if (!converter.decodeToFramebuffer(path, renderer, config)) return false;
-  renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+  const bool useAbsoluteGrayscale = renderer.supportsAbsoluteGrayscale();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
+  if (!useAbsoluteGrayscale) {
+    if (!converter.decodeToFramebuffer(path, renderer, config)) return false;
+    renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayGrayBuffer();
     renderer.setRenderMode(GfxRenderer::BW);
-    return true;
-  }
-  renderer.copyGrayscaleLsbBuffers();
+  } else {
+    // absolute lut mode renders inverted
+    renderer.invertScreen();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_LSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_MSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayAbsoluteGrayBuffer();
     renderer.setRenderMode(GfxRenderer::BW);
-    return true;
   }
-  renderer.copyGrayscaleMsbBuffers();
 
-  renderer.displayGrayBuffer();
-  renderer.setRenderMode(GfxRenderer::BW);
   return true;
 }
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -558,7 +558,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     Bitmap bitmap(file, true);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false, true);
       file.close();
       return;
     }
@@ -577,7 +577,7 @@ void SleepActivity::renderCustomSleepScreen() const {
       delay(100);
       Bitmap bitmap(randFile, true);
       if (bitmap.parseHeaders() == BmpReaderError::Ok) {
-        renderBitmapSleepScreen(bitmap);
+        renderBitmapSleepScreen(bitmap, false, true);
         randFile.close();
         return;
       }
@@ -609,7 +609,8 @@ void SleepActivity::renderDefaultSleepScreen() const {
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
 }
 
-void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool preserveBackground) const {
+void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool preserveBackground,
+                                            const bool absoluteLut) const {
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
   const auto placement = calculateBitmapPlacement(bitmap.getWidth(), bitmap.getHeight(), renderer);
@@ -626,7 +627,15 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
       bitmap.hasGreyscale() && (preserveBackground || SETTINGS.sleepScreenCoverFilter ==
                                                           CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER);
 
-  renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  const bool useAbsoluteGrayscale =
+      renderer.supportsAbsoluteGrayscale() && absoluteLut && hasGreyscale && !preserveBackground &&
+      SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+
+  LOG_DBG("SLP", "Using absolute lut: %s", useAbsoluteGrayscale ? "true" : "false");
+
+  if (!useAbsoluteGrayscale) {
+    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+  }
 
   if (!preserveBackground &&
       SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::INVERTED_BLACK_AND_WHITE) {
@@ -634,30 +643,41 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
   }
 
   if (hasGreyscale) {
-    // OEM grayscale pipeline base. Must stay HALF: the gray nudge LUT is
-    // calibrated against the pixel state the single-pass HALF waveform leaves
-    // behind. A FULL (GC) base parks pixels in a different charge state and
-    // the differential nudge then lands unevenly (blotchy noise in gray areas).
-    renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+    if (!useAbsoluteGrayscale) {
+      // OEM grayscale pipeline base. Must stay HALF: the gray nudge LUT is
+      // calibrated against the pixel state the single-pass HALF waveform leaves
+      // behind. A FULL (GC) base parks pixels in a different charge state and
+      // the differential nudge then lands unevenly (blotchy noise in gray areas).
+      renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+
+      bitmap.rewindToData();
+      renderer.clearScreen(0x00);
+      renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+      renderer.copyGrayscaleLsbBuffers();
+
+      bitmap.rewindToData();
+      renderer.clearScreen(0x00);
+      renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+      renderer.copyGrayscaleMsbBuffers();
+
+      renderer.displayGrayBuffer();
+    } else {
+      renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_LSB);
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+      renderer.copyGrayscaleLsbBuffers();
+
+      bitmap.rewindToData();
+      renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_MSB);
+      renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
+      renderer.copyGrayscaleMsbBuffers();
+
+      renderer.displayAbsoluteGrayBuffer();
+    }
+    renderer.setRenderMode(GfxRenderer::BW);
   } else {
     renderer.displayBuffer(HalDisplay::HALF_REFRESH);
-  }
-
-  if (hasGreyscale) {
-    bitmap.rewindToData();
-    renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
-    renderer.copyGrayscaleLsbBuffers();
-
-    bitmap.rewindToData();
-    renderer.clearScreen(0x00);
-    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-    renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
-    renderer.copyGrayscaleMsbBuffers();
-
-    renderer.displayGrayBuffer();
-    renderer.setRenderMode(GfxRenderer::BW);
   }
 }
 
@@ -764,6 +784,7 @@ void SleepActivity::renderCoverSleepScreen() const {
 
   std::string coverBmpPath;
   bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
+  bool absoluteLut = false;
 
   // Check if the current book is XTC, TXT, or EPUB
   if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
@@ -803,12 +824,17 @@ void SleepActivity::renderCoverSleepScreen() const {
       return (this->*renderNoCoverSleepScreen)();
     }
 
-    if (!lastEpub.generateCoverBmp(cropped)) {
+    // figure out which cover image renderBitmapSleepScreen will need. The othre conditions in that
+    // method (hasGreyscale and !preserveBackground) are known to be true when rendering a cover.
+    absoluteLut = renderer.supportsAbsoluteGrayscale() &&
+                  SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+
+    if (!lastEpub.generateCoverBmp(cropped, absoluteLut)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");
       return (this->*renderNoCoverSleepScreen)();
     }
 
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped);
+    coverBmpPath = lastEpub.getCoverBmpPath(cropped, absoluteLut);
   } else {
     return (this->*renderNoCoverSleepScreen)();
   }
@@ -818,7 +844,7 @@ void SleepActivity::renderCoverSleepScreen() const {
     Bitmap bitmap(file);
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
-      renderBitmapSleepScreen(bitmap);
+      renderBitmapSleepScreen(bitmap, false, absoluteLut);
       return;
     }
   }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -213,7 +213,7 @@ uint8_t bayerThreshold4x4(const int x, const int y) {
   return BAYER_4X4[((y & 0x03) << 2) | (x & 0x03)];
 }
 
-enum class TransparentOverlayPass : uint8_t { BW, GrayscaleLsb, GrayscaleMsb };
+enum class TransparentOverlayPass : uint8_t { BW, GrayscaleLsb, GrayscaleMsb, AbsoluteLsb, AbsoluteMsb };
 
 uint8_t quantizeOverlayLum(const uint8_t lum) {
   // Match Bitmap's native-palette path: 0, 85, 170, 255 map directly to levels 0..3.
@@ -289,6 +289,12 @@ bool renderTransparentOverlayPass(HalFile& file, const OverlayBmpInfo& info, con
         case TransparentOverlayPass::GrayscaleMsb:
           if (level == 1 || level == 2) renderer.drawPixel(screenX, screenY, false);
           break;
+        case TransparentOverlayPass::AbsoluteLsb:
+          renderer.drawPixel(screenX, screenY, level & 1);
+          break;
+        case TransparentOverlayPass::AbsoluteMsb:
+          renderer.drawPixel(screenX, screenY, level > 1);
+          break;
       }
     }
   }
@@ -341,29 +347,61 @@ AlphaOverlayResult tryRenderTransparentOverlayBmp(HalFile& file, GfxRenderer& re
 
   LOG_DBG("SLP", "Rendering transparent overlay: %s (%dx%d)", pathForLog, info.width, info.height);
 
-  if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(), TransparentOverlayPass::BW))
-    return AlphaOverlayResult::Error;
-  renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+  const bool useAbsoluteGrayscale = renderer.supportsAbsoluteGrayscale();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-  if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(), TransparentOverlayPass::GrayscaleLsb)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    // The BW composite is already on the panel. Keep it instead of falling
-    // through to another overlay with this grayscale work buffer cleared.
-    return AlphaOverlayResult::Rendered;
+  LOG_DBG("SLP", "Using absolute lut: %s", useAbsoluteGrayscale ? "true" : "false");
+
+  if (!useAbsoluteGrayscale) {
+    if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(), TransparentOverlayPass::BW))
+      return AlphaOverlayResult::Error;
+    renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(),
+                                      TransparentOverlayPass::GrayscaleLsb)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      // The BW composite is already on the panel. Keep it instead of falling
+      // through to another overlay with this grayscale work buffer cleared.
+      return AlphaOverlayResult::Rendered;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(),
+                                      TransparentOverlayPass::GrayscaleMsb)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return AlphaOverlayResult::Rendered;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayGrayBuffer();
+  } else {
+    // absolute lut mode renders inverted
+    renderer.invertScreen();
+
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_LSB);
+    if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(),
+                                      TransparentOverlayPass::AbsoluteLsb)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      // The BW composite is already on the panel. Keep it instead of falling
+      // through to another overlay with this grayscale work buffer cleared.
+      return AlphaOverlayResult::Rendered;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_MSB);
+    if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(),
+                                      TransparentOverlayPass::AbsoluteMsb)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return AlphaOverlayResult::Rendered;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayAbsoluteGrayBuffer();
   }
-  renderer.copyGrayscaleLsbBuffers();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-  if (!renderTransparentOverlayPass(file, info, placement, renderer, row.get(), TransparentOverlayPass::GrayscaleMsb)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    return AlphaOverlayResult::Rendered;
-  }
-  renderer.copyGrayscaleMsbBuffers();
-
-  renderer.displayGrayBuffer();
   renderer.setRenderMode(GfxRenderer::BW);
   return AlphaOverlayResult::Rendered;
 }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -719,27 +719,52 @@ bool SleepActivity::renderTransparentOverlayPng(const std::string& path) const {
   PngToFramebufferConverter converter;
   LOG_DBG("SLP", "Rendering transparent PNG overlay: %s (%dx%d)", path.c_str(), dimensions.width, dimensions.height);
 
-  if (!converter.decodeToFramebuffer(path, renderer, config)) return false;
-  renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+  const bool useAbsoluteGrayscale = renderer.supportsAbsoluteGrayscale();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    return true;
+  if (!useAbsoluteGrayscale) {
+    if (!converter.decodeToFramebuffer(path, renderer, config)) return false;
+    renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.clearScreen(0x00);
+    renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayGrayBuffer();
+  } else {
+    // absolute lut mode renders inverted
+    renderer.invertScreen();
+
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_LSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleLsbBuffers();
+
+    renderer.setRenderMode(GfxRenderer::ABSOLUTE_GRAY_MSB);
+    if (!converter.decodeToFramebuffer(path, renderer, config)) {
+      renderer.setRenderMode(GfxRenderer::BW);
+      return true;
+    }
+    renderer.copyGrayscaleMsbBuffers();
+
+    renderer.displayAbsoluteGrayBuffer();
   }
-  renderer.copyGrayscaleLsbBuffers();
 
-  renderer.clearScreen(0x00);
-  renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
-  if (!converter.decodeToFramebuffer(path, renderer, config)) {
-    renderer.setRenderMode(GfxRenderer::BW);
-    return true;
-  }
-  renderer.copyGrayscaleMsbBuffers();
-
-  renderer.displayGrayBuffer();
   renderer.setRenderMode(GfxRenderer::BW);
+
   return true;
 }
 

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -593,7 +593,7 @@ void SleepActivity::renderCustomSleepScreen() const {
   // This takes priority over the /sleep folder.
   HalFile file;
   if (Storage.openFileForRead("SLP", "/sleep.bmp", file)) {
-    Bitmap bitmap(file, true);
+    Bitmap bitmap(file, true, useOriginalThresholds());
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Loading: /sleep.bmp");
       renderBitmapSleepScreen(bitmap, false, true);
@@ -613,7 +613,7 @@ void SleepActivity::renderCustomSleepScreen() const {
     if (Storage.openFileForRead("SLP", selectedPath, randFile)) {
       LOG_DBG("SLP", "Randomly loading: %s", selectedPath.c_str());
       delay(100);
-      Bitmap bitmap(randFile, true);
+      Bitmap bitmap(randFile, true, useOriginalThresholds());
       if (bitmap.parseHeaders() == BmpReaderError::Ok) {
         renderBitmapSleepScreen(bitmap, false, true);
         randFile.close();
@@ -887,10 +887,7 @@ void SleepActivity::renderCoverSleepScreen() const {
       return (this->*renderNoCoverSleepScreen)();
     }
 
-    // figure out which cover image renderBitmapSleepScreen will need. The othre conditions in that
-    // method (hasGreyscale and !preserveBackground) are known to be true when rendering a cover.
-    absoluteLut = renderer.supportsAbsoluteGrayscale() &&
-                  SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
+    absoluteLut = useOriginalThresholds();
 
     if (!lastEpub.generateCoverBmp(cropped, absoluteLut)) {
       LOG_ERR("SLP", "Failed to generate cover bmp");
@@ -904,7 +901,7 @@ void SleepActivity::renderCoverSleepScreen() const {
 
   HalFile file;
   if (Storage.openFileForRead("SLP", coverBmpPath, file)) {
-    Bitmap bitmap(file);
+    Bitmap bitmap(file);  // dithering and original thresholds not needed as ignored for true 2 bit BMP
     if (bitmap.parseHeaders() == BmpReaderError::Ok) {
       LOG_DBG("SLP", "Rendering sleep cover: %s", coverBmpPath.c_str());
       renderBitmapSleepScreen(bitmap, false, absoluteLut);
@@ -930,4 +927,10 @@ void SleepActivity::renderLastScreenSleepScreen() const {
 void SleepActivity::renderBlankSleepScreen() const {
   renderer.clearScreen();
   renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+}
+
+bool SleepActivity::useOriginalThresholds() const {
+  // figure out whether the bitmap draw or creation needs the original thresholds:
+  return renderer.supportsAbsoluteGrayscale() &&
+         SETTINGS.sleepScreenCoverFilter == CrossPointSettings::SLEEP_SCREEN_COVER_FILTER::NO_FILTER;
 }

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -16,7 +16,8 @@ class SleepActivity final : public Activity {
   void renderDefaultSleepScreen() const;
   void renderCustomSleepScreen() const;
   void renderCoverSleepScreen() const;
-  void renderBitmapSleepScreen(const Bitmap& bitmap, bool preserveBackground = false) const;
+  void renderBitmapSleepScreen(const Bitmap& bitmap, bool preserveBackground = false,
+                               const bool absoluteLut = false) const;
   bool renderSleepOverlayFile(HalFile& file, const char* pathForLog) const;
   bool renderTransparentOverlayPng(const std::string& path) const;
   bool renderSleepOverlayPath(const std::string& path) const;

--- a/src/activities/boot_sleep/SleepActivity.h
+++ b/src/activities/boot_sleep/SleepActivity.h
@@ -25,5 +25,7 @@ class SleepActivity final : public Activity {
   void renderTransparentCustomSleepScreen() const;
   void renderBlankSleepScreen() const;
 
+  bool useOriginalThresholds() const;
+
   bool fromTimeout = false;
 };


### PR DESCRIPTION
## Summary

Second try of adding absolute lut sleep screen rendering for X4 with SSD1677 display controller.

Based on the work of zgredex, who unfortunately didn't continue his efforts: https://github.com/crosspoint-reader/crosspoint-reader/pull/1614

My first attempt + never merged fix are here: https://github.com/crosspoint-reader/crosspoint-reader/pull/3018 and https://github.com/crosspoint-reader/crosspoint-reader/pull/3031

Needs an update of the FreeSDK beforehand to detect absolute lut capabilities.

### Before / After pictures

See: https://github.com/crosspoint-reader/crosspoint-reader/pull/3031

### What changed:

* On X4 with SSD1677 display controller the epub cover and the custom sleep screen are rendered with the absolute lut extracted from the original firmware, which look way better than the differential approach.
* In that case a "cover_original[_crop].bmp" is generated. The standard rendering patch creates slightly brighter (= not original thresholds, thus the name) bmp. Those are still used for all cases where absolute lut rendering is not used:
* This works only without sleep screen filter activated.
* Transparent sleep screen, empty and Crosspoint logo are not touched.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
