### PR TITLE
docs: correct contributing guide to branch from develop

### DIFF
--- a/docs/contributing/development-workflow.md
+++ b/docs/contributing/development-workflow.md
@@ -8,7 +8,7 @@ This page defines the expected local workflow before opening a pull request.
 - Clone your fork locally and add the upstream repository if needed
 - Enable repo hooks once per clone: `git config core.hooksPath .githooks && chmod +x .githooks/pre-commit`
 
-- Branch from `master`
+- Branch from `develop`
 - Keep each PR focused on one fix or feature area
 
 ## 2) Implement with scope in mind

--- a/docs/contributing/development-workflow.md
+++ b/docs/contributing/development-workflow.md
@@ -30,6 +30,7 @@ If `clang-format` is missing or too old locally, see [Getting Started](./getting
 
 ## 4) Open the PR
 
+- Target `develop` (the repository's default branch)
 - Use a semantic title (example: `fix: avoid crash when opening malformed epub`)
 - Fill out `.github/PULL_REQUEST_TEMPLATE.md`
 - Describe the problem, approach, and any tradeoffs


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Align the contributor onboarding page with the current branching model.
* **What changes are included?** Two lines in `docs/contributing/development-workflow.md`:
  * §1: `Branch from master` → `Branch from develop`.
  * §4: add `Target develop (the repository's default branch)` — the section never said what to target.

The page still tells new contributors to branch from `master`. That instruction predates the gitflow migration: `develop` became the default branch in July, announced in #2339 (where the modified gitflow was agreed) and #2507 (where open PRs were asked to retarget from `master` to `develop`) — which is also the case the new §4 line is meant to prevent.

`AGENTS.md` already describes the current model — "Integration branches and PR comparisons target `develop`, not `master`" — so this page was the only spot left out of step, and the two files currently contradict each other.

Deliberately kept to what is actually practised: I did not document the `release/*` and `hotfix/*` branches from the #2339 proposal, since no such branches exist on the repo today, nor a branch-naming convention, since current branches use a mix (`feat-`, `fix-`, `feature/`, `fix/`, `chore/`). Happy to expand the page into a full gitflow description if you'd rather have the target state written down.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. *(N/A — documentation only.)*
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. *(N/A — none of these are touched.)*

## Additional Context

* Documentation only — no code, no build or memory impact.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
