### PR TITLE
fix: x4 usb attach freeze

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -168,6 +168,16 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
     esp_sleep_enable_gpio_wakeup();
   }
 
+  // Wake the instant USB is attached so a plug-in never lands inside a sleep
+  // slice: the next poll then sees USB and declines all further sleep, closing
+  // the mid-slice attach window the cached guard can't cover. X4's usbDetect is
+  // a real VBUS-driven GPIO (HIGH = attached); X3 has none (usbDetect < 0).
+  const int8_t usbPin = BoardConfig::ACTIVE.usbDetect;
+  if (usbPin >= 0) {
+    gpio_wakeup_enable(static_cast<gpio_num_t>(usbPin), GPIO_INTR_HIGH_LEVEL);
+    esp_sleep_enable_gpio_wakeup();
+  }
+
   // The C3 flash-leakage workaround pulls its DIO-unused SPIWP pad low during
   // light sleep. Hold GPIO13 high only on the X3/X4 boards that use that pad as
   // a power control; on other boards GPIO13 may be a bus signal.
@@ -199,6 +209,10 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
   if (powerPin >= 0) {
     gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
     gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE);
+  }
+  if (usbPin >= 0) {
+    gpio_wakeup_disable(static_cast<gpio_num_t>(usbPin));
+    gpio_set_intr_type(static_cast<gpio_num_t>(usbPin), GPIO_INTR_DISABLE);
   }
 
   xSemaphoreGive(sleepMutex);
@@ -244,6 +258,12 @@ bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t bu
     gpio_wakeup_enable(static_cast<gpio_num_t>(powerPin),
                        BoardConfig::ACTIVE.input.powerActiveHigh ? GPIO_INTR_HIGH_LEVEL : GPIO_INTR_LOW_LEVEL);
   }
+  // Wake on USB attach mid-refresh too, so a plug-in never sleeps through the
+  // enumeration transient (see lightSleep(); X4 usbDetect only, X3 < 0).
+  const int8_t usbPin = BoardConfig::ACTIVE.usbDetect;
+  if (usbPin >= 0) {
+    gpio_wakeup_enable(static_cast<gpio_num_t>(usbPin), GPIO_INTR_HIGH_LEVEL);
+  }
   esp_sleep_enable_gpio_wakeup();
   esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(BUSY_SLEEP_SLICE_MS) * 1000ULL);
 
@@ -274,6 +294,10 @@ bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t bu
   if (powerPin >= 0) {
     gpio_wakeup_disable(static_cast<gpio_num_t>(powerPin));
     gpio_set_intr_type(static_cast<gpio_num_t>(powerPin), GPIO_INTR_DISABLE);
+  }
+  if (usbPin >= 0) {
+    gpio_wakeup_disable(static_cast<gpio_num_t>(usbPin));
+    gpio_set_intr_type(static_cast<gpio_num_t>(usbPin), GPIO_INTR_DISABLE);
   }
 
   xSemaphoreGive(sleepMutex);

--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -179,6 +179,15 @@ bool HalPowerManager::lightSleep(const HalGPIO& gpio) const {
 
   const esp_err_t err = esp_light_sleep_start();
 
+  if (gpio.isXteinkDevice()) {
+    // Return GPIO13 to live GPIO-matrix control the moment we wake. The hold is
+    // only needed to survive the in-sleep flash-leakage workaround (see above);
+    // left latched across idle, the battery-MOSFET pad cannot follow a USB-attach
+    // power-path transition and the device hangs.
+    gpio_hold_dis(XTEINK_C3_GPIO13);
+    gpio_set_level(XTEINK_C3_GPIO13, 1);
+  }
+
   // Disarm immediately: an armed timer wake persists across sleep calls and would
   // carry over into startDeepSleep(), waking the device on USB power after 50 ms.
   // gpio_wakeup_disable() clears only the wake-enable bit — the pin's LEVEL
@@ -247,6 +256,13 @@ bool HalPowerManager::onEinkBusyWaitSlice(const int8_t busyPin, const uint8_t bu
   }
 
   const esp_err_t err = esp_light_sleep_start();
+
+  if (gpio.isXteinkDevice()) {
+    // Release the GPIO13 latch on wake; see lightSleep() for why leaving it held
+    // across idle wedges the battery-MOSFET pad on USB attach.
+    gpio_hold_dis(XTEINK_C3_GPIO13);
+    gpio_set_level(XTEINK_C3_GPIO13, 1);
+  }
 
   // Disarm everything armed above; an armed source persisting into
   // startDeepSleep() would wake the device on USB power (see lightSleep()).


### PR DESCRIPTION
hopefully fixes the usb hangup issue reported by @itsthisjustin [here](https://github.com/crosspoint-reader/crosspoint-reader/pull/2525#issuecomment-5309202346). **I don't have an x4 device, so I'm unable to test this on my own**, but the reasoning Claude gave is fairly convincing. I never had any issue on my x3, and these new commits don't change that.

The root cause looks like the light-sleep path leaving GPIO13 (the battery-MOSFET gate) latched HIGH via `gpio_hold_en` across the *entire* idle period, not just during each sleep slice. A frozen pad can't follow the power-path transition when USB VBUS arrives, which is consistent with the "entire device is dead" symptom (hold latches survive a reset).

> Commit 1 (a91b5136) — Adds gpio_hold_dis(GPIO13) + re-drive HIGH right after each esp_light_sleep_start() returns, in both lightSleep() and onEinkBusyWaitSlice(). GPIO13 is now latch-frozen only for the ~50 ms sleep interval instead of permanently across idle. Zero power cost.

> Commit 2 (c450cce5) — the window-closer. Arms BoardConfig::ACTIVE.usbDetect (X4 = GPIO20) as a light-sleep level wake in both paths, with matching disarm + interrupt-type clear. An attach now wakes the chip immediately; the next poll declines further sleep. No-op on X3 (usbDetect < 0).

The two commits are independent — if you flash at commit 1 alone and the freeze is already gone, that confirms the GPIO13 latch was the cause and commit 2 is just additional defense.

I'll go ahead and also re-measure power consumption on https://github.com/crosspoint-reader/crosspoint-reader/pull/3077 incase we are unable to resolve the usb-freezing issue.