### PR TITLE
feat: strip embedded fonts during EPUB optimization

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4160,7 +4160,7 @@ function collectFontPaths(zip, opfContent, opfPath) {
 // multi-hundred-KB data: URIs, so this is a size win even without font files.
 function stripFontFaceRules(css) {
   let count = 0;
-  const stripped = css.replace(/@font-face\s*\{[^{}]*\}/gi, () => { count++; return ''; });
+  const stripped = css.replace(/@font-face(?:\s|\/\*[\s\S]*?\*\/)*\{[^{}]*\}/gi, () => { count++; return ''; });
   return { css: stripped, count };
 }
 
@@ -5163,7 +5163,8 @@ async function convertEpubFile(file, progressCallback) {
 
   // Embedded fonts are dropped entirely — CrossPoint never renders with them.
   // Counters cover font files, @font-face rules (incl. data: URI fonts), and
-  // encryption.xml shrinkage so the savings report reflects every strip site.
+  // encryption.xml shrinkage; they count uncompressed content bytes removed
+  // (the final archive-size delta is reported separately by logSummary).
   const fontPaths = collectFontPaths(zip, opfContent, opfPath);
   let removedFontCount = 0;
   let removedFontBytes = 0;
@@ -5420,7 +5421,7 @@ async function convertEpubFile(file, progressCallback) {
   }
 
   if (removedFontCount > 0 || removedFontFaceRules > 0) {
-    log(`Removed ${removedFontCount} embedded font(s) and ${removedFontFaceRules} @font-face rule(s), saved ${formatBytes(removedFontBytes)}`, '', 'INFO');
+    log(`Removed ${removedFontCount} embedded font(s) and ${removedFontFaceRules} @font-face rule(s), ${formatBytes(removedFontBytes)} of font data`, '', 'INFO');
   }
 
   if (progressCallback) progressCallback(100);

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4124,12 +4124,79 @@ function syncNCXIdentifier(ncxText, mainIdentifier) {
   return t;
 }
 
+// ===== Embedded font removal =====
+// CrossPoint renders with built-in / SD-card fonts and never loads fonts
+// embedded in an EPUB, so they are dead weight (often 100KB-2MB per book).
+const FONT_EXT_REGEX = /\.(ttf|otf|woff2?|eot)$/;
+const FONT_MEDIA_TYPE_REGEX = /^(font\/|application\/font-|application\/x-font-|application\/vnd\.ms-(opentype|fontobject)$)/i;
+
+// Returns a Set of zip-root-relative paths of embedded font files, detected by
+// file extension and by OPF manifest media-type (catches odd extensions).
+function collectFontPaths(zip, opfContent, opfPath) {
+  const fontPaths = new Set();
+  zip.forEach(p => { if (FONT_EXT_REGEX.test(p.toLowerCase())) fontPaths.add(p); });
+
+  if (opfContent && opfPath) {
+    try {
+      const doc = new DOMParser().parseFromString(opfContent, 'application/xml');
+      if (!doc.querySelector('parsererror')) {
+        for (const item of [...doc.getElementsByTagNameNS('*', 'item')]) {
+          const type = item.getAttribute('media-type') || '';
+          const href = item.getAttribute('href') || '';
+          if (href && FONT_MEDIA_TYPE_REGEX.test(type)) {
+            const resolved = resolvePath(opfPath, decodeHref(href));
+            if (zip.files[resolved]) fontPaths.add(resolved);
+          }
+        }
+      }
+    } catch (e) {
+      // Extension-based detection already covers the common cases
+    }
+  }
+  return fontPaths;
+}
+
+// Strips all @font-face rules from CSS. Rules can also embed fonts directly as
+// multi-hundred-KB data: URIs, so this is a size win even without font files.
+function stripFontFaceRules(css) {
+  let count = 0;
+  const stripped = css.replace(/@font-face\s*\{[^{}]*\}/gi, () => { count++; return ''; });
+  return { css: stripped, count };
+}
+
+// Removes font-obfuscation <EncryptedData> entries from META-INF/encryption.xml.
+// Returns { dropFile: true } when nothing meaningful remains, { modified, xml }
+// when some entries were removed, or { modified: false } to keep the file as-is.
+function stripFontEncryptionEntries(xmlText, fontPaths) {
+  try {
+    const doc = new DOMParser().parseFromString(xmlText, 'application/xml');
+    if (doc.querySelector('parsererror')) return { modified: false };
+    const entries = [...doc.getElementsByTagNameNS('*', 'EncryptedData')];
+    let removed = 0;
+    for (const entry of entries) {
+      const ref = entry.getElementsByTagNameNS('*', 'CipherReference')[0];
+      const uri = ref ? decodeHref(ref.getAttribute('URI') || '') : '';
+      if (fontPaths.has(uri.replace(/^\//, ''))) {
+        entry.parentNode.removeChild(entry);
+        removed++;
+      }
+    }
+    if (!removed) return { modified: false };
+    const remaining = doc.getElementsByTagNameNS('*', 'EncryptedData').length +
+                      doc.getElementsByTagNameNS('*', 'EncryptedKey').length;
+    if (remaining === 0) return { dropFile: true };
+    return { modified: true, xml: safeSerialize(doc, xmlText) };
+  } catch (e) {
+    return { modified: false };
+  }
+}
+
 /**
  * Fix OPF content: fix media-types, strip svg properties,
- * update split image manifest entries, ensure cover meta.
- * DOMParser with regex fallback.
+ * update split image manifest entries, remove stripped font
+ * entries, ensure cover meta. DOMParser with regex fallback.
  */
-function fixOPF(opfText, opfOriginal, opfDir, splitImages = {}) {
+function fixOPF(opfText, opfOriginal, opfDir, splitImages = {}, fontPaths = null) {
   let t = opfText;
 
   try {
@@ -4156,6 +4223,15 @@ function fixOPF(opfText, opfOriginal, opfDir, splitImages = {}) {
         const newProps = props.split(/\s+/).filter(p => p !== 'svg').join(' ').trim();
         if (newProps) item.setAttribute('properties', newProps);
         else item.removeAttribute('properties');
+      }
+    }
+
+    // Remove manifest entries for stripped embedded fonts
+    if (fontPaths && fontPaths.size) {
+      for (const item of items) {
+        const href = decodeHref(item.getAttribute('href') || '');
+        const full = resolvePath((opfDir ? opfDir + '/' : '') + 'x', href);
+        if (fontPaths.has(full)) item.parentNode.removeChild(item);
       }
     }
 
@@ -4194,6 +4270,13 @@ function fixOPF(opfText, opfOriginal, opfDir, splitImages = {}) {
     t = t.replace(/(<(?:\w+:)?item\b[^>]*href="[^"]+\.jpg"[^>]*)media-type="image\/(png|gif|webp|bmp)"/g, '$1media-type="image/jpeg"');
     t = t.replace(/(<(?:\w+:)?item\b[^>]*)media-type="image\/(png|gif|webp|bmp)"([^>]*href="[^"]+\.jpg")/g, '$1media-type="image/jpeg"$3');
     t = t.replace(/\s+svg(?=["'\s>])/g, '');
+    if (fontPaths && fontPaths.size) {
+      for (const p of fontPaths) {
+        const href = opfDir && p.startsWith(opfDir + '/') ? p.substring(opfDir.length + 1) : p;
+        const itemRegex = new RegExp(`<(?:\\w+:)?item\\b[^>]*href=["']${escapeRegex(href)}["'][^>]*\\/?>\\s*`, 'gi');
+        t = t.replace(itemRegex, '');
+      }
+    }
     for (const [splitKey, splitInfo] of Object.entries(splitImages)) {
       const parts = splitInfo.parts || splitInfo;
       let origHref = opfDir && splitKey.startsWith(opfDir + '/') ? splitKey.substring(opfDir.length + 1) : splitKey;
@@ -5078,6 +5161,14 @@ async function convertEpubFile(file, progressCallback) {
     if (progressCallback) progressCallback((i / entries.length) * 60);
   }
 
+  // Embedded fonts are dropped entirely — CrossPoint never renders with them.
+  // Counters cover font files, @font-face rules (incl. data: URI fonts), and
+  // encryption.xml shrinkage so the savings report reflects every strip site.
+  const fontPaths = collectFontPaths(zip, opfContent, opfPath);
+  let removedFontCount = 0;
+  let removedFontBytes = 0;
+  let removedFontFaceRules = 0;
+
   // Second pass: update XHTML using DOMParser
   for (const [xhtmlPath, content] of Object.entries(xhtmlFiles)) {
     if (operationCancelled) throw new Error('Cancelled by user');
@@ -5236,6 +5327,17 @@ async function convertEpubFile(file, progressCallback) {
       console.warn('DOMParser error for', xhtmlPath, e.message);
     }
 
+    // Strip @font-face rules from inline <style> blocks — embedded font files
+    // are removed, so leftover rules would reference missing resources
+    t = t.replace(/(<style\b[^>]*>)([\s\S]*?)(<\/style>)/gi, (m, open, css, close) => {
+      const ff = stripFontFaceRules(css);
+      if (!ff.count) return m;
+      removedFontFaceRules += ff.count;
+      removedFontBytes += new TextEncoder().encode(css).length - new TextEncoder().encode(ff.css).length;
+      logFix('@font-face', `${ff.count} rule(s) removed from ${escapeHtml(xhtmlPath.split('/').pop())}`);
+      return open + ff.css + close;
+    });
+
     // Inject universal image constraint — prevents overflow on e-ink displays
     if (t.includes('</head>')) {
       t = t.replace('</head>', DEFENSIVE_STYLE + '</head>');
@@ -5256,7 +5358,7 @@ async function convertEpubFile(file, progressCallback) {
       t = t.split(o.split('/').pop()).join(n.split('/').pop());
     }
     const opfDir = opfPath.includes('/') ? opfPath.substring(0, opfPath.lastIndexOf('/')) : '';
-    t = fixOPF(t, opfContent, opfDir, splitImages);
+    t = fixOPF(t, opfContent, opfDir, splitImages, fontPaths);
     if (t !== opfContent) logFix('OPF', 'manifest updated');
     out.file(opfPath, t, { compression: 'DEFLATE', compressionOptions: { level: 8 }, createFolders: false });
   }
@@ -5268,13 +5370,42 @@ async function convertEpubFile(file, progressCallback) {
     const low = path.toLowerCase();
     if (low.match(/\.(png|gif|webp|bmp|jpg|jpeg)$/) || low.match(/\.(xhtml|html|htm)$/) || low.endsWith('.opf')) continue;
 
+    if (fontPaths.has(path)) {
+      const fontData = await fileObj.async('arraybuffer');
+      removedFontCount++;
+      removedFontBytes += fontData.byteLength;
+      log(`${escapeHtml(path.split('/').pop())} <span class="log-detail">(${formatBytes(fontData.byteLength)})</span>`, 'success', 'REMOVE');
+      continue;
+    }
+
     let data = await fileObj.async('arraybuffer');
     if (low.endsWith('.css')) {
       let t = await safeReadText(fileObj);
       for (const [o, n] of Object.entries(renamed)) {
         t = t.split(o.split('/').pop()).join(n.split('/').pop());
       }
+      const ff = stripFontFaceRules(t);
+      if (ff.count) {
+        removedFontFaceRules += ff.count;
+        removedFontBytes += new TextEncoder().encode(t).length - new TextEncoder().encode(ff.css).length;
+        t = ff.css;
+        logFix('@font-face', `${ff.count} rule(s) removed from ${escapeHtml(path.split('/').pop())}`);
+      }
       data = new TextEncoder().encode(t);
+    } else if (path === 'META-INF/encryption.xml' && fontPaths.size) {
+      const t = await safeReadText(fileObj);
+      const enc = stripFontEncryptionEntries(t, fontPaths);
+      if (enc.dropFile) {
+        removedFontBytes += data.byteLength;
+        logFix('encryption.xml', 'removed (contained only font obfuscation entries)');
+        continue;
+      }
+      if (enc.modified) {
+        const encoded = new TextEncoder().encode(enc.xml);
+        removedFontBytes += Math.max(0, data.byteLength - encoded.length);
+        data = encoded;
+        logFix('encryption.xml', 'font obfuscation entries removed');
+      }
     } else if (low.endsWith('.ncx')) {
       let t = await safeReadText(fileObj);
       for (const [o, n] of Object.entries(renamed)) {
@@ -5286,6 +5417,10 @@ async function convertEpubFile(file, progressCallback) {
       data = new TextEncoder().encode(t);
     }
     out.file(path, data, { compression: 'DEFLATE', compressionOptions: { level: 8 }, createFolders: false });
+  }
+
+  if (removedFontCount > 0 || removedFontFaceRules > 0) {
+    log(`Removed ${removedFontCount} embedded font(s) and ${removedFontFaceRules} @font-face rule(s), saved ${formatBytes(removedFontBytes)}`, '', 'INFO');
   }
 
   if (progressCallback) progressCallback(100);


### PR DESCRIPTION
Per @serialx's recommendation and @Uri-Tauber's request in [#1757 (comment)](https://github.com/crosspoint-reader/crosspoint-reader/discussions/1757#discussioncomment-17997328), this PR upstreams my commit `ae85f2a5` from serialx's fork. This PR is reopened with the earlier submission's issues fixed and the change hardened by review and device testing.

## Summary

* **What is the goal of this PR?** The browser-side Optimize & Upload pipeline now strips embedded fonts from EPUBs. CrossPoint renders with built-in / SD-card fonts and never loads fonts embedded in a book, so they are dead weight — commonly 100 KB–2 MB, and up to 18.5 MB in the Korean novels I tested. Removing them shrinks books dramatically and reduces on-device unzip/parse cost.
* **What changes are included?** One file, `src/network/html/FilesPage.html` (+139/−4):
  * Font detection by file extension (`ttf/otf/woff/woff2/eot`, case-insensitive) and by OPF manifest media-type (`font/*`, `application/font-*`, `application/x-font-*`, `vnd.ms-opentype`, `vnd.ms-fontobject`) for odd extensions
  * OPF manifest entries for removed fonts are deleted (DOM path with regex fallback, same structure as the existing `fixOPF` repairs)
  * `@font-face` rules stripped from CSS files **and** inline XHTML `<style>` blocks, including `data:` URI fonts embedded directly in CSS
  * Font-obfuscation entries removed from `META-INF/encryption.xml`; the file is dropped entirely when nothing meaningful remains
  * Conversion log reports each removal (`[REMOVE]`/`[FIX]` lines) and a total: fonts removed, `@font-face` rules removed, bytes saved across all strip sites

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. *(N/A — this PR touches none of those areas.)*

Related: the CrossPoint Calibre plugin already strips fonts off-device, which validates the approach — this PR brings the same capability to users who upload through the built-in web optimizer without Calibre. Complementary to #1825 (font *extraction/conversion* for the web optimizer): stripping is the simple default; extraction can layer on top later.

## Additional Context

* **Flash impact (measured):** +1,768 bytes (5,697,185 → 5,698,953; +0.031%) on the `default` env. The page is minified and gzip-compressed at embed time, so the ~120 lines of JS cost little.
* **EPUB savings (measured, on device):** two Korean novels tested — 7.3 MB → 305.6 KB (2 fonts, 16.7 MB uncompressed removed) and 13.1 MB → 459.0 KB, −96.6% (4 fonts, 18.5 MB removed). Both open and render correctly on an X3 with built-in fonts.
* **Validation:** optimized output passes epubcheck 5.3.0 with zero errors on 8 test books — IDPF samples (including `wasteland-otf-obf` and `wasteland-woff-obf` with obfuscated fonts, where `encryption.xml` is correctly removed), Project Gutenberg #1342, and a synthetic book with `@font-face` inside an inline `<style>` block. No-font EPUBs pass through untouched.
* **Review feedback from the earlier #3085 run is addressed:** inline `<style>` blocks are now stripped, and the bytes-saved report covers CSS/`data:`-URI and `encryption.xml` savings, not just deleted font files.
* **Known limitations (deliberate):** a `}` inside a CSS comment inside an `@font-face` block leaves inert residue (pathological input; the regex structurally cannot eat adjacent rules — its failure mode is under-matching only); the regex fallback for malformed OPFs does not match percent-encoded hrefs (consistent with the existing fallback behavior for split images).
* **Areas to focus on:** the `@font-face` regex and the `encryption.xml` handling are the parts with edge-case surface; both have the test evidence above.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — the implementation and tests were developed with AI assistance under my direction and review; I take full responsibility for the change, and I tested it on real hardware.
