### PR TITLE
fix: Release SD font cache before render transparent sleep overlay

### DIFF
--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -477,7 +477,7 @@ bool drawSleepPopupPreservingFrame(GfxRenderer& renderer) {
   return true;
 }
 
-void releaseSdFontCachesForDecode(GfxRenderer& renderer) {
+void releaseSdFontCachesForDecode(const GfxRenderer& renderer) {
   if (auto* fcm = renderer.getFontCacheManager()) {
     LOG_DBG("SLP", "Free heap before SD font cache release: %d bytes", ESP.getFreeHeap());
     fcm->releaseSdFontCaches();

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <Epub.h>
 #include <Epub/converters/PngToFramebufferConverter.h>
+#include <FontCacheManager.h>
 #include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalDisplay.h>
@@ -476,6 +477,14 @@ bool drawSleepPopupPreservingFrame(GfxRenderer& renderer) {
   return true;
 }
 
+void releaseSdFontCachesForDecode(GfxRenderer& renderer) {
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    LOG_DBG("SLP", "Free heap before SD font cache release: %d bytes", ESP.getFreeHeap());
+    fcm->releaseSdFontCaches();
+    LOG_DBG("SLP", "Free heap before sleep image decode: %d bytes", ESP.getFreeHeap());
+  }
+}
+
 }  // namespace
 
 void SleepActivity::onEnter() {
@@ -509,6 +518,7 @@ void SleepActivity::onEnter() {
     if (APP_STATE.lastSleepFromReader) {
       renderer.setOrientation(GfxRenderer::Orientation::Portrait);
     }
+    releaseSdFontCachesForDecode(renderer);
     return renderTransparentCustomSleepScreen();
   }
 


### PR DESCRIPTION
## Summary

When using a CJK Font (Chinese, Korean, Japanese etc) and it's cached (Thanks to PR https://github.com/crosspoint-reader/crosspoint-reader/pull/3026), and when using the new "Transparent" sleep overlay option with a PNG file, the device would frequently simply display the Dark sleep screen, presumably due to running out of heap space.

This change reuses the method as https://github.com/crosspoint-reader/crosspoint-reader/pull/3035, by simply releasing the SD font cache before rendering.

## Scope Check
- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Tested on my XTEINK X3, with a Chinese Font, after opening a Traditional Chinese epub book, and putting multiple PNG files in the sleep-overlay folder.
* There were other areas that also frequently fail (See an abort() error or out of memory error) that I suspect is due to the CJK fonts being cached, namely:
  - KOReader Sync
  - OPDS browser
  - Font Download screen
 
  However, adding the free font cache code doesn't seem to consistently fix the issue, therefore I omitted those and chose to just raise a PR for the sleep-overlay screen alone.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
