### PR TITLE
fix: block cursor mangles non-ASCII characters in cursor mode

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -716,9 +716,20 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   const int maxLineWidth = textAreaWidth;
   const bool centerText = metrics.keyboardCenteredText;
 
+  // The cursor spans a whole code point: a lone byte of it renders as a replacement glyph.
+  // Masking is per byte, so displayText keeps text's length and the same span applies to both.
+  const size_t cursorCharBytes = (cursorPos < text.length()) ? utf8Next(text, cursorPos) - cursorPos : 0;
+  char cursorChar[8] = {};         // the character under the cursor
+  char displayCursorChar[8] = {};  // same span of displayText, masked for passwords
+  if (cursorCharBytes > 0) {
+    const size_t n = std::min(cursorCharBytes, sizeof(cursorChar) - 1);
+    memcpy(cursorChar, text.data() + cursorPos, n);
+    memcpy(displayCursorChar, displayText.data() + cursorPos, n);
+  }
+
   int cursorCharWidth = 6;
-  if (cursorPos < text.length()) {
-    int w = renderer.getTextWidth(UI_12_FONT_ID, text.substr(cursorPos, 1).c_str());
+  if (cursorCharBytes > 0) {
+    int w = renderer.getTextWidth(UI_12_FONT_ID, cursorChar);
     if (w > cursorCharWidth) cursorCharWidth = w;
   }
 
@@ -745,12 +756,11 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         }
         int beforeWidth = renderer.getTextAdvanceX(UI_12_FONT_ID, beforeCursor.c_str(), EpdFontFamily::REGULAR);
         int kernOffset = 0;
-        if (cursorPos < displayText.length()) {
-          std::string beforeAndCursor = beforeCursor + displayText.substr(cursorPos, 1);
+        if (cursorCharBytes > 0) {
+          std::string beforeAndCursor = beforeCursor + displayCursorChar;
           int beforeAndCursorWidth =
               renderer.getTextAdvanceX(UI_12_FONT_ID, beforeAndCursor.c_str(), EpdFontFamily::REGULAR);
-          int charAdvance =
-              renderer.getTextAdvanceX(UI_12_FONT_ID, displayText.substr(cursorPos, 1).c_str(), EpdFontFamily::REGULAR);
+          int charAdvance = renderer.getTextAdvanceX(UI_12_FONT_ID, displayCursorChar, EpdFontFamily::REGULAR);
           kernOffset = beforeAndCursorWidth - beforeWidth - charAdvance;
         }
         if (centerText) {
@@ -772,7 +782,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
         renderer.drawText(UI_12_FONT_ID, lineStartX, inputStartY + inputHeight, part1.c_str());
         // Part 2: skip cursor slot (block + actual char drawn later)
         // Part 3: chars after cursor position (skip char under cursor), starting at cursorPixelX + cursorCharWidth
-        const int afterStart = static_cast<int>(cursorPos) + (cursorPos < text.length() ? 1 : 0);
+        const int afterStart = static_cast<int>(cursorPos + cursorCharBytes);
         const int afterEnd = lineEndIdx;
         if (afterStart < afterEnd) {
           const std::string part3 = displayText.substr(afterStart, afterEnd - afterStart);
@@ -798,9 +808,8 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   if (cursorMode && !togglePos && cursorPos <= displayText.length()) {
     static constexpr int blockPadding = 1;
     renderer.fillRect(cursorPixelX - blockPadding, cursorLineY, cursorCharWidth + blockPadding * 2, lineHeight, true);
-    if (cursorPos < text.length()) {
-      const char buf[2] = {text[cursorPos], '\0'};
-      renderer.drawText(UI_12_FONT_ID, cursorPixelX, cursorLineY, buf, false);
+    if (cursorCharBytes > 0) {
+      renderer.drawText(UI_12_FONT_ID, cursorPixelX, cursorLineY, cursorChar, false);
     }
   } else if (cursorPos <= displayText.length()) {
     static constexpr int serifW = 3;


### PR DESCRIPTION
## Symptom

In cursor mode, the block cursor over any non-ASCII character is drawn one glyph too narrow and the character underneath is not rendered inside the block. This affects every layout that has accented letters — `é` on AzertyFr, `ü`/`ß` on QwertzDe, `ñ` on SpanishEs — and any text loaded from outside (OPDS server names, download folder names).

**Before** — French UI, server name `Café`, cursor on `é`:

![before](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-before.png)

**After** — same screen, same keypresses:

![after](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-after.png)

The block should be as wide as the character and show it reversed out, which is exactly what it already does for ASCII.

## Steps to reproduce

No special hardware or data needed — this is reproducible on `develop` in the simulator:

1. Set the UI language to French (`Settings → System → Language`).
2. Open any text field, e.g. `Settings → System → OPDS Servers → <server> → Server Name`.
3. Type `é` (bottom letter row on the AZERTY layout).
4. Hold **Up** to enter cursor mode, then press **Left** until the cursor sits on the `é`.

## Cause

`cursorPos` is a byte offset that is always kept on a code point boundary, but four places in `render()` sliced exactly **one byte** at that offset:

| Code | Purpose |
|---|---|
| `text.substr(cursorPos, 1)` | block width |
| `displayText.substr(cursorPos, 1)` (×2) | kerning offset |
| `cursorPos + 1` | start of the trailing run |
| `char buf[2] = {text[cursorPos], '\0'}` | drawing the character in the block |

For a two-byte character that single byte is a lone lead byte. `utf8NextCodepoint()` (`lib/Utf8/Utf8.cpp`) validates continuation bytes, finds none, and returns `REPLACEMENT_GLYPH` (`0xFFFD`) — so the width is measured for the replacement glyph and the draw call paints that instead of the letter.

Byte-identical to the old behaviour for ASCII, where one byte *is* one code point.

## Fix

Uses the existing `utf8Next()` helper to take the whole code point in all four places. No new helper, no behaviour change for ASCII.

The masked-password path is unaffected: `displayText` is all `*` there, so the span is still one byte — that is why the fix computes the span separately for `text` and `displayText`.

## Testing

- Verified in the simulator on `develop` (bug) and on this branch (fixed) — the screenshots above are those two runs, same input script, only the branch differs.
- ASCII behaviour unchanged (checked with a Latin server name in the same screen).
- `clang-format` 21 clean.
- Not tested on hardware.

<details>
<summary>Full screenshots</summary>

Before:

![before-full](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-before-full.png)

After:

![after-full](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-after-full.png)

</details>

Split out of #2828 at @Uri-Tauber's request — this fix is independent of where the keyboard layout tables live.

Replaces #2840, which carried this fix and the line-wrapping one together; the wrapping half is now a separate PR.
