### PR TITLE
fix: text-field line wrapping splits multi-byte characters

### DIFF
--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -386,7 +386,16 @@ int KeyboardEntryActivity::lineBreakEnd(std::string& s, const int start, const i
       hi = mid - 1;
     }
   }
-  return best;
+
+  // The byte-index search can stop inside a character; snap back to a boundary,
+  // keeping one whole character so the wrap loop always advances.
+  const int firstCharEnd = static_cast<int>(utf8Next(s, static_cast<size_t>(start)));
+  while (best > start && (static_cast<uint8_t>(s[best]) & 0xC0) == 0x80) best--;
+  // Widths measured mid-character are unreliable, so the search can overshoot.
+  while (best > firstCharEnd && measureRange(s, start, best) > maxWidth) {
+    best = static_cast<int>(utf8Prev(s, static_cast<size_t>(best)));
+  }
+  return best < firstCharEnd ? firstCharEnd : best;
 }
 
 bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, size_t& position) const {


### PR DESCRIPTION
## Symptom

A text-field value long enough to wrap loses a character at every wrap point, if that point falls inside a multi-byte character. A Cyrillic OPDS server name shows it plainly — `литературы` renders as `литера` / `уры`, the `т` is simply gone:

![line wrap](https://raw.githubusercontent.com/winst0niuss/crossword/assets/cursor-utf8-screenshots/docs-assets/cursor-utf8-wrap.png)

## Steps to reproduce

Reproducible on `develop` in the simulator, no special hardware or data:

1. Open a text field, e.g. `Settings → System → OPDS Servers → <server> → Server Name`.
2. Enter a non-ASCII value long enough to wrap onto a second line.
3. A character disappears wherever the wrap lands mid-sequence.

## Cause

`lineBreakEnd()` (`src/activities/util/KeyboardEntryActivity.cpp`) binary-searches over **byte** indices for the widest prefix that fits, so the returned wrap point can land inside a multi-byte character. `render()` then slices the line at that byte and hands both halves to the renderer as incomplete sequences. Each decodes to `U+FFFD`, and since no built-in font carries that glyph, the character is not drawn at all.

## Fix

Snap the wrap point back to a code point boundary. Because widths measured mid-sequence are unreliable, the snapped line is re-measured and stepped back whole characters until it fits, and a line always keeps at least one whole character so the wrap loop still advances.

ASCII is unaffected — the snap is a no-op there.

## Testing

- Verified in the simulator on `develop` (character lost) and on this branch (intact).
- Long Latin name still fills the line to the same edge as before.
- `clang-format` 21 clean.
- Not tested on hardware.

Found by @coderabbitai's review on #2840, which carried this fix together with the cursor-block one. That PR is now split: the cursor half is a separate PR, this is the wrapping half.
