### PR TITLE
fix: stop negative font IDs from stealing scan slots

### DIFF
--- a/lib/GfxRenderer/FontCacheManager.cpp
+++ b/lib/GfxRenderer/FontCacheManager.cpp
@@ -73,12 +73,14 @@ void FontCacheManager::recordText(const char* text, int fontId, EpdFontFamily::S
 
   ScanEntry* entry = nullptr;
   for (auto& e : scanEntries_) {
-    if (e.fontId == fontId) {
+    if (e.used && e.fontId == fontId) {
       entry = &e;
       break;
     }
-    if (e.fontId < 0) {
+    if (!e.used) {
+      e.used = true;
       e.fontId = fontId;
+      e.text.clear();
       // Entry 0 typically accumulates the page body; later entries hold short
       // furniture strings (status bar, headers).
       e.text.reserve(&e == &scanEntries_[0] ? 2048 : 256);
@@ -96,7 +98,8 @@ void FontCacheManager::recordText(const char* text, int fontId, EpdFontFamily::S
 
 void FontCacheManager::resetScanEntries() {
   for (auto& e : scanEntries_) {
-    e.fontId = -1;
+    e.used = false;
+    e.fontId = 0;
     e.styleMask = 0;
     e.text.clear();
     e.text.shrink_to_fit();
@@ -116,7 +119,7 @@ void FontCacheManager::PrewarmScope::endScanAndPrewarm() {
   manager_->scanMode_ = ScanMode::None;
 
   for (auto& e : manager_->scanEntries_) {
-    if (e.fontId < 0 || e.text.empty()) continue;
+    if (!e.used || e.text.empty()) continue;
     manager_->prewarmCache(e.fontId, e.text.c_str(), e.styleMask != 0 ? e.styleMask : 1);
   }
   manager_->resetScanEntries();

--- a/lib/GfxRenderer/FontCacheManager.h
+++ b/lib/GfxRenderer/FontCacheManager.h
@@ -65,7 +65,11 @@ class FontCacheManager {
   // (they fall back to the per-string prewarm in GfxRenderer).
   static constexpr uint8_t MAX_SCAN_FONTS = 4;
   struct ScanEntry {
-    int fontId = -1;
+    // Occupancy is tracked separately: font ids are FNV hashes cast to int
+    // (SdCardFontManager::computeFontId, src/fontIds.h) and are routinely
+    // negative, so no id value can serve as the "free slot" sentinel.
+    bool used = false;
+    int fontId = 0;
     std::string text;
     uint8_t styleMask = 0;
   };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a regression that silently disables the per-font batch prewarm. On a Korean EPUB with an SD font, observed page render time drops from **33.5s to 4.1s** (X3).
* **What changes are included?** `FontCacheManager::ScanEntry` now tracks slot occupancy with a dedicated `used` flag instead of using `fontId = -1` as a sentinel, and clears stale text when a slot is claimed.

### The bug

`ScanEntry` used `fontId = -1` to mean "free slot", tested in `recordText()` as `e.fontId < 0`. But font IDs are FNV-1a hashes cast to `int` (`SdCardFontManager::computeFontId`, `src/fontIds.h`) and are negative roughly half the time — `computeFontId` only guards against `0`.

So a font with a negative ID makes *its own* slot look free to every subsequent lookup. The next font to record claims that same slot, and because the claim never cleared `e.text`, the previous font's accumulated text is silently reattributed to it.

Concretely, on a Korean EPUB with an SD reader font (ID `-1853923692`):

1. The page body claims slot 0 and accumulates ~688 bytes of Hangul.
2. The status bar draws with the built-in `SMALL_FONT_ID` (`674098198`), sees slot 0 as "free", and takes it over — inheriting the body's text.
3. The batch prewarm therefore asks the SD font for only the 19-byte status-bar title: **8 codepoints instead of 98**.
4. Every body glyph then faults in one at a time through the 8-entry overflow ring — on every grayscale strip pass (on X3, 7 strips per plane x 2 planes = 14 full-page re-renders).

Debug trace before the fix (from temporary instrumentation, not included in this PR — note slot 0 claimed twice):

```
DIAG scan-newslot: slot=0 fontId=-1853923692      <- body claims slot 0
   ... 16 blocks of Korean body text recorded ...
DIAG scan-newslot: slot=0 fontId=674098198        <- slot 0 claimed AGAIN
DIAG scan-entry:   fontId=674098198 sd=0 bytes=688 <- body text, mislabeled
DIAG rebuild:      req=8 valid=7                   <- SD font gets only the status bar
Overflow: loaded U+AC83 style 0 on demand (slot 0/8)
Overflow: loaded U+C73C style 0 on demand (slot 1/8)
   ... ~25 more per page ...
```

### Not CJK-specific

`NOTOSERIF_14`, `NOTOSERIF_18` and `NOTOSANS_14` also have negative IDs, so any page mixing one of them with a second font loses its batch prewarm too. It is just far harder to notice with built-in fonts, where the per-glyph fallback is a flash read rather than an SD seek.

### Regression source

Introduced by a0daab99 ("fix: Slow CJK TOC & Lists", #3071), which added both the per-font scan slots and the negative sentinel. The batching design is right — it is what stops a mixed-font page from faulting glyph by glyph — but the sentinel collides with the negative half of the FNV hash space, which silently defeats the batching it added, hardest in exactly the CJK case it targeted.

Negative IDs are by design, not incidental: `build-font-ids.sh` generates the built-in IDs with `% (2 ** 32) - (2 ** 31)`, deliberately spanning the signed range, and `computeFontId` guards only against `0`. An audit of the rest of the codebase found no other site that assumes a non-negative ID — every other hash (ZipFile, BookMetadataCache, ContentOpfParser, CssParser, cache directory names) stays unsigned. `ScanEntry` was the only place the invariant was broken.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Performance** (X3, Korean EPUB, SD font, anti-aliasing on, same page turned in both runs):

| | Before | After |
|---|---|---|
| Body prewarm request | 8 codepoints | 98 codepoints |
| Per-glyph SD faults | ~25+ per page | 0 |
| `gray_lsb` / `gray_msb` | 15577ms / 15287ms | 2226ms / 102ms |
| **Observed page render** | **33544ms** | **4057ms** (~8.3x faster) |

Observed render traces, before:

```
[ERS] Page render (tiled): prewarm=9ms bw_render=2369ms display=26ms gray_lsb=15577ms gray_msb=15287ms gray_display=227ms cleanup=49ms total=33544ms
[ERS] Rendered page in 33547ms
```

and after:

```
[ERS] Page render (tiled): prewarm=337ms bw_render=62ms display=1053ms gray_lsb=2226ms gray_msb=102ms gray_display=227ms cleanup=50ms total=4057ms
[ERS] Rendered page in 4059ms
```

The `gray_msb` figure is the clearest signal: on the second grayscale plane every glyph is already resident in RAM, so it costs 102ms instead of re-reading the SD card for each syllable. `prewarm` rises from 9ms to 337ms — that is the batch prewarm doing the work it was always supposed to do, once, instead of the render passes paying for it on every strip.

**Memory / flash impact:** negligible — one `bool` per `ScanEntry`, 4 entries total. No new allocations; `e.text.clear()` preserves the reserved capacity, so the claim path does not touch the allocator.

**Risk / areas to focus on:** the change touches the batching path for *every* font, not just SD fonts. Tested on X3 with a Korean SD font and with built-in Latin fonts; both render correctly.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
