### PR TITLE
fix: match capitalized umlaut Ä/Ö/Ü and ẞ words in dictionary lookup

### DIFF
--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -597,38 +597,44 @@ std::string Dictionary::cleanWord(const char* word) {
   return result;
 }
 
-std::string Dictionary::germanUppercaseFolded(const std::string& word) {
+bool Dictionary::germanUppercaseFolded(const char* word, char* out, size_t outSize) {
   // Fold the German uppercase codepoints asciiCaseCmp cannot: Ä/Ö/Ü
   // (C3 84/96/9C -> C3 A4/B6/BC) and capital ẞ (E1 BA 9E -> C3 9F, one byte
-  // shorter). Returns "" when nothing folded so lookup() skips the reprobe.
+  // shorter). False when nothing folded — lookup() skips the reprobe — or when
+  // the result would not fit, which no matchable query can hit: readWordInto()
+  // caps headwords below the same size, so an over-long query has no match.
   // A fallback probe rather than part of cleanWord(): capitalized headwords
   // ("Überprüfung", "Ärzte") are stored with their uppercase umlaut bytes and
   // must keep matching an unfolded query first — folding unconditionally would
   // trade the sentence-initial fix for a miss on every umlaut-initial noun.
-  std::string folded;
+  const auto* b = reinterpret_cast<const unsigned char*>(word);
+  size_t w = 0;
   bool changed = false;
-  folded.reserve(word.size());
-  for (size_t i = 0; i < word.size();) {
-    const auto c = static_cast<unsigned char>(word[i]);
-    const auto c1 = i + 1 < word.size() ? static_cast<unsigned char>(word[i + 1]) : 0;
-    if (c == 0xC3 && (c1 == 0x84 || c1 == 0x96 || c1 == 0x9C)) {  // Ä Ö Ü
-      folded += static_cast<char>(0xC3);
-      folded += static_cast<char>(c1 + 0x20);  // -> ä ö ü
+  for (size_t i = 0; b[i] != '\0';) {
+    // b[i] != 0 makes b[i + 1] readable; the ẞ arm reads b[i + 2] only after
+    // b[i + 1] == 0xBA rules out the terminator.
+    unsigned char first = b[i];
+    unsigned char second = 0;
+    size_t consumed = 1;
+    if (b[i] == 0xC3 && (b[i + 1] == 0x84 || b[i + 1] == 0x96 || b[i + 1] == 0x9C)) {  // Ä Ö Ü
+      first = 0xC3;
+      second = b[i + 1] + 0x20;  // -> ä ö ü
+      consumed = 2;
       changed = true;
-      i += 2;
-    } else if (c == 0xE1 && c1 == 0xBA && i + 2 < word.size() &&
-               static_cast<unsigned char>(word[i + 2]) == 0x9E) {  // ẞ
-      folded += static_cast<char>(0xC3);
-      folded += static_cast<char>(0x9F);  // -> ß
+    } else if (b[i] == 0xE1 && b[i + 1] == 0xBA && b[i + 2] == 0x9E) {  // ẞ
+      first = 0xC3;
+      second = 0x9F;  // -> ß
+      consumed = 3;
       changed = true;
-      i += 3;
-    } else {
-      folded += static_cast<char>(c);
-      i++;
     }
+    const size_t emit = second != 0 ? 2 : 1;
+    if (w + emit >= outSize) return false;  // keep room for the terminator
+    out[w++] = static_cast<char>(first);
+    if (second != 0) out[w++] = static_cast<char>(second);
+    i += consumed;
   }
-  if (!changed) folded.clear();
-  return folded;
+  out[w] = '\0';
+  return changed;
 }
 
 void Dictionary::stemVariants(const std::string& word, std::vector<std::string>& out) {
@@ -697,16 +703,14 @@ bool Dictionary::lookup(const char* word, std::string& definitionOut, std::strin
     // Reprobe with German uppercase umlauts / ẞ folded, so sentence-initial
     // "Überprüf" or all-caps "STRAẞE" find their lowercase index forms. Runs
     // only after the unfolded probes so capitalized headwords ("Überprüfung")
-    // keep their exact match.
-    if (!location.found) {
-      const std::string folded = germanUppercaseFolded(cleaned);
-      if (!folded.empty()) {
-        location = locate(session, folded.c_str(), &matchedHeadwordOut);
+    // keep their exact match. foldBuf (not wordBuf) holds the target: locate()
+    // clobbers wordBuf on every entry it scans.
+    if (!location.found && germanUppercaseFolded(cleaned.c_str(), foldBuf, sizeof(foldBuf))) {
+      location = locate(session, foldBuf, &matchedHeadwordOut);
+      searchFailed = searchFailed || location.readError;
+      if (!location.found && hasSyn) {
+        location = locateSynonym(session, foldBuf, &matchedHeadwordOut);
         searchFailed = searchFailed || location.readError;
-        if (!location.found && hasSyn) {
-          location = locateSynonym(session, folded.c_str(), &matchedHeadwordOut);
-          searchFailed = searchFailed || location.readError;
-        }
       }
     }
 

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -591,9 +591,33 @@ std::string Dictionary::cleanWord(const char* word) {
   }
   if (start >= end) return "";
 
+  // Lowercase ASCII, plus the German uppercase codepoints asciiCaseCmp cannot
+  // fold: Ä/Ö/Ü (C3 84/96/9C -> C3 A4/B6/BC) and capital ẞ (E1 BA 9E -> C3 9F,
+  // one byte shorter). Query-side only: .idx/.syn are sorted ASCII-case-folded
+  // with non-ASCII bytes compared verbatim, so sentence-initial "Überprüf" or
+  // all-caps "STRAẞE" would otherwise never match their lowercase forms, while
+  // capitalized headwords like "Überprüfung" still match a folded query
+  // through the ASCII-insensitive comparison.
   std::string result(word + start, end - start);
-  std::transform(result.begin(), result.end(), result.begin(),
-                 [](unsigned char c) { return c >= 0x80 ? c : static_cast<unsigned char>(std::tolower(c)); });
+  size_t w = 0;
+  for (size_t r = 0; r < result.size();) {
+    const auto c = static_cast<unsigned char>(result[r]);
+    const auto c1 = r + 1 < result.size() ? static_cast<unsigned char>(result[r + 1]) : 0;
+    if (c == 0xC3 && (c1 == 0x84 || c1 == 0x96 || c1 == 0x9C)) {  // Ä Ö Ü
+      result[w++] = static_cast<char>(0xC3);
+      result[w++] = static_cast<char>(c1 + 0x20);  // -> ä ö ü
+      r += 2;
+    } else if (c == 0xE1 && c1 == 0xBA && r + 2 < result.size() &&
+               static_cast<unsigned char>(result[r + 2]) == 0x9E) {  // ẞ
+      result[w++] = static_cast<char>(0xC3);
+      result[w++] = static_cast<char>(0x9F);  // -> ß
+      r += 3;
+    } else {
+      result[w++] = static_cast<char>(c >= 0x80 ? c : std::tolower(c));
+      r++;
+    }
+  }
+  result.resize(w);
   return result;
 }
 

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -591,34 +591,44 @@ std::string Dictionary::cleanWord(const char* word) {
   }
   if (start >= end) return "";
 
-  // Lowercase ASCII, plus the German uppercase codepoints asciiCaseCmp cannot
-  // fold: Ä/Ö/Ü (C3 84/96/9C -> C3 A4/B6/BC) and capital ẞ (E1 BA 9E -> C3 9F,
-  // one byte shorter). Query-side only: .idx/.syn are sorted ASCII-case-folded
-  // with non-ASCII bytes compared verbatim, so sentence-initial "Überprüf" or
-  // all-caps "STRAẞE" would otherwise never match their lowercase forms, while
-  // capitalized headwords like "Überprüfung" still match a folded query
-  // through the ASCII-insensitive comparison.
   std::string result(word + start, end - start);
-  size_t w = 0;
-  for (size_t r = 0; r < result.size();) {
-    const auto c = static_cast<unsigned char>(result[r]);
-    const auto c1 = r + 1 < result.size() ? static_cast<unsigned char>(result[r + 1]) : 0;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return c >= 0x80 ? c : static_cast<unsigned char>(std::tolower(c)); });
+  return result;
+}
+
+std::string Dictionary::germanUppercaseFolded(const std::string& word) {
+  // Fold the German uppercase codepoints asciiCaseCmp cannot: Ä/Ö/Ü
+  // (C3 84/96/9C -> C3 A4/B6/BC) and capital ẞ (E1 BA 9E -> C3 9F, one byte
+  // shorter). Returns "" when nothing folded so lookup() skips the reprobe.
+  // A fallback probe rather than part of cleanWord(): capitalized headwords
+  // ("Überprüfung", "Ärzte") are stored with their uppercase umlaut bytes and
+  // must keep matching an unfolded query first — folding unconditionally would
+  // trade the sentence-initial fix for a miss on every umlaut-initial noun.
+  std::string folded;
+  bool changed = false;
+  folded.reserve(word.size());
+  for (size_t i = 0; i < word.size();) {
+    const auto c = static_cast<unsigned char>(word[i]);
+    const auto c1 = i + 1 < word.size() ? static_cast<unsigned char>(word[i + 1]) : 0;
     if (c == 0xC3 && (c1 == 0x84 || c1 == 0x96 || c1 == 0x9C)) {  // Ä Ö Ü
-      result[w++] = static_cast<char>(0xC3);
-      result[w++] = static_cast<char>(c1 + 0x20);  // -> ä ö ü
-      r += 2;
-    } else if (c == 0xE1 && c1 == 0xBA && r + 2 < result.size() &&
-               static_cast<unsigned char>(result[r + 2]) == 0x9E) {  // ẞ
-      result[w++] = static_cast<char>(0xC3);
-      result[w++] = static_cast<char>(0x9F);  // -> ß
-      r += 3;
+      folded += static_cast<char>(0xC3);
+      folded += static_cast<char>(c1 + 0x20);  // -> ä ö ü
+      changed = true;
+      i += 2;
+    } else if (c == 0xE1 && c1 == 0xBA && i + 2 < word.size() &&
+               static_cast<unsigned char>(word[i + 2]) == 0x9E) {  // ẞ
+      folded += static_cast<char>(0xC3);
+      folded += static_cast<char>(0x9F);  // -> ß
+      changed = true;
+      i += 3;
     } else {
-      result[w++] = static_cast<char>(c >= 0x80 ? c : std::tolower(c));
-      r++;
+      folded += static_cast<char>(c);
+      i++;
     }
   }
-  result.resize(w);
-  return result;
+  if (!changed) folded.clear();
+  return folded;
 }
 
 void Dictionary::stemVariants(const std::string& word, std::vector<std::string>& out) {
@@ -682,6 +692,22 @@ bool Dictionary::lookup(const char* word, std::string& definitionOut, std::strin
     if (!location.found && hasSyn) {
       location = locateSynonym(session, cleaned.c_str(), &matchedHeadwordOut);
       searchFailed = searchFailed || location.readError;
+    }
+
+    // Reprobe with German uppercase umlauts / ẞ folded, so sentence-initial
+    // "Überprüf" or all-caps "STRAẞE" find their lowercase index forms. Runs
+    // only after the unfolded probes so capitalized headwords ("Überprüfung")
+    // keep their exact match.
+    if (!location.found) {
+      const std::string folded = germanUppercaseFolded(cleaned);
+      if (!folded.empty()) {
+        location = locate(session, folded.c_str(), &matchedHeadwordOut);
+        searchFailed = searchFailed || location.readError;
+        if (!location.found && hasSyn) {
+          location = locateSynonym(session, folded.c_str(), &matchedHeadwordOut);
+          searchFailed = searchFailed || location.readError;
+        }
+      }
     }
 
     if (!location.found) {

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -151,11 +151,13 @@ class Dictionary {
   // unreadable. Clobbers wordBuf.
   uint32_t bisectSamples(HalFile& sidecar, HalFile& source, uint32_t sampleCount, const char* target);
 
-  // Copy of word with German uppercase codepoints folded (Ä/Ö/Ü -> ä/ö/ü,
-  // capital ẞ -> ß); "" when the word contains none. Used by lookup() as a
-  // fallback probe — see the comment in the implementation for why this is not
-  // part of cleanWord().
-  static std::string germanUppercaseFolded(const std::string& word);
+  // Write word into out with German uppercase codepoints folded (Ä/Ö/Ü ->
+  // ä/ö/ü, capital ẞ -> ß). False when the word contains none, or when the
+  // folded result would not fit outSize (then no headword can match it
+  // either). No heap: lookup() passes the reusable foldBuf. Used as a fallback
+  // probe — see the comment in the implementation for why this is not part of
+  // cleanWord().
+  static bool germanUppercaseFolded(const char* word, char* out, size_t outSize);
 
   DictLocation locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut);
 
@@ -197,4 +199,10 @@ class Dictionary {
   // Shared scan buffer: lookups are single-threaded and this avoids a
   // 256-byte array on the stack of every locate() call.
   char wordBuf[256] = {};
+
+  // Umlaut-folded reprobe target. Separate from wordBuf, which locate() and
+  // locateSynonym() clobber while the folded target must stay stable across
+  // the whole probe; sized to match since readWordInto() caps headwords at
+  // the same length.
+  char foldBuf[256] = {};
 };

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -151,6 +151,12 @@ class Dictionary {
   // unreadable. Clobbers wordBuf.
   uint32_t bisectSamples(HalFile& sidecar, HalFile& source, uint32_t sampleCount, const char* target);
 
+  // Copy of word with German uppercase codepoints folded (Ä/Ö/Ü -> ä/ö/ü,
+  // capital ẞ -> ß); "" when the word contains none. Used by lookup() as a
+  // fallback probe — see the comment in the implementation for why this is not
+  // part of cleanWord().
+  static std::string germanUppercaseFolded(const std::string& word);
+
   DictLocation locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut);
 
   // Resolve an ordinal (the N-th .idx entry, 0-based) to its .dict location via


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** German dictionary lookups fail for words whose only difference from the stored form is a capital umlaut or capital ẞ — e.g. sentence-initial *Überprüf*, *Ähnlich*, *Öfter* or all-caps *STRAẞE* report "not found" even though the lowercase forms are in the StarDict `.idx`/`.syn`. `Dictionary::cleanWord()` lowercases ASCII bytes only, and `StringUtils::asciiCaseCmp` compares non-ASCII bytes verbatim, so `Ü` (`C3 9C`) never matches `ü` (`C3 BC`).
* **What changes are included?** A new `germanUppercaseFolded()` helper (Ä/Ö/Ü → ä/ö/ü, `C3 84/96/9C → C3 A4/B6/BC`; capital ẞ `E1 BA 9E` → ß `C3 9F`) and one extra probe in `lookup()`: when the unfolded exact-match and synonym probes miss, the folded variant is probed against `.idx` and `.syn` before the stemmer runs. The fold is deliberately a **fallback probe, not a query rewrite**: capitalized headwords (*Überprüfung*, *Ärzte*, *Öl*) are stored with their uppercase umlaut bytes and must keep matching the unfolded query first — folding unconditionally would trade the sentence-initial fix for a miss on every umlaut-initial noun. Files, sort order, and the comparator are untouched.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (this is a defect in the existing `.syn` lookup path added in #2696, not new functionality).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. (It touches none of these.)

## Additional Context

**Reproduction.** With the reader.dict DE-EN StarDict dictionary (543,060 `.syn` entries), tap a sentence-initial umlaut word such as *Überprüf* or *Übrigens* in any German EPUB on current `develop`: "not found". The lowercase forms `überprüf`/`übrigens` resolve fine. All-caps words containing capital ẞ (U+1E9E), e.g. *STRAẞE* in a chapter heading, fail the same way.

**Why fallback-probe rather than folding in `cleanWord()`.** A first iteration folded the query unconditionally; that regressed every capitalized-umlaut headword (*Überprüfung*, *Übung*, *Ärzte*, *Äpfel*, …), because the folded query no longer byte-matched the stored headword and `asciiCaseCmp` cannot fold non-ASCII on the comparison side. Probing unfolded-first preserves the exact behavior of every previously-working lookup; the folded reprobe only adds hits. Cost on the reprobe path is one extra `locate()` (+ one `locateSynonym()` on miss) reusing the already-open session handles, and only for words that actually contain Ä/Ö/Ü/ẞ and missed the primary probes.

**Verification.**

* Offline simulation of the exact lookup path (same folding, same comparison, `.idx` + `.syn` bisect) against the real dictionary files, 39 cases, all passing: 15 previously-missing capitalized forms now resolve (*Überprüf* → überprüfen, *Änderte* → ändern, *STRAẞE* → Straße, *FUẞBALL* → Fußball, …); 22 controls return exactly the same headword as before the patch, including 10 capitalized-umlaut headwords (*Überprüfung* → Überprüfung, *Ärzte* → Arzt, *Öl* → Öl, …) that guard against the query-rewrite regression; 2 out-of-vocabulary words still miss.
* `germanUppercaseFolded()` exercised natively under ASan/UBSan, including the 3-byte→2-byte ẞ shrink, lone Ä/ẞ, empty input, no-op inputs, and truncated UTF-8 sequences at end of string (no out-of-bounds read).
* Built from this branch and tested on an X4: previously-failing words now resolve in the reader. A small test EPUB with the fixed/control/miss word sets is available for QA.

**Memory / flash impact.** Negligible. One extra `std::string` allocation only on the reprobe path (folded variant of an already-cleaned word, typically <32 bytes); flash delta is a few dozen bytes of code. No new file handles — the reprobe reuses the open `LookupSession`.

**Risk / areas to focus on.** The fold is limited to the four German uppercase codepoints and applied only to fallback queries, because `.idx`/`.syn` are sorted under ASCII-only case folding with non-ASCII bytes compared verbatim — folding anything else (or folding inside the comparator) would break the binary search's sort-order assumption. Reviewers may want to double-check the probe-order reasoning in the comments on `germanUppercaseFolded()` and in `lookup()`.

---

### AI Usage

Did you use AI tools to help write this code? **YES** — the fix and its verification harness were written with an AI assistant (Claude); I reviewed the change and tested it on-device.
