### PR TITLE
fix: guard CSS loading from cache against OOM abort

### DIFF
--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -814,7 +814,14 @@ bool CssParser::loadFromCache() {
   // cannot plausibly cover it; the caller degrades to uncached CSS instead.
   // The floor is MIN_FREE_HEAP_FOR_CSS: resolveStyle() returns an empty style
   // below it, so rules loaded into a heap that tight would never be applied.
-  constexpr uint32_t CSS_CACHE_BYTES_PER_RULE = sizeof(CssStyle) + 56;  // node + selector + bucket slot
+  // Per rule: the map node (CssStyle + hash + next pointer), the selector's
+  // heap buffer, and one bucket slot. Selectors up to MAX_SELECTOR_LENGTH are
+  // accepted, but short ones fit std::string's inline buffer and allocate
+  // nothing, so a worst-case 256 bytes each would refuse loads that would
+  // comfortably fit. 96 covers typical selectors with margin; the guard only
+  // decides whether to attempt the load, and erring low risks the abort() this
+  // is meant to prevent, so it is deliberately not the tightest estimate.
+  constexpr uint32_t CSS_CACHE_BYTES_PER_RULE = sizeof(CssStyle) + 96;
   const uint32_t cssEstBytes = static_cast<uint32_t>(ruleCount) * CSS_CACHE_BYTES_PER_RULE;
   const uint32_t cssFreeHeap = ESP.getFreeHeap();
   if (cssFreeHeap < cssEstBytes + MIN_FREE_HEAP_FOR_CSS) {

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -808,6 +808,21 @@ bool CssParser::loadFromCache() {
     return false;
   }
 
+  // unordered_map allocates a node per rule (plus the selector string) and
+  // operator new is fatal under -fno-exceptions: a failed insert calls
+  // abort() and reboots the device mid-book. Refuse the load when the heap
+  // cannot plausibly cover it; the caller degrades to uncached CSS instead.
+  // The floor is MIN_FREE_HEAP_FOR_CSS: resolveStyle() returns an empty style
+  // below it, so rules loaded into a heap that tight would never be applied.
+  constexpr uint32_t CSS_CACHE_BYTES_PER_RULE = sizeof(CssStyle) + 56;  // node + selector + bucket slot
+  const uint32_t cssEstBytes = static_cast<uint32_t>(ruleCount) * CSS_CACHE_BYTES_PER_RULE;
+  const uint32_t cssFreeHeap = ESP.getFreeHeap();
+  if (cssFreeHeap < cssEstBytes + MIN_FREE_HEAP_FOR_CSS) {
+    LOG_ERR("CSS", "Insufficient heap for %u cached rules (need ~%u, free %u)", ruleCount, cssEstBytes, cssFreeHeap);
+    rulesBySelector_.clear();
+    return false;
+  }
+
   // Size the bucket array up front to avoid incremental rehashes while loading rules.
   rulesBySelector_.reserve(ruleCount);
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop a reproducible `abort()` / device reboot when opening a book while the heap is tight.
* **What changes are included?** `CssParser::loadFromCache()` now checks the heap before building the rules map and returns `false` if it cannot cover it, instead of letting an allocation failure abort the firmware.

### The bug

`loadFromCache()` inserts one `unordered_map` node per cached rule (`CssParser.cpp:951`) with no heap check. Under `-fno-exceptions` a failed `operator new` does **not** return null — it throws `bad_alloc`, which reaches `__cxxabiv1::__terminate` and calls `abort()`. The device reboots mid-book.

Reproduced on an X3 opening a 203-rule book with the heap already tight (`Free: 31964`, `MaxAlloc: 11252`). Decoded backtrace (ELF hash verified against the crash dump):

```
operator new(unsigned int)             -> std::bad_alloc
  -> __cxxabiv1::__terminate           -> abort()
CssParser::loadFromCache()  CssParser.cpp:951
  <- Section::startBuild()   Section.cpp:373
```

```
[DBG] [CSS] Loaded 203 rules from cache      <- succeeds when the heap allows
abort() was called at PC 0x421bf731 on core 0
...
Rebooting...
```

This is the hazard AGENTS.md/CLAUDE.md documents for bare `new`, except the allocation is inside an STL container, so the usual `makeUniqueNoThrow` pattern does not reach it.

### The fix

Estimate the map's cost from `ruleCount` and refuse the load when the heap cannot cover it, returning `false` — a path `Section::startBuild()` already handles by logging and continuing without cached CSS. Degraded styling beats a reboot.

The floor is the existing `MIN_FREE_HEAP_FOR_CSS` rather than a new constant, which keeps the policy self-consistent: `resolveStyle()` already returns an empty style below that threshold, so rules loaded into a heap that tight would never be applied anyway.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Memory / flash impact:** negligible — one comparison and a few locals on the cache-load path. No new allocations. When the guard trips it *saves* the map's worth of heap.

**Risk / areas to focus on:** the estimate (`sizeof(CssStyle) + 56` bytes per rule) is deliberately rough; it only decides whether to attempt the load. If it is too conservative a book could lose cached CSS on a heap that would in fact have held it — the failure mode is degraded styling, not a crash. Reviewers may want to sanity-check that per-rule figure against `CssStyle` on their target.

Found while investigating slow CJK page rendering on an X3 with an SD font; the crash is not CJK-specific and needs only a tight heap plus a rule-heavy book.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
