### PR TITLE
fix: keep the glyph arena usable under heap pressure

### DIFF
--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -912,17 +912,19 @@ int SdCardFont::prewarm(TextGetter getter, const void* ctx, uint32_t textCount, 
     int missedForStyle = prewarmStyle(si, codepoints.get(), cpCount, metadataOnly, loadKernLig);
     if (missedForStyle == PREWARM_ARENA_TOO_LARGE) {
       // The arena is one contiguous block, so a fragmented heap can fail it with
-      // ample free bytes. measuredBytesPerGlyph is exact for this set, so retry
-      // with the largest prefix the biggest free block holds rather than dropping
-      // every glyph to the per-glyph overflow ring.
+      // ample free bytes. Retry with the estimated largest prefix, backing off
+      // if variable-size glyphs made that estimate too large.
       const uint32_t perGlyph = styles_[si].measuredBytesPerGlyph > 0 ? styles_[si].measuredBytesPerGlyph : 1;
       const uint32_t maxAlloc = ESP.getMaxAllocHeap();
       const uint32_t arenaBytes = maxAlloc > PREWARM_MAX_ALLOC_RESERVE ? maxAlloc - PREWARM_MAX_ALLOC_RESERVE : 0;
       uint32_t fit = arenaBytes / perGlyph;
       if (fit > cpCount) fit = cpCount;
-      LOG_DBG("SDCF", "Arena retry: %u -> %u glyphs (%uB/glyph, maxAlloc=%u)", cpCount, fit, perGlyph, maxAlloc);
-      missedForStyle =
-          fit > 0 ? prewarmStyle(si, codepoints.get(), fit, metadataOnly, loadKernLig) : PREWARM_ARENA_TOO_LARGE;
+      while (fit > 0) {
+        LOG_DBG("SDCF", "Arena retry: %u -> %u glyphs (%uB/glyph, maxAlloc=%u)", cpCount, fit, perGlyph, maxAlloc);
+        missedForStyle = prewarmStyle(si, codepoints.get(), fit, metadataOnly, loadKernLig);
+        if (missedForStyle != PREWARM_ARENA_TOO_LARGE) break;
+        fit /= 2;
+      }
       if (missedForStyle == PREWARM_ARENA_TOO_LARGE) {
         missedForStyle = static_cast<int>(cpCount);  // nothing resident
       } else {

--- a/lib/EpdFont/SdCardFont.cpp
+++ b/lib/EpdFont/SdCardFont.cpp
@@ -71,6 +71,8 @@ const char* asCStr(const char* s) { return s; }
 // resetStyleMiniData retention bounds (see the PerStyle comment in the header).
 constexpr size_t MINI_RETAIN_MIN_FREE_HEAP = 40 * 1024;
 constexpr uint8_t MINI_UNDERUSE_RUNS_BEFORE_FREE = 3;
+// Working headroom left outside the mini bitmap arena's single contiguous block.
+constexpr uint32_t PREWARM_MAX_ALLOC_RESERVE = 4 * 1024;
 
 // Keep-if-fits buffer reuse: only reallocate when the needed size exceeds the
 // current capacity. Freeing + reallocating slightly different sizes every page
@@ -907,7 +909,27 @@ int SdCardFont::prewarm(TextGetter getter, const void* ctx, uint32_t textCount, 
   int totalMissed = 0;
   for (uint8_t si = 0; si < MAX_STYLES; si++) {
     if (!(styleMask & (1 << si)) || !styles_[si].present) continue;
-    totalMissed += prewarmStyle(si, codepoints.get(), cpCount, metadataOnly, loadKernLig);
+    int missedForStyle = prewarmStyle(si, codepoints.get(), cpCount, metadataOnly, loadKernLig);
+    if (missedForStyle == PREWARM_ARENA_TOO_LARGE) {
+      // The arena is one contiguous block, so a fragmented heap can fail it with
+      // ample free bytes. measuredBytesPerGlyph is exact for this set, so retry
+      // with the largest prefix the biggest free block holds rather than dropping
+      // every glyph to the per-glyph overflow ring.
+      const uint32_t perGlyph = styles_[si].measuredBytesPerGlyph > 0 ? styles_[si].measuredBytesPerGlyph : 1;
+      const uint32_t maxAlloc = ESP.getMaxAllocHeap();
+      const uint32_t arenaBytes = maxAlloc > PREWARM_MAX_ALLOC_RESERVE ? maxAlloc - PREWARM_MAX_ALLOC_RESERVE : 0;
+      uint32_t fit = arenaBytes / perGlyph;
+      if (fit > cpCount) fit = cpCount;
+      LOG_DBG("SDCF", "Arena retry: %u -> %u glyphs (%uB/glyph, maxAlloc=%u)", cpCount, fit, perGlyph, maxAlloc);
+      missedForStyle =
+          fit > 0 ? prewarmStyle(si, codepoints.get(), fit, metadataOnly, loadKernLig) : PREWARM_ARENA_TOO_LARGE;
+      if (missedForStyle == PREWARM_ARENA_TOO_LARGE) {
+        missedForStyle = static_cast<int>(cpCount);  // nothing resident
+      } else {
+        missedForStyle += static_cast<int>(cpCount - fit);  // the dropped suffix is absent too
+      }
+    }
+    totalMissed += missedForStyle;
   }
 
   stats_.prewarmTotalMs = millis() - startMs;
@@ -1155,12 +1177,16 @@ int SdCardFont::prewarmStyle(uint8_t styleIdx, const uint32_t* codepoints, uint3
       totalBitmapSize += s.miniGlyphs[i].dataLength;
     }
 
+    // Rounded up: the retry multiplies this back out to size a glyph set, and a
+    // floored figure can yield an arena that still does not fit.
+    if (validCount > 0) s.measuredBytesPerGlyph = (totalBitmapSize + validCount - 1) / validCount;
+
     if (!ensureArrayCapacity(s.miniBitmap, s.miniBitmapCapacity, totalBitmapSize)) {
       LOG_ERR("SDCF", "Failed to allocate mini bitmap (%u bytes) for style %u", totalBitmapSize, styleIdx);
       delete[] readOrder;
       delete[] mappings;
       freeStyleMiniData(s);
-      return static_cast<int>(cpCount);
+      return PREWARM_ARENA_TOO_LARGE;
     }
     s.miniBitmapUsed = totalBitmapSize;  // underuse-hysteresis signal for resetStyleMiniData
 

--- a/lib/EpdFont/SdCardFont.h
+++ b/lib/EpdFont/SdCardFont.h
@@ -22,6 +22,9 @@
 class SdCardFont {
  public:
   static constexpr uint16_t MAX_PAGE_GLYPHS = 512;
+  // prewarmStyle: the bitmap arena did not fit the largest free block.
+  // Distinct from a missed-glyph count so the caller can retry smaller.
+  static constexpr int PREWARM_ARENA_TOO_LARGE = -2;
   static constexpr uint8_t MAX_STYLES = 4;
 
   SdCardFont() = default;
@@ -223,6 +226,8 @@ class SdCardFont {
     // underuse-hysteresis signal; 0 = no bitmap built this scope (metadata-only
     // prewarm), which leaves the hysteresis counter untouched.
     uint32_t miniBitmapUsed = 0;
+    // Exact bitmap bytes per glyph of the last requested set, for the arena retry.
+    uint32_t measuredBytesPerGlyph = 0;
     uint8_t miniUnderuseRuns = 0;
     // True when the resident mini was built metadata-only (no bitmaps): it can
     // serve metadata requests but a full render request must rebuild.


### PR DESCRIPTION
I still occasionally get 10s+ renders when using Korean SD fonts, digged around for root cuase. Current develop seem to suffer heavy heap fragmentation. This does NOT fix the root cause, which is heap fragmentation. But tries to gracefully fall back and use whatever we have left.

PS. I finally got unlocked X3. Serial and scripts/debugging_monitor.py is just awesome!

## Summary

* **What is the goal of this PR?** Stop a fragmented heap from costing a page its entire SD-font glyph arena. On an X3 with a Korean SD font this turned ~1.3s page renders into 21-33s.
* **What changes are included?** One change: when the mini bitmap arena allocation fails, retry once with the largest glyph set that actually fits, instead of dropping every glyph. +33/−2 in `SdCardFont.cpp`/`.h`, no behaviour change unless the allocation fails.

### The bug

The mini bitmap arena is **one contiguous allocation**. When it failed, `prewarmStyle()` freed the whole arena and reported every glyph missed, so all of a page's glyphs faulted in one at a time through the 8-entry overflow ring — on every grayscale strip pass (7 strips × 2 planes = 14 full-page re-renders on X3).

Total free heap was never the binding constraint. One observed failure:

```
[ERR] [SDCF] Failed to allocate mini bitmap (32772 bytes) for style 0
[INF] [MEM] Free: 74024 bytes, Min Free: 13128, MaxAlloc: 32756
```

74KB free, largest block 32756 — **short by 16 bytes**, and the page cost 33s.

### The change

`prewarmStyle()` already knows the exact bitmap size of the requested set before it tries the allocation (it has read every glyph's metadata). Record the rounded-up bytes/glyph there, and return a distinct `PREWARM_ARENA_TOO_LARGE` sentinel when the arena does not fit. `prewarm()` then retries once with the largest prefix the biggest free block holds (`getMaxAllocHeap()` minus a 4KB working reserve), counting the dropped suffix as missed:

```
[ERR] [SDCF] Failed to allocate mini bitmap (23868 bytes) for style 1
[DBG] [SDCF] Arena retry: 140 -> 107 glyphs (171B/glyph, maxAlloc=22516)
```

That page rendered in 1792ms with six overflow faults, instead of losing all 140 glyphs.

Bytes/glyph swings ~3.6× between pages (45-162 observed), so no stored average predicts the next page — which is why this measures the actual set rather than trying to size the request up front. The earlier revision of this PR also carried a predictive budget and an idle-prewarm heap gate; those are dropped here to keep the change minimal and the happy path untouched.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does **not** touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Performance** (X3, Korean EPUB, SD font, anti-aliasing on):

| | Before | After |
|---|---|---|
| Page render (arena lost) | 21000-33000ms | — |
| Page render (typical) | — | 1031-1792ms |

**Memory / flash impact:** one `uint32_t` per style (`measuredBytesPerGlyph`) and a few locals. The retry only ever allocates a *smaller* arena than the first attempt.

**Still needed?** Yes. With heap instrumentation on current `develop` (2026-08-28) the reader's steady state after a font change + section rebuild is `free=52252, largest=14324, 33 free blocks`, and a single section build logged five failed 16KB allocations — a fragmented heap is the normal state with an SD font, not a corner case. The root causes are identified separately (a 16KB per-page scratch in `buildAdvanceTableRange` and a realloc ratchet in `mergeIntoAdvanceTable`) and will come as their own PRs; this one is the small safety net so a fragmented heap degrades to a few faulted glyphs rather than a 30s page. #2884 (chunked arena) would make it unnecessary if it lands first.

**Risk / areas to focus on:**

- The retry drops the tail of the codepoint list, so the last glyphs of a dense page can still fault. That is deliberate — partial residency beats none.
- The retry re-reads glyph metadata for the smaller set (SD I/O for up to a few hundred glyphs); it runs only on the failure path.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it 
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
