### PR TITLE
feat: Adding 2-Bit cover creation for XTC

### DIFF
--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -36,6 +36,11 @@ struct BmpHeader {
   };
   RgbQuad colors[2];
 };
+
+struct BmpHeader2Bit : public BmpHeader {
+  RgbQuad further_colors[2];
+};
+
 #pragma pack(pop)
 
 enum class BmpReaderError : uint8_t {

--- a/lib/GfxRenderer/BitmapHelpers.cpp
+++ b/lib/GfxRenderer/BitmapHelpers.cpp
@@ -154,6 +154,12 @@ void createBmpHeader2Bit(BmpHeader2Bit* bmpHeader, int width, int height, BmpRow
 
   createBmpHeader(bmpHeader, width, height, rowOrder);
 
+  uint32_t rowSize = (width * 2 + 31) / 32 * 4;
+  uint32_t imageSize = rowSize * height;
+  uint32_t fileSize = sizeof(BmpHeader2Bit) + imageSize;
+  bmpHeader->fileHeader.bfSize = fileSize;
+  bmpHeader->infoHeader.biSizeImage = imageSize;
+
   bmpHeader->fileHeader.bfOffBits = sizeof(BmpHeader2Bit);
   bmpHeader->infoHeader.biBitCount = 2;
   bmpHeader->infoHeader.biClrUsed = 4;

--- a/lib/GfxRenderer/BitmapHelpers.cpp
+++ b/lib/GfxRenderer/BitmapHelpers.cpp
@@ -148,3 +148,38 @@ void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder ro
   bmpHeader->colors[1].rgbRed = 255;
   bmpHeader->colors[1].rgbReserved = 0;
 }
+
+void createBmpHeader2Bit(BmpHeader2Bit* bmpHeader, int width, int height, BmpRowOrder rowOrder) {
+  if (!bmpHeader) return;
+
+  createBmpHeader(bmpHeader, width, height, rowOrder);
+
+  bmpHeader->fileHeader.bfOffBits = sizeof(BmpHeader2Bit);
+  bmpHeader->infoHeader.biBitCount = 2;
+  bmpHeader->infoHeader.biClrUsed = 4;
+  bmpHeader->infoHeader.biClrImportant = 4;
+
+  // Color 0 (black) (set in createBmpHeader)
+  bmpHeader->colors[0].rgbBlue = 0;
+  bmpHeader->colors[0].rgbGreen = 0;
+  bmpHeader->colors[0].rgbRed = 0;
+  bmpHeader->colors[0].rgbReserved = 0;
+
+  // Color 1 (dark grey)
+  bmpHeader->colors[1].rgbBlue = 85;
+  bmpHeader->colors[1].rgbGreen = 85;
+  bmpHeader->colors[1].rgbRed = 85;
+  bmpHeader->colors[1].rgbReserved = 0;
+
+  // Color 2 (light grey)
+  bmpHeader->further_colors[0].rgbBlue = 170;
+  bmpHeader->further_colors[0].rgbGreen = 170;
+  bmpHeader->further_colors[0].rgbRed = 170;
+  bmpHeader->further_colors[0].rgbReserved = 0;
+
+  // Color 3 (white)
+  bmpHeader->further_colors[1].rgbBlue = 255;
+  bmpHeader->further_colors[1].rgbGreen = 255;
+  bmpHeader->further_colors[1].rgbRed = 255;
+  bmpHeader->further_colors[1].rgbReserved = 0;
+}

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -4,6 +4,7 @@
 #include <cstring>
 
 struct BmpHeader;
+struct BmpHeader2Bit;
 
 // Helper functions
 uint8_t quantize(int gray, int x, int y);
@@ -15,6 +16,8 @@ enum class BmpRowOrder { BottomUp, TopDown };
 
 // Populates a 1-bit BMP header in the provided memory.
 void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder rowOrder);
+// Populates a 2-bit BMP header in the provided memory.
+void createBmpHeader2Bit(BmpHeader2Bit* bmpHeader, int width, int height, BmpRowOrder rowOrder);
 
 // 1-bit Atkinson dithering - better quality than noise dithering for thumbnails
 // Error distribution pattern (same as 2-bit but quantizes to 2 levels):

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -228,14 +228,15 @@ bool Xtc::generateCoverBmp() const {
         const size_t bitInByte = 7 - (y % 8);  // MSB = topmost pixel
 
         const size_t byteOffset = colIndex * colBytes + byteInCol;
-        const uint8_t bit2 = (plane1[byteOffset] >> bitInByte) & 1;
-        const uint8_t bit1 = (plane2[byteOffset] >> bitInByte) & 1;
-        const uint8_t pixelValue = (bit1 << 1) | bit2;
+        const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
+        const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
+        // BMP has another bit order than XTC
+        const uint8_t bmpPixelValue = (bit2 << 1) | bit1;
 
         // Set 2 bits to value in BMP format
         const size_t dstByte = x / 4;
         const size_t dstBits = 6 - (x % 4) * 2;
-        rowBuffer[dstByte] &= ~(pixelValue << dstBits);
+        rowBuffer[dstByte] &= ~(bmpPixelValue << dstBits);
       }
 
       // Write converted row

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -183,16 +183,22 @@ bool Xtc::generateCoverBmp() const {
     return false;
   }
 
-  // Write 1-bit BMP header (top-down row order)
-  BmpHeader bmpHeader;
-  createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
-  coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
-
-  const uint32_t rowSize = ((pageInfo.width + 31) / 32) * 4;
+  if (bitDepth == 1) {
+    // Write 1-bit BMP header (top-down row order)
+    BmpHeader bmpHeader;
+    createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
+    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+  } else {
+    // Write 2-bit BMP header (top-down row order)
+    BmpHeader2Bit bmpHeader;
+    createBmpHeader2Bit(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
+    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+  }
 
   // Write bitmap data
   // BMP requires 4-byte row alignment
-  const size_t dstRowSize = (pageInfo.width + 7) / 8;  // 1-bit destination row size
+  const uint32_t rowSize = ((pageInfo.width * bitDepth + 31) / 32) * 4;
+  const size_t dstRowSize = (pageInfo.width * bitDepth + 7) / 8;  // 1/2-bit destination row size
 
   if (bitDepth == 2) {
     // XTH 2-bit mode: Two bit planes, column-major order
@@ -222,17 +228,14 @@ bool Xtc::generateCoverBmp() const {
         const size_t bitInByte = 7 - (y % 8);  // MSB = topmost pixel
 
         const size_t byteOffset = colIndex * colBytes + byteInCol;
-        const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
-        const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
+        const uint8_t bit2 = (plane1[byteOffset] >> bitInByte) & 1;
+        const uint8_t bit1 = (plane2[byteOffset] >> bitInByte) & 1;
         const uint8_t pixelValue = (bit1 << 1) | bit2;
 
-        // Threshold: 0=white (1); 1,2,3=black (0)
-        if (pixelValue >= 1) {
-          // Set bit to 0 (black) in BMP format
-          const size_t dstByte = x / 8;
-          const size_t dstBit = 7 - (x % 8);
-          rowBuffer[dstByte] &= ~(1 << dstBit);
-        }
+        // Set 2 bits to value in BMP format
+        const size_t dstByte = x / 4;
+        const size_t dstBits = 6 - (x % 4) * 2;
+        rowBuffer[dstByte] &= ~(pixelValue << dstBits);
       }
 
       // Write converted row


### PR DESCRIPTION
## Summary

While playing around with absolute lut cover rendering for XTC I noticed, that 2-Bit XTC still render only an 1-Bit Cover, which looks awful (of course depending on the image).

### Book Cover (first page) in Reader:

<img width="390" alt="image" src="https://github.com/user-attachments/assets/6086aa06-2313-4f4c-82b0-c85c2d2d775d" />

### Rendered cover bitmap (from cache / photo)

<img width="390" alt="cover_vorboten_alt" src="https://github.com/user-attachments/assets/4d39049b-f988-4ff6-b078-80b09171d559" /><img width="390" alt="image" src="https://github.com/user-attachments/assets/df818e82-3743-4361-976e-e1461d0a1ddc" />

### My version (from cache / photo)

<img width="390" alt="cover_vorboten_neu" src="https://github.com/user-attachments/assets/ba2577fd-9180-481d-9c3e-1a0b7777b299" /><img width="390" alt="image" src="https://github.com/user-attachments/assets/0205baca-4be5-4317-8c40-70015f34ee87" />

### Change

The change itself is small. I need to create a bmp header for 2 bpp and write slightly different bits into the bmp.


## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Tbh I don't know how many users are using 2-Bit XTC at all, but hey: If we have such a feature, the cover should also look nice.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
