### PR TITLE
fix(epub): ignore trailing non-XML data after </html> tag in ChapterHtmlSlimParser

### DIFF
--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1542,11 +1542,15 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
   if (strcmp(name, "body") == 0) {
     self->insideBody = false;
   }
+  if (strcmp(name, "html") == 0) {
+    self->htmlEnded_ = true;
+  }
 }
 
 ChapterHtmlSlimParser::~ChapterHtmlSlimParser() { abortParse(); }
 
 bool ChapterHtmlSlimParser::beginParse() {
+  htmlEnded_ = false;
   // Initialize block style stack with a root entry representing "no ancestor block elements".
   // The user's paragraph alignment is set as the default so child elements without explicit
   // text-align inherit it correctly through getCombinedBlockStyle.
@@ -1610,6 +1614,10 @@ ChapterHtmlSlimParser::ParseStatus ChapterHtmlSlimParser::parseStep() {
   const int done = parseFile_.available() == 0;
 
   if (XML_ParseBuffer(xmlParser_, static_cast<int>(len), done) == XML_STATUS_ERROR) {
+    if (htmlEnded_) {
+      LOG_DBG("EHP", "Ignoring trailing data after </html>: %s", XML_ErrorString(XML_GetErrorCode(xmlParser_)));
+      return done ? ParseStatus::Done : ParseStatus::More;
+    }
     LOG_ERR("EHP", "Parse error at line %lu:\n%s", XML_GetCurrentLineNumber(xmlParser_),
             XML_ErrorString(XML_GetErrorCode(xmlParser_)));
     return ParseStatus::Error;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -1616,7 +1616,7 @@ ChapterHtmlSlimParser::ParseStatus ChapterHtmlSlimParser::parseStep() {
   if (XML_ParseBuffer(xmlParser_, static_cast<int>(len), done) == XML_STATUS_ERROR) {
     if (htmlEnded_) {
       LOG_DBG("EHP", "Ignoring trailing data after </html>: %s", XML_ErrorString(XML_GetErrorCode(xmlParser_)));
-      return done ? ParseStatus::Done : ParseStatus::More;
+      return ParseStatus::Done;
     }
     LOG_ERR("EHP", "Parse error at line %lu:\n%s", XML_GetCurrentLineNumber(xmlParser_),
             XML_ErrorString(XML_GetErrorCode(xmlParser_)));

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -103,6 +103,7 @@ class ChapterHtmlSlimParser {
   uint32_t currentPageVisibleOffset = 0;
   bool currentPageVisibleOffsetSet = false;
   bool insideBody = false;
+  bool htmlEnded_ = false;
   bool syntheticCharacterData = false;
   uint16_t nonVisibleTextDepth = 0;
 


### PR DESCRIPTION
Fixes an issue where EPUB files containing trailing padding bytes or non-XML data after the closing `</html>` tag cause background incremental section builds to fail (`Parse error during incremental build`), resetting the user's reading position back to page 0 / chapter start.

### Problem
Certain EPUB files have padding bytes (such as `\x05\x05...`, `\x02\x02`, or `\x10\x10...`) appended after `</html>`. 
While standard web browsers and HTML parsers ignore bytes after `</html>`, Expat returns `XML_STATUS_ERROR` (`not well-formed (invalid token)`) when reading the final chunk. When this happens during background section compilation (`Section::buildSomeMore()`), the incomplete section cache is abandoned, causing the reader to reload the section and reset pagination to page 0.

### Fix
- Added `htmlEnded_` to `ChapterHtmlSlimParser` to track when `endElement()` processes `</html>`.
- In `ChapterHtmlSlimParser::parseStep()`, if Expat returns `XML_STATUS_ERROR` after `htmlEnded_` is already `true`, the error is treated as non-fatal trailing data (`ParseStatus::Done`) instead of failing with `ParseStatus::Error`.

### Testing
- Tested in the desktop simulator and verified on physical hardware (CrossPoint X4 Pro). EPUBs with trailing padding now parse cleanly to completion without resetting section pagination.