### PR TITLE
feat: language-specific fonts

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -286,3 +286,45 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/jacobxperez/lexica-ultralegible/main/fonts/ttf/LexicaUltralegible-BoldItalic.ttf"}
+
+  # ── Hebrew ─────────────────────────────────────────────────────────────
+
+  - name: FrankRuhlLibre
+    description: "Hebrew serif (Hebrew, Latin)"
+    scripts: [hebrew, latin]
+    intervals: hebrew,latin-ext,ipa-chars,punctuation,reading,symbols
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/frankruhllibre/FrankRuhlLibre%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/frankruhllibre/FrankRuhlLibre%5Bwght%5D.ttf", variable: {wght: 700}}
+
+  - name: DavidLibre
+    description: "Traditional Hebrew serif (Hebrew, Latin)"
+    scripts: [hebrew, latin]
+    intervals: hebrew,latin-ext,ipa-chars,punctuation,reading,symbols
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/davidlibre/DavidLibre-Regular.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/davidlibre/DavidLibre-Bold.ttf"}
+
+  - name: Alef
+    description: "Simple, legible Hebrew sans-serif (Hebrew, Latin)"
+    scripts: [hebrew, latin]
+    intervals: hebrew,latin-ext,ipa-chars,punctuation,reading,symbols
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alef/Alef-Regular.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/alef/Alef-Bold.ttf"}
+
+  # ── Arabic ─────────────────────────────────────────────────────────────
+
+  - name: Amiri
+    description: "Arabic naskh-style serif (Arabic, Latin)"
+    scripts: [arabic, latin]
+    intervals: arabic,latin-ext,ipa-chars
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Regular.ttf"}
+      bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Bold.ttf"}
+      italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
+      bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -328,3 +328,49 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}
+
+  # ── Korean ─────────────────────────────────────────────────────────────
+
+  - name: Pretendard
+    description: "Modern Korean sans-serif (Hangul, Latin)"
+    scripts: [hangul, latin]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Regular.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Bold.otf"}
+
+  - name: PretendardMedium
+    description: "Pretendard at Medium weight, slightly heavier body text (Hangul, Latin)"
+    scripts: [hangul, latin]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Medium.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-ExtraBold.otf"}
+
+  - name: RIDIBatang
+    description: "RIDI's e-book serif, single weight (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/RIDIBatang/f1628238e56fd41c12451dfc7d975527b61ebfc7/RIDIBatang.otf"}
+
+  - name: MaruBuri
+    description: "Naver's serif for screen reading (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Regular.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Bold.otf"}
+
+  - name: MaruBuriSemiBold
+    description: "MaruBuri at SemiBold weight, heavier body text (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-SemiBold.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Bold.otf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -329,6 +329,33 @@ families:
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}
 
+  - name: NotoNaskhArabicUI
+    description: "Arabic naskh tuned for screen reading (Arabic)"
+    scripts: [arabic]
+    intervals: arabic,ascii,latin1,punctuation
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Regular.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+
+  - name: NotoNaskhArabicUISemiBold
+    description: "Noto Naskh Arabic UI at SemiBold weight, heavier body text (Arabic)"
+    scripts: [arabic]
+    intervals: arabic,ascii,latin1,punctuation
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-SemiBold.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+
+  - name: NotoKufiArabic
+    description: "Arabic kufi-style sans-serif (Arabic, Latin)"
+    scripts: [arabic, latin]
+    intervals: arabic,latin-ext,ipa-chars
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/notokufiarabic/NotoKufiArabic%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/notokufiarabic/NotoKufiArabic%5Bwght%5D.ttf", variable: {wght: 700}}
+
   # ── Korean ─────────────────────────────────────────────────────────────
 
   - name: Pretendard


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** 

With the new script-grouping, we can add more fonts without harming the user UX.
I will start this with three Hebrew fonts + Arabic Amiri from #2610.
Ultimately, I want 3-4 fonts for every language which the built-in reader fonts doesn't cover.
The branch would be merged before release 1.6.0

A few rules for contributing:
1. Direct your PR to `chore/fonts`, not `develop`.
2. **Suggest fonts only for your own native language**. Typography is something non-speakers find much harder to judge.
3. Open source fonts with permissive license. 

A reminder: CrossPoint doesn't support Indic scripts.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< NO >**_
