### PR TITLE
fix: (dictionary) stop styled HTML definitions refusing their own first page

### DIFF
--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -18,11 +18,31 @@ namespace {
 // use, removed after the parse.
 constexpr const char* TMP_HTML_PATH = "/.crosspoint/dicthtml.tmp";
 
-// Keep enough contiguous heap for the parser's 16KB SD-font advance scratch
-// plus page/layout allocations. Falling back to plain text is cheaper than
-// entering a throwing allocation path under pressure.
+// ENTRY gate: is there room to start a styled layout at all? Keeps enough
+// contiguous heap for the parser's 16KB SD-font advance scratch plus
+// page/layout allocations. Falling back to plain text is cheaper than entering
+// a throwing allocation path under pressure.
 constexpr size_t MIN_STYLED_FREE_HEAP = 40 * 1024;
 constexpr size_t MIN_STYLED_MAX_ALLOC = 20 * 1024;
+
+// RETAIN gate: is there still room to keep the pages coming? Checked per
+// completed page, and necessarily much lower than the entry gate, because it
+// measures a different heap: the parser is alive and holding its working set.
+//
+// Measured on an X4 with a 2554-byte definition: 50772 bytes free on entry,
+// 29400 one page in. The parse and layout cost ~21KB while they run, all of it
+// returned when the parser is destroyed. Testing the entry number here charged
+// that cost against the gate deciding whether the layout may continue, so the
+// styled path refused its own first page unless entry heap was around 61KB --
+// which, stacked over the reader, it never is. Every HTML definition silently
+// took the plain-text path.
+//
+// The pages actually retained are bounded by the two count caps below, so this
+// only has to catch genuine exhaustion. A single page's layout was seen costing
+// ~8KB between two checks, so 16KB keeps about that much in hand at the low
+// point while still sitting far below any successful entry heap.
+constexpr size_t MIN_STYLED_RETAIN_HEAP = 16 * 1024;
+constexpr size_t MIN_STYLED_RETAIN_ALLOC = 8 * 1024;
 
 // Bound retained layout independently of input bytes: compact markup can emit
 // far more objects than its source size suggests.
@@ -214,6 +234,7 @@ bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definiti
 
   bool ok = false;
   bool resourceLimitHit = false;
+  const char* limitReason = nullptr;
   size_t retainedElements = 0;
   {
     const std::string tmpPath = TMP_HTML_PATH;  // the parser stores a reference
@@ -224,11 +245,25 @@ bool buildDictionaryHtmlPages(GfxRenderer& renderer, const std::string& definiti
         nullptr, tmpPath, renderer, SETTINGS.getReaderFontId(), SETTINGS.getReaderLineCompression(),
         SETTINGS.extraParagraphSpacing, SETTINGS.paragraphAlignment, viewportWidth, viewportHeight,
         SETTINGS.hyphenationEnabled, SETTINGS.focusReadingEnabled,
-        [&pagesOut, &resourceLimitHit, &retainedElements](std::unique_ptr<Page> page, uint16_t, uint16_t, uint32_t) {
+        [&pagesOut, &resourceLimitHit, &retainedElements, &limitReason](std::unique_ptr<Page> page, uint16_t, uint16_t,
+                                                                        uint32_t) {
           if (resourceLimitHit) return;
           const size_t pageElements = page->elements.size();
-          if (pagesOut.size() >= MAX_STYLED_PAGES || pageElements > MAX_STYLED_PAGE_ELEMENTS - retainedElements ||
-              ESP.getFreeHeap() < MIN_STYLED_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_STYLED_MAX_ALLOC) {
+          // Name the limit that fired. The three causes mean different things --
+          // the count caps say the definition is genuinely too big to hold,
+          // while the heap floor says only that this moment was a bad one -- and
+          // a single "exceeded the budget" message cannot tell them apart.
+          if (pagesOut.size() >= MAX_STYLED_PAGES) {
+            limitReason = "page count";
+          } else if (pageElements > MAX_STYLED_PAGE_ELEMENTS - retainedElements) {
+            limitReason = "element count";
+          } else if (ESP.getFreeHeap() < MIN_STYLED_RETAIN_HEAP || ESP.getMaxAllocHeap() < MIN_STYLED_RETAIN_ALLOC) {
+            limitReason = "free heap";
+          }
+          if (limitReason != nullptr) {
+            LOG_ERR("DHTML", "Styled definition stopped on %s (pages=%u elements=%u free=%u contig=%u)", limitReason,
+                    static_cast<unsigned>(pagesOut.size()), static_cast<unsigned>(retainedElements + pageElements),
+                    ESP.getFreeHeap(), ESP.getMaxAllocHeap());
             resourceLimitHit = true;
             pagesOut.clear();
             return;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make styled HTML dictionary definitions actually render. Today the per-page budget check refuses the first page of almost every definition, so they fall back to plain text.
* **What changes are included?** Split the per-page retain gate from the entry gate, and name which limit fired in the log.

`buildDictionaryHtmlPages()` tests `MIN_STYLED_FREE_HEAP` (40 KB) twice — once on entry, and again on every completed page:

```cpp
if (pagesOut.size() >= MAX_STYLED_PAGES || pageElements > MAX_STYLED_PAGE_ELEMENTS - retainedElements ||
    ESP.getFreeHeap() < MIN_STYLED_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_STYLED_MAX_ALLOC) {
```

The second test measures a different heap: the parser is alive and holding its working set, so the layout's own cost is charged against the gate deciding whether the layout may continue.

Measured on an X4 with a 2554-byte definition, instrumented either side of the layout:

```
Styled layout starting (2554 bytes, free=50772 contig=45044)
Styled definition stopped on free heap (pages=0 elements=14 free=29400 contig=26612)
```

Fourteen elements on the first page — neither count cap is anywhere near. The parse and layout cost ~21 KB while they run, all of it returned when the parser is destroyed. So the per-page test needs roughly **61 KB of entry heap just to survive page one**, and stacked over the reader that does not happen. Every HTML definition silently takes the plain-text path.

**The fix.** `MIN_STYLED_RETAIN_HEAP` is 16 KB rather than 40: the pages actually retained are already bounded by `MAX_STYLED_PAGES` and `MAX_STYLED_PAGE_ELEMENTS`, so the heap test only has to catch genuine exhaustion. 16 KB is sized from measurement — a single page's layout was seen costing ~8 KB between two checks, bottoming at 7592 free against a 12 KB floor.

**Also**: the failure now names which of the three limits fired and prints the heap either side. The causes mean different things — the count caps say the definition is genuinely too big to hold, the heap floor says only that this moment was a bad one — and one message for all three cannot tell them apart. That log is what located this bug.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this is a defect fix in existing dictionary code.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

Found while porting the dictionary into a fork, where the identical structure produced the identical symptom; the numbers above are from the fork, on the same device class and the same code path.

After the change, same device and dictionary: 2554-byte and 293-byte definitions lay out styled, and a 7184-byte one still stops — at `pages=2` with 7592 free, which is the guard doing its actual job rather than refusing up front. `pio run` on `develop` with this patch builds clean.

I have **not** been able to test this against a stock CrossPoint build on hardware — only against the fork's port of the same code. Worth a maintainer confirming the retained-page behaviour on a stock device before merge; if 16 KB looks too low for your heap profile, the number is the only thing that needs changing.

Memory / flash impact: none of consequence — two constants and a log line.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — written with Claude Code. The instrumentation, the on-device measurements quoted above and the before/after verification were run and reviewed by me.
