### PR TITLE
fix: display chapter tilde in 10pt font

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -902,22 +902,29 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     // Right aligned text for progress counter
     char progressStr[32];
 
-    // Prefix the page count with "~" while a still-building spine only yields an estimated total.
-    const char* estimatePrefix = pageCountEstimated ? "~" : "";
+    // Draw the estimate marker separately so it can use the next UI font size.
+    const bool showEstimate = pageCountEstimated && sb.showChapterPageCount;
 
     if (sb.showBookProgressPercent && sb.showChapterPageCount) {
-      snprintf(progressStr, sizeof(progressStr), "%s%d/%d  %.0f%%", estimatePrefix, currentPage, pageCount,
-               bookProgress);
+      snprintf(progressStr, sizeof(progressStr), "%d/%d  %.0f%%", currentPage, pageCount, bookProgress);
     } else if (sb.showBookProgressPercent) {
       snprintf(progressStr, sizeof(progressStr), "%.0f%%", bookProgress);
     } else {
-      snprintf(progressStr, sizeof(progressStr), "%s%d/%d", estimatePrefix, currentPage, pageCount);
+      snprintf(progressStr, sizeof(progressStr), "%d/%d", currentPage, pageCount);
     }
 
     int progressTextWidth = renderer.getTextWidth(SMALL_FONT_ID, progressStr);
-    renderer.drawText(SMALL_FONT_ID, rightClusterX - progressTextWidth, textY, progressStr);
+    const int estimateWidth = showEstimate ? renderer.getTextWidth(UI_10_FONT_ID, "~") : 0;
+    constexpr int estimateGap = 2;
+    const int estimateSpacing = showEstimate ? estimateGap : 0;
+    const int progressX = rightClusterX - estimateWidth - estimateSpacing - progressTextWidth;
+    if (showEstimate) {
+      const int estimateY = textY + (renderer.getLineHeight(SMALL_FONT_ID) - renderer.getLineHeight(UI_10_FONT_ID)) / 2;
+      renderer.drawText(UI_10_FONT_ID, progressX, estimateY, "~");
+    }
+    renderer.drawText(SMALL_FONT_ID, progressX + estimateWidth + estimateSpacing, textY, progressStr);
 
-    rightClusterWidth += progressTextWidth;
+    rightClusterWidth += estimateWidth + estimateSpacing + progressTextWidth;
   }
 
   // Draw Progress Bar


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Make the estimated chapter-page marker (`~`) larger in the reader status bar so it's not confused with a dash (`-`), especially on lower PPI devices.

* **What changes are included?**
  * Render the estimate marker separately with the 10pt UI font.
  * Preserve its placement in the right-side status-bar layout, including when a clock is shown.
  * Keep the marker limited to estimated chapter counts; it is not shown for book-progress-only status bars.
  * Adds a 2px right margin since it was colliding with the chapter page number without it.

## Additional Context

* This is a visual-only status-bar change in `BaseTheme::drawStatusBar`; it adds no heap allocation or persistent-state changes.

**X4 - Before**
<img width="493" height="640" alt="X4 Before" src="https://github.com/user-attachments/assets/b9f471ee-71c2-4aea-9d92-b868dbb4f995" />

**X4 - After**
<img width="525" height="640" alt="X4 After" src="https://github.com/user-attachments/assets/4b7a167f-2217-4219-a1b4-ca49f91998fd" />

**X3 - After**
<img width="598" height="640" alt="X3 After" src="https://github.com/user-attachments/assets/f5b59c8c-66a3-4d9d-a716-8f2ce24a9678" />
