### PR TITLE
docs: fix Settings path for Manage Fonts

### DIFF
--- a/docs/sd-card-fonts.md
+++ b/docs/sd-card-fonts.md
@@ -10,7 +10,7 @@ There are three ways to install fonts:
 ### Option 1: Download from device (recommended)
 
 1. Connect your CrossPoint reader to Wi-Fi
-2. Go to **Settings > System > Manage Fonts**
+2. Go to **Settings > Reader > Manage Fonts**
 3. Browse available font families and tap to download
 4. Downloaded fonts appear immediately in **Settings > Reader > Font Family**
 


### PR DESCRIPTION
## Summary

Fixes an incorrect navigation path in the _Installing Fonts_ section of `docs/sd-card-fonts.md`.

**Before:** `Settings > System > Manage Fonts`
**After:** `Settings > Reader > Manage Fonts`