### PR TITLE
feat(opds): per-server save directory for downloads 

### DIFF
--- a/docs/webserver-endpoints.md
+++ b/docs/webserver-endpoints.md
@@ -336,6 +336,7 @@ Response:
     "name": "My Catalog",
     "url": "http://calibre.local:8080/opds",
     "username": "reader",
+    "saveDirectory": "/Calibre",
     "hasPassword": true
   }
 ]
@@ -349,7 +350,7 @@ If `password` is omitted during an update, the existing password is preserved.
 ```bash
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"name":"My Catalog","url":"http://calibre.local:8080/opds","username":"reader","password":"secret"}' \
+  -d '{"name":"My Catalog","url":"http://calibre.local:8080/opds","username":"reader","password":"secret","saveDirectory":"/Calibre"}' \
   http://crosspoint.local/api/opds
 ```
 

--- a/src/OpdsServerStore.cpp
+++ b/src/OpdsServerStore.cpp
@@ -14,6 +14,7 @@ void OpdsServerStore::toJson(JsonDocument& doc) const {
     obj["url"] = server.url;
     obj["username"] = server.username;
     obj["password_obf"] = obfuscation::obfuscateToBase64(server.password);
+    obj["saveDirectory"] = server.saveDirectory;
   }
 }
 
@@ -32,6 +33,7 @@ bool OpdsServerStore::fromJson(JsonVariantConst doc) {
     server.url = obj["url"] | "";
     server.username = obj["username"] | "";
     server.password = extractPassword(obj, needsResave);
+    server.saveDirectory = obj["saveDirectory"] | "";
     servers.push_back(std::move(server));
   }
 

--- a/src/OpdsServerStore.h
+++ b/src/OpdsServerStore.h
@@ -10,6 +10,9 @@ struct OpdsServer {
   std::string url;
   std::string username;
   std::string password;  // Plaintext in memory; obfuscated with hardware key on disk
+  // Optional per-server download folder. Empty => use SETTINGS.opdsDownloadFolder
+  // (or SD root when that is also empty). Normalized: leading '/', no trailing '/'.
+  std::string saveDirectory;
 };
 
 /**

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -468,9 +468,11 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // Build full download URL relative to the current feed, not the root server URL
   const std::string feedUrl = UrlUtils::buildUrl(server.url, currentPath);
   std::string downloadUrl = UrlUtils::buildUrl(feedUrl, book.href);
-  // opdsDownloadFolder is already a null-terminated char[64]; use it directly —
-  // no std::string copy. exists()/mkdir() take const char*.
-  const char* folder = SETTINGS.opdsDownloadFolder;  // "" => SD root
+  // Prefer per-server saveDirectory; fall back to the global setting ("" => SD root).
+  // Both are null-terminated (std::string::c_str() / char[64]); exists()/mkdir()
+  // take const char*.
+  const char* folder = !server.saveDirectory.empty() ? server.saveDirectory.c_str()
+                                                     : SETTINGS.opdsDownloadFolder;
   bool haveFolder = folder[0] != '\0';
   if (haveFolder && !Storage.exists(folder) && !Storage.mkdir(folder)) {
     // exists()-guard first: mkdir's return-on-existing is unconfirmed, and every

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -471,8 +471,7 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   // Prefer per-server saveDirectory; fall back to the global setting ("" => SD root).
   // Both are null-terminated (std::string::c_str() / char[64]); exists()/mkdir()
   // take const char*.
-  const char* folder = !server.saveDirectory.empty() ? server.saveDirectory.c_str()
-                                                     : SETTINGS.opdsDownloadFolder;
+  const char* folder = !server.saveDirectory.empty() ? server.saveDirectory.c_str() : SETTINGS.opdsDownloadFolder;
   bool haveFolder = folder[0] != '\0';
   if (haveFolder && !Storage.exists(folder) && !Storage.mkdir(folder)) {
     // exists()-guard first: mkdir's return-on-existing is unconfirmed, and every

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -34,9 +34,9 @@ OpdsSettingsActivity::OpdsSettingsActivity(GfxRenderer& renderer, MappedInputMan
     : UiListActivity("OpdsSettings", renderer, mappedInput), serverIndex(serverIndex) {
   // Labels never change (unlike the values, which track editServer's fields
   // live), so they're set once here rather than every buildScreen() call.
-  static constexpr StrId fieldNames[BASE_ITEMS] = {
-      StrId::STR_SERVER_NAME, StrId::STR_OPDS_SERVER_URL, StrId::STR_USERNAME, StrId::STR_PASSWORD,
-      StrId::STR_OPDS_DOWNLOAD_FOLDER};
+  static constexpr StrId fieldNames[BASE_ITEMS] = {StrId::STR_SERVER_NAME, StrId::STR_OPDS_SERVER_URL,
+                                                   StrId::STR_USERNAME, StrId::STR_PASSWORD,
+                                                   StrId::STR_OPDS_DOWNLOAD_FOLDER};
   for (int i = 0; i < BASE_ITEMS; i++) {
     fieldRowItems[i].label = I18N.get(fieldNames[i]);
     fieldRowItems[i].actionValue = static_cast<int16_t>(i);
@@ -173,10 +173,9 @@ void OpdsSettingsActivity::handleSelection() {
         requestUpdate();
       }
     };
-    startActivityForResult(
-        std::make_unique<KeyboardEntryActivity>(renderer, mappedInput, tr(STR_OPDS_DOWNLOAD_FOLDER),
-                                                editServer.saveDirectory, 63, InputType::Text),
-        handler);
+    startActivityForResult(std::make_unique<KeyboardEntryActivity>(renderer, mappedInput, tr(STR_OPDS_DOWNLOAD_FOLDER),
+                                                                   editServer.saveDirectory, 63, InputType::Text),
+                           handler);
   } else if (nav.selected == 5 && !isNewServer) {
     // Delete flow is only available for existing servers.
     if (!OPDS_STORE.removeServer(static_cast<size_t>(serverIndex))) {
@@ -213,8 +212,7 @@ void OpdsSettingsActivity::buildScreen(UiScreen& screen) {
   fieldRowItems[1].value = editServer.url.empty() ? tr(STR_NOT_SET) : editServer.url.c_str();
   fieldRowItems[2].value = editServer.username.empty() ? tr(STR_NOT_SET) : editServer.username.c_str();
   fieldRowItems[3].value = editServer.password.empty() ? tr(STR_NOT_SET) : "******";
-  fieldRowItems[4].value =
-      editServer.saveDirectory.empty() ? tr(STR_OPDS_SD_ROOT) : editServer.saveDirectory.c_str();
+  fieldRowItems[4].value = editServer.saveDirectory.empty() ? tr(STR_OPDS_SD_ROOT) : editServer.saveDirectory.c_str();
 
   fui::ListProps props;
   props.items = fieldRowItems;

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -12,9 +12,21 @@
 namespace fui = freeink::ui;
 
 namespace {
-// Editable fields: Name, URL, Username, Password.
+// Normalizes a user-typed folder: trims spaces, "" => SD root, otherwise a
+// single leading '/' and no trailing '/'. Cold path (runs once per edit).
+std::string normalizeFolder(std::string v) {
+  while (!v.empty() && (v.front() == ' ' || v.front() == '\t')) v.erase(v.begin());
+  while (!v.empty() && (v.back() == ' ' || v.back() == '\t')) v.pop_back();
+  if (v.empty()) return "";
+  if (v.front() != '/') v.insert(v.begin(), '/');
+  while (v.size() > 1 && v.back() == '/') v.pop_back();
+  if (v == "/") return "";  // a bare slash is SD root, same as empty
+  return v;
+}
+
+// Editable fields: Name, URL, Username, Password, Save directory.
 // Existing servers also show a Delete option (BASE_ITEMS + 1).
-constexpr int BASE_ITEMS = 4;
+constexpr int BASE_ITEMS = 5;
 }  // namespace
 
 OpdsSettingsActivity::OpdsSettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
@@ -22,8 +34,9 @@ OpdsSettingsActivity::OpdsSettingsActivity(GfxRenderer& renderer, MappedInputMan
     : UiListActivity("OpdsSettings", renderer, mappedInput), serverIndex(serverIndex) {
   // Labels never change (unlike the values, which track editServer's fields
   // live), so they're set once here rather than every buildScreen() call.
-  static constexpr StrId fieldNames[BASE_ITEMS] = {StrId::STR_SERVER_NAME, StrId::STR_OPDS_SERVER_URL,
-                                                   StrId::STR_USERNAME, StrId::STR_PASSWORD};
+  static constexpr StrId fieldNames[BASE_ITEMS] = {
+      StrId::STR_SERVER_NAME, StrId::STR_OPDS_SERVER_URL, StrId::STR_USERNAME, StrId::STR_PASSWORD,
+      StrId::STR_OPDS_DOWNLOAD_FOLDER};
   for (int i = 0; i < BASE_ITEMS; i++) {
     fieldRowItems[i].label = I18N.get(fieldNames[i]);
     fieldRowItems[i].actionValue = static_cast<int16_t>(i);
@@ -150,7 +163,21 @@ void OpdsSettingsActivity::handleSelection() {
     startActivityForResult(std::make_unique<KeyboardEntryActivity>(renderer, mappedInput, tr(STR_PASSWORD),
                                                                    editServer.password, 63, InputType::Text),
                            handler);
-  } else if (nav.selected == 4 && !isNewServer) {
+  } else if (nav.selected == 4) {
+    // Save directory (per-server). Empty => use global opdsDownloadFolder / SD root.
+    auto handler = [this](const ActivityResult& result) {
+      if (!result.isCancelled) {
+        const auto& kb = std::get<KeyboardResult>(result.data);
+        editServer.saveDirectory = normalizeFolder(kb.text);
+        saveServer();
+        requestUpdate();
+      }
+    };
+    startActivityForResult(
+        std::make_unique<KeyboardEntryActivity>(renderer, mappedInput, tr(STR_OPDS_DOWNLOAD_FOLDER),
+                                                editServer.saveDirectory, 63, InputType::Text),
+        handler);
+  } else if (nav.selected == 5 && !isNewServer) {
     // Delete flow is only available for existing servers.
     if (!OPDS_STORE.removeServer(static_cast<size_t>(serverIndex))) {
       LOG_ERR("OPS", "Failed to remove OPDS server at index %d", serverIndex);
@@ -186,6 +213,8 @@ void OpdsSettingsActivity::buildScreen(UiScreen& screen) {
   fieldRowItems[1].value = editServer.url.empty() ? tr(STR_NOT_SET) : editServer.url.c_str();
   fieldRowItems[2].value = editServer.username.empty() ? tr(STR_NOT_SET) : editServer.username.c_str();
   fieldRowItems[3].value = editServer.password.empty() ? tr(STR_NOT_SET) : "******";
+  fieldRowItems[4].value =
+      editServer.saveDirectory.empty() ? tr(STR_OPDS_SD_ROOT) : editServer.saveDirectory.c_str();
 
   fui::ListProps props;
   props.items = fieldRowItems;

--- a/src/activities/settings/OpdsSettingsActivity.h
+++ b/src/activities/settings/OpdsSettingsActivity.h
@@ -33,11 +33,11 @@ class OpdsSettingsActivity final : public UiListActivity {
   void handleSelection();
   bool saveServer();
 
-  // Row storage: at most 5 rows (Name/URL/Username/Password + Delete, see
+  // Row storage: at most 6 rows (Name/URL/Username/Password/Save directory + Delete, see
   // BASE_ITEMS in the .cpp), so a fixed-capacity array avoids any heap
   // allocation for the row list. Labels are set once in the constructor
   // (they never change); buildScreen() only refreshes the value pointers,
   // which already point at editServer's own fields (no new strings built).
-  static constexpr int MAX_MENU_ITEMS = 5;
+  static constexpr int MAX_MENU_ITEMS = 6;
   freeink::ui::ListItem fieldRowItems[MAX_MENU_ITEMS]{};
 };

--- a/src/network/CrossPointWebServer.cpp
+++ b/src/network/CrossPointWebServer.cpp
@@ -1347,6 +1347,7 @@ void CrossPointWebServer::handleGetOpdsServers() const {
     doc["name"] = servers[i].name;
     doc["url"] = servers[i].url;
     doc["username"] = servers[i].username;
+    doc["saveDirectory"] = servers[i].saveDirectory;
     // Never expose passwords over the API — only indicate whether one is set
     doc["hasPassword"] = !servers[i].password.empty();
 
@@ -1382,6 +1383,7 @@ void CrossPointWebServer::handlePostOpdsServer() {
   opdsServer.name = doc["name"] | std::string("");
   opdsServer.url = doc["url"] | std::string("");
   opdsServer.username = doc["username"] | std::string("");
+  opdsServer.saveDirectory = doc["saveDirectory"] | std::string("");
 
   // The password field is optional in the JSON payload. When absent (vs. present but empty),
   // we preserve the existing password — the web UI omits it when the user hasn't changed it.

--- a/src/network/html/SettingsPage.html
+++ b/src/network/html/SettingsPage.html
@@ -735,6 +735,10 @@
         '<span class="setting-name">Password</span>' +
         '<span class="setting-control"><input type="password" id="opds-pass-' + id + '" placeholder="' + (srv.hasPassword ? '(unchanged)' : '') + '"></span>' +
       '</div>' +
+      '<div class="setting-row">' +
+        '<span class="setting-name">Save directory</span>' +
+        '<span class="setting-control"><input type="text" id="opds-dir-' + id + '" value="' + escapeHtml(srv.saveDirectory || '') + '" placeholder="(global / SD root)"></span>' +
+      '</div>' +
       '<div class="opds-actions">' +
         '<button class="btn-small btn-save-server" onclick="saveOpdsServer(' + idx + ')">Save</button>' +
         (isNew ? '' : '<button class="btn-small btn-delete" onclick="deleteOpdsServer(' + idx + ')">Delete</button>') +
@@ -777,7 +781,7 @@
     const addBtn = card.querySelector('.btn-add').parentElement;
     // Prevent multiple unsaved new-server forms at once (idx -1 → id "new")
     if (document.getElementById('opds-new')) return;
-    addBtn.insertAdjacentHTML('beforebegin', renderOpdsServer({name:'',url:'',username:'',hasPassword:false}, -1));
+    addBtn.insertAdjacentHTML('beforebegin', renderOpdsServer({name:'',url:'',username:'',saveDirectory:'',hasPassword:false}, -1));
   }
 
   async function saveOpdsServer(idx) {
@@ -786,6 +790,7 @@
       name: document.getElementById('opds-name-' + id).value,
       url: document.getElementById('opds-url-' + id).value,
       username: document.getElementById('opds-user-' + id).value,
+      saveDirectory: document.getElementById('opds-dir-' + id).value.trim(),
     };
     // Only include password in payload when the user actually typed something;
     // omitting it tells the server to keep the existing password.


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**  
  Add an optional **per-server save directory** for OPDS downloads so books from different catalogs can land in different folders on the SD card instead of one shared directory.

* **What changes are included?**
  - `OpdsServer.saveDirectory` field, persisted in `/.crosspoint/opds.json`
  - Download path prefers per-server folder; empty falls back to global `opdsDownloadFolder` / SD root
  - On-device OPDS server editor: new Download folder row
  - Web Settings UI + `/api/opds` GET/POST include `saveDirectory`
  - Docs: `docs/webserver-endpoints.md`

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This only extends the existing OPDS multi-server feature (already in tree). It does not add a new network protocol or connector.

## Additional Context

* Backward compatible: missing `saveDirectory` in existng `opds.json` loads as empty (global folder behavior unchanged).
* If `mkdir` for the chosen folder fails, download falls back to SD root so the file is not lost.
* Tested on X4: per-server path (e.g. `/RdLtr`) receives downloads; empty per-server field still uses global/SD root.
* Touch surface is small (store, one download path, settings UI, web API/HTML). No HAL/SDK/OTA chages.
* Memory / flash impact: one extra `std::string` per saved server (max 8); negligible.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? **NO**