### PR TITLE
fix: skip hop headers on plugin file downloads

### DIFF
--- a/docs/sd-plugins.md
+++ b/docs/sd-plugins.md
@@ -180,7 +180,7 @@ Two browse formats:
   "download": {
     "url": "https://.../books/{id}/download",
     "method": "POST",
-    "headers": { "Authorization": "Bearer {token}" },  // sent on the file GET too
+    "headers": { "Authorization": "Bearer {token}" },  // file GET too, unless url_path is set
     "body": "{}",
     "url_path": "url",                      // response field with the file URL;
                                             // omit to treat "url" itself as the file URL

--- a/src/activities/plugins/PluginCatalogActivity.cpp
+++ b/src/activities/plugins/PluginCatalogActivity.cpp
@@ -1220,12 +1220,19 @@ void PluginCatalogActivity::downloadItem(const Item& item) {
 
   const std::string dlUser = substituted(manifest.dlUser, &item);
   const std::string dlPass = substituted(manifest.dlPass, &item);
-  const auto dlHeaders = substitutedHeaders(manifest.dlHeaders, &item);
+  // url_path already authenticated the JSON hop; the resolved file URL must not
+  // inherit those headers (S3 pre-signed GETs reject a second Authorization).
+  const std::vector<HttpDownloader::Header> fileHeaders = manifest.dlUrlPath.empty()
+                                                              ? substitutedHeaders(manifest.dlHeaders, &item)
+                                                              : std::vector<HttpDownloader::Header>{};
   dlLastRenderedPercent = -1;
   dlLastProgressUpdateMs = 0;
+  session.reset();  // free browse TLS before the large file GET
   const auto result = HttpDownloader::downloadToFile(
       fileUrl, dest, [this](const size_t downloaded, const size_t total) { onDownloadProgress(downloaded, total); },
-      &cancelDownload, dlUser, dlPass, dlHeaders);
+      &cancelDownload, dlUser, dlPass, fileHeaders);
+  session.reset(new (std::nothrow) freeink::SecureHttpClient());
+  if (session) session->setReuse(true);
 
   if (result == HttpDownloader::ABORTED) {
     finishCancelledDownload();


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix on-device SD plugin catalog downloads that resolve a file URL via `url_path` (BookFusion and similar). Large books currently fail around 1.5 to 2 MB with `Error: Download failed`.
* **What changes are included?**
  * Skip hop headers (`Authorization`, `Accept`, `Content-Type`) on the file GET when `url_path` resolved the URL. Those headers still go on the API hop. Plugins that omit `url_path` (Wallabag) still send headers on the file GET.
  * Drop the reused browse TLS session before `HttpDownloader::downloadToFile`, then recreate it afterwards, so the large GET does not share the ESP32-C3 heap with a kept-alive wolfSSL context.
  * Docs: `download.headers` are only sent on the file GET when `url_path` is omitted.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

This is a bug fix to the plugin catalog download already on `feat-sd-plugins` ([#3114](https://github.com/crosspoint-reader/crosspoint-reader/pull/3114)), not a new connector. The native BookFusion fork does download these books, which is why this path needs to work in official CrossPoint too.

## Additional Context

Two firmware bugs. The SD plugin JSON/JS is fine.

**1. The login token was sent to the wrong place.**

BookFusion download is two requests:

1. Ask BookFusion for a download link (needs your login token).
2. Fetch the file from that link. That second URL is usually Amazon S3, and the token is already baked into the link. Sending `Authorization` again makes S3 refuse the download.

Small public-domain books could still work. Larger Libby EPUBs tended to hit this.

**2. The device ran out of RAM mid-download.**

The reader kept the "browsing the library" network session open while also downloading the book. On the X3 that is too much TLS at once. The download died around 1.5 to 2 MB with `Error: Download failed`.

**Fix:** keep the token on the first request only, and drop the browse session before the file download starts. Flashing firmware is required. Copying the plugin to the SD card does not help.

Opened against `feat-sd-plugins` rather than `develop` because `PluginCatalogActivity` only exists on that branch. No Range-resume changes. `HttpDownloader` is untouched.

**How to test**

1. Flash an X3/X4 build of this branch.
2. Use the official BookFusion SD plugin (sign-in, browse).
3. Download a larger EPUB that previously failed around 1.6 MB. It should complete.
4. Confirm a small public-domain book still downloads.
5. If you have a Wallabag plugin (no `url_path`), confirm download still authenticates.

Reproduced and verified on X3 with BookFusion. Related: [itsthisjustin/sd-plugins#6](https://github.com/itsthisjustin/sd-plugins/issues/6).

Memory: one extra `session.reset()` around the file GET. The empty headers vector is stack-empty when `url_path` is set. No new persistent allocations.

---

### AI Usage

Did you use AI tools to help write this code? **YES**