### PR TITLE
refactor: give book formats a single home

### DIFF
--- a/src/RecentBooksStore.cpp
+++ b/src/RecentBooksStore.cpp
@@ -1,13 +1,12 @@
 #include "RecentBooksStore.h"
 
-#include <Epub.h>
-#include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Logging.h>
-#include <Xtc.h>
 
 #include <algorithm>
 #include <iterator>
+
+#include "util/BookFile.h"
 
 void RecentBooksStore::toJson(JsonDocument& doc) const {
   JsonArray arr = doc["books"].to<JsonArray>();
@@ -112,29 +111,6 @@ bool RecentBooksStore::pruneMissing() {
 }
 
 RecentBook RecentBooksStore::getDataFromBook(std::string path) const {
-  std::string lastBookFileName = "";
-  const size_t lastSlash = path.find_last_of('/');
-  if (lastSlash != std::string::npos) {
-    lastBookFileName = path.substr(lastSlash + 1);
-  }
-
-  LOG_DBG("RBS", "Loading recent book: %s", path.c_str());
-
-  // If epub, try to load the metadata for title/author and cover.
-  // Use buildIfMissing=false to avoid heavy epub loading on boot; getTitle()/getAuthor() may be
-  // blank until the book is opened, and entries with missing title are omitted from recent list.
-  if (FsHelpers::hasEpubExtension(lastBookFileName)) {
-    Epub epub(path, "/.crosspoint");
-    epub.load(false, true);
-    return RecentBook{path, epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
-  } else if (FsHelpers::hasXtcExtension(lastBookFileName)) {
-    // Handle XTC file
-    Xtc xtc(path, "/.crosspoint");
-    if (xtc.load()) {
-      return RecentBook{path, xtc.getTitle(), xtc.getAuthor(), xtc.getThumbBmpPath()};
-    }
-  } else if (FsHelpers::hasTxtExtension(lastBookFileName) || FsHelpers::hasMarkdownExtension(lastBookFileName)) {
-    return RecentBook{path, lastBookFileName, "", ""};
-  }
-  return RecentBook{path, "", "", ""};
+  const BookInfo info = readBookInfo(path);
+  return RecentBook{path, info.title, info.author, info.thumbBmpPath};
 }

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -1,6 +1,5 @@
 #include "SleepActivity.h"
 
-#include <Epub.h>
 #include <Epub/converters/PngToFramebufferConverter.h>
 #include <FontCacheManager.h>
 #include <FsHelpers.h>
@@ -11,8 +10,6 @@
 #include <I18n.h>
 #include <Memory.h>
 #include <PNGdec.h>
-#include <Txt.h>
-#include <Xtc.h>
 
 #include <algorithm>
 #include <cmath>
@@ -28,6 +25,7 @@
 #include "fontIds.h"
 #include "images/Logo120.h"
 #include "images/MoonIcon.h"
+#include "util/BookFile.h"
 
 namespace {
 
@@ -762,54 +760,9 @@ void SleepActivity::renderCoverSleepScreen() const {
     return (this->*renderNoCoverSleepScreen)();
   }
 
-  std::string coverBmpPath;
-  bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
-
-  // Check if the current book is XTC, TXT, or EPUB
-  if (FsHelpers::hasXtcExtension(APP_STATE.openEpubPath)) {
-    // Handle XTC file
-    Xtc lastXtc(APP_STATE.openEpubPath, "/.crosspoint");
-    if (!lastXtc.load()) {
-      LOG_ERR("SLP", "Failed to load last XTC");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    if (!lastXtc.generateCoverBmp()) {
-      LOG_ERR("SLP", "Failed to generate XTC cover bmp");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    coverBmpPath = lastXtc.getCoverBmpPath();
-  } else if (FsHelpers::hasTxtExtension(APP_STATE.openEpubPath)) {
-    // Handle TXT file - looks for cover image in the same folder
-    Txt lastTxt(APP_STATE.openEpubPath, "/.crosspoint");
-    if (!lastTxt.load()) {
-      LOG_ERR("SLP", "Failed to load last TXT");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    if (!lastTxt.generateCoverBmp()) {
-      LOG_ERR("SLP", "No cover image found for TXT file");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    coverBmpPath = lastTxt.getCoverBmpPath();
-  } else if (FsHelpers::hasEpubExtension(APP_STATE.openEpubPath)) {
-    // Handle EPUB file
-    Epub lastEpub(APP_STATE.openEpubPath, "/.crosspoint");
-    // Skip loading css since we only need metadata here
-    if (!lastEpub.load(true, true)) {
-      LOG_ERR("SLP", "Failed to load last epub");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    if (!lastEpub.generateCoverBmp(cropped)) {
-      LOG_ERR("SLP", "Failed to generate cover bmp");
-      return (this->*renderNoCoverSleepScreen)();
-    }
-
-    coverBmpPath = lastEpub.getCoverBmpPath(cropped);
-  } else {
+  const bool cropped = SETTINGS.sleepScreenCoverMode == CrossPointSettings::SLEEP_SCREEN_COVER_MODE::CROP;
+  const std::string coverBmpPath = generateBookCoverBmp(APP_STATE.openEpubPath, cropped);
+  if (coverBmpPath.empty()) {
     return (this->*renderNoCoverSleepScreen)();
   }
 

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -15,6 +15,7 @@
 #include "components/UiAppHelpers.h"
 #include "fontIds.h"
 #include "util/BookCacheUtils.h"
+#include "util/BookFile.h"
 
 namespace fui = freeink::ui;
 
@@ -67,9 +68,7 @@ void FileBrowserActivity::loadFiles() {
         if (FsHelpers::checkFileExtension(filename, ".bin")) {
           files.emplace_back(filename);
         }
-      } else if (FsHelpers::hasEpubExtension(filename) || FsHelpers::hasXtcExtension(filename) ||
-                 FsHelpers::hasTxtExtension(filename) || FsHelpers::hasMarkdownExtension(filename) ||
-                 FsHelpers::hasBmpExtension(filename) || FsHelpers::hasPngExtension(filename)) {
+      } else if (isBook(filename) || FsHelpers::hasBmpExtension(filename) || FsHelpers::hasPngExtension(filename)) {
         files.emplace_back(filename);
       }
     }

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -1,14 +1,11 @@
 #include "HomeActivity.h"
 
 #include <Bitmap.h>
-#include <Epub.h>
-#include <FsHelpers.h>
 #include <GfxRenderer.h>
 #include <HalDisplay.h>
 #include <HalStorage.h>
 #include <I18n.h>
 #include <Utf8.h>
-#include <Xtc.h>
 
 #include <algorithm>
 #include <cstring>
@@ -21,6 +18,7 @@
 #include "RecentBooksStore.h"
 #include "components/UITheme.h"
 #include "fontIds.h"
+#include "util/BookFile.h"
 
 int HomeActivity::getMenuItemCount() const {
   int count = 4;  // File Browser, Recents, File transfer, Settings
@@ -63,43 +61,19 @@ void HomeActivity::loadRecentCovers(int coverHeight) {
     if (!book.coverBmpPath.empty()) {
       std::string coverPath = UITheme::getCoverThumbPath(book.coverBmpPath, coverHeight);
       if (!Storage.exists(coverPath.c_str())) {
-        // If epub, try to load the metadata for title/author and cover
-        if (FsHelpers::hasEpubExtension(book.path)) {
-          Epub epub(book.path, "/.crosspoint");
-          // Skip loading css since we only need metadata here
-          epub.load(false, true);
-
-          // Try to generate thumbnail image for Continue Reading card
+        if (hasThumbnail(bookFormat(book.path))) {
           if (!showingLoading) {
             showingLoading = true;
             popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
           }
           GUI.fillPopupProgress(renderer, popupRect, 10 + progress * (90 / recentBooks.size()));
-          bool success = epub.generateThumbBmp(coverHeight);
-          if (!success) {
+
+          if (!generateBookThumb(book.path, coverHeight)) {
             RECENT_BOOKS.updateBook(book.path, book.title, book.author, "");
             book.coverBmpPath = "";
           }
           coverRendered = false;
           requestUpdate();
-        } else if (FsHelpers::hasXtcExtension(book.path)) {
-          // Handle XTC file
-          Xtc xtc(book.path, "/.crosspoint");
-          if (xtc.load()) {
-            // Try to generate thumbnail image for Continue Reading card
-            if (!showingLoading) {
-              showingLoading = true;
-              popupRect = GUI.drawPopup(renderer, tr(STR_LOADING_POPUP));
-            }
-            GUI.fillPopupProgress(renderer, popupRect, 10 + progress * (90 / recentBooks.size()));
-            bool success = xtc.generateThumbBmp(coverHeight);
-            if (!success) {
-              RECENT_BOOKS.updateBook(book.path, book.title, book.author, "");
-              book.coverBmpPath = "";
-            }
-            coverRendered = false;
-            requestUpdate();
-          }
         }
       }
     }

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -1,6 +1,5 @@
 #include "ReaderActivity.h"
 
-#include <FsHelpers.h>
 #include <HalStorage.h>
 #include <Memory.h>
 
@@ -14,6 +13,7 @@
 #include "SdCardFontSystem.h"
 #include "TxtReaderActivity.h"
 #include "XtcReaderActivity.h"
+#include "util/BookFile.h"
 
 ReaderActivity::ReaderActivity(const char* name, GfxRenderer& renderer, MappedInputManager& mappedInput,
                                std::string bookPath, const bool allowFastInitialRefresh)
@@ -28,12 +28,17 @@ std::unique_ptr<ReaderActivity> ReaderActivity::create(GfxRenderer& renderer, Ma
                                                        std::string path, const bool allowFastInitialRefresh) {
   // ActivityManager requires heap ownership; each branch allocates exactly one screen-lifetime object.
   std::unique_ptr<ReaderActivity> activity;
-  if (FsHelpers::hasXtcExtension(path)) {
-    activity = makeUniqueNoThrow<XtcReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
-  } else if (FsHelpers::hasTxtExtension(path) || FsHelpers::hasMarkdownExtension(path)) {
-    activity = makeUniqueNoThrow<TxtReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
-  } else {
-    activity = makeUniqueNoThrow<EpubReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
+  switch (bookFormat(path)) {
+    case BookFormat::Xtc:
+      activity = makeUniqueNoThrow<XtcReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
+      break;
+    case BookFormat::Txt:
+      activity = makeUniqueNoThrow<TxtReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
+      break;
+    case BookFormat::Epub:
+    case BookFormat::Unknown:
+      activity = makeUniqueNoThrow<EpubReaderActivity>(renderer, mappedInput, std::move(path), allowFastInitialRefresh);
+      break;
   }
 
   if (!activity) {

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -14,6 +14,7 @@
 #include "components/themes/lyra/Lyra3CoversTheme.h"
 #include "components/themes/lyra/LyraTheme.h"
 #include "components/themes/roundedraff/RoundedRaffTheme.h"
+#include "util/BookFile.h"
 
 UITheme UITheme::instance;
 
@@ -133,11 +134,14 @@ UIIcon UITheme::getFileIcon(const std::string& filename) {
   if (filename.back() == '/') {
     return Folder;
   }
-  if (FsHelpers::hasEpubExtension(filename) || FsHelpers::hasXtcExtension(filename)) {
-    return Book;
-  }
-  if (FsHelpers::hasTxtExtension(filename) || FsHelpers::hasMarkdownExtension(filename)) {
-    return Text;
+  switch (bookFormat(filename)) {
+    case BookFormat::Epub:
+    case BookFormat::Xtc:
+      return Book;
+    case BookFormat::Txt:
+      return Text;
+    case BookFormat::Unknown:
+      break;
   }
   if (FsHelpers::hasBmpExtension(filename) || FsHelpers::hasPngExtension(filename)) {
     return Image;

--- a/src/util/BookFile.cpp
+++ b/src/util/BookFile.cpp
@@ -1,0 +1,132 @@
+#include "BookFile.h"
+
+#include <Epub.h>
+#include <FsHelpers.h>
+#include <Logging.h>
+#include <Txt.h>
+#include <Xtc.h>
+
+namespace {
+
+std::string fileNameOf(const std::string& path) {
+  const size_t lastSlash = path.find_last_of('/');
+  return lastSlash == std::string::npos ? path : path.substr(lastSlash + 1);
+}
+
+}  // namespace
+
+BookFormat bookFormat(const std::string_view path) {
+  if (FsHelpers::hasEpubExtension(path)) {
+    return BookFormat::Epub;
+  }
+  if (FsHelpers::hasXtcExtension(path)) {
+    return BookFormat::Xtc;
+  }
+  // Markdown is read by the TXT reader, so it counts as the same format here.
+  if (FsHelpers::hasTxtExtension(path) || FsHelpers::hasMarkdownExtension(path)) {
+    return BookFormat::Txt;
+  }
+  return BookFormat::Unknown;
+}
+
+bool isBook(const std::string_view path) { return bookFormat(path) != BookFormat::Unknown; }
+
+BookInfo readBookInfo(const std::string& path) {
+  LOG_DBG("BookFile", "Reading book info: %s", path.c_str());
+
+  switch (bookFormat(path)) {
+    case BookFormat::Epub: {
+      Epub epub(path, BOOK_CACHE_ROOT);
+      epub.load(false, true);
+      return {epub.getTitle(), epub.getAuthor(), epub.getThumbBmpPath()};
+    }
+    case BookFormat::Xtc: {
+      Xtc xtc(path, BOOK_CACHE_ROOT);
+      if (!xtc.load()) {
+        return {};
+      }
+      return {xtc.getTitle(), xtc.getAuthor(), xtc.getThumbBmpPath()};
+    }
+    case BookFormat::Txt:
+      // Reading the file would cost SD I/O on boot for a title the name already carries.
+      return {fileNameOf(path), "", ""};
+    case BookFormat::Unknown:
+      return {};
+  }
+  return {};
+}
+
+bool hasThumbnail(const BookFormat format) {
+  switch (format) {
+    case BookFormat::Epub:
+    case BookFormat::Xtc:
+      return true;
+    case BookFormat::Txt:
+    case BookFormat::Unknown:
+      return false;
+  }
+  return false;
+}
+
+bool generateBookThumb(const std::string& path, const int height) {
+  switch (bookFormat(path)) {
+    case BookFormat::Epub: {
+      Epub epub(path, BOOK_CACHE_ROOT);
+      epub.load(false, true);
+      return epub.generateThumbBmp(height);
+    }
+    case BookFormat::Xtc: {
+      Xtc xtc(path, BOOK_CACHE_ROOT);
+      return xtc.load() && xtc.generateThumbBmp(height);
+    }
+    case BookFormat::Txt:
+    case BookFormat::Unknown:
+      return false;
+  }
+  return false;
+}
+
+std::string generateBookCoverBmp(const std::string& path, const bool cropped) {
+  switch (bookFormat(path)) {
+    case BookFormat::Epub: {
+      Epub epub(path, BOOK_CACHE_ROOT);
+      if (!epub.load(true, true)) {
+        LOG_ERR("BookFile", "Failed to load EPUB: %s", path.c_str());
+        return {};
+      }
+      if (!epub.generateCoverBmp(cropped)) {
+        LOG_ERR("BookFile", "Failed to generate EPUB cover bmp: %s", path.c_str());
+        return {};
+      }
+      return epub.getCoverBmpPath(cropped);
+    }
+    case BookFormat::Xtc: {
+      Xtc xtc(path, BOOK_CACHE_ROOT);
+      if (!xtc.load()) {
+        LOG_ERR("BookFile", "Failed to load XTC: %s", path.c_str());
+        return {};
+      }
+      if (!xtc.generateCoverBmp()) {
+        LOG_ERR("BookFile", "Failed to generate XTC cover bmp: %s", path.c_str());
+        return {};
+      }
+      return xtc.getCoverBmpPath();
+    }
+    case BookFormat::Txt: {
+      // The cover is a sibling image file, not something stored in the book.
+      Txt txt(path, BOOK_CACHE_ROOT);
+      if (!txt.load()) {
+        LOG_ERR("BookFile", "Failed to load TXT: %s", path.c_str());
+        return {};
+      }
+      if (!txt.generateCoverBmp()) {
+        LOG_DBG("BookFile", "No cover image found for TXT: %s", path.c_str());
+        return {};
+      }
+      return txt.getCoverBmpPath();
+    }
+    case BookFormat::Unknown:
+      return {};
+  }
+  return {};
+}

--- a/src/util/BookFile.cpp
+++ b/src/util/BookFile.cpp
@@ -90,40 +90,28 @@ std::string generateBookCoverBmp(const std::string& path, const bool cropped) {
   switch (bookFormat(path)) {
     case BookFormat::Epub: {
       Epub epub(path, BOOK_CACHE_ROOT);
-      if (!epub.load(true, true)) {
-        LOG_ERR("BookFile", "Failed to load EPUB: %s", path.c_str());
-        return {};
+      if (epub.load(true, true) && epub.generateCoverBmp(cropped)) {
+        return epub.getCoverBmpPath(cropped);
       }
-      if (!epub.generateCoverBmp(cropped)) {
-        LOG_ERR("BookFile", "Failed to generate EPUB cover bmp: %s", path.c_str());
-        return {};
-      }
-      return epub.getCoverBmpPath(cropped);
+      LOG_ERR("BookFile", "No EPUB cover: %s", path.c_str());
+      return {};
     }
     case BookFormat::Xtc: {
       Xtc xtc(path, BOOK_CACHE_ROOT);
-      if (!xtc.load()) {
-        LOG_ERR("BookFile", "Failed to load XTC: %s", path.c_str());
-        return {};
+      if (xtc.load() && xtc.generateCoverBmp()) {
+        return xtc.getCoverBmpPath();
       }
-      if (!xtc.generateCoverBmp()) {
-        LOG_ERR("BookFile", "Failed to generate XTC cover bmp: %s", path.c_str());
-        return {};
-      }
-      return xtc.getCoverBmpPath();
+      LOG_ERR("BookFile", "No XTC cover: %s", path.c_str());
+      return {};
     }
     case BookFormat::Txt: {
-      // The cover is a sibling image file, not something stored in the book.
+      // A sibling image file, so having none is the normal case, not a failure.
       Txt txt(path, BOOK_CACHE_ROOT);
-      if (!txt.load()) {
-        LOG_ERR("BookFile", "Failed to load TXT: %s", path.c_str());
-        return {};
+      if (txt.load() && txt.generateCoverBmp()) {
+        return txt.getCoverBmpPath();
       }
-      if (!txt.generateCoverBmp()) {
-        LOG_DBG("BookFile", "No cover image found for TXT: %s", path.c_str());
-        return {};
-      }
-      return txt.getCoverBmpPath();
+      LOG_DBG("BookFile", "No TXT cover: %s", path.c_str());
+      return {};
     }
     case BookFormat::Unknown:
       return {};

--- a/src/util/BookFile.h
+++ b/src/util/BookFile.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+inline constexpr char BOOK_CACHE_ROOT[] = "/.crosspoint";
+
+// The one list of readable book formats. Switches over it are exhaustive and
+// carry no default, so adding a format breaks the build at every site that has
+// to handle it.
+enum class BookFormat : uint8_t { Unknown, Epub, Xtc, Txt };
+
+BookFormat bookFormat(std::string_view path);
+
+// Every format ReaderActivity can open. BMP and PNG are viewer files, not books.
+bool isBook(std::string_view path);
+
+struct BookInfo {
+  std::string title;
+  std::string author;
+  std::string thumbBmpPath;
+};
+
+// Never builds a missing cache, so it stays cheap enough for boot: title and
+// cover stay blank until the book has been opened once.
+BookInfo readBookInfo(const std::string& path);
+
+// TXT covers are sibling image files, offered at full size only.
+bool hasThumbnail(BookFormat format);
+
+// Cover thumbnail at a given height. False when the format has none.
+bool generateBookThumb(const std::string& path, int height);
+
+// Full-size cover for the sleep screen, empty when there is none.
+// `cropped` applies to EPUB only.
+std::string generateBookCoverBmp(const std::string& path, bool cropped);

--- a/src/util/NextBookFinder.cpp
+++ b/src/util/NextBookFinder.cpp
@@ -8,16 +8,11 @@
 #include <algorithm>
 #include <string_view>
 
+#include "BookFile.h"
 #include "CrossPointSettings.h"
 
 namespace {
 constexpr size_t NAME_BUFFER_SIZE = 500;
-
-bool isSupportedBookFile(const std::string_view name) {
-  // Formats ReaderActivity can open (bmp is a viewer, not a book, so it is excluded)
-  return FsHelpers::hasEpubExtension(name) || FsHelpers::hasXtcExtension(name) || FsHelpers::hasTxtExtension(name) ||
-         FsHelpers::hasMarkdownExtension(name);
-}
 }  // namespace
 
 std::vector<std::string> NextBookFinder::findNextBooks(const std::string& currentBookPath, const size_t maxCount) {
@@ -60,7 +55,7 @@ std::vector<std::string> NextBookFinder::findNextBooks(const std::string& curren
     if (!SETTINGS.showHiddenFiles && nameBuffer[0] == '.') {
       continue;
     }
-    if (!isSupportedBookFile(nameBuffer.get())) {
+    if (!isBook(nameBuffer.get())) {
       continue;
     }
     std::string name{nameBuffer.get()};


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Give the list of readable book formats one home. It was re-derived as a chain of extension checks at every site that needed it, and had already diverged: markdown is read by the TXT reader, but several chains only tested `.txt`.
* **What changes are included?**

Adds `src/util/BookFile.h`: a `BookFormat` enum, `bookFormat()`, `isBook()`, and accessors for the three things callers actually want from a book of any format — metadata, thumbnail, sleep cover. Switches over the enum carry no `default`, so a new format is a compile error at every site that has to handle it instead of a silent omission.

Moved onto it: `RecentBooksStore`, `HomeActivity`, `SleepActivity`, `NextBookFinder`, `FileBrowserActivity`, `ReaderActivity::create`, `UITheme::getFileIcon`.

Two behaviour changes fall out of the unification:

- an XTC whose `load()` fails now clears its stored cover path, instead of retrying the same broken file on every boot
- a `.md` file now gets the sibling-image sleep cover that a `.txt` already got

`src/util/BookCacheUtils.cpp` still has its own chain. It is being reworked in another change already in flight, so it is left alone here to avoid conflicting with it.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well — this is consolidation of existing code, no new capability.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

`bookFormat()` and `isBook()` take a `std::string_view`: `FileBrowserActivity` classifies every directory entry in a loop, and a `const std::string&` would have cost an allocation per file. The accessors that open a book keep `const std::string&`, since they have to build a real string for `Epub`/`Xtc`/`Txt` anyway.

No polymorphism, no templates, no `std::function`: the book objects are still stack-constructed at the same points, so there is no new heap traffic.

Flash impact is a small reduction (~40 bytes) from the removed duplicate chains; DRAM is unchanged.

Reviewers may want to focus on the two behaviour changes listed above, and on `UITheme::getFileIcon`, where the switch is a prefix rather than the whole function — `Unknown` falls through to the image and generic-file checks.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
