### PR TITLE
fix: render 2-bit XTC sleep covers in grayscale

### DIFF
--- a/lib/GfxRenderer/Bitmap.h
+++ b/lib/GfxRenderer/Bitmap.h
@@ -7,34 +7,45 @@
 #include "BitmapHelpers.h"
 
 #pragma pack(push, 1)
+struct BmpFileHeader {
+  uint16_t bfType;
+  uint32_t bfSize;
+  uint16_t bfReserved1;
+  uint16_t bfReserved2;
+  uint32_t bfOffBits;
+};
+
+struct BmpInfoHeader {
+  uint32_t biSize;
+  int32_t biWidth;
+  int32_t biHeight;
+  uint16_t biPlanes;
+  uint16_t biBitCount;
+  uint32_t biCompression;
+  uint32_t biSizeImage;
+  int32_t biXPelsPerMeter;
+  int32_t biYPelsPerMeter;
+  uint32_t biClrUsed;
+  uint32_t biClrImportant;
+};
+
+struct BmpRgbQuad {
+  uint8_t rgbBlue;
+  uint8_t rgbGreen;
+  uint8_t rgbRed;
+  uint8_t rgbReserved;
+};
+
 struct BmpHeader {
-  struct {
-    uint16_t bfType;
-    uint32_t bfSize;
-    uint16_t bfReserved1;
-    uint16_t bfReserved2;
-    uint32_t bfOffBits;
-  } fileHeader;
-  struct {
-    uint32_t biSize;
-    int32_t biWidth;
-    int32_t biHeight;
-    uint16_t biPlanes;
-    uint16_t biBitCount;
-    uint32_t biCompression;
-    uint32_t biSizeImage;
-    int32_t biXPelsPerMeter;
-    int32_t biYPelsPerMeter;
-    uint32_t biClrUsed;
-    uint32_t biClrImportant;
-  } infoHeader;
-  struct RgbQuad {
-    uint8_t rgbBlue;
-    uint8_t rgbGreen;
-    uint8_t rgbRed;
-    uint8_t rgbReserved;
-  };
-  RgbQuad colors[2];
+  BmpFileHeader fileHeader;
+  BmpInfoHeader infoHeader;
+  BmpRgbQuad colors[2];
+};
+
+struct Bmp2BitHeader {
+  BmpFileHeader fileHeader;
+  BmpInfoHeader infoHeader;
+  BmpRgbQuad colors[4];
 };
 #pragma pack(pop)
 

--- a/lib/GfxRenderer/BitmapHelpers.cpp
+++ b/lib/GfxRenderer/BitmapHelpers.cpp
@@ -108,43 +108,57 @@ uint8_t quantize1bit(int gray, int x, int y) {
   return (gray >= adjustedThreshold) ? 1 : 0;
 }
 
+// Fills everything but the palette, which the callers size themselves
+static void fillBmpHeaders(BmpFileHeader& fileHeader, BmpInfoHeader& infoHeader, int width, int height,
+                           BmpRowOrder rowOrder, uint16_t bitCount, uint32_t headerSize) {
+  const uint32_t rowSize = (width * bitCount + 31) / 32 * 4;
+  const uint32_t imageSize = rowSize * height;
+
+  fileHeader.bfType = 0x4D42;
+  fileHeader.bfSize = headerSize + imageSize;
+  fileHeader.bfReserved1 = 0;
+  fileHeader.bfReserved2 = 0;
+  fileHeader.bfOffBits = headerSize;
+
+  infoHeader.biSize = sizeof(infoHeader);
+  infoHeader.biWidth = width;
+  infoHeader.biHeight = (rowOrder == BmpRowOrder::TopDown) ? -height : height;
+  infoHeader.biPlanes = 1;
+  infoHeader.biBitCount = bitCount;
+  infoHeader.biCompression = 0;
+  infoHeader.biSizeImage = imageSize;
+  infoHeader.biXPelsPerMeter = 2835;  // 72 DPI
+  infoHeader.biYPelsPerMeter = 2835;  // 72 DPI
+  infoHeader.biClrUsed = 1u << bitCount;
+  infoHeader.biClrImportant = 1u << bitCount;
+}
+
+static void setGray(BmpRgbQuad& color, uint8_t level) {
+  color.rgbBlue = level;
+  color.rgbGreen = level;
+  color.rgbRed = level;
+  color.rgbReserved = 0;
+}
+
 void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder rowOrder) {
   if (!bmpHeader) return;
 
   // Zero out the memory to ensure no garbage data if called on uninitialized stack memory
   std::memset(bmpHeader, 0, sizeof(BmpHeader));
+  fillBmpHeaders(bmpHeader->fileHeader, bmpHeader->infoHeader, width, height, rowOrder, 1, sizeof(BmpHeader));
 
-  uint32_t rowSize = (width + 31) / 32 * 4;
-  uint32_t imageSize = rowSize * height;
-  uint32_t fileSize = sizeof(BmpHeader) + imageSize;
+  setGray(bmpHeader->colors[0], 0);
+  setGray(bmpHeader->colors[1], 255);
+}
 
-  bmpHeader->fileHeader.bfType = 0x4D42;
-  bmpHeader->fileHeader.bfSize = fileSize;
-  bmpHeader->fileHeader.bfReserved1 = 0;
-  bmpHeader->fileHeader.bfReserved2 = 0;
-  bmpHeader->fileHeader.bfOffBits = sizeof(BmpHeader);
+void createBmp2BitHeader(Bmp2BitHeader* bmpHeader, int width, int height, BmpRowOrder rowOrder) {
+  if (!bmpHeader) return;
 
-  bmpHeader->infoHeader.biSize = sizeof(bmpHeader->infoHeader);
-  bmpHeader->infoHeader.biWidth = width;
-  bmpHeader->infoHeader.biHeight = (rowOrder == BmpRowOrder::TopDown) ? -height : height;
-  bmpHeader->infoHeader.biPlanes = 1;
-  bmpHeader->infoHeader.biBitCount = 1;
-  bmpHeader->infoHeader.biCompression = 0;
-  bmpHeader->infoHeader.biSizeImage = imageSize;
-  bmpHeader->infoHeader.biXPelsPerMeter = 2835;  // 72 DPI
-  bmpHeader->infoHeader.biYPelsPerMeter = 2835;  // 72 DPI
-  bmpHeader->infoHeader.biClrUsed = 2;
-  bmpHeader->infoHeader.biClrImportant = 2;
+  std::memset(bmpHeader, 0, sizeof(Bmp2BitHeader));
+  fillBmpHeaders(bmpHeader->fileHeader, bmpHeader->infoHeader, width, height, rowOrder, 2, sizeof(Bmp2BitHeader));
 
-  // Color 0 (black)
-  bmpHeader->colors[0].rgbBlue = 0;
-  bmpHeader->colors[0].rgbGreen = 0;
-  bmpHeader->colors[0].rgbRed = 0;
-  bmpHeader->colors[0].rgbReserved = 0;
-
-  // Color 1 (white)
-  bmpHeader->colors[1].rgbBlue = 255;
-  bmpHeader->colors[1].rgbGreen = 255;
-  bmpHeader->colors[1].rgbRed = 255;
-  bmpHeader->colors[1].rgbReserved = 0;
+  // Luminances quantize losslessly to the four native display levels (lum >> 6)
+  for (uint8_t i = 0; i < 4; i++) {
+    setGray(bmpHeader->colors[i], i * 85);
+  }
 }

--- a/lib/GfxRenderer/BitmapHelpers.h
+++ b/lib/GfxRenderer/BitmapHelpers.h
@@ -4,6 +4,7 @@
 #include <cstring>
 
 struct BmpHeader;
+struct Bmp2BitHeader;
 
 // Helper functions
 uint8_t quantize(int gray, int x, int y);
@@ -15,6 +16,10 @@ enum class BmpRowOrder { BottomUp, TopDown };
 
 // Populates a 1-bit BMP header in the provided memory.
 void createBmpHeader(BmpHeader* bmpHeader, int width, int height, BmpRowOrder rowOrder);
+
+// Populates a 2-bit BMP header in the provided memory.
+// Palette indices follow the display's native levels: 0 = black, 1 = dark gray, 2 = light gray, 3 = white.
+void createBmp2BitHeader(Bmp2BitHeader* bmpHeader, int width, int height, BmpRowOrder rowOrder);
 
 // 1-bit Atkinson dithering - better quality than noise dithering for thumbnails
 // Error distribution pattern (same as 2-bit but quantizes to 2 levels):

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -297,24 +297,8 @@ bool Xtc::generateThumbBmp(int height) const {
   float scale = (scaleX > scaleY) ? scaleX : scaleY;  // for cropping
 
   // Only scale down, never up
-  if (scale >= 1.0f) {
-    // Page is already small enough, just use cover.bmp
-    // Copy cover.bmp to thumb.bmp
-    if (generateCoverBmp()) {
-      HalFile src, dst;
-      if (Storage.openFileForRead("XTC", getCoverBmpPath(), src)) {
-        if (Storage.openFileForWrite("XTC", getThumbBmpPath(height), dst)) {
-          uint8_t buffer[512];
-          while (src.available()) {
-            size_t bytesRead = src.read(buffer, sizeof(buffer));
-            dst.write(buffer, bytesRead);
-          }
-        }
-      }
-      LOG_DBG("XTC", "Copied cover to thumb (no scaling needed)");
-      return Storage.exists(getThumbBmpPath(height).c_str());
-    }
-    return false;
+  if (scale > 1.0f) {
+    scale = 1.0f;
   }
 
   uint16_t thumbWidth = static_cast<uint16_t>(pageInfo.width * scale);

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -165,18 +165,14 @@ bool Xtc::generateCoverBmp() const {
   }
 
   const size_t dstRowSize = (static_cast<size_t>(pageInfo.width) * bitDepth + 7) / 8;
-  const size_t colBytes = (pageInfo.height + 7) / 8;  // Bytes per column, 2-bit only
 
   // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
-  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes.
-  // A height that is not a multiple of 8 leaves the last column partly filled, so the
-  // plane the columns actually span is longer than the declared plane size.
+  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes
   size_t planeSize = 0;
   size_t bitmapSize;
   if (bitDepth == 2) {
     planeSize = (static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8;
-    const size_t spannedSize = static_cast<size_t>(pageInfo.width) * colBytes;
-    bitmapSize = planeSize + std::max(planeSize, spannedSize);
+    bitmapSize = planeSize * 2;
   } else {
     bitmapSize = dstRowSize * pageInfo.height;
   }
@@ -213,6 +209,11 @@ bool Xtc::generateCoverBmp() const {
   const uint8_t padding[4] = {0, 0, 0, 0};
   const size_t paddingSize = (4 - dstRowSize % 4) % 4;  // BMP rows are 4-byte aligned
 
+  bool writeOk = true;
+  const auto writeChunk = [&](const void* data, size_t size) {
+    writeOk = writeOk && coverBmp.write(data, size) == size;
+  };
+
   if (bitDepth == 2) {
     // XTH 2-bit mode: Two bit planes, column-major order
     // - Columns scanned right to left (x = width-1 down to 0)
@@ -224,17 +225,16 @@ bool Xtc::generateCoverBmp() const {
 
     Bmp2BitHeader bmpHeader;
     createBmp2BitHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
-    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+    writeChunk(&bmpHeader, sizeof(bmpHeader));
 
-    for (uint16_t y = 0; y < pageInfo.height; y++) {
+    for (uint16_t y = 0; y < pageInfo.height && writeOk; y++) {
       memset(rowBuffer.get(), 0, dstRowSize);
-
-      const size_t byteInCol = y / 8;
-      const size_t bitInByte = 7 - (y % 8);  // MSB = topmost pixel
 
       for (uint16_t x = 0; x < pageInfo.width; x++) {
         // Column-major, right to left: column index = (width - 1 - x)
-        const size_t byteOffset = (pageInfo.width - 1 - x) * colBytes + byteInCol;
+        const size_t bitIndex = static_cast<size_t>(pageInfo.width - 1 - x) * pageInfo.height + y;
+        const size_t byteOffset = bitIndex / 8;
+        const size_t bitInByte = 7 - (bitIndex % 8);  // MSB = topmost pixel
         const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
         const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
         const uint8_t pixelValue = (bit1 << 1) | bit2;
@@ -242,23 +242,31 @@ bool Xtc::generateCoverBmp() const {
         rowBuffer[x >> 2] |= XTC_LEVEL_TO_PALETTE[pixelValue] << (6 - ((x & 3) * 2));
       }
 
-      coverBmp.write(rowBuffer.get(), dstRowSize);
+      writeChunk(rowBuffer.get(), dstRowSize);
       if (paddingSize > 0) {
-        coverBmp.write(padding, paddingSize);
+        writeChunk(padding, paddingSize);
       }
     }
   } else {
     // Source rows are already packed as 1-bit BMP rows
     BmpHeader bmpHeader;
     createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
-    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+    writeChunk(&bmpHeader, sizeof(bmpHeader));
 
-    for (uint16_t y = 0; y < pageInfo.height; y++) {
-      coverBmp.write(pageBuffer.get() + y * dstRowSize, dstRowSize);
+    for (uint16_t y = 0; y < pageInfo.height && writeOk; y++) {
+      writeChunk(pageBuffer.get() + y * dstRowSize, dstRowSize);
       if (paddingSize > 0) {
-        coverBmp.write(padding, paddingSize);
+        writeChunk(padding, paddingSize);
       }
     }
+  }
+
+  if (!writeOk) {
+    LOG_ERR("XTC", "Failed to write cover BMP: %s", coverPath.c_str());
+    // Close before removing the half-written file, otherwise the next run caches it
+    coverBmp.close();
+    Storage.remove(coverPath.c_str());
+    return false;
   }
 
   LOG_DBG("XTC", "Generated cover BMP: %s (%u-bit)", coverPath.c_str(), bitDepth);
@@ -317,14 +325,11 @@ bool Xtc::generateThumbBmp(int height) const {
   LOG_DBG("XTC", "Generating thumb BMP: %dx%d -> %dx%d (scale: %.3f)", pageInfo.width, pageInfo.height, thumbWidth,
           thumbHeight, scale);
 
-  // Allocate buffer for page data, sized like generateCoverBmp() so partly filled
-  // columns of an XTH plane stay inside the buffer
+  // Allocate buffer for page data
   const size_t planeSize = (bitDepth == 2) ? ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) : 0;
-  const size_t planeBytes =
-      (bitDepth == 2) ? std::max(planeSize, static_cast<size_t>(pageInfo.width) * ((pageInfo.height + 7) / 8)) : 0;
   size_t bitmapSize;
   if (bitDepth == 2) {
-    bitmapSize = planeSize + planeBytes;
+    bitmapSize = planeSize * 2;
   } else {
     bitmapSize = ((pageInfo.width + 7) / 8) * pageInfo.height;
   }
@@ -370,7 +375,6 @@ bool Xtc::generateThumbBmp(int height) const {
   // Pre-calculate plane info for 2-bit mode
   const uint8_t* plane1 = (bitDepth == 2) ? pageBuffer : nullptr;
   const uint8_t* plane2 = (bitDepth == 2) ? pageBuffer + planeSize : nullptr;
-  const size_t colBytes = (bitDepth == 2) ? ((pageInfo.height + 7) / 8) : 0;
   const size_t srcRowBytes = (bitDepth == 1) ? ((pageInfo.width + 7) / 8) : 0;
   uint8_t rowsSinceYield = 0;
 
@@ -406,12 +410,11 @@ bool Xtc::generateThumbBmp(int height) const {
             // XTH 2-bit mode: pixel value 0-3
             // Bounds check for column index
             if (srcX < pageInfo.width) {
-              const size_t colIndex = pageInfo.width - 1 - srcX;
-              const size_t byteInCol = srcY / 8;
-              const size_t bitInByte = 7 - (srcY % 8);
-              const size_t byteOffset = colIndex * colBytes + byteInCol;
+              const size_t bitIndex = (pageInfo.width - 1 - srcX) * static_cast<size_t>(pageInfo.height) + srcY;
+              const size_t byteOffset = bitIndex / 8;
+              const size_t bitInByte = 7 - (bitIndex % 8);
               // Bounds check for buffer access
-              if (byteOffset < planeBytes) {
+              if (byteOffset < planeSize) {
                 const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
                 const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
                 const uint8_t pixelValue = (bit1 << 1) | bit2;

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -10,6 +10,7 @@
 #include <Bitmap.h>
 #include <HalStorage.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
@@ -19,6 +20,9 @@ void yieldDuringThumbnail(uint8_t& rowsSinceYield) {
   rowsSinceYield = 0;
   vTaskDelay(1);
 }
+
+// XTC 2-bit level -> BMP palette index (0 = black, 1 = dark gray, 2 = light gray, 3 = white)
+constexpr uint8_t XTC_LEVEL_TO_PALETTE[4] = {3, 1, 2, 0};
 }  // namespace
 
 bool Xtc::load() {
@@ -121,14 +125,13 @@ const std::vector<xtc::ChapterInfo>& Xtc::getChapters() {
   return parser->getChapters();
 }
 
-std::string Xtc::getCoverBmpPath() const { return cachePath + "/cover.bmp"; }
+std::string Xtc::getCoverBmpPath() const {
+  // Depth in the name keeps a cover written for the other bit depth from being reused
+  const bool grayscale = loaded && parser && parser->getBitDepth() == 2;
+  return cachePath + (grayscale ? "/cover_2bit.bmp" : "/cover.bmp");
+}
 
 bool Xtc::generateCoverBmp() const {
-  // Already generated
-  if (Storage.exists(getCoverBmpPath().c_str())) {
-    return true;
-  }
-
   if (!loaded || !parser) {
     LOG_ERR("XTC", "Cannot generate cover BMP, file not loaded");
     return false;
@@ -138,6 +141,16 @@ bool Xtc::generateCoverBmp() const {
     LOG_ERR("XTC", "No pages in XTC file");
     return false;
   }
+
+  const std::string coverPath = getCoverBmpPath();
+
+  // Already generated
+  if (Storage.exists(coverPath.c_str())) {
+    return true;
+  }
+
+  // The BMP keeps the source depth: 2-bit pages hold their four gray levels
+  const uint8_t bitDepth = parser->getBitDepth();
 
   // Setup cache directory
   setupCacheDir();
@@ -149,9 +162,6 @@ bool Xtc::generateCoverBmp() const {
     return false;
   }
 
-  // Get bit depth
-  const uint8_t bitDepth = parser->getBitDepth();
-
   // Allocate buffer for page data
   // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
   // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes
@@ -161,38 +171,29 @@ bool Xtc::generateCoverBmp() const {
   } else {
     bitmapSize = ((pageInfo.width + 7) / 8) * pageInfo.height;
   }
-  uint8_t* pageBuffer = static_cast<uint8_t*>(malloc(bitmapSize));
+  auto pageBuffer = makeUniqueNoThrow<uint8_t[]>(bitmapSize);
   if (!pageBuffer) {
     LOG_ERR("XTC", "Failed to allocate page buffer (%lu bytes)", bitmapSize);
     return false;
   }
 
   // Load first page (cover)
-  size_t bytesRead = const_cast<xtc::XtcParser*>(parser.get())->loadPage(0, pageBuffer, bitmapSize);
+  size_t bytesRead = const_cast<xtc::XtcParser*>(parser.get())->loadPage(0, pageBuffer.get(), bitmapSize);
   if (bytesRead == 0) {
     LOG_ERR("XTC", "Failed to load cover page");
-    free(pageBuffer);
     return false;
   }
 
   // Create BMP file
   HalFile coverBmp;
-  if (!Storage.openFileForWrite("XTC", getCoverBmpPath(), coverBmp)) {
+  if (!Storage.openFileForWrite("XTC", coverPath, coverBmp)) {
     LOG_DBG("XTC", "Failed to create cover BMP file");
-    free(pageBuffer);
     return false;
   }
 
-  // Write 1-bit BMP header (top-down row order)
-  BmpHeader bmpHeader;
-  createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
-  coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
-
-  const uint32_t rowSize = ((pageInfo.width + 31) / 32) * 4;
-
-  // Write bitmap data
-  // BMP requires 4-byte row alignment
-  const size_t dstRowSize = (pageInfo.width + 7) / 8;  // 1-bit destination row size
+  const size_t dstRowSize = (static_cast<size_t>(pageInfo.width) * bitDepth + 7) / 8;
+  const uint8_t padding[4] = {0, 0, 0, 0};
+  const size_t paddingSize = (4 - dstRowSize % 4) % 4;  // BMP rows are 4-byte aligned
 
   if (bitDepth == 2) {
     // XTH 2-bit mode: Two bit planes, column-major order
@@ -201,72 +202,56 @@ bool Xtc::generateCoverBmp() const {
     // - First plane: Bit1, Second plane: Bit2
     // - Pixel value = (bit1 << 1) | bit2
     const size_t planeSize = (static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8;
-    const uint8_t* plane1 = pageBuffer;                 // Bit1 plane
-    const uint8_t* plane2 = pageBuffer + planeSize;     // Bit2 plane
-    const size_t colBytes = (pageInfo.height + 7) / 8;  // Bytes per column
+    const uint8_t* plane1 = pageBuffer.get();              // Bit1 plane
+    const uint8_t* plane2 = pageBuffer.get() + planeSize;  // Bit2 plane
+    const size_t colBytes = (pageInfo.height + 7) / 8;     // Bytes per column
 
-    // Allocate a row buffer for 1-bit output
-    uint8_t* rowBuffer = static_cast<uint8_t*>(malloc(dstRowSize));
+    Bmp2BitHeader bmpHeader;
+    createBmp2BitHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
+    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
+
+    auto rowBuffer = makeUniqueNoThrow<uint8_t[]>(dstRowSize);
     if (!rowBuffer) {
-      free(pageBuffer);
+      LOG_ERR("XTC", "Failed to allocate row buffer (%lu bytes)", dstRowSize);
       return false;
     }
 
     for (uint16_t y = 0; y < pageInfo.height; y++) {
-      memset(rowBuffer, 0xFF, dstRowSize);  // Start with all white
+      memset(rowBuffer.get(), 0, dstRowSize);
+
+      const size_t byteInCol = y / 8;
+      const size_t bitInByte = 7 - (y % 8);  // MSB = topmost pixel
 
       for (uint16_t x = 0; x < pageInfo.width; x++) {
         // Column-major, right to left: column index = (width - 1 - x)
-        const size_t colIndex = pageInfo.width - 1 - x;
-        const size_t byteInCol = y / 8;
-        const size_t bitInByte = 7 - (y % 8);  // MSB = topmost pixel
-
-        const size_t byteOffset = colIndex * colBytes + byteInCol;
+        const size_t byteOffset = (pageInfo.width - 1 - x) * colBytes + byteInCol;
         const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
         const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
         const uint8_t pixelValue = (bit1 << 1) | bit2;
 
-        // Threshold: 0=white (1); 1,2,3=black (0)
-        if (pixelValue >= 1) {
-          // Set bit to 0 (black) in BMP format
-          const size_t dstByte = x / 8;
-          const size_t dstBit = 7 - (x % 8);
-          rowBuffer[dstByte] &= ~(1 << dstBit);
-        }
+        rowBuffer[x >> 2] |= XTC_LEVEL_TO_PALETTE[pixelValue] << (6 - ((x & 3) * 2));
       }
 
-      // Write converted row
-      coverBmp.write(rowBuffer, dstRowSize);
-
-      // Pad to 4-byte boundary
-      uint8_t padding[4] = {0, 0, 0, 0};
-      size_t paddingSize = rowSize - dstRowSize;
+      coverBmp.write(rowBuffer.get(), dstRowSize);
       if (paddingSize > 0) {
         coverBmp.write(padding, paddingSize);
       }
     }
-
-    free(rowBuffer);
   } else {
-    // 1-bit source: write directly with proper padding
-    const size_t srcRowSize = (pageInfo.width + 7) / 8;
+    // Source rows are already packed as 1-bit BMP rows
+    BmpHeader bmpHeader;
+    createBmpHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
+    coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
 
     for (uint16_t y = 0; y < pageInfo.height; y++) {
-      // Write source row
-      coverBmp.write(pageBuffer + y * srcRowSize, srcRowSize);
-
-      // Pad to 4-byte boundary
-      uint8_t padding[4] = {0, 0, 0, 0};
-      size_t paddingSize = rowSize - srcRowSize;
+      coverBmp.write(pageBuffer.get() + y * dstRowSize, dstRowSize);
       if (paddingSize > 0) {
         coverBmp.write(padding, paddingSize);
       }
     }
   }
 
-  free(pageBuffer);
-
-  LOG_DBG("XTC", "Generated cover BMP: %s", getCoverBmpPath().c_str());
+  LOG_DBG("XTC", "Generated cover BMP: %s (%u-bit)", coverPath.c_str(), bitDepth);
   return true;
 }
 

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -317,10 +317,14 @@ bool Xtc::generateThumbBmp(int height) const {
   LOG_DBG("XTC", "Generating thumb BMP: %dx%d -> %dx%d (scale: %.3f)", pageInfo.width, pageInfo.height, thumbWidth,
           thumbHeight, scale);
 
-  // Allocate buffer for page data
+  // Allocate buffer for page data, sized like generateCoverBmp() so partly filled
+  // columns of an XTH plane stay inside the buffer
+  const size_t planeSize = (bitDepth == 2) ? ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) : 0;
+  const size_t planeBytes =
+      (bitDepth == 2) ? std::max(planeSize, static_cast<size_t>(pageInfo.width) * ((pageInfo.height + 7) / 8)) : 0;
   size_t bitmapSize;
   if (bitDepth == 2) {
-    bitmapSize = ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) * 2;
+    bitmapSize = planeSize + planeBytes;
   } else {
     bitmapSize = ((pageInfo.width + 7) / 8) * pageInfo.height;
   }
@@ -364,7 +368,6 @@ bool Xtc::generateThumbBmp(int height) const {
   uint32_t scaleInv_fp = static_cast<uint32_t>(65536.0f / scale);
 
   // Pre-calculate plane info for 2-bit mode
-  const size_t planeSize = (bitDepth == 2) ? ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) : 0;
   const uint8_t* plane1 = (bitDepth == 2) ? pageBuffer : nullptr;
   const uint8_t* plane2 = (bitDepth == 2) ? pageBuffer + planeSize : nullptr;
   const size_t colBytes = (bitDepth == 2) ? ((pageInfo.height + 7) / 8) : 0;
@@ -408,7 +411,7 @@ bool Xtc::generateThumbBmp(int height) const {
               const size_t bitInByte = 7 - (srcY % 8);
               const size_t byteOffset = colIndex * colBytes + byteInCol;
               // Bounds check for buffer access
-              if (byteOffset < planeSize) {
+              if (byteOffset < planeBytes) {
                 const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
                 const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
                 const uint8_t pixelValue = (bit1 << 1) | bit2;

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -14,6 +14,8 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
+#include <algorithm>
+
 namespace {
 void yieldDuringThumbnail(uint8_t& rowsSinceYield) {
   if (++rowsSinceYield < 8) return;
@@ -162,19 +164,36 @@ bool Xtc::generateCoverBmp() const {
     return false;
   }
 
-  // Allocate buffer for page data
+  const size_t dstRowSize = (static_cast<size_t>(pageInfo.width) * bitDepth + 7) / 8;
+  const size_t colBytes = (pageInfo.height + 7) / 8;  // Bytes per column, 2-bit only
+
   // XTG (1-bit): Row-major, ((width+7)/8) * height bytes
-  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes
+  // XTH (2-bit): Two bit planes, column-major, ((width * height + 7) / 8) * 2 bytes.
+  // A height that is not a multiple of 8 leaves the last column partly filled, so the
+  // plane the columns actually span is longer than the declared plane size.
+  size_t planeSize = 0;
   size_t bitmapSize;
   if (bitDepth == 2) {
-    bitmapSize = ((static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8) * 2;
+    planeSize = (static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8;
+    const size_t spannedSize = static_cast<size_t>(pageInfo.width) * colBytes;
+    bitmapSize = planeSize + std::max(planeSize, spannedSize);
   } else {
-    bitmapSize = ((pageInfo.width + 7) / 8) * pageInfo.height;
+    bitmapSize = dstRowSize * pageInfo.height;
   }
   auto pageBuffer = makeUniqueNoThrow<uint8_t[]>(bitmapSize);
   if (!pageBuffer) {
     LOG_ERR("XTC", "Failed to allocate page buffer (%lu bytes)", bitmapSize);
     return false;
+  }
+
+  // Allocated before the file is opened so a failure never leaves a truncated cover cached
+  std::unique_ptr<uint8_t[]> rowBuffer;
+  if (bitDepth == 2) {
+    rowBuffer = makeUniqueNoThrow<uint8_t[]>(dstRowSize);
+    if (!rowBuffer) {
+      LOG_ERR("XTC", "Failed to allocate row buffer (%lu bytes)", dstRowSize);
+      return false;
+    }
   }
 
   // Load first page (cover)
@@ -191,7 +210,6 @@ bool Xtc::generateCoverBmp() const {
     return false;
   }
 
-  const size_t dstRowSize = (static_cast<size_t>(pageInfo.width) * bitDepth + 7) / 8;
   const uint8_t padding[4] = {0, 0, 0, 0};
   const size_t paddingSize = (4 - dstRowSize % 4) % 4;  // BMP rows are 4-byte aligned
 
@@ -201,20 +219,12 @@ bool Xtc::generateCoverBmp() const {
     // - 8 vertical pixels per byte (MSB = topmost pixel in group)
     // - First plane: Bit1, Second plane: Bit2
     // - Pixel value = (bit1 << 1) | bit2
-    const size_t planeSize = (static_cast<size_t>(pageInfo.width) * pageInfo.height + 7) / 8;
     const uint8_t* plane1 = pageBuffer.get();              // Bit1 plane
     const uint8_t* plane2 = pageBuffer.get() + planeSize;  // Bit2 plane
-    const size_t colBytes = (pageInfo.height + 7) / 8;     // Bytes per column
 
     Bmp2BitHeader bmpHeader;
     createBmp2BitHeader(&bmpHeader, pageInfo.width, pageInfo.height, BmpRowOrder::TopDown);
     coverBmp.write(reinterpret_cast<const uint8_t*>(&bmpHeader), sizeof(bmpHeader));
-
-    auto rowBuffer = makeUniqueNoThrow<uint8_t[]>(dstRowSize);
-    if (!rowBuffer) {
-      LOG_ERR("XTC", "Failed to allocate row buffer (%lu bytes)", dstRowSize);
-      return false;
-    }
 
     for (uint16_t y = 0; y < pageInfo.height; y++) {
       memset(rowBuffer.get(), 0, dstRowSize);

--- a/lib/Xtc/Xtc.cpp
+++ b/lib/Xtc/Xtc.cpp
@@ -415,9 +415,9 @@ bool Xtc::generateThumbBmp(int height) const {
                 const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
                 const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
                 const uint8_t pixelValue = (bit1 << 1) | bit2;
-                // Convert 2-bit (0-3) to grayscale: 0=black, 3=white
-                // pixelValue: 0=white, 1=light gray, 2=dark gray, 3=black (XTC polarity)
-                grayValue = (3 - pixelValue) * 85;  // 0->255, 1->170, 2->85, 3->0
+                // XTC levels are not ordered by darkness: 0=white, 1=dark gray, 2=light gray, 3=black
+                static constexpr uint8_t XTC_LEVEL_TO_GRAY[4] = {255, 85, 170, 0};
+                grayValue = XTC_LEVEL_TO_GRAY[pixelValue];
               }
             }
           } else {

--- a/src/activities/reader/XtcReaderActivity.cpp
+++ b/src/activities/reader/XtcReaderActivity.cpp
@@ -180,13 +180,12 @@ void XtcReaderActivity::renderPage() {
     const size_t planeSize = (static_cast<size_t>(pageWidth) * pageHeight + 7) / 8;
     const uint8_t* plane1 = pageBuffer;
     const uint8_t* plane2 = pageBuffer + planeSize;
-    const size_t colBytes = (pageHeight + 7) / 8;
 
     auto getPixelValue = [&](uint16_t x, uint16_t y) -> uint8_t {
-      const size_t colIndex = pageWidth - 1 - x;
-      const size_t byteInCol = y / 8;
-      const size_t bitInByte = 7 - (y % 8);
-      const size_t byteOffset = colIndex * colBytes + byteInCol;
+      // Columns run right to left and their bits are packed continuously, as loadPage() reads them
+      const size_t bitIndex = static_cast<size_t>(pageWidth - 1 - x) * pageHeight + y;
+      const size_t byteOffset = bitIndex / 8;
+      const size_t bitInByte = 7 - (bitIndex % 8);
       const uint8_t bit1 = (plane1[byteOffset] >> bitInByte) & 1;
       const uint8_t bit2 = (plane2[byteOffset] >> bitInByte) & 1;
       return (bit1 << 1) | bit2;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes #214: 2-bit XTC (XTCH) covers were rendered as black and white on the sleep screen, while the same page shows four gray levels in the reader.
* **What changes are included?**
  * `Xtc::generateCoverBmp()` writes a 2-bit BMP for 2-bit pages, one palette index per pixel, instead of thresholding every non-white level to black. 1-bit pages are unchanged.
  * The cover cache file is named after its depth (`cover.bmp` / `cover_2bit.bmp`), so a cover written at the other depth is never reused, following the existing `cover.bmp` / `cover_crop.bmp` convention in `Epub`.
  * `createBmp2BitHeader()` / `Bmp2BitHeader` added next to the existing 1-bit helper in `lib/GfxRenderer`; both now share the header-filling code. The palette uses the display's native levels (0/85/170/255), which `Bitmap` maps back losslessly through its `nativePalette` path, so no dithering runs.

The sleep screen itself needed no changes: `SleepActivity` already keys the grayscale passes off `Bitmap::hasGreyscale()`.

Note that with **Sleep Screen Cover Filter** set to anything other than `None`, the sleep screen intentionally stays black and white, so the four levels only show with the filter off.

### Fixes found in the surrounding XTH code

Review of the touched file surfaced four defects in code this PR had to rely on. They are separate commits:

* **Thumbnails stayed 1-bit.** The no-scaling shortcut byte-copied the cover into the thumbnail cache, which after the change would have produced a 2-bit thumbnail for small pages only. The scale is clamped instead, so every thumbnail goes through the regular 1-bit path.
* **Thumbnail gray order.** The XTH spec defines `0=white, 1=dark grey, 2=light grey, 3=black` — the two middle levels are not ordered by darkness. The thumbnail conversion had them swapped, which put them on the wrong side of the 1-bit threshold.
* **Plane indexing.** `XtcParser::loadPage()` reads two planes of `ceil(width * height / 8)` bytes, so column bits are packed continuously. The cover, thumbnail and reader decoders all indexed them as if each column were padded to whole bytes; for a height that is not a multiple of 8 that addressed bytes the parser never read (an out-of-bounds read in the reader, dropped pixels in the thumbnail). All three now use the packed offset. For heights that are multiples of 8 — every page in practice — the two formulas are identical, so rendering is unchanged.
* **Failed writes.** Every cover BMP write is now checked, and a half-written file is removed instead of being cached as a valid cover.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* Memory: no new long-lived allocations. The cover row buffer grows from `width/8` to `width/4` bytes (132 bytes for a 528px page), and `drawBitmap` allocates a proportionally larger row buffer while rendering. The 2-bit cover file is twice the size on SD (~96KB instead of ~48KB for a 528x792 page).
* Existing 1-bit covers stay on the SD card as orphans until the cache is cleared.
* Verified on device (X4, `The Blade Itself.xtc`, 528x792): reader page and sleep cover match level for level, and the home screen thumbnail is unchanged.
* The level-to-palette mapping was checked against the LSB/MSB plane membership in `XtcReaderActivity::renderPage()`, and the packed plane offsets against a host-side round-trip over 7x16, 528x792, 13x13 and 2x10 pages.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
