### PR TITLE
feat: add Korean font families

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -334,7 +334,7 @@ families:
   - name: Pretendard
     description: "Modern Korean sans-serif (Hangul, Latin)"
     scripts: [hangul, latin]
-    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+    intervals: hangul,latin-ext,punctuation,reading,symbols
     sizes: [8, 10, 12, 14, 16, 18]
     styles:
       regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Regular.otf"}
@@ -343,17 +343,34 @@ families:
   - name: PretendardMedium
     description: "Pretendard at Medium weight, slightly heavier body text (Hangul, Latin)"
     scripts: [hangul, latin]
-    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+    intervals: hangul,latin-ext,punctuation,reading,symbols
     sizes: [8, 10, 12, 14, 16, 18]
     styles:
       regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Medium.otf"}
       bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-ExtraBold.otf"}
 
-  - name: PretendardSemiBold
-    description: "Pretendard at SemiBold weight, heavier body text (Hangul, Latin)"
-    scripts: [hangul, latin]
-    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+  - name: RIDIBatang
+    description: "RIDI's e-book serif, single weight (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
     sizes: [8, 10, 12, 14, 16, 18]
     styles:
-      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-SemiBold.otf"}
-      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Black.otf"}
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/RIDIBatang/f1628238e56fd41c12451dfc7d975527b61ebfc7/RIDIBatang.otf"}
+
+  - name: MaruBuri
+    description: "Naver's serif for screen reading (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Regular.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Bold.otf"}
+
+  - name: MaruBuriSemiBold
+    description: "MaruBuri at SemiBold weight, heavier body text (Hangul, Latin)"
+    scripts: [hangul]
+    intervals: hangul,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-SemiBold.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/fonts-archive/MaruBuri/977eeff68d1d40bcef341f09c1f56cce1903bb8a/MaruBuri-Bold.otf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -328,3 +328,32 @@ families:
       bold:       {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Bold.ttf"}
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}
+
+  # ── Korean ─────────────────────────────────────────────────────────────
+
+  - name: Pretendard
+    description: "Modern Korean sans-serif (Hangul, Latin)"
+    scripts: [hangul, latin]
+    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Regular.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Bold.otf"}
+
+  - name: PretendardMedium
+    description: "Pretendard at Medium weight, slightly heavier body text (Hangul, Latin)"
+    scripts: [hangul, latin]
+    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Medium.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-ExtraBold.otf"}
+
+  - name: PretendardSemiBold
+    description: "Pretendard at SemiBold weight, heavier body text (Hangul, Latin)"
+    scripts: [hangul, latin]
+    intervals: hangul,cjk,latin-ext,punctuation,reading,symbols
+    sizes: [8, 10, 12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-SemiBold.otf"}
+      bold:    {url: "https://raw.githubusercontent.com/orioncactus/pretendard/v1.3.9/packages/pretendard/dist/public/static/Pretendard-Black.otf"}


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**

Adds Korean coverage to the SD font catalog, following the contribution rules in #3146 (native language, permissive license, targeted at `chore/fonts`). All fonts are SIL OFL 1.1.

| Family | regular / bold | Source | Notes |
|---|---|---|---|
| `Pretendard` | Regular / Bold | [orioncactus/pretendard](https://github.com/orioncactus/pretendard) v1.3.9 | Modern sans, Inter-based Latin |
| `PretendardMedium` | Medium / ExtraBold | same | Heavier body weight |
| `RIDIBatang` | single weight | [RIDI](https://ridicorp.com/ridibatang/), mirror pinned by commit | RIDI's e-book serif |
| `MaruBuri` | Regular / Bold | [Naver](https://hangeul.naver.com/fonts/search?f=maruburi), mirror pinned by commit | Screen-reading serif |
| `MaruBuriSemiBold` | SemiBold / Bold | same | Heavier body weight |

Details:
- Sizes **8, 10, 12** are generated alongside 12–18 so the size-matched CJK UI fallback (`docs/sd-card-fonts.md`) renders Korean book titles and file names in the library/browser. These are the first catalog families to enable that.
- Intervals: `hangul,latin-ext,punctuation,reading,symbols` — no `cjk` preset. Korean books don't need the ideograph block, and including it roughly doubled file size and made the largest sizes fail to load on device.
- Weight-variant families exist because none of these fonts ship italics but all ship several weights; pairing a heavier regular with a heavier bold keeps `<b>` distinguishable.
- Source URLs are pinned to a tag (Pretendard) or commit SHA (mirrors) so the release workflow rebuilds reproducibly.
- No firmware changes: the `hangul` browser group and glyph preset already exist.

Built locally with `build-sd-fonts.py` (12–24 MB per family, six `.cpfont` each) and tested on an Xteink X3: Korean renders correctly in book content and in the 8/10/12 pt UI rows.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_ — Claude Code drafted the catalog entries, verified licenses/coverage and ran the local font builds; font selection, weight pairings and on-device testing were done by me.