### PR TITLE
fix(settings): a tapped row doesn't keep the focus (touch boards)

### DIFF
--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -185,6 +185,13 @@ void SettingsActivity::activateIndex(const int index) {
   // a lingering tap flash would gray an unrelated element.
   app.clearTapFlash();
   toggleCurrentSetting();
+  // Tap-first: a tapped row is not a cursor position. Leaving it focused
+  // (inverted) after the tap meant the row stayed black once its sub-screen or
+  // popup closed, and Back then had to clear that focus before a second Back
+  // left Settings. Hand the focus back to the tab band; the viewport stays put.
+  if (mappedInput.hasTouch()) {
+    activeNav().selected = 0;
+  }
 }
 
 void SettingsActivity::onExit() {


### PR DESCRIPTION
## What

On touch boards, tapping a Settings row gave it the button-navigation focus, so the row stayed inverted (black) after its sub-screen or option popup closed — and Back then had to clear that focus first (`ringPos() > 0` → focus to the tab band) before a second Back actually left Settings.

After a tap has activated its row, the focus now goes back to the tab band (viewport untouched): no lingering black row, and one Back leaves Settings. Button navigation (Up/Down cursor, Confirm, Back-to-tab-band) is unchanged.

## Testing

Reproduced and verified on a LilyGo T5 S3 (touch): tap "Customise…"-style submenu row → Back → row no longer highlighted → Back → Home. Built `default` and `x4pro` via CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNEivZGmSZU46JfUe8Ac8D