### PR TITLE
docs: document X4 Pro frontlight controls

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -6,6 +6,7 @@ Welcome to the **CrossPoint** firmware. This guide outlines the hardware control
   - [1. Hardware Overview](#1-hardware-overview)
     - [Button Layout](#button-layout)
     - [Taking a Screenshot](#taking-a-screenshot)
+    - [Frontlight (X4 Pro only)](#frontlight-x4-pro-only)
   - [2. Power \& Startup](#2-power--startup)
     - [Power On / Off](#power-on--off)
     - [First Launch](#first-launch)
@@ -68,6 +69,16 @@ Button layout can be customized in the **[Controls Settings](#363-controls)**.
 When the Power Button and Volume Down button are pressed at the same time, it will take a screenshot and save it in the folder `screenshots/`.
 
 Alternatively, while reading a book, press the **Confirm** button to open the reader menu and select **Take screenshot**.
+
+### Frontlight (X4 Pro only)
+
+The X4 Pro has a built-in frontlight with adjustable brightness and warmth. It is controlled from a swipe panel rather than the Settings menu:
+
+* **Open the frontlight panel:** Swipe down from the top edge of the screen, from almost any screen (Home, Browse Files, Reading Mode, etc.). Drag the brightness and warmth sliders to adjust the light live, or tap the sun icon to turn it on or off.
+* **Quick toggle:** Double-click the **Power** button to turn the frontlight on or off instantly, without opening the panel.
+
+> [!NOTE]
+> Frontlight brightness, warmth, and on/off state are intentionally not listed in **[Display Settings](#361-display)** — the swipe panel is the only place to control them.
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -78,7 +78,7 @@ The X4 Pro has a built-in frontlight with adjustable brightness and warmth. It i
 * **Quick toggle:** Double-click the **Power** button to turn the frontlight on or off instantly, without opening the panel.
 
 > [!NOTE]
-> Frontlight brightness, warmth, and on/off state are intentionally not listed in **[Display Settings](#361-display)** — the swipe panel is the only place to control them.
+> Frontlight brightness and warmth are intentionally not listed in **[Display Settings](#361-display)** — the swipe panel is the only place to adjust them. The on/off state can also be toggled with the Power-button double-click above.
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -80,6 +80,8 @@ The X4 Pro has a built-in frontlight with adjustable brightness and warmth. It i
 > [!NOTE]
 > Frontlight brightness and warmth are intentionally not listed in **[Display Settings](#361-display)** — the swipe panel is the only place to adjust them. The on/off state can also be toggled with the Power-button double-click above.
 
+If the frontlight doesn't come back on after the device wakes from sleep, check **Restore Light on Wake** in **[Display Settings](#361-display)** (on by default). Turning it off is intentional if you'd rather have the light stay off on wake and switch it on yourself each time — but it's easy to forget you changed it.
+
 ---
 
 ## 2. Power & Startup


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Document the X4 Pro's frontlight controls, which exist and work but aren't mentioned anywhere in `USER_GUIDE.md`.
* **What changes are included?** Adds a "Frontlight (X4 Pro only)" subsection under Hardware Overview covering the top-edge swipe panel (brightness/warmth sliders + on/off) and the power-button double-click quick toggle, plus a note on why it's intentionally absent from Display Settings. TOC updated accordingly.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code (docs only).

## Additional Context

Docs-only change, no memory/flash impact. Verified against the current source (`SettingsList.h`, `main.cpp`, `FrontlightPanelActivity.cpp`, `BoardConfig.h`) that the frontlight is X4 Pro-specific and deliberately excluded from the Settings menu in favor of the swipe panel, so the doc reflects intended behavior rather than a bug.

### AI Usage

Did you use AI tools to help write this code? **YES** — Claude (Anthropic) was used to trace the frontlight control paths through the source and draft the documentation; reviewed by the submitter before opening this PR.
