### PR TITLE
fix: progress bar thickness setting ignored in landscape (X4 Pro)

### DIFF
--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -1,5 +1,6 @@
 #include "BaseTheme.h"
 
+#include <BoardConfig.h>
 #include <FreeInkUIGfxRenderer.h>
 #include <GfxRenderer.h>
 #include <HalClock.h>
@@ -932,8 +933,17 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
     const int barMarginLeft = fillMargin ? 0 : orientedMarginLeft;
     const int barMarginRight = fillMargin ? 0 : orientedMarginRight;
     const int progressBarMaxWidth = renderer.getScreenWidth() - barMarginLeft - barMarginRight;
-    const int progressBarY = renderer.getScreenHeight() - orientedMarginBottom - sb.progressBarHeightPx -
-                             paddingBottom + (fillMargin ? 1 : 0);
+    // The fill-to-edge extension below is deliberately NOT orientedMarginBottom:
+    // that rotates per reading orientation, and on boards whose left/right
+    // viewableInsets differ from their top/bottom (e.g. the X4 Pro, where
+    // left/right were tuned for scrollbar visibility, not bezel overlap) it
+    // makes the bar's total rendered height — meant to reflect only the
+    // user's Progress Bar Thickness setting — swing with orientation instead.
+    // Anchoring to the board's actual bottom inset keeps the fill amount (and
+    // so the bar's apparent thickness) identical in every orientation.
+    const int edgeFillMargin = BoardConfig::ACTIVE.viewableInsets.bottom;
+    const int progressBarY =
+        renderer.getScreenHeight() - edgeFillMargin - sb.progressBarHeightPx - paddingBottom + (fillMargin ? 1 : 0);
     size_t progress;
     if (sb.progressBarMode == CrossPointSettings::STATUS_BAR_PROGRESS_BAR::BOOK_PROGRESS) {
       progress = static_cast<size_t>(bookProgress);
@@ -942,7 +952,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
       progress = (pageCount > 0) ? (static_cast<float>(currentPage) / pageCount) * 100 : 0;
     }
     const int barWidth = progressBarMaxWidth * progress / 100;
-    const int barHeight = sb.progressBarHeightPx + (fillMargin ? orientedMarginBottom - 1 : 0);
+    const int barHeight = sb.progressBarHeightPx + (fillMargin ? edgeFillMargin - 1 : 0);
     renderer.fillRect(barMarginLeft, progressBarY, barWidth, barHeight, true);
   }
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix #3017 — the reader's progress bar thickness setting appears to have little to no effect in landscape orientations on the X4 Pro, and the bar looks permanently thick there.
* **What changes are included?** `BaseTheme::drawStatusBar`'s progress-bar fill-to-edge extension used `orientedMarginBottom`, which rotates with reading orientation. On the X4 Pro, `viewableInsets.right`/`left` (7px — tuned for scrollbar visibility, per the existing code comment, not measured bezel overlap) differ a lot from `top`/`bottom` (9/3px), so landscape orientations picked up a much larger fill amount than portrait, inflating the bar's rendered height independently of the user's Progress Bar Thickness setting. The fill amount now always uses the board's actual (unrotated) bottom inset, so it's identical in every orientation. Portrait's appearance is unchanged; landscape now matches it.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code — the fix stays entirely inside `BaseTheme.cpp` and reads existing `BoardConfig` data, doesn't change it.

## Additional Context

While investigating, I measured the X4 Pro's actual physical bezel overlap with a throwaway diagnostic firmware (a full-screen pixel ruler) and photographed it: all four edges show close to 0px real overlap, versus the 9/7/3/7px `viewableInsets` currently assumed for this board. That's a separate, bigger question about the underlying hardware calibration data (which lives in the `freeink-sdk` submodule, a different repo) — filed as [Free-Ink/freeink-sdk#54](https://github.com/Free-Ink/freeink-sdk/issues/54) rather than bundled in here. This PR only fixes the orientation-inconsistency bug in crosspoint-reader's own rendering logic, independent of whatever those numbers turn out to be.

Docs-only... no — code-only change, no memory/flash impact (single `int` swap). Verify by opening a book with Progress Bar set to "Chapter"/Thin vs Thick, comparing Portrait vs Landscape CW/CCW — the bar's height should now match between orientations for the same setting.

### AI Usage

Did you use AI tools to help write this code? **YES** — Claude (Anthropic) traced the rendering path, took and analyzed the hardware measurement, and drafted the fix; reviewed by the submitter before opening this PR.
