### PR TITLE
fix: run title check after PR pushes

### DIFF
--- a/.github/workflows/pr-formatting-check.yml
+++ b/.github/workflows/pr-formatting-check.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Ensure Title Check runs for the current PR head after commits are pushed.
* **What changes are included?** Add the `synchronize` activity type to the existing `pull_request_target` workflow.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

Without `synchronize`, pushing commits does not trigger this workflow, leaving Title Check without a result for the new head. GitHub documents `synchronize` as the pull-request activity emitted when the head branch is updated: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

Validated with `git diff --check` and a local YAML syntax parse. Firmware memory and flash impact: none.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
