### PR TITLE
feat: add Noto Naskh Arabic UI and Noto Kufi Arabic

### DIFF
--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -329,6 +329,33 @@ families:
       italic:     {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-Italic.ttf"}
       bolditalic: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/amiri/Amiri-BoldItalic.ttf"}
 
+  - name: NotoNaskhArabicUI
+    description: "Arabic naskh tuned for screen reading (Arabic)"
+    scripts: [arabic]
+    intervals: arabic,latin-ext
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Regular.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+
+  - name: NotoNaskhArabicUIBold
+    description: "Noto Naskh Arabic UI at Bold weight, heavier body text (Arabic)"
+    scripts: [arabic]
+    intervals: arabic,latin-ext
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+      bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+
+  - name: NotoKufiArabic
+    description: "Arabic kufi-style sans-serif (Arabic, Latin)"
+    scripts: [arabic, latin]
+    intervals: arabic,latin-ext,ipa-chars
+    sizes: [12, 14, 16, 18]
+    styles:
+      regular: {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/notokufiarabic/NotoKufiArabic%5Bwght%5D.ttf", variable: {wght: 400}}
+      bold:    {url: "https://raw.githubusercontent.com/google/fonts/main/ofl/notokufiarabic/NotoKufiArabic%5Bwght%5D.ttf", variable: {wght: 700}}
+
   # ── Korean ─────────────────────────────────────────────────────────────
 
   - name: Pretendard

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -332,7 +332,7 @@ families:
   - name: NotoNaskhArabicUI
     description: "Arabic naskh tuned for screen reading (Arabic)"
     scripts: [arabic]
-    intervals: arabic,latin-ext
+    intervals: arabic,ascii,latin1,punctuation
     sizes: [12, 14, 16, 18]
     styles:
       regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Regular.ttf"}
@@ -341,7 +341,7 @@ families:
   - name: NotoNaskhArabicUIBold
     description: "Noto Naskh Arabic UI at Bold weight, heavier body text (Arabic)"
     scripts: [arabic]
-    intervals: arabic,latin-ext
+    intervals: arabic,ascii,latin1,punctuation
     sizes: [12, 14, 16, 18]
     styles:
       regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}

--- a/lib/EpdFont/scripts/sd-fonts.yaml
+++ b/lib/EpdFont/scripts/sd-fonts.yaml
@@ -338,13 +338,13 @@ families:
       regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Regular.ttf"}
       bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
 
-  - name: NotoNaskhArabicUIBold
-    description: "Noto Naskh Arabic UI at Bold weight, heavier body text (Arabic)"
+  - name: NotoNaskhArabicUISemiBold
+    description: "Noto Naskh Arabic UI at SemiBold weight, heavier body text (Arabic)"
     scripts: [arabic]
     intervals: arabic,ascii,latin1,punctuation
     sizes: [12, 14, 16, 18]
     styles:
-      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
+      regular: {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-SemiBold.ttf"}
       bold:    {url: "https://raw.githubusercontent.com/notofonts/notofonts.github.io/main/fonts/NotoNaskhArabicUI/hinted/ttf/NotoNaskhArabicUI-Bold.ttf"}
 
   - name: NotoKufiArabic


### PR DESCRIPTION
Follow-up to #3146 as requested in https://github.com/crosspoint-reader/crosspoint-reader/pull/3146#issuecomment-5381736232 — the two remaining Arabic faces I tested on-device that render well on the panel, alongside Amiri.

**Based on `chore/fonts`**, so the diff is just the three new entries appended to the Arabic section that PR already adds. Retarget to `develop` once #3146 lands.

Config-only, no code changes.

| Family | Weights | Scripts | Built size (12/14/16/18) |
|---|---|---|---|
| `NotoNaskhArabicUI` | 400 / 700 | arabic | 1.5 MB |
| `NotoNaskhArabicUIBold` | 700 / 700 | arabic | 1.6 MB |
| `NotoKufiArabic` | 400 / 700 | arabic, latin | 3.0 MB |

### Notes on the choices

**Naskh UI is Arabic-only.** Its cmap carries no Latin letters — just the digits, `!,.:` and `«»` — so it is listed under the Arabic group only. Kufi covers ASCII in full (plus ~31% of latin-ext), so it gets `[arabic, latin]` like Amiri.

**`NotoNaskhArabicUIBold`** is the same face pinned to Bold, for a heavier stem weight on a 1-bit panel — the same idea as `PretendardMedium` / `MaruBuriSemiBold`. Noto Naskh Arabic UI has no Black weight upstream (`wght` axis is 400–700), so 700 is the heaviest instance that exists. Happy to drop this entry, or pin its regular to SemiBold 600 to keep some regular/bold contrast, if you'd prefer.

**Naskh UI is sourced from the upstream hinted statics, not google/fonts.** The variable file's `STAT` table has zero AxisValue records, so the instancing path in `build-sd-fonts.py` fails outright:

```
ERROR: Cannot update name table since there are no STAT Axis Values
```

`instantiateVariableFont(..., updateFontNames=True)` can't run on it. Using `notofonts/notofonts.github.io` hinted static TTFs sidesteps the instancer entirely and gives better hinting at 12pt as a bonus. Noto Kufi Arabic has a usable `STAT` table and stays on the variable-instancing path against google/fonts.

Both are OFL.

**Narrow intervals on the Naskh families.** The validator in `fontconvert_sdcard.py` keeps a codepoint when *either* the face or the fallback has a glyph for it, and `build-sd-fonts.py:218` always passes the default fallback. `latin-ext` on an Arabic-only face therefore pulled ~1000 NotoSans Latin glyphs in, in a design that doesn't match naskh. Measured at 16pt, regular only:

| intervals | .cpfont |
|---|---|
| `arabic` | 183 KB |
| `arabic,ascii,punctuation` | 200 KB |
| `arabic,ascii,latin1,punctuation` | 212 KB |
| `arabic,latin-ext` | 305 KB |

Settled on `arabic,ascii,latin1,punctuation` — keeps the digits, punctuation and guillemets the face actually draws plus fallback Latin for the occasional English word, and takes each Naskh family from 2.2 MB to 1.6 MB. Kufi keeps `latin-ext` because its own Latin coverage is complete.

### Verification

Built all three families with `build-sd-fonts.py --manifest`:

```
  OK: NotoNaskhArabicUI (4 files, 1.5 MB)
  OK: NotoNaskhArabicUIBold (4 files, 1.6 MB)
  OK: NotoKufiArabic (4 files, 3.0 MB)
Total: 12 .cpfont files (6.1 MB)
```

Manifest emits the expected `styles` and `scripts` for each family.