### PR TITLE
fix: slider handle sticks at the ends of its travel

### DIFF
--- a/src/components/UiAppHelpers.h
+++ b/src/components/UiAppHelpers.h
@@ -186,8 +186,13 @@ inline freeink::ui::InputSnapshot touchSnapshotFrom(const MappedInputManager& ma
   }
   if (mappedInput.wasScreenTouchDown(tx, ty)) {
     snap.touchPressed = true;
-    snap.touchX = static_cast<int16_t>(tx);
-    snap.touchY = static_cast<int16_t>(ty);
+    // wasScreenTouchDown reports the landing point for the whole tap-slop
+    // window, so overwriting a held position would pin a drag there. The two
+    // are within slop of each other, so the press hit test is unaffected.
+    if (!snap.touchHeld) {
+      snap.touchX = static_cast<int16_t>(tx);
+      snap.touchY = static_cast<int16_t>(ty);
+    }
   }
   if (mappedInput.wasScreenTapped(tx, ty)) {
     snap.touchReleased = true;


### PR DESCRIPTION
## What

A slider handle stops following the finger for a moment after it is grabbed. It shows at the ends of a scale — brightness or warmth pinned at 0% or 100% refuse a small nudge — while a broad drag across the track always felt fine.

## Why

`touchSnapshotFrom()` writes the live contact position into the snapshot, then lets the press edge overwrite it:

```cpp
if (mappedInput.isScreenTouchHeld(tx, ty))  { snap.touchHeld = true; snap.touchX = tx; }   // live
if (mappedInput.wasScreenTouchDown(tx, ty)) { snap.touchPressed = true; snap.touchX = tx; } // landing point
```

`wasScreenTouchDown()` is not an edge. It is gated on `InputManager::isTouchTapCandidate()`, documented as *"True while the current touch is still a tap candidate ... Writes the original touch-down position"*, plus a 90 ms delay. So from 90 ms until the finger leaves the 28 px tap slop, every frame replaces the drag's position with where the contact started.

That is why it looks like an ends-only fault: near 0% or 100% the useful adjustment is a few pixels and the gesture never leaves the slop, so the handle stays pinned for the whole contact. Anywhere else the finger escapes the slop at once and tracking looks normal.

## Fix

Keep the live position while the contact is down. The two readings are within tap slop of each other by construction, so the press-time hit test — which only marks the pressed element active — is unaffected.

## Verification

Instrumented the frontlight panel in the desktop simulator (X4 Pro, the touch-capable target) and drove a 30 px adjustment held near 100%:

| | before | after |
|---|---|---|
| frames pinned to the landing point | 56 | 0 |
| distinct values across 55 frames | 7 | 31 |

Before, the value walked to ~87% and snapped back to 98% for the rest of the gesture. After, it tracks continuously.

Builds clean against `develop` (`pio run`, ESP32-C3). Not yet exercised on hardware — the simulator is the only place I could measure this frame by frame.