### PR TITLE
fix(x4pro): hold power-latch pins HIGH through deep sleep

### DIFF
--- a/lib/hal/HalPowerManager.cpp
+++ b/lib/hal/HalPowerManager.cpp
@@ -89,6 +89,27 @@ void HalPowerManager::startDeepSleep(HalGPIO& gpio) const {
   }
 #endif
 
+  // Hold every configured power-latch pin HIGH through deep sleep. These are
+  // keep-alive enables (the X4 Pro's master peripheral rail on GPIO1, the
+  // Sticky's PWR_HOLD/PWR_LOCK): deepSleep() isolates all pads
+  // (esp_sleep_config_gpio_isolate), so a latch without an armed hold loses its
+  // output driver and floats — on the X4 Pro the latch drops as soon as
+  // external power leaves (serial/pogo adapter unplugged), and the next power-
+  // button press cold-boots instead of fast-waking. holdPowerRails() asserted
+  // the latches at boot but arms no sleep hold; arm it here instead. Skips
+  // XTEINK_C3_GPIO13: it IS power.latch0 on the C3 Xteink boards, where the
+  // block above drives it LOW on purpose (battery power-off).
+  for (const int8_t pin : {BoardConfig::ACTIVE.power.latch0, BoardConfig::ACTIVE.power.latch1}) {
+    if (pin < 0 || static_cast<gpio_num_t>(pin) == XTEINK_C3_GPIO13) continue;
+    const auto g = static_cast<gpio_num_t>(pin);
+    // Release any surviving pad hold first: a held pad silently ignores the
+    // drive below (same trap as the GPIO13 block above).
+    gpio_hold_dis(g);
+    pinMode(pin, OUTPUT);
+    digitalWrite(pin, HIGH);
+    gpio_hold_en(g);
+  }
+
   // Cut the gated peripheral rails (touch/SD/EPD on boards like the Sticky) and
   // hold the enables off through deep sleep — otherwise the GT911 and SD card
   // stay powered all through "off" and drain the battery. No-op on boards with


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fixes the battery-only deep-sleep wake bug on the Xteink X4 Pro (crosspoint-reader/crosspoint-reader#2863). After a battery-only sleep, the next power-button press cold-booted (~8–15 s to content) instead of fast-waking (~1–2 s). With the serial/pogo adapter connected, external power masked the problem.
* **What changes are included?** One change in `HalPowerManager::startDeepSleep()` (+21 lines, `lib/hal/HalPowerManager.cpp` only): every configured power-latch pin (`BoardConfig::ACTIVE.power.latch0/latch1`) is driven HIGH and armed with `gpio_hold_en()` before entering deep sleep.

Root cause: `freeink::PowerManager::deepSleep()` calls `esp_sleep_config_gpio_isolate()`, which strips every pad without an armed hold. The X4 Pro's master peripheral-rail enable is `power.latch0` = GPIO1 — `holdPowerRails()` drives it HIGH at boot but arms no sleep hold, so once isolated the latch floats LOW when external power is removed. The fix keeps all configured power-latch pins driven and held HIGH through sleep; peripheral rails (SD / touch / EPD reset) keep their existing OFF-level holds from `powerDownRailsForSleep()`, so standby current doesn't regress. The loop deliberately skips GPIO13 on the C3 Xteink boards: it *is* `power.latch0` there and is driven LOW on purpose as the battery power-off. Generic over the profile's latch pins — also covers the Sticky's PWR_HOLD/PWR_LOCK (GPIO45/46).

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.
      → Touches `lib/hal/` only (`HalPowerManager.cpp`); filed against #2863 where maintainer triage is already happening. No SDK changes required (SDK pointer unchanged at `e4d3cc3`).

Stock firmware note: this restores behavior stock users get implicitly (adapter plugged in or self-latching hardware revisions); it fixes wake for battery-only use, which stock firmware does not handle well.

## Additional Context

* Memory / flash impact: none measurable — ~21 lines of flash, no new RAM, no heap allocation. Runs once per sleep entry.
* Risk area to focus on: the C3 GPIO13 exclusion (battery power-off must still drop the pin LOW); covered by keeping that block ahead of the new loop and skipping the pin in the loop.
* Verification evidence:
  - `pio run -e x4pro` SUCCESS locally on this exact commit.
  - Identical patch fully green on CI twice: upstream run 32916960939 (Build default/sticky/papermono/x4pro, unit tests, cppcheck, clang-format) and Belphemur/crosspoint-reader#3 (all checks pass incl. CodeRabbit).
  - Hardware test procedure for reviewers: flash, sleep on battery, unplug adapter 60 s, short-press power → expect instant wake landing back on the page (`ESP_RST_DEEPSLEEP` + `ESP_SLEEP_WAKEUP_GPIO`), not splash/cold boot (`ESP_RST_POWERON`).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — root-cause analysis and patch drafted with an AI coding agent (Hermes), reviewed and tested by hand before submission.