### PR TITLE
fix(kosync): advertise percentage progress support

### DIFF
--- a/lib/KOReaderSync/KOReaderSyncClient.cpp
+++ b/lib/KOReaderSync/KOReaderSyncClient.cpp
@@ -148,7 +148,8 @@ KOReaderSyncClient::Error KOReaderSyncClient::getProgress(const std::string& doc
     return NO_CREDENTIALS;
   }
 
-  const std::string url = KOREADER_STORE.getBaseUrl() + "/syncs/progress/" + documentHash;
+  const std::string url =
+      KOREADER_STORE.getBaseUrl() + "/syncs/progress/" + documentHash + "?position_kinds=locator,percentage";
   LOG_DBG("KOSync", "Getting progress: %s (heap: %u)", url.c_str(), (unsigned)ESP.getFreeHeap());
   if (insufficientHeap()) return LOW_MEMORY;
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix KOSync progress pulls when a server has a percentage-only reading position.
* **What changes are included?**
  * Advertise `position_kinds=locator,percentage` on the existing progress GET.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

## Additional Context

### Problem

Calibre-Web NextGen's [KOSync protocol](https://github.com/new-usemame/Calibre-Web-NextGen/blob/main/cps/progress_syncing/README.md#position-encodings-and-position_kinds) can store positions that contain a percentage but no locator. Clients advertise support for these positions with:

```text
?position_kinds=locator,percentage
```

Without that advertisement, the server withholds a percentage-only record and returns a capability hint such as:

```json
{"position_kinds_available":["percentage"]}
```

CrossPoint currently parses that successful but fieldless response into default values, resulting in UI such as `Progress found: 0.00%, from null` rather than retrieving the stored position.

### Approach

This change advertises both position types on the initial GET, allowing the server to return either a normal locator response or a percentage-only response in one request.

The change stays within the existing KOSync client and does not add a connector or alter authentication, progress uploads, rich-position parsing, or progress mapping. Legacy locator responses remain accepted. There are no new persistent data structures or allocations; the existing request URL only gains the capability query string. I have also verified the official kosync server ignores this parameter and functions normally. I have verified syncing with the officiel `sync.crosspointreader.com` koreader sync server, a self hosted Calibre-Web-Automated server, and a self hosted Calibre-Web-NextGen server.

### Verification

- [x] Reproduced the percentage-only response behavior before the change.
- [x] Physical Xteink X3 test against a percentage-only Calibre-Web NextGen record: the stored progress was retrieved correctly.
- [x] CrossPoint's official hosted KOSync service (`sync.crosspointreader.com`): authentication and progress updates succeeded, and parameterized and plain GETs returned the same sored locator/percentage record.
- [x] Host CMake/CTest suite: 144/144 passed.
- [x] `./bin/clang-format-fix` passed.
- [x] `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high`: no defects.
- [x] `pio run -e default`: success.
- [x] GitHub Actions: unit tests, all firmware builds, formatting, and static analysis passed.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES** — OpenAI Codex (GPT 5.6 Sol max) assisted with protocol research and implementation with heavy supervision by myself helping restrain scope, focus implementation, and keep changes minimal. The final behavior was validated on physical Xteink X3 hardware.