### PR TITLE
chore: fix clang-format-21 violation in FontCacheManagerTest

### DIFF
--- a/test/font_cache_manager/FontCacheManagerTest.cpp
+++ b/test/font_cache_manager/FontCacheManagerTest.cpp
@@ -123,8 +123,7 @@ TEST(FontCacheManagerTest, PrewarmScanDoesNotAllocateHeapMemory) {
   heapAllocationCount = 0;
   countHeapAllocations = true;
   auto scope = manager.createPrewarmScope();
-  manager.recordText("Repeated text: \xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80", 7,
-                     EpdFontFamily::REGULAR);
+  manager.recordText("Repeated text: \xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80", 7, EpdFontFamily::REGULAR);
   scope.endScanAndPrewarm();
   countHeapAllocations = false;
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** `develop`'s own tip currently fails the `clang-format` CI check (`test/font_cache_manager/FontCacheManagerTest.cpp`), independent of any specific feature/fix PR's content. Since GitHub tests each PR against a merge with the current `develop` tip, this one file is failing the `clang-format` check on unrelated PRs (found while investigating a spurious failure on #3187, a docs-only change that never touches C++).
* **What changes are included?** Ran `bin/clang-format-fix` with the pinned clang-format-21 (21.1.8, matching CI's `apt install clang-format-21`) against a clean `develop` checkout — collapses one `recordText(...)` call onto a single line, its only output.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (n/a — CI hygiene, not a firmware feature).
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code.

## Additional Context

Reproduced directly against `origin/develop` alone (no other branch merged in) with the exact CI toolchain version, confirmed via `git diff` hash match against the CI log (`fdb56f6..44652f6`) — this is not a side effect of any other PR, just something that slipped through. Test-only whitespace change, no logic/behavior change, no memory/flash impact.

### AI Usage

Did you use AI tools to help write this code? **YES** — Claude (Anthropic) diagnosed the CI failure (traced it to `develop`'s own tip rather than the PR under investigation), installed the matching clang-format-21 toolchain, and ran the project's own `bin/clang-format-fix`; reviewed by the submitter before opening this PR.
