### PR TITLE
fix(KOSync): keep WiFi awake during KOReader authentication and sync

### DIFF
--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -5,7 +5,6 @@
 #include <I18n.h>
 #include <Logging.h>
 #include <WiFi.h>
-#include <esp_sntp.h>
 #include <esp_wifi.h>
 
 #include <algorithm>
@@ -46,29 +45,6 @@ const char* matchMethodName(const DocumentMatchMethod method) {
   return method == DocumentMatchMethod::FILENAME ? "filename" : "binary";
 }
 
-void syncTimeWithNTP() {
-  // Reuse an active SNTP session. Stopping it from this activity task can call
-  // into lwIP timer cancellation without the TCP/IP core lock and panic.
-  if (!esp_sntp_enabled()) {
-    esp_sntp_setoperatingmode(ESP_SNTP_OPMODE_POLL);
-    esp_sntp_setservername(0, "pool.ntp.org");
-    esp_sntp_init();
-  }
-
-  // Wait for time to sync (with timeout)
-  int retry = 0;
-  const int maxRetries = 50;  // 5 seconds max
-  while (sntp_get_sync_status() != SNTP_SYNC_STATUS_COMPLETED && retry < maxRetries) {
-    vTaskDelay(100 / portTICK_PERIOD_MS);
-    retry++;
-  }
-
-  if (retry < maxRetries) {
-    LOG_DBG("KOSync", "NTP time synced");
-  } else {
-    LOG_DBG("KOSync", "NTP sync timeout, using fallback");
-  }
-}
 }  // namespace
 
 KOReaderSyncActivity::KOReaderSyncActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
@@ -160,9 +136,6 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
     statusMessage = tr(STR_SYNCING_TIME);
   }
   requestUpdate(true);
-
-  // Sync time with NTP before making API requests
-  syncTimeWithNTP();
 
   {
     RenderLock lock(*this);

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -47,15 +47,13 @@ const char* matchMethodName(const DocumentMatchMethod method) {
 }
 
 void syncTimeWithNTP() {
-  // Stop SNTP if already running (can't reconfigure while running)
-  if (esp_sntp_enabled()) {
-    esp_sntp_stop();
+  // Reuse an active SNTP session. Stopping it from this activity task can call
+  // into lwIP timer cancellation without the TCP/IP core lock and panic.
+  if (!esp_sntp_enabled()) {
+    esp_sntp_setoperatingmode(ESP_SNTP_OPMODE_POLL);
+    esp_sntp_setservername(0, "pool.ntp.org");
+    esp_sntp_init();
   }
-
-  // Configure SNTP
-  esp_sntp_setoperatingmode(ESP_SNTP_OPMODE_POLL);
-  esp_sntp_setservername(0, "pool.ntp.org");
-  esp_sntp_init();
 
   // Wait for time to sync (with timeout)
   int retry = 0;
@@ -149,6 +147,12 @@ void KOReaderSyncActivity::onWifiSelectionComplete(const bool success) {
   }
 
   LOG_DBG("KOSync", "WiFi connected, starting sync");
+
+  // Keep the station fully awake for the short sync transaction. The web server
+  // does the same because ESP32 modem sleep can introduce multi-second network
+  // stalls that surface as HTTP timeouts. WiFi is torn down when this activity exits.
+  WiFi.setSleep(false);
+  LOG_DBG("KOSync", "WiFi sleep disabled for sync");
 
   {
     RenderLock lock(*this);

--- a/src/activities/settings/KOReaderAuthActivity.cpp
+++ b/src/activities/settings/KOReaderAuthActivity.cpp
@@ -2,6 +2,7 @@
 
 #include <GfxRenderer.h>
 #include <I18n.h>
+#include <Logging.h>
 #include <WiFi.h>
 
 #include "KOReaderCredentialStore.h"
@@ -22,6 +23,9 @@ void KOReaderAuthActivity::onWifiSelectionComplete(const bool success) {
     requestUpdate();
     return;
   }
+
+  WiFi.setSleep(false);
+  LOG_DBG("KOAuth", "WiFi sleep disabled for authentication");
 
   {
     RenderLock lock(*this);

--- a/test/font_cache_manager/FontCacheManagerTest.cpp
+++ b/test/font_cache_manager/FontCacheManagerTest.cpp
@@ -123,8 +123,7 @@ TEST(FontCacheManagerTest, PrewarmScanDoesNotAllocateHeapMemory) {
   heapAllocationCount = 0;
   countHeapAllocations = true;
   auto scope = manager.createPrewarmScope();
-  manager.recordText("Repeated text: \xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80", 7,
-                     EpdFontFamily::REGULAR);
+  manager.recordText("Repeated text: \xC3\xA9 \xE4\xB8\xAD \xF0\x9F\x98\x80", 7, EpdFontFamily::REGULAR);
   scope.endScanAndPrewarm();
   countHeapAllocations = false;
 


### PR DESCRIPTION
## Summary

Fixes #3228

KOReader authentication and progress sync can intermittently stall after WiFi has connected and TLS negotiation has completed successfully.

Hardware A/B testing on both X4 and X4 Pro showed that keeping the WiFi station fully awake for the short KOReader HTTP transaction eliminates the observed repeated-attempt `http=-1` failures.

This PR keeps WiFi modem sleep disabled while KOReader authentication or progress synchronization is actively using the network.

The existing activity lifecycle continues shutting WiFi down afterward, so the change is scoped to the short interactive network transaction.

## Related issues / PRs

- Fixes #3228 — X4 / X4 Pro KOReader Sync intermittent post-TLS HTTP stalls
- Related to #3048 — X4 Pro panic after syncing progress
- Related to #3185 — avoid redundant NTP sync before KOReader sync

The intermittent transport failure addressed here is separate from the NTP/lwIP panic tracked by #3048 and addressed by #3185.

## Problem

KOReader Sync could behave as follows:

```text
[KOSync] Getting progress: https://<server>/syncs/progress/<document>
[SecureClient] handshake ok (auto): TLSv1.3 / TLS_AES_128_GCM_SHA256 in 400 ms
...
[KOSync] Get progress response: -1
[KOSync] Primary remote (binary): result=2 http=-1
```

The TLS connection succeeds, but the subsequent HTTP transaction stalls until the client timeout expires.

The failure can occur on either the primary or alternate lookup and becomes especially visible across repeated sync attempts.

The same behavior was reproduced on:

- X4 / ESP32-C3 / CrossPoint 1.5.0
- X4 Pro / ESP32-S3 / CrossPoint 1.6.0 RC

## Root-cause evidence

The server was instrumented during testing.

Requests that reached the KOReader Sync server normally completed in approximately 110-120 ms, so normal server processing latency did not explain the multi-second client stalls.

TLS was also ruled out as the primary cause:

- normal TLS 1.3 reproduced the failure
- forced TLS 1.2 also reproduced the failure

The decisive A/B test was WiFi power saving.

With WiFi sleep left at its normal setting, repeated sync attempts intermittently failed with `http=-1`.

With WiFi kept awake during the short KOReader transaction, repeated attempts became reliable.

On X4, five consecutive progress-sync attempts completed successfully with normal TLS 1.3.

The same behavior was then confirmed on X4 Pro.

Reflashing the X4 Pro back to unmodified 1.6.0 RC caused the repeated-attempt failure to return.

## Existing project precedent

CrossPoint already disables WiFi sleep in `CrossPointWebServer.cpp`:

```cpp
// Disable WiFi sleep to improve responsiveness and prevent 'unreachable' errors.
WiFi.setSleep(false);
```

and later documents:

```cpp
// We rely on disabling WiFi sleep for responsiveness.
```

The KOReader client performs similarly latency-sensitive HTTP work, but previously did not apply the same networking behavior.

## Changes

### KOReader progress sync

After WiFi selection completes successfully, keep the station awake before starting the sync transaction:

```cpp
LOG_DBG("KOSync", "WiFi connected, starting sync");

WiFi.setSleep(false);
LOG_DBG("KOSync", "WiFi sleep disabled for sync");
```

The existing KOReader Sync activity still disconnects/shuts down WiFi when the activity exits.

### KOReader authentication

Apply the same behavior before authentication:

```cpp
WiFi.setSleep(false);
LOG_DBG("KOAuth", "WiFi sleep disabled for authentication");
```

This is included because X4 Pro testing showed the same repeated-attempt reliability problem could affect authentication as well as progress sync.

## NTP lifecycle / #3185

The final hardware-tested firmware also used the behavior proposed by #3185 and did not perform a redundant KOReader-specific NTP sync before the HTTP transaction.

If #3185 is merged first, this PR should remain focused on the WiFi power-save change and should not duplicate its NTP cleanup.

The intended network flow is:

```text
WiFi connected
    |
    v
Keep WiFi awake
    |
    v
KOReader authentication / progress HTTP transaction
    |
    v
Existing activity cleanup shuts WiFi down
```

## Why this is scoped rather than global

This PR does not globally disable WiFi power saving.

`WiFi.setSleep(false)` is applied only after the KOReader activity has established a connection and immediately before its short HTTP transaction.

The existing activity cleanup remains unchanged and turns WiFi off when the operation is complete.

This keeps the change limited to the period where responsive network I/O is required.

## Hardware validation

### X4

Before the change:

- TLS handshake succeeds
- primary or alternate GET can stall
- `Get progress response: -1`
- repeated attempts are unreliable

After keeping WiFi awake, five consecutive sync attempts completed successfully.

Representative results:

```text
TLSv1.3 / TLS_AES_128_GCM_SHA256 in 396 ms -> HTTP 200
TLSv1.3 / TLS_AES_128_GCM_SHA256 in 371 ms -> HTTP 200
TLSv1.3 / TLS_AES_128_GCM_SHA256 in 389 ms -> HTTP 200
TLSv1.3 / TLS_AES_128_GCM_SHA256 in 381 ms -> HTTP 200
TLSv1.3 / TLS_AES_128_GCM_SHA256 in 367 ms -> HTTP 200
```

### X4 Pro

Tested using firmware based on 1.6.0 RC.

With the patch:

- KOReader authentication succeeds repeatedly
- progress sync succeeds repeatedly
- WiFi can be torn down and reconnected between activities
- repeated sync cycles continue to work

The device was then reflashed with unmodified 1.6.0 RC.

The original behavior returned:

- authentication may work initially
- subsequent attempts become unreliable
- progress sync fails on later retries

This provides a direct hardware A/B comparison.

## Experiments that were not retained

The following diagnostic changes were tested and reverted:

- forcing TLS 1.2
- custom wolfSSL receive/peek handling

Neither fixed the intermittent failure.

No `SecureClient` / wolfSSL modifications are required by this PR.

## Testing

Hardware:

- [x] X4 / ESP32-C3
- [x] X4 Pro / ESP32-S3
- [x] repeated sync attempts
- [x] repeated X4 Pro authentication attempts
- [x] WiFi teardown/reconnect between X4 Pro sync activities
- [x] reflash stock X4 Pro 1.6.0 RC and reproduce regression

Host tests:

- 167 / 168 pass
- existing unrelated failure remains:
  - `CssParserTest.FailedPromotionRestoresTheOnlyBackupCache`

No new host-test failures were introduced by the KOReader networking changes.

## Scope

Files affected by the WiFi reliability portion:

- `src/activities/reader/KOReaderSyncActivity.cpp`
- `src/activities/settings/KOReaderAuthActivity.cpp`

The patch does not modify:

- `SecureClient`
- wolfSSL
- HTTP timeout values
- server API behavior
- global WiFi defaults

## Result

KOReader network operations now use the same "keep WiFi awake while responsiveness matters" approach already used by CrossPoint's web server.

This eliminates the intermittent post-TLS HTTP stalls observed during repeated hardware testing on both X4 and X4 Pro while preserving the existing WiFi shutdown behavior after the activity completes.

### X4 Compile FW based in 1.5.0 with this fix applied.

- FW SHA256: 1BC3DA20084762C6709542A95524B3683CEF377F86370AA4A7CD9215D32F878C

- ZIP SHA256: 24ba868dc0b530f0d3b7963e6b64e09933ae80fa7df91283a736e2b46dbc0d70

[crosspoint-pr3228-x4-7ad5276.zip](https://github.com/user-attachments/files/31505556/crosspoint-pr3228-x4-7ad5276.zip)

### X4 PRO Compile FW based on 1.6.0rc with this fix applied.

- FW SHA256: 7CAAE6A63CC8FBABC9D0628D046674277D2414B0B24508213C3F9E7B37DAECD3
- ZIP SHA256: 4acb4413cd52381710512c9f64405e3bf1001471e596ba806485959c216cde6a

[crosspoint-pr3228-x4pro-7ad5276.zip](https://github.com/user-attachments/files/31505741/crosspoint-pr3228-x4pro-7ad5276.zip)




## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [X] I have read SCOPE.md and ROADMAP.md.
- [X] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [X] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [X] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [X] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
