### PR TITLE
feat: add EEGO A4 board profile + LM3630A frontlight

### DIFF
--- a/lib/hal/HalFrontlight.cpp
+++ b/lib/hal/HalFrontlight.cpp
@@ -5,9 +5,10 @@
 HalFrontlight HalFrontlight::instance;
 
 void HalFrontlight::begin(const uint8_t brightness, const uint8_t warmth, const bool on) {
-  if (!manager.present()) return;
-
+  // Run the probe first: for the EEGO A4, present() reflects whether begin()
+  // detected the LM3630A, so it must run before the presence gate below.
   manager.begin();
+  if (!manager.present()) return;
   lastBrightness = brightness > 100 ? 100 : brightness;
   manager.setColorTemperature(warmth > 100 ? 100 : warmth);
   lit = on;

--- a/platformio.ini
+++ b/platformio.ini
@@ -325,3 +325,23 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+
+; --- EEGO Reader A4 — ESP32-S3 N16R8, UC8279C (768x552) + GSLX680 touch --------
+; UC8279C SPI panel (Uc8279cA4Driver), GSLX680 touch + PCF8563 RTC on the shared
+; I2C bus, dedicated HSPI MicroSD. CAP_TOUCH / CAP_RTC auto-enable. The frontlit
+; A4 variant's light is an I2C LED driver (not PWM) — see freeink-sdk
+; docs/eego-a4-support.md.
+;   pio run -e eego_a4 -t upload
+[env:eego_a4]
+extends = base
+board = esp32-s3-devkitc1-n16r8
+board_build.mcu = esp32s3
+board_build.arduino.memory_type = dio_opi
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_EEGO_A4=1
+  -DBOARD_HAS_PSRAM
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-eego-a4\"
+  -DENABLE_SERIAL_LOG
+  -DCROSSPOINT_WAIT_FOR_USB_SERIAL
+  -DLOG_LEVEL=2

--- a/src/network/FirmwareBoardTag.cpp
+++ b/src/network/FirmwareBoardTag.cpp
@@ -26,6 +26,8 @@
 #define CROSSPOINT_BOARD_NAME "murphy"
 #elif FREEINK_DEVICE_DELINK
 #define CROSSPOINT_BOARD_NAME "delink"
+#elif FREEINK_DEVICE_EEGO_A4
+#define CROSSPOINT_BOARD_NAME "eego_a4"
 #else
 #error "FirmwareBoardTag: no FREEINK_DEVICE_* flag set; cannot derive board name"
 #endif


### PR DESCRIPTION
Adds the EEGO A4 (ESP32-S3 N16R8, UC8279C 768x552) board profile and fixes the HAL frontlight so the LM3630A controller actually initializes.

- platformio.ini: adds [env:eego_a4] extending [base] with esp32-s3-devkitc1-n16r8, EEGO A4 PSRAM/revision flags, and the frontlight-defines.
- FirmwareBoardTag: maps FREEINK_DEVICE_EEGO_A4 to board name 'eego_a4'.
- HalFrontlight: LM3630A-present check now runs after manager.begin() (the controller is probed there), so the UI frontlight control shows up. Requires the LM3630A driver in Free-Ink/freeink-sdk (see Free-Ink/freeink-sdk#62).