### PR TITLE
fix: prevent size_t underflow on ZipFile read errors

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -49,7 +49,10 @@ size_t zipFillCallback(void* vctx, const uint8_t** data) {
   // rather than letting the negative-to-size_t conversion underflow fileRemaining
   // and report a huge bytesRead, which would have the inflate library read past
   // the end of readBuf.
-  if (result < 0) return 0;
+  if (result < 0) {
+    LOG_ERR("ZIP", "Failed to read compressed data: %d", result);
+    return 0;
+  }
   const size_t bytesRead = static_cast<size_t>(result);
   ctx->fileRemaining -= bytesRead;
 

--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -44,7 +44,13 @@ size_t zipFillCallback(void* vctx, const uint8_t** data) {
   if (ctx->fileRemaining == 0) return 0;
 
   const size_t toRead = ctx->fileRemaining < ctx->readBufSize ? ctx->fileRemaining : ctx->readBufSize;
-  const size_t bytesRead = ctx->file->read(ctx->readBuf, toRead);
+  const int result = ctx->file->read(ctx->readBuf, toRead);
+  // HalFile::read() returns a negative int on error. Treat it as end-of-stream
+  // rather than letting the negative-to-size_t conversion underflow fileRemaining
+  // and report a huge bytesRead, which would have the inflate library read past
+  // the end of readBuf.
+  if (result < 0) return 0;
+  const size_t bytesRead = static_cast<size_t>(result);
   ctx->fileRemaining -= bytesRead;
 
   *data = ctx->readBuf;


### PR DESCRIPTION
## Bug

`zipFillCallback()` in `lib/ZipFile/ZipFile.cpp` is the inflate library's
read callback for streaming a ZIP entry off SD. It stored the return value
of `ctx->file->read(ctx->readBuf, toRead)` directly into a `size_t`:

```cpp
const size_t bytesRead = ctx->file->read(ctx->readBuf, toRead);
ctx->fileRemaining -= bytesRead;
```

`HalFile::read()` returns a negative `int` on an I/O error. Converting a
negative value to `size_t` produces a huge unsigned number, which:

1. Is reported back to the inflate library as `bytesRead`, i.e. "this many
   valid bytes are in `readBuf`" — but `readBuf` was never filled past
   whatever a partial/failed read left in it, so the library reads
   uninitialized/stale bytes past the end of the buffer it's owed.
2. Underflows `ctx->fileRemaining`, corrupting the remaining-length
   accounting for any subsequent calls.

## Fix

Check `result < 0` before converting to `size_t`, and treat an I/O error as
end-of-stream (`return 0`) rather than propagating a corrupt byte count —
consistent with how a normal short/zero read already signals "no more data"
to the inflate library.

## Testing

- `pio run -e default` and `pio run -e x4pro`: both SUCCESS.
- `pio check -e default --skip-packages` (cppcheck): No defects found.
- `./bin/clang-format-fix -g`: clean.

## Scope note

`zipFillCallback()` and `ZipInflateCtx` are both file-local (anonymous
namespace) and not exposed via `ZipFile.h`, so this function isn't directly
reachable from a host unit test without a disproportionate refactor of
working code. I did not add one, to keep this the smallest possible fix;
happy to revisit if a reviewer prefers otherwise.