### PR TITLE
fix: guard framebuffer access when frameBuffer is temporarily unavailable

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1702,7 +1702,7 @@ void GfxRenderer::waitRefreshComplete() const { display.waitRefreshComplete(); }
 bool GfxRenderer::supportsAsyncRefresh() const { return !fadingFix && display.supportsAsyncRefresh(); }
 
 size_t GfxRenderer::readFramebufferRegion(int x, int y, int w, int h, uint8_t* dst, size_t dstCapacity) const {
-  if (dst == nullptr || w <= 0 || h <= 0) return 0;
+  if (dst == nullptr || w <= 0 || h <= 0 || !frameBuffer) return 0;
 
   const AlignedMemRect mem = screenRectToAlignedMemRect(orientation, x, y, w, h, panelWidth, panelHeight);
   if (!mem.valid) return 0;
@@ -1720,7 +1720,7 @@ size_t GfxRenderer::readFramebufferRegion(int x, int y, int w, int h, uint8_t* d
 }
 
 void GfxRenderer::writeFramebufferRegion(int x, int y, int w, int h, const uint8_t* src) {
-  if (src == nullptr || w <= 0 || h <= 0) return;
+  if (src == nullptr || w <= 0 || h <= 0 || !frameBuffer) return;
 
   const AlignedMemRect mem = screenRectToAlignedMemRect(orientation, x, y, w, h, panelWidth, panelHeight);
   if (!mem.valid) return;


### PR DESCRIPTION
## Bug

`GfxRenderer::readFramebufferRegion()` and `GfxRenderer::writeFramebufferRegion()`
both dereference `frameBuffer` unconditionally past their early-return guards:

```cpp
size_t GfxRenderer::readFramebufferRegion(int x, int y, int w, int h, uint8_t* dst, size_t dstCapacity) const {
  if (dst == nullptr || w <= 0 || h <= 0) return 0;
  ...
  const uint8_t* srcRow = frameBuffer + (...);  // no null check
```

Under `EINK_DISPLAY_SINGLE_BUFFER_MODE` there is only one framebuffer, and it
is temporarily released and reallocated around grayscale rendering (see
`storeBwBuffer()`/`restoreBwBuffer()`). Any call into these two accessors
during that window dereferences a null `frameBuffer`.

## Fix

Add `!frameBuffer` to the existing early-return guard in both functions,
consistent with how they already reject other invalid-state inputs
(`dst == nullptr`, `w <= 0`, `h <= 0`).

## Testing

- `pio run -e default` and `pio run -e x4pro`: both SUCCESS.
- `pio check -e default --skip-packages` (cppcheck): No defects found.
- `./bin/clang-format-fix -g`: clean.

## Scope note

Both functions are private-state accessors on the full `GfxRenderer` class,
which is tightly coupled to real display/panel initialization. There's no
existing host-test scaffold for `GfxRenderer`, and standing one up is out of
scope for this small a fix; happy to revisit if a reviewer prefers otherwise.