### PR TITLE
chore: make custom_sdkconfig opt-in per env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -70,41 +70,11 @@ board_build.flash_mode = dio
 board_build.flash_size = 16MB
 board_build.partitions = partitions.csv
 
-; MEMFIX-PORT: custom_sdkconfig heap reclamation (~32-37 KB). Rebuilds the
-; Arduino core libs on first build (slower once, cached after; needs the CMake
-; pin in platformio.local.ini on macOS).
-;
-; If an interrupted rebuild fails with "multiple definition of 'app_main'"
-; (stale generated scaffold), clean it up with:
-;   rm -rf .dummy CMakeLists.txt sdkconfig.default sdkconfig.defaults .pio/build/default
-; Do NOT use `git clean -fdX` — it deletes platformio.local.ini.
-custom_sdkconfig =
-  ; Task stack right-sizing from measured high-water marks (heap block map +
-  ; per-task stack audit, July 2026): esp_timer used ~0.8 KB of 8 KB across
-  ; every capture; the FreeRTOS timer service used ~0.5 KB
-  ; of 4 KB. Neither runs TLS or app code. ~7 KB back to the heap.
-  CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096
-  CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=2560
-  ; Move the WiFi stack's non-critical hot paths out of IRAM into flash.
-  ; On the C3, IRAM and DRAM share one SRAM pool, so the ~25-30 KB this
-  ; frees lands directly in the heap — paid for with lower WiFi throughput
-  ; during transfers (occasional sync/OTA use, not streaming: acceptable).
-  ; IRAM cost is static, so the heap gain applies even with WiFi off.
-  CONFIG_ESP_WIFI_IRAM_OPT=n
-  CONFIG_ESP_WIFI_RX_IRAM_OPT=n
-  ; Keep the Arduino wrappers for the removed cloud components (below) out of
-  ; the core source list; all other bundled libraries default to enabled.
-  CONFIG_ARDUINO_SELECTIVE_COMPILATION=y
-  CONFIG_ARDUINO_SELECTIVE_RainMaker=n
-  CONFIG_ARDUINO_SELECTIVE_Insights=n
-  ; ESP_SR (speech recognition) only exists in the S3 core; its wrapper includes
-  ; ESP_I2S.h, which the isolated core rebuild can't resolve. Unused here anyway,
-  ; so drop it or the sticky env fails to build.
-  CONFIG_ARDUINO_SELECTIVE_ESP_SR=n
-
-; Drop unused cloud components from the core rebuild. esp_insights/rainmaker
-; require embedded server certs the lib builder can't generate
-; ("https_server.crt.S not found"); this firmware uses none of them.
+; Drop unused cloud components from the hybrid core rebuild. esp_insights/
+; rainmaker require embedded server certs the lib builder can't generate
+; ("https_server.crt.S not found"); this firmware uses none of them. Only
+; consumed by envs that opt into custom_sdkconfig (see [hybrid]); inert for
+; prebuilt-core envs.
 custom_component_remove =
   espressif/esp_insights
   espressif/esp_rainmaker
@@ -148,8 +118,49 @@ lib_deps =
 lib_ignore =
   BLE
 
+; MEMFIX-PORT: custom_sdkconfig heap reclamation (~32-37 KB). Rebuilds the
+; Arduino core libs on first build (slower once, cached after; needs the CMake
+; pin in platformio.local.ini on macOS).
+;
+; NOT part of [base]: pioarduino triggers its hybrid core rebuild on the mere
+; presence of the custom_sdkconfig option (inherited counts), and the hybrid
+; lib-compile pass discards build_unflags (espidf.py replaces BUILD_UNFLAGS
+; with ""), so any env that must unflag base options (e.g. a classic-ESP32
+; board unflagging the USB-CDC defines: no HWCDC) would fail to compile.
+; Envs opt in with: custom_sdkconfig = ${hybrid.custom_sdkconfig}
+;
+; If an interrupted rebuild fails with "multiple definition of 'app_main'"
+; (stale generated scaffold), clean it up with:
+;   rm -rf .dummy CMakeLists.txt sdkconfig.default sdkconfig.defaults .pio/build/default
+; Do NOT use `git clean -fdX` — it deletes platformio.local.ini.
+[hybrid]
+custom_sdkconfig =
+  ; Task stack right-sizing from measured high-water marks (heap block map +
+  ; per-task stack audit, July 2026): esp_timer used ~0.8 KB of 8 KB across
+  ; every capture; the FreeRTOS timer service used ~0.5 KB
+  ; of 4 KB. Neither runs TLS or app code. ~7 KB back to the heap.
+  CONFIG_ESP_TIMER_TASK_STACK_SIZE=4096
+  CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=2560
+  ; Move the WiFi stack's non-critical hot paths out of IRAM into flash.
+  ; On the C3, IRAM and DRAM share one SRAM pool, so the ~25-30 KB this
+  ; frees lands directly in the heap — paid for with lower WiFi throughput
+  ; during transfers (occasional sync/OTA use, not streaming: acceptable).
+  ; IRAM cost is static, so the heap gain applies even with WiFi off.
+  CONFIG_ESP_WIFI_IRAM_OPT=n
+  CONFIG_ESP_WIFI_RX_IRAM_OPT=n
+  ; Keep the Arduino wrappers for the removed cloud components (below) out of
+  ; the core source list; all other bundled libraries default to enabled.
+  CONFIG_ARDUINO_SELECTIVE_COMPILATION=y
+  CONFIG_ARDUINO_SELECTIVE_RainMaker=n
+  CONFIG_ARDUINO_SELECTIVE_Insights=n
+  ; ESP_SR (speech recognition) only exists in the S3 core; its wrapper includes
+  ; ESP_I2S.h, which the isolated core rebuild can't resolve. Unused here anyway,
+  ; so drop it or the sticky env fails to build.
+  CONFIG_ARDUINO_SELECTIVE_ESP_SR=n
+
 [env:default]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 build_flags =
   ${base.build_flags}
   ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
@@ -162,6 +173,7 @@ build_flags =
 
 [env:gh_release]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
@@ -172,6 +184,7 @@ build_flags =
 
 [env:gh_release_rc]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
@@ -182,6 +195,7 @@ build_flags =
 
 [env:slim]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
@@ -197,6 +211,7 @@ build_flags =
 ;   pio run -e sticky -t upload
 [env:sticky]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -208,6 +223,7 @@ build_flags =
 
 [env:sticky-gh_release]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -219,6 +235,7 @@ build_flags =
 
 [env:sticky-gh_release_rc]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -232,6 +249,11 @@ build_flags =
 ; Minimal X4 Pro target: the SDK profile supplies the board pinout, display,
 ; touch controller, and capacitive Home key.
 ;   pio run -e x4pro -t upload
+; No [hybrid] custom_sdkconfig here: the hybrid core rebuild cannot build the
+; arduino_tinyusb component (it exists only in Espressif's lib-builder), so a
+; rebuilt S3 core loses CONFIG_TINYUSB_ENABLED and USB-OTG/USBMSC breaks.
+; X4 Pro envs (USB mass storage) must use the prebuilt core. The 8MB-PSRAM S3
+; does not need the C3 heap trims anyway.
 [env:x4pro]
 extends = base
 board = esp32-s3-devkitc1-n16r8
@@ -286,6 +308,7 @@ build_flags =
 ;   pio run -e papermono -t upload
 [env:papermono]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -302,6 +325,7 @@ build_flags =
 
 [env:papermono-gh_release]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -315,6 +339,7 @@ build_flags =
 
 [env:papermono-gh_release_rc]
 extends = base
+custom_sdkconfig = ${hybrid.custom_sdkconfig}
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 build_flags =
@@ -325,3 +350,4 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+


### PR DESCRIPTION
pioarduino triggers its hybrid Arduino-core rebuild on the mere presence of the custom_sdkconfig option, inherited from [base] included, and the hybrid lib-compile pass discards build_unflags (espidf.py replaces BUILD_UNFLAGS with "" after build_flags are already applied). Any env that needs to unflag base options can therefore never compile, and the hybrid-rebuilt S3 core also lacks the arduino_tinyusb component, which breaks USBMSC/USB on the X4 Pro.

Move the sdkconfig block to a [hybrid] section and have envs opt in explicitly with custom_sdkconfig = ${hybrid.custom_sdkconfig}. The resolved configuration is unchanged for every env except x4pro, which now stays on the prebuilt core (with TinyUSB) as it must.

Pairs with #3242 