### PR TITLE
fix: apply viewable insets to top and bottom bars

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -293,6 +293,28 @@ void HomeActivity::render(RenderLock&&) {
   // self-insets in drawHeader, so only the cover/menu need it here.
   const Rect content = UITheme::getInstance().getContentArea(renderer);
 
+  // Record the tile rect so storeCoverBuffer (called from the theme) knows which
+  // sub-region of the framebuffer to snapshot. ~16 KB in Portrait instead of the
+  // 48 KB full framebuffer the previous bind captured. Assigned before the
+  // restore below because a stored buffer is only valid for the geometry it was
+  // captured at: a theme/orientation change (the control center can move
+  // SETTINGS.orientation while Home sits on the stack and re-renders) shifts the
+  // tile, so drop the stale buffer instead of blitting it into the new rect and
+  // skipping the repaint.
+  const int coverRectXNew = content.x;
+  const int coverRectYNew = metrics.homeTopPadding;
+  const int coverRectWNew = content.width;
+  const int coverRectHNew = metrics.homeCoverTileHeight;
+  if (coverRectXNew != coverRectX || coverRectYNew != coverRectY || coverRectWNew != coverRectW ||
+      coverRectHNew != coverRectH) {
+    freeCoverBuffer();  // clears coverBufferStored
+    coverRendered = false;
+  }
+  coverRectX = coverRectXNew;
+  coverRectY = coverRectYNew;
+  coverRectW = coverRectWNew;
+  coverRectH = coverRectHNew;
+
   renderer.clearScreen();
   bool bufferRestored = coverBufferStored && restoreCoverBuffer();
 
@@ -302,16 +324,8 @@ void HomeActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.homeTopPadding - metrics.topPadding},
                  metrics.homeContinueReadingInMenu && !recentBooks.empty() ? recentBooks[0].title.c_str() : nullptr);
 
-  // Record the tile rect so storeCoverBuffer (called from the theme) knows
-  // which sub-region of the framebuffer to snapshot. ~16 KB in Portrait
-  // instead of the 48 KB full framebuffer the previous bind captured.
-  coverRectX = content.x;
-  coverRectY = metrics.homeTopPadding;
-  coverRectW = content.width;
-  coverRectH = metrics.homeCoverTileHeight;
-
-  GUI.drawRecentBookCover(renderer, Rect{content.x, metrics.homeTopPadding, content.width, metrics.homeCoverTileHeight},
-                          recentBooks, selectorIndex, coverRendered, coverBufferStored, bufferRestored,
+  GUI.drawRecentBookCover(renderer, Rect{coverRectX, coverRectY, coverRectW, coverRectH}, recentBooks, selectorIndex,
+                          coverRendered, coverBufferStored, bufferRestored,
                           std::bind(&HomeActivity::storeCoverBuffer, this));
 
   // Build menu items dynamically

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -229,12 +229,17 @@ void HomeActivity::loop() {
     return;
   }
 
+  // Match the rendered cover grid, which lays tiles inside getContentArea()
+  // (origin content.x + contentSidePadding, span content.width). Using
+  // screen-relative getScreenWidth()/contentSidePadding here offset the touch
+  // targets from the drawn covers by content.x on bezel-inset panels (EEGO A4).
+  const Rect content = UITheme::getInstance().getContentArea(renderer);
   const int coverColumnCount = std::max(1, metrics.homeRecentBooksCount);
   const int recentCount = std::min(static_cast<int>(recentBooks.size()), coverColumnCount);
-  const int coverColumnWidth = (renderer.getScreenWidth() - 2 * metrics.contentSidePadding) / coverColumnCount;
+  const int coverColumnWidth = (content.width - 2 * metrics.contentSidePadding) / coverColumnCount;
   int touchedBook = -1;
-  const auto coverTouch = mappedInput.colTouch(touchedBook, metrics.contentSidePadding, coverColumnWidth, recentCount,
-                                               metrics.homeTopPadding,
+  const auto coverTouch = mappedInput.colTouch(touchedBook, content.x + metrics.contentSidePadding, coverColumnWidth,
+                                               recentCount, metrics.homeTopPadding,
                                                metrics.homeTopPadding + metrics.homeCoverTileHeight, coverColumnWidth);
   if (coverTouch != MappedInputManager::RowTouch::None) {
     if (coverTouch == MappedInputManager::RowTouch::Down) {
@@ -284,6 +289,9 @@ void HomeActivity::render(RenderLock&&) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
+  // Content columns clear the bezel insets on rounded panels. The header
+  // self-insets in drawHeader, so only the cover/menu need it here.
+  const Rect content = UITheme::getInstance().getContentArea(renderer);
 
   renderer.clearScreen();
   bool bufferRestored = coverBufferStored && restoreCoverBuffer();
@@ -297,12 +305,12 @@ void HomeActivity::render(RenderLock&&) {
   // Record the tile rect so storeCoverBuffer (called from the theme) knows
   // which sub-region of the framebuffer to snapshot. ~16 KB in Portrait
   // instead of the 48 KB full framebuffer the previous bind captured.
-  coverRectX = 0;
+  coverRectX = content.x;
   coverRectY = metrics.homeTopPadding;
-  coverRectW = pageWidth;
+  coverRectW = content.width;
   coverRectH = metrics.homeCoverTileHeight;
 
-  GUI.drawRecentBookCover(renderer, Rect{0, metrics.homeTopPadding, pageWidth, metrics.homeCoverTileHeight},
+  GUI.drawRecentBookCover(renderer, Rect{content.x, metrics.homeTopPadding, content.width, metrics.homeCoverTileHeight},
                           recentBooks, selectorIndex, coverRendered, coverBufferStored, bufferRestored,
                           std::bind(&HomeActivity::storeCoverBuffer, this));
 
@@ -324,7 +332,7 @@ void HomeActivity::render(RenderLock&&) {
 
   GUI.drawButtonMenu(
       renderer,
-      Rect{0, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, pageWidth,
+      Rect{content.x, metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset, content.width,
            pageHeight - (metrics.headerHeight + metrics.homeTopPadding + metrics.verticalSpacing +
                          metrics.homeMenuTopOffset + metrics.buttonHintsHeight)},
       static_cast<int>(menuItems.size()),

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -844,7 +844,10 @@ void WifiSelectionActivity::render(RenderLock&&) {
   // so 32 truncated it. See ClockSyncActivity for the same class of bug.
   char countStr[64];
   snprintf(countStr, sizeof(countStr), tr(STR_NETWORKS_FOUND), realNetworkCount);
-  GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
+  // drawHeader self-insets by the board's viewable margins, so it takes a
+  // full-width rect (the contract every other caller uses). Passing the already
+  // safe-inset `screen` here double-inset the header on bezel panels (EEGO A4).
+  GUI.drawHeader(renderer, Rect{0, screen.y + metrics.topPadding, renderer.getScreenWidth(), metrics.headerHeight},
                  tr(STR_WIFI_NETWORKS), countStr);
   GUI.drawSubHeader(
       renderer,

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -844,10 +844,7 @@ void WifiSelectionActivity::render(RenderLock&&) {
   // so 32 truncated it. See ClockSyncActivity for the same class of bug.
   char countStr[64];
   snprintf(countStr, sizeof(countStr), tr(STR_NETWORKS_FOUND), realNetworkCount);
-  // drawHeader self-insets by the board's viewable margins, so it takes a
-  // full-width rect (the contract every other caller uses). Passing the already
-  // safe-inset `screen` here double-inset the header on bezel panels (EEGO A4).
-  GUI.drawHeader(renderer, Rect{0, screen.y + metrics.topPadding, renderer.getScreenWidth(), metrics.headerHeight},
+  GUI.drawHeader(renderer, Rect{screen.x, screen.y + metrics.topPadding, screen.width, metrics.headerHeight},
                  tr(STR_WIFI_NETWORKS), countStr);
   GUI.drawSubHeader(
       renderer,
@@ -899,12 +896,11 @@ void WifiSelectionActivity::buildListScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content below the header + MAC sub-band, above the legend line.
-  screen.setContentMargin(fui::Insets{
-      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight +
-                           metrics.verticalSpacing),
-      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.verticalSpacing * 2),
-      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top +=
+      static_cast<int16_t>(metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight + metrics.verticalSpacing);
+  margins.bottom += static_cast<int16_t>(metrics.verticalSpacing * 2);
+  screen.setContentMargin(margins);
 
   if (state == WifiSelectionState::SAVE_PROMPT || state == WifiSelectionState::FORGET_PROMPT) {
     buildPromptDialog(screen);

--- a/src/activities/reader/EndOfBookOptions.cpp
+++ b/src/activities/reader/EndOfBookOptions.cpp
@@ -162,10 +162,10 @@ void EndOfBookOptions::buildListScreen(UiScreen& screen) {
   const int titleY = safe.y + safe.height / 8;
   const int subtitleY = titleY + renderer.getLineHeight(UI_12_FONT_ID) + metrics.verticalSpacing;
   const int listTop = subtitleY + renderer.getLineHeight(UI_10_FONT_ID) + metrics.verticalSpacing * 2;
-  screen.setContentMargin(fui::Insets{
-      static_cast<int16_t>(listTop), static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.verticalSpacing),
-      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(listTop - safe.y);
+  margins.bottom += static_cast<int16_t>(metrics.verticalSpacing);
+  screen.setContentMargin(margins);
 
   // rowLabels/rowItems were built once in loadOnce() (see buildRowItems())
   // and reused here on every repaint.

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -197,10 +197,9 @@ void EpubReaderBookmarksActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the title band render() paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (bookmarks.empty()) {

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -129,10 +129,9 @@ void EpubReaderChapterSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band drawChrome paints the title in.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (!epub) {

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -58,10 +58,9 @@ void EpubReaderFootnotesActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (footnotes.empty()) {

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -8,6 +8,7 @@
 #include "MappedInputManager.h"
 #include "ReaderUtils.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 
 namespace fui = freeink::ui;
 
@@ -93,7 +94,7 @@ void EpubReaderMenuActivity::activateIndex(const int index) {
                        // SETTINGS.orientation stays unchanged so the reader's
                        // result handler still detects the change and reflows.
                        ReaderUtils::applyOrientation(renderer, pendingOrientation);
-                       app.setDevice(uiTarget.deviceContext());  // hit rects follow the new frame
+                       app.setDevice(uiDeviceContext(renderer, uiTarget));  // hit rects follow the new frame
                        requestUpdate(true);
                      });
     requestUpdate();
@@ -152,10 +153,9 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
 
   // Progress summary where the old sub-header band sat.
   std::string progressLine;

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
@@ -96,10 +96,9 @@ void XtcReaderChapterSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band drawChrome paints the title in.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (!xtc) {

--- a/src/activities/settings/ButtonRemapActivity.cpp
+++ b/src/activities/settings/ButtonRemapActivity.cpp
@@ -153,11 +153,12 @@ void ButtonRemapActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   const int topOffset = metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight + metrics.verticalSpacing;
-  screen.setContentMargin(
-      fui::Insets{static_cast<int16_t>(safe.y + topOffset),
-                  static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width) + metrics.verticalSpacing),
-                  static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.verticalSpacing),
-                  static_cast<int16_t>(safe.x + metrics.verticalSpacing)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(topOffset);
+  margins.right += static_cast<int16_t>(metrics.verticalSpacing);
+  margins.bottom += static_cast<int16_t>(metrics.verticalSpacing);
+  margins.left += static_cast<int16_t>(metrics.verticalSpacing);
+  screen.setContentMargin(margins);
 
   for (uint8_t i = 0; i < kRoleCount; ++i) {
     const uint8_t assignedButton = tempMapping[i];

--- a/src/activities/settings/LanguageSelectActivity.cpp
+++ b/src/activities/settings/LanguageSelectActivity.cpp
@@ -66,10 +66,9 @@ void LanguageSelectActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // rowItems was built once in onEnter() and is reused here on every repaint.

--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -190,14 +190,12 @@ void OpdsServerListActivity::handleSelection() {
 
 void OpdsServerListActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  // Content below the GUI.drawHeader band, above the button hints; derived
-  // from the safe area so board bezel insets apply (same as LanguageSelect).
+  // Content below the GUI.drawHeader band and above the button hints.
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
-  screen.setContentMargin(
-      fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                  static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                  static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.buttonHintsHeight),
-                  static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  margins.bottom += static_cast<int16_t>(metrics.buttonHintsHeight);
+  screen.setContentMargin(margins);
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   const int itemCount = getItemCount();

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -164,14 +164,12 @@ void OpdsSettingsActivity::handleSelection() {
 
 void OpdsSettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  // Content below the GUI.drawHeader band, above the button hints; derived
-  // from the safe area so board bezel insets apply (same as LanguageSelect).
+  // Content below the GUI.drawHeader band and above the button hints.
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
-  screen.setContentMargin(
-      fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                  static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                  static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.buttonHintsHeight),
-                  static_cast<int16_t>(safe.x)});
+  auto margins = contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight);
+  margins.bottom += static_cast<int16_t>(metrics.buttonHintsHeight);
+  screen.setContentMargin(margins);
 
   // URL hint where the old sub-header band sat.
   const fui::Rect band = screen.takeTop(static_cast<int16_t>(metrics.tabBarHeight));

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -8,6 +8,7 @@
 
 #include "MappedInputManager.h"
 #include "components/UITheme.h"
+#include "components/UiAppHelpers.h"
 #include "fontIds.h"
 
 namespace fui = freeink::ui;
@@ -946,7 +947,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   fui::GfxRendererTarget target(renderer);
   target.setFont(fui::GfxRendererTarget::FONT_SMALL, SMALL_FONT_ID);
   target.setFont(fui::GfxRendererTarget::FONT_BODY, UI_12_FONT_ID);
-  const fui::DeviceContext device = target.deviceContext();
+  const fui::DeviceContext device = uiDeviceContext(renderer, target);
   const fui::InputSnapshot noInput{};
   fui::Frame<48> frame(target, device, noInput, interactions);
 

--- a/src/activities/util/KeyboardEntryActivity.cpp
+++ b/src/activities/util/KeyboardEntryActivity.cpp
@@ -403,24 +403,29 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   // never the text field, so skip the wrap/measure work entirely.
   if (y >= keyboardRect().y) return false;
 
-  const int pageWidth = renderer.getScreenWidth();
   const auto& metrics = UITheme::getInstance().getMetrics();
+  // Text and cursor hit-testing live in the same bezel-safe content box the
+  // field underline (drawTextField) and keyboard use; deriving the margin from
+  // getScreenWidth() instead offset taps from the glyphs by content.x on
+  // inset panels (EEGO A4).
+  const Rect content = UITheme::getContentArea(renderer);
 
   const int lineHeight = renderer.getLineHeight(UI_12_FONT_ID);
   const int inputStartY = metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing +
                           metrics.verticalSpacing * 4 + metrics.keyboardVerticalOffset;
 
-  int availableWidth = pageWidth;
+  int availableWidth = content.width;
   if (gpio.deviceIsX3()) {
     availableWidth -= 2 * metrics.sideButtonHintsWidth;
   }
-  const int effectiveMargin = (pageWidth - availableWidth * metrics.keyboardTextFieldWidthPercent / 100) / 2;
+  const int effectiveMargin = (content.width - availableWidth * metrics.keyboardTextFieldWidthPercent / 100) / 2;
+  const int textLeft = content.x + effectiveMargin;
   const int toggleGap = inputType == InputType::Password ? 4 : 0;
   const int toggleReserve = inputType == InputType::Password ? std::max(renderer.getTextWidth(UI_12_FONT_ID, "[abc]"),
                                                                         renderer.getTextWidth(UI_12_FONT_ID, "[***]")) +
                                                                    toggleGap
                                                              : 0;
-  const int textAreaWidth = pageWidth - 2 * effectiveMargin - toggleReserve;
+  const int textAreaWidth = content.width - 2 * effectiveMargin - toggleReserve;
   const int maxLineWidth = textAreaWidth;
   const bool centerText = metrics.keyboardCenteredText;
   std::string displayText = displayTextForCurrentState();
@@ -429,13 +434,13 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   int lineY = inputStartY;
   int lastLineStartIdx = 0;
   int lastLineEndIdx = static_cast<int>(displayText.length());
-  int lastLineStartX = effectiveMargin;
+  int lastLineStartX = textLeft;
   int lastLineWidth = 0;
 
   while (true) {
     const int lineEndIdx = lineBreakEnd(displayText, lineStartIdx, maxLineWidth);
     const int textWidth = measureRange(displayText, lineStartIdx, lineEndIdx);
-    const int lineStartX = centerText ? effectiveMargin + (maxLineWidth - textWidth) / 2 : effectiveMargin;
+    const int lineStartX = centerText ? textLeft + (maxLineWidth - textWidth) / 2 : textLeft;
     lastLineStartIdx = lineStartIdx;
     lastLineEndIdx = lineEndIdx;
     lastLineStartX = lineStartX;
@@ -474,8 +479,8 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
   }
 
   const int underlineBottom = lineY + lineHeight + metrics.verticalSpacing + 8;
-  if (y >= inputStartY - metrics.verticalSpacing && y < underlineBottom && x >= effectiveMargin &&
-      x < effectiveMargin + maxLineWidth + toggleReserve) {
+  if (y >= inputStartY - metrics.verticalSpacing && y < underlineBottom && x >= textLeft &&
+      x < textLeft + maxLineWidth + toggleReserve) {
     position = x < lastLineStartX + lastLineWidth ? static_cast<size_t>(lastLineStartIdx)
                                                   : static_cast<size_t>(lastLineEndIdx);
     return true;
@@ -486,13 +491,13 @@ bool KeyboardEntryActivity::cursorPositionFromPoint(const int x, const int y, si
 
 fui::Rect KeyboardEntryActivity::keyboardRect() const {
   const auto& metrics = UITheme::getInstance().getMetrics();
-  const int pageWidth = renderer.getScreenWidth();
+  const Rect content = UITheme::getContentArea(renderer);  // clear the bezel on rounded panels
   const int pageHeight = renderer.getScreenHeight();
   const int rows = currentLayout().rowCount;
   const int gap = metrics.keyboardKeySpacing;
   const int height = rows * metrics.keyboardKeyHeight + (rows > 1 ? (rows - 1) * gap : 0);
-  const int width = pageWidth * metrics.keyboardWidthPercent / 100;
-  const int x = (pageWidth - width) / 2;
+  const int width = content.width * metrics.keyboardWidthPercent / 100;
+  const int x = content.x + (content.width - width) / 2;
   const int y =
       pageHeight - metrics.buttonHintsHeight - metrics.verticalSpacing - height + metrics.keyboardVerticalOffset;
   return fui::Rect{static_cast<int16_t>(x), static_cast<int16_t>(y), static_cast<int16_t>(width),
@@ -699,6 +704,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   renderer.clearScreen();
 
   const auto pageWidth = renderer.getScreenWidth();
+  const Rect content = UITheme::getContentArea(renderer);  // bezel-safe content bounds
   const auto& metrics = UITheme::getInstance().getMetrics();
 
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.headerHeight}, title.c_str());
@@ -711,17 +717,21 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   std::string displayText = displayTextForCurrentState();
 
   const bool isPassword = (inputType == InputType::Password);
-  int availableWidth = pageWidth;
+  // Field text/cursor share the bezel-safe content box the underline and
+  // keyboard use (matches cursorPositionFromPoint); content.x offsets them past
+  // the bezel on inset panels (EEGO A4).
+  int availableWidth = content.width;
   if (gpio.deviceIsX3()) {
     availableWidth -= 2 * metrics.sideButtonHintsWidth;
   }
-  const int effectiveMargin = (pageWidth - availableWidth * metrics.keyboardTextFieldWidthPercent / 100) / 2;
+  const int effectiveMargin = (content.width - availableWidth * metrics.keyboardTextFieldWidthPercent / 100) / 2;
+  const int textLeft = content.x + effectiveMargin;
   const int toggleGap = isPassword ? 4 : 0;
   const int toggleReserve = isPassword ? std::max(renderer.getTextWidth(UI_12_FONT_ID, "[abc]"),
                                                   renderer.getTextWidth(UI_12_FONT_ID, "[***]")) +
                                              toggleGap
                                        : 0;
-  const int textAreaWidth = pageWidth - 2 * effectiveMargin - toggleReserve;
+  const int textAreaWidth = content.width - 2 * effectiveMargin - toggleReserve;
   const int maxLineWidth = textAreaWidth;
   const bool centerText = metrics.keyboardCenteredText;
 
@@ -744,7 +754,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
 
   int lineStartIdx = 0;
   int textWidth = 0;
-  int cursorPixelX = effectiveMargin;
+  int cursorPixelX = textLeft;
   int cursorLineY = inputStartY;
   bool cursorDrawn = false;
 
@@ -773,16 +783,16 @@ void KeyboardEntryActivity::render(RenderLock&&) {
           kernOffset = beforeAndCursorWidth - beforeWidth - charAdvance;
         }
         if (centerText) {
-          cursorPixelX = effectiveMargin + (maxLineWidth - textWidth) / 2 + beforeWidth + kernOffset;
+          cursorPixelX = textLeft + (maxLineWidth - textWidth) / 2 + beforeWidth + kernOffset;
         } else {
-          cursorPixelX = effectiveMargin + beforeWidth + kernOffset;
+          cursorPixelX = textLeft + beforeWidth + kernOffset;
         }
         cursorLineY = inputStartY + inputHeight;
         cursorDrawn = true;
         isCursorLine = true;
       }
 
-      const int lineStartX = centerText ? effectiveMargin + (maxLineWidth - textWidth) / 2 : effectiveMargin;
+      const int lineStartX = centerText ? textLeft + (maxLineWidth - textWidth) / 2 : textLeft;
       if (isCursorLine && cursorMode && isPassword && !passwordVisible && !togglePos) {
         // Draw text in 3 parts to avoid block cursor overflowing onto next char.
         // displayText uses '*' for all chars; actual char may be wider than '*'.
@@ -811,8 +821,8 @@ void KeyboardEntryActivity::render(RenderLock&&) {
 
   const int fieldWidth = (inputHeight > 0) ? maxLineWidth : textWidth;
   const int lineMargin = effectiveMargin;
-  GUI.drawTextField(renderer, Rect{0, inputStartY, pageWidth, inputHeight}, fieldWidth, cursorMode, lineMargin,
-                    pageWidth - 2 * lineMargin);
+  GUI.drawTextField(renderer, Rect{content.x, inputStartY, content.width, inputHeight}, fieldWidth, cursorMode,
+                    lineMargin, content.width - 2 * lineMargin);
 
   if (cursorMode && !togglePos && cursorPos <= displayText.length()) {
     static constexpr int blockPadding = 1;
@@ -835,7 +845,7 @@ void KeyboardEntryActivity::render(RenderLock&&) {
   if (isPassword) {
     const char* toggleLabel = passwordVisible ? "[***]" : "[abc]";
     const int toggleWidth = renderer.getTextWidth(UI_12_FONT_ID, toggleLabel);
-    const int toggleX = pageWidth - effectiveMargin - toggleWidth;
+    const int toggleX = content.x + content.width - effectiveMargin - toggleWidth;
     const int toggleY = inputStartY + inputHeight;
     const bool toggleSelected = cursorMode && togglePos;
 

--- a/src/components/OptionPopup.h
+++ b/src/components/OptionPopup.h
@@ -152,7 +152,7 @@ class OptionPopup {
     const fui::ThemeTokens& theme = refreshSharedUiThemeTokens(target);
     // Frame stores a const DeviceContext&; keep it in a local that outlives
     // the frame (a deviceContext() temporary would dangle).
-    const fui::DeviceContext device = target.deviceContext();
+    const fui::DeviceContext device = uiDeviceContext(renderer, target);
     // Routing happens on the loop task against the member buffer; the frame
     // itself never dispatches, so it gets an empty snapshot.
     const fui::InputSnapshot noInput{};

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -68,12 +68,21 @@ const ThemeMetrics& UITheme::getMetrics() const {
   return adjustedMetrics;
 }
 
-// Screen area excluding the button hints
+// Full drawable content area: screen minus the board's viewable insets (bezel /
+// rounded-corner clearance), oriented to the current rotation. The single place
+// the inset math lives; every screen derives its content bounds from here (or
+// from getScreenSafeArea, which builds on it).
+Rect UITheme::getContentArea(const GfxRenderer& renderer) {
+  int viTop = 0, viRight = 0, viBottom = 0, viLeft = 0;
+  renderer.getOrientedViewableTRBL(&viTop, &viRight, &viBottom, &viLeft);
+  return Rect{viLeft, viTop, renderer.getScreenWidth() - viLeft - viRight,
+              renderer.getScreenHeight() - viTop - viBottom};
+}
+
+// Content area excluding the button hints.
 Rect UITheme::getScreenSafeArea(const GfxRenderer& renderer, bool hasFrontButtonHints, bool hasSideButtonHints) {
   auto orientation = renderer.getOrientation();
-  const int screenWidth = renderer.getScreenWidth();
-  const int screenHeight = renderer.getScreenHeight();
-  Rect safeArea = Rect{0, 0, screenWidth, screenHeight};
+  Rect safeArea = getContentArea(renderer);
   const ThemeMetrics metrics = getMetrics();
   switch (orientation) {
     case GfxRenderer::Orientation::Portrait:

--- a/src/components/UITheme.cpp
+++ b/src/components/UITheme.cpp
@@ -68,10 +68,8 @@ const ThemeMetrics& UITheme::getMetrics() const {
   return adjustedMetrics;
 }
 
-// Full drawable content area: screen minus the board's viewable insets (bezel /
-// rounded-corner clearance), oriented to the current rotation. The single place
-// the inset math lives; every screen derives its content bounds from here (or
-// from getScreenSafeArea, which builds on it).
+// Drawable bounds for legacy firmware layouts. FreeInkUI receives the same
+// oriented board insets through DeviceContext.
 Rect UITheme::getContentArea(const GfxRenderer& renderer) {
   int viTop = 0, viRight = 0, viBottom = 0, viLeft = 0;
   renderer.getOrientedViewableTRBL(&viTop, &viRight, &viBottom, &viLeft);

--- a/src/components/UITheme.h
+++ b/src/components/UITheme.h
@@ -20,11 +20,7 @@ class UITheme {
 
   const ThemeMetrics& getMetrics() const;
   const BaseTheme& getTheme() const { return *currentTheme; }
-  // The drawable content area: full screen minus the board's viewable insets
-  // (bezel / rounded-corner clearance from BoardConfig::ACTIVE.viewableInsets,
-  // oriented to the current rotation). THE single place activities should get
-  // their content bounds from so every screen clears the bezel identically.
-  // Zero-inset on rectangular panels, so no visible change there.
+  // Drawable bounds for legacy layouts that do not use FreeInkUI's device-safe frame.
   static Rect getContentArea(const GfxRenderer& renderer);
   Rect getScreenSafeArea(const GfxRenderer& renderer, bool hasFrontButtonHints = false,
                          bool hasSideButtonHints = false);

--- a/src/components/UITheme.h
+++ b/src/components/UITheme.h
@@ -20,6 +20,12 @@ class UITheme {
 
   const ThemeMetrics& getMetrics() const;
   const BaseTheme& getTheme() const { return *currentTheme; }
+  // The drawable content area: full screen minus the board's viewable insets
+  // (bezel / rounded-corner clearance from BoardConfig::ACTIVE.viewableInsets,
+  // oriented to the current rotation). THE single place activities should get
+  // their content bounds from so every screen clears the bezel identically.
+  // Zero-inset on rectangular panels, so no visible change there.
+  static Rect getContentArea(const GfxRenderer& renderer);
   Rect getScreenSafeArea(const GfxRenderer& renderer, bool hasFrontButtonHints = false,
                          bool hasSideButtonHints = false);
   static void drawCenteredText(const GfxRenderer& renderer, Rect screen, int fontId, int y, const char* text,

--- a/src/components/UIThemeTokens.h
+++ b/src/components/UIThemeTokens.h
@@ -21,13 +21,13 @@ inline freeink::ui::ThemeTokens uiThemeTokens(const freeink::ui::GfxRendererTarg
   tokens.listSelectionStyle = static_cast<fui::SelectionStyle>(metrics.listSelectionStyle);
   tokens.listScrollWidth = static_cast<int16_t>(metrics.listScrollWidth);
   tokens.listScrollSide = static_cast<uint8_t>(metrics.listScrollSide);
-  // The scroll track hugs the band edge; on boards whose panel sits recessed
-  // behind the bezel the edge columns are covered, so push the indicator
-  // inward past the covered side. Bezel truth is per-board data
-  // (BoardConfig::ViewableInsets); lists render in the portrait UI frame, so
-  // the panel-native portrait insets apply directly.
-  const auto& vi = BoardConfig::ACTIVE.viewableInsets;
-  tokens.listScrollInset = static_cast<int16_t>(metrics.listScrollSide == 1 ? vi.left : vi.right);
+  // The scroll track hugs the band edge. Bezel clearance on recessed panels is
+  // now handled systemically: the fui DeviceContext carries the board's
+  // ViewableInsets as its safe area, so every list rect (Screen::body()) is
+  // already recessed past the covered columns. Adding the inset again here would
+  // double-count it (the track would sit twice as far in as the header battery),
+  // so the track only needs to hug that already-safe edge.
+  tokens.listScrollInset = 0;
   // Screen::header()/status() band height. Without this the SDK's
   // line-height-derived default applies and fui-drawn headers (OPDS) come out
   // a different height than every GUI.drawHeader band.

--- a/src/components/UIThemeTokens.h
+++ b/src/components/UIThemeTokens.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <BoardConfig.h>
 #include <FreeInkUIGfxRenderer.h>
 
 #include "UITheme.h"
@@ -21,12 +20,7 @@ inline freeink::ui::ThemeTokens uiThemeTokens(const freeink::ui::GfxRendererTarg
   tokens.listSelectionStyle = static_cast<fui::SelectionStyle>(metrics.listSelectionStyle);
   tokens.listScrollWidth = static_cast<int16_t>(metrics.listScrollWidth);
   tokens.listScrollSide = static_cast<uint8_t>(metrics.listScrollSide);
-  // The scroll track hugs the band edge. Bezel clearance on recessed panels is
-  // now handled systemically: the fui DeviceContext carries the board's
-  // ViewableInsets as its safe area, so every list rect (Screen::body()) is
-  // already recessed past the covered columns. Adding the inset again here would
-  // double-count it (the track would sit twice as far in as the header battery),
-  // so the track only needs to hug that already-safe edge.
+  // The scroll track hugs the edge of DeviceContext's already-safe content area.
   tokens.listScrollInset = 0;
   // Screen::header()/status() band height. Without this the SDK's
   // line-height-derived default applies and fui-drawn headers (OPDS) come out

--- a/src/components/UiAppHelpers.h
+++ b/src/components/UiAppHelpers.h
@@ -71,6 +71,16 @@ inline freeink::ui::GfxRendererTarget makeUiTarget(const GfxRenderer& renderer) 
   return target;
 }
 
+inline freeink::ui::DeviceContext uiDeviceContext(const GfxRenderer& renderer,
+                                                  const freeink::ui::GfxRendererTarget& target) {
+  auto device = target.deviceContext();
+  int top, right, bottom, left;
+  renderer.getOrientedViewableTRBL(&top, &right, &bottom, &left);
+  device.safeArea = freeink::ui::Insets{static_cast<int16_t>(top), static_cast<int16_t>(right),
+                                        static_cast<int16_t>(bottom), static_cast<int16_t>(left)};
+  return device;
+}
+
 // Tap release with coords, plus the raw release the tap classifier never
 // reports (swipe end, drag-off) delivered off-target: nothing dispatches,
 // but routing drops its pressed-element state instead of ghosting it onto

--- a/src/components/UiAppHost.cpp
+++ b/src/components/UiAppHost.cpp
@@ -5,7 +5,7 @@
 namespace fui = freeink::ui;
 
 UiAppHost::UiAppHost(const GfxRenderer& renderer)
-    : uiTarget(makeUiTarget(renderer)), app(uiTarget, uiTarget.deviceContext()) {}
+    : uiTarget(makeUiTarget(renderer)), app(uiTarget, uiDeviceContext(renderer, uiTarget)), uiRenderer(renderer) {}
 
 void UiAppHost::resetUi() {
   uiReady = false;
@@ -13,9 +13,17 @@ void UiAppHost::resetUi() {
 }
 
 void UiAppHost::renderUi() {
-  app.setDevice(uiTarget.deviceContext());
+  app.setDevice(uiDeviceContext(uiRenderer, uiTarget));
   app.render();
   uiReady = true;
+}
+
+fui::Insets UiAppHost::contentMargins(const GfxRenderer& renderer, const Rect& bounds) {
+  const Rect content = UITheme::getContentArea(renderer);
+  return fui::Insets{static_cast<int16_t>(bounds.y - content.y),
+                     static_cast<int16_t>(content.x + content.width - bounds.x - bounds.width),
+                     static_cast<int16_t>(content.y + content.height - bounds.y - bounds.height),
+                     static_cast<int16_t>(bounds.x - content.x)};
 }
 
 UiAppHost::TouchRoute UiAppHost::routeTouch(const MappedInputManager& input, const bool withLongPress,

--- a/src/components/UiAppHost.h
+++ b/src/components/UiAppHost.h
@@ -6,6 +6,7 @@
 
 class GfxRenderer;
 class MappedInputManager;
+struct Rect;
 
 // Owns the FreeInkApp hosting protocol every FUI screen shares, list-shaped or
 // not: the font-bound render target, the app, and the uiReady handshake that
@@ -43,6 +44,9 @@ class UiAppHost {
   // should paint; chrome before, hints after.
   void renderUi();
 
+  // Converts absolute firmware bounds to margins inside FreeInkUI's device-safe frame.
+  static freeink::ui::Insets contentMargins(const GfxRenderer& renderer, const Rect& bounds);
+
   // What loop-task routing saw this pass. `routed` is true when the gate was
   // open and the snapshot carried relevant touch input — the invalidated()
   // repaint check belongs behind it, so a pending render requested elsewhere
@@ -72,6 +76,7 @@ class UiAppHost {
   UiApp app;
 
  private:
+  const GfxRenderer& uiRenderer;
   // Opened by the render task after publication and closed on lifecycle/state
   // resets; read by the loop task (route*).
   std::atomic<bool> uiReady{false};

--- a/src/components/UiSliderDialog.h
+++ b/src/components/UiSliderDialog.h
@@ -32,10 +32,9 @@ inline void buildSliderDialogScreen(UiAppHost::UiScreen& screen, const GfxRender
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the title band render() paints, dropped down
   // to where the legacy fixed layout placed the readout.
-  screen.setContentMargin(fui::Insets{
-      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing * 4),
-      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
+  auto margins = UiAppHost::contentMargins(renderer, safe);
+  margins.top += static_cast<int16_t>(metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing * 4);
+  screen.setContentMargin(margins);
 
   // Value readout, centered above the slider.
   fui::TextStyle readout = theme.titleText;

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -290,7 +290,13 @@ void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
   // subtitles.
   ui.target.setFont(fui::GfxRendererTarget::FONT_SMALL, SMALL_FONT_ID);
   const ThemeMetrics& metrics = UITheme::getInstance().getMetrics();
-  const fui::Rect band{static_cast<int16_t>(rect.x), static_cast<int16_t>(rect.y), static_cast<int16_t>(rect.width),
+  // Callers pass a full-width header rect, so the battery/title would sit at the
+  // true screen edges — clipped on rounded-corner panels (EEGO A4). Inset the band
+  // horizontally by the board's viewable insets so header chrome clears the bezel.
+  int hMarginTop, hMarginRight, hMarginBottom, hMarginLeft;
+  renderer.getOrientedViewableTRBL(&hMarginTop, &hMarginRight, &hMarginBottom, &hMarginLeft);
+  const fui::Rect band{static_cast<int16_t>(rect.x + hMarginLeft), static_cast<int16_t>(rect.y),
+                       static_cast<int16_t>(rect.width - hMarginLeft - hMarginRight),
                        static_cast<int16_t>(rect.height)};
 
   const bool showBatteryPercentage =

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -278,6 +278,7 @@ void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
   namespace fui = freeink::ui;
   const auto spec = uiScaleSpec();
   fui::GfxRendererFrame<1> ui(renderer, spec.smallFontId, spec.bodyFontId, spec.titleFontId);
+  ui.device = uiDeviceContext(renderer, ui.target);
   // Refresh the app-wide shared tokens instead of copying ~1.5KB of
   // ThemeTokens onto this render-path stack frame; the values derived here
   // are identical to what every FreeInkApp screen derives. Goes through the
@@ -290,14 +291,15 @@ void BaseTheme::drawHeader(const GfxRenderer& renderer, Rect rect, const char* t
   // subtitles.
   ui.target.setFont(fui::GfxRendererTarget::FONT_SMALL, SMALL_FONT_ID);
   const ThemeMetrics& metrics = UITheme::getInstance().getMetrics();
-  // Callers pass a full-width header rect, so the battery/title would sit at the
-  // true screen edges — clipped on rounded-corner panels (EEGO A4). Inset the band
-  // horizontally by the board's viewable insets so header chrome clears the bezel.
-  int hMarginTop, hMarginRight, hMarginBottom, hMarginLeft;
-  renderer.getOrientedViewableTRBL(&hMarginTop, &hMarginRight, &hMarginBottom, &hMarginLeft);
-  const fui::Rect band{static_cast<int16_t>(rect.x + hMarginLeft), static_cast<int16_t>(rect.y),
-                       static_cast<int16_t>(rect.width - hMarginLeft - hMarginRight),
-                       static_cast<int16_t>(rect.height)};
+  // Accept full-screen or already-safe bounds and apply the device safe area once.
+  const fui::Rect safe = ui.frame.safeRect();
+  const int left = std::max(rect.x, static_cast<int>(safe.x));
+  const int top = std::max(rect.y, static_cast<int>(safe.y));
+  const int right = std::min(rect.x + rect.width, static_cast<int>(safe.right()));
+  const int bottom = std::min(rect.y + rect.height, static_cast<int>(safe.bottom()));
+  const fui::Rect band{static_cast<int16_t>(left), static_cast<int16_t>(top),
+                       static_cast<int16_t>(std::max(0, right - left)),
+                       static_cast<int16_t>(std::max(0, bottom - top))};
 
   const bool showBatteryPercentage =
       SETTINGS.hideBatteryPercentage != CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_ALWAYS;

--- a/src/components/themes/lyra/Lyra3CoversTheme.cpp
+++ b/src/components/themes/lyra/Lyra3CoversTheme.cpp
@@ -34,7 +34,7 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
            i < std::min(static_cast<int>(recentBooks.size()), Lyra3CoversMetrics::values.homeRecentBooksCount); i++) {
         std::string coverPath = recentBooks[i].coverBmpPath;
         bool hasCover = true;
-        int tileX = Lyra3CoversMetrics::values.contentSidePadding + tileWidth * i;
+        int tileX = rect.x + Lyra3CoversMetrics::values.contentSidePadding + tileWidth * i;
         if (coverPath.empty()) {
           hasCover = false;
         } else {
@@ -84,7 +84,7 @@ void Lyra3CoversTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
          i++) {
       bool bookSelected = (selectorIndex == i);
 
-      int tileX = Lyra3CoversMetrics::values.contentSidePadding + tileWidth * i;
+      int tileX = rect.x + Lyra3CoversMetrics::values.contentSidePadding + tileWidth * i;
 
       const int maxLineWidth = tileWidth - 2 * hPaddingInSelection;
 

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -215,7 +215,7 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
     if (!coverRendered) {
       std::string coverPath = book.coverBmpPath;
       bool hasCover = true;
-      int tileX = LyraMetrics::values.contentSidePadding;
+      int tileX = rect.x + LyraMetrics::values.contentSidePadding;
       if (coverPath.empty()) {
         hasCover = false;
       } else {
@@ -254,7 +254,7 @@ void LyraTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, const std:
 
     bool bookSelected = (selectorIndex == 0);
 
-    int tileX = LyraMetrics::values.contentSidePadding;
+    int tileX = rect.x + LyraMetrics::values.contentSidePadding;
     int textWidth = tileWidth - 2 * hPaddingInSelection - LyraMetrics::values.verticalSpacing - coverWidth;
 
     if (bookSelected) {

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -66,7 +66,7 @@ void RoundedRaffTheme::drawRecentBookCover(GfxRenderer& renderer, Rect rect, con
     coverWidth = RoundedRaffMetrics::values.homeCoverHeight * 0.6;
   }
   const int imgY = tileY + (tileHeight - RoundedRaffMetrics::values.homeCoverHeight) / 2;
-  const int tileX = RoundedRaffMetrics::values.contentSidePadding;
+  const int tileX = rect.x + RoundedRaffMetrics::values.contentSidePadding;
 
   // Draw book card regardless, fill with message based on `hasContinueReading`
   // Draw cover image as background if available (inside the box)


### PR DESCRIPTION
Centralize the board viewable-inset math (bezel / rounded-corner clearance from BoardConfig::ACTIVE.viewableInsets) in a single UITheme::getContentArea, oriented to the current rotation, and derive getScreenSafeArea from it. Headers, status bars, and button hints previously applied insets only on the sides, so panels with top/bottom bezel overlap (recessed or rounded-corner glass) clipped the bars.

Align Home and keyboard touch targets with the inset-adjusted layout so taps land on what is drawn, and fix the WiFi network-list header, which passed the already-inset safe area into drawHeader (which self-insets) and double-inset on bezel panels.
