### PR TITLE
fix: clear stale panic marker after write attempt regardless of outcome

### DIFF
--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -106,9 +106,6 @@ void checkPanic() {
       const size_t written = file.write(panicInfo.c_str(), panicInfo.size());
       file.close();
       if (written == panicInfo.size()) {
-        // Keep the crash data for CrashActivity, but mark it consumed so a
-        // later watchdog reset cannot be mistaken for this panic.
-        panicCaptureMarker = 0;
         LOG_INF("SYS", "Dumped panic info to SD card");
       } else {
         LOG_ERR("SYS", "Failed to write complete crash report (%zu of %zu bytes)", written, panicInfo.size());
@@ -116,6 +113,11 @@ void checkPanic() {
     } else {
       LOG_ERR("SYS", "Failed to open crash_report.txt for writing");
     }
+    // Keep panicMessage/panicStack for CrashActivity, but mark the panic
+    // consumed after this boot's write attempt regardless of outcome -- a
+    // marker left set by a failed SD write would otherwise make a later,
+    // unrelated watchdog reset misreport as this same stale panic.
+    panicCaptureMarker = 0;
   }
 }
 


### PR DESCRIPTION
## Bug

`HalSystem::checkPanic()` only clears `panicCaptureMarker` inside the
success branch of the SD-card crash-report write:

```cpp
if (written == panicInfo.size()) {
  panicCaptureMarker = 0;
  LOG_INF("SYS", "Dumped panic info to SD card");
} else {
  LOG_ERR("SYS", "Failed to write complete crash report ...");
  // marker still set
}
```

If opening `/crash_report.txt` fails (`Storage.open()` returns falsy) or the
write is incomplete, `panicCaptureMarker` is never cleared.
`isRebootFromPanic()` only checks whether the marker equals
`PANIC_CAPTURE_MAGIC` — it has no way to distinguish "this boot's genuine
panic" from "leftover marker from a panic several boots ago whose SD write
failed." A later, completely unrelated watchdog reset would then be
misreported as a continuation of that stale panic.

## Fix

Move `panicCaptureMarker = 0` to run once after the write attempt,
unconditionally — the marker is cleared whether the write succeeded or
failed. `panicMessage`/`panicStack` (the actual crash data `CrashActivity`
displays) are untouched, so the in-memory crash info for *this* boot is
still shown even if the SD write itself failed; only the RTC-memory marker
used to detect "was the last reboot due to a panic" is cleared.

## Testing

- `pio run -e default` and `pio run -e x4pro`: both SUCCESS.
- `pio check -e default --skip-packages` (cppcheck): No defects found.
- `./bin/clang-format-fix -g`: clean.

## Scope note

`checkPanic()` uses `RTC_NOINIT_ATTR` (ESP32 RTC memory) and calls through
`HalStorage`, so it isn't host-testable without a disproportionate hardware
abstraction layer; no existing test scaffold covers this file. Did not add
one to keep this the smallest possible fix.