### PR TITLE
fix: disable WiFi power-save during OPDS/book HTTP downloads

### DIFF
--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -53,8 +53,14 @@ bool isRedirect(int status) {
 // likely to be hit the longer a transfer takes, so small feeds mostly get
 // away with it while a large category consistently doesn't.
 struct WifiPowerSaveGuard {
-  WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_NONE); }
-  ~WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_MIN_MODEM); }
+  WifiPowerSaveGuard() {
+    esp_err_t err = esp_wifi_set_ps(WIFI_PS_NONE);
+    if (err != ESP_OK) LOG_ERR("HTTP", "Failed to disable WiFi power-save: %d", err);
+  }
+  ~WifiPowerSaveGuard() {
+    esp_err_t err = esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
+    if (err != ESP_OK) LOG_ERR("HTTP", "Failed to restore WiFi power-save: %d", err);
+  }
 };
 
 #if defined(FREEINK_NET_WOLFSSL)

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -4,6 +4,7 @@
 #include <Logging.h>
 #include <Memory.h>
 #include <base64.h>
+#include <esp_wifi.h>
 
 #include <functional>
 #include <string>
@@ -45,9 +46,21 @@ bool isRedirect(int status) {
   return status == 301 || status == 302 || status == 303 || status == 307 || status == 308;
 }
 
+// OtaUpdater.cpp already disables WiFi power-save for firmware downloads, but
+// OPDS feed/book fetches never did despite being able to run just as long for
+// a large category. Modem sleep periodically powers the radio down between
+// DTIM beacon intervals, which can drop or stall packets mid-transfer -- more
+// likely to be hit the longer a transfer takes, so small feeds mostly get
+// away with it while a large category consistently doesn't.
+struct WifiPowerSaveGuard {
+  WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_NONE); }
+  ~WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_MIN_MODEM); }
+};
+
 #if defined(FREEINK_NET_WOLFSSL)
 HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std::string& username,
                                          const std::string& password, Sink& sink) {
+  WifiPowerSaveGuard psGuard;
   std::string url = startUrl;
 
   for (int hop = 0; hop <= MAX_REDIRECTS; ++hop) {
@@ -117,6 +130,7 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
 // large/slow files and surfaces a short read directly.
 HttpDownloader::DownloadError runGet(const std::string& url, const std::string& username, const std::string& password,
                                      Sink& sink) {
+  WifiPowerSaveGuard psGuard;
   esp_http_client_config_t config = {};
   config.url = url.c_str();
   config.buffer_size = HTTP_RX_BUF;


### PR DESCRIPTION
## What

Adds a small RAII guard around both HTTP download paths
(`runGet()`/mbedTLS and `runGetWolf()`/wolfSSL in `src/network/HttpDownloader.cpp`)
that disables WiFi power-save for the duration of the request and restores it
on exit, regardless of which return path is taken.

## Why

`OtaUpdater.cpp` already does exactly this for firmware downloads:

```cpp
/* For better timing and connectivity, we disable power saving for WiFi */
esp_wifi_set_ps(WIFI_PS_NONE);
...
/* Return back to default power saving for WiFi in case of failing */
esp_wifi_set_ps(WIFI_PS_MIN_MODEM);
```

`HttpDownloader.cpp`'s OPDS feed and book fetches never got the same
treatment, despite being able to run just as long for a large category.
Modem sleep periodically powers the radio down between DTIM beacon
intervals, which can drop or stall packets mid-transfer -- more likely to be
hit the longer a transfer takes, so small feeds mostly get away with it
while a large category consistently doesn't.

## Design

A tiny RAII struct rather than duplicating the manual set/restore calls at
every return point in both functions:

```cpp
struct WifiPowerSaveGuard {
  WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_NONE); }
  ~WifiPowerSaveGuard() { esp_wifi_set_ps(WIFI_PS_MIN_MODEM); }
};
```

Both `runGet()` and `runGetWolf()` have several early-return error paths;
RAII guarantees power-save is restored on all of them without touching each
one individually.

## Testing

- `pio run -e default` and `pio run -e x4pro`: both SUCCESS.
- `pio check -e default --skip-packages` (cppcheck): No defects found.
- `./bin/clang-format-fix -g`: clean.

## Scope note

No dedicated test added -- both functions are ESP-IDF/Arduino-coupled
(`esp_http_client`, `esp_wifi_set_ps`) with no existing host-test scaffold
for this file.