### PR TITLE
fix: drop the home cover snapshot when the orientation changes

### DIFF
--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -151,6 +151,7 @@ bool HomeActivity::storeCoverBuffer() {
     coverBufferSize = 0;
     return false;
   }
+  coverBufferOrientation = renderer.getOrientation();
   return true;
 }
 
@@ -285,6 +286,24 @@ void HomeActivity::render(RenderLock&&) {
   const auto pageWidth = renderer.getScreenWidth();
   const auto pageHeight = renderer.getScreenHeight();
 
+  const int tileY = metrics.homeTopPadding;
+  const int tileHeight = metrics.homeCoverTileHeight;
+
+  // The snapshot holds raw panel bytes for the region the tile mapped to, so it
+  // goes stale once that mapping moves. coverRect* still holds the rect it was
+  // captured at.
+  if (coverBufferStored && (coverBufferOrientation != renderer.getOrientation() || coverRectY != tileY ||
+                            coverRectW != pageWidth || coverRectH != tileHeight)) {
+    freeCoverBuffer();
+    coverRendered = false;
+  }
+
+  // Region storeCoverBuffer snapshots: the tile, not the whole framebuffer.
+  coverRectX = 0;
+  coverRectY = tileY;
+  coverRectW = pageWidth;
+  coverRectH = tileHeight;
+
   renderer.clearScreen();
   bool bufferRestored = coverBufferStored && restoreCoverBuffer();
 
@@ -294,16 +313,8 @@ void HomeActivity::render(RenderLock&&) {
   GUI.drawHeader(renderer, Rect{0, metrics.topPadding, pageWidth, metrics.homeTopPadding - metrics.topPadding},
                  metrics.homeContinueReadingInMenu && !recentBooks.empty() ? recentBooks[0].title.c_str() : nullptr);
 
-  // Record the tile rect so storeCoverBuffer (called from the theme) knows
-  // which sub-region of the framebuffer to snapshot. ~16 KB in Portrait
-  // instead of the 48 KB full framebuffer the previous bind captured.
-  coverRectX = 0;
-  coverRectY = metrics.homeTopPadding;
-  coverRectW = pageWidth;
-  coverRectH = metrics.homeCoverTileHeight;
-
-  GUI.drawRecentBookCover(renderer, Rect{0, metrics.homeTopPadding, pageWidth, metrics.homeCoverTileHeight},
-                          recentBooks, selectorIndex, coverRendered, coverBufferStored, bufferRestored,
+  GUI.drawRecentBookCover(renderer, Rect{coverRectX, coverRectY, coverRectW, coverRectH}, recentBooks, selectorIndex,
+                          coverRendered, coverBufferStored, bufferRestored,
                           std::bind(&HomeActivity::storeCoverBuffer, this));
 
   // Build menu items dynamically

--- a/src/activities/home/HomeActivity.h
+++ b/src/activities/home/HomeActivity.h
@@ -27,6 +27,8 @@ class HomeActivity final : public Activity {
   int coverRectY = 0;
   int coverRectW = 0;
   int coverRectH = 0;
+  // Orientation the snapshot was captured at; valid while coverBufferStored.
+  GfxRenderer::Orientation coverBufferOrientation = GfxRenderer::Orientation::Portrait;
   std::vector<RecentBook> recentBooks;
   const HomeMenuItem initialMenuItem;
   const bool cleanInitialRefresh;


### PR DESCRIPTION
Fixes #3258.

### The bug

The home screen draws the "continue reading" cover from SD once, then snapshots that framebuffer region and restores the raw bytes on every later render (`HomeActivity::storeCoverBuffer()` / `restoreCoverBuffer()`).

Nothing invalidated that snapshot when the orientation changed. `coverRendered` and `coverBufferStored` are cleared only in `freeCoverBuffer()`, which runs from `onExit()` and `loadRecentCovers()`. So after switching orientation from the quick-settings panel, a snapshot taken for one physical mapping was restored into a region that now maps somewhere else: the image sheared diagonally across the tile, part of it spilled past the tile edge, and the title text was drawn over the garbage. It stayed corrupted until something reloaded the recent-books list.

### The fix

`copyRegionToBuffer()` maps the logical rect through `logicalRectToPhysicalBounds(orientation, ...)` and copies raw panel bytes, so a snapshot is only valid for the orientation it was taken at. `HomeActivity` now records that orientation and, when it no longer matches, drops the snapshot and re-renders the cover from SD.

Comparing the screen dimensions instead would not be enough: Portrait/PortraitInverted are both 480x800 and the two landscape modes are both 800x480, so a flipped snapshot would pass a size check.

The check is guarded by `coverBufferStored` so it only runs when there is a snapshot to invalidate.

### Verification

Built for `default` (ESP32-C3) and exercised in the desktop simulator on the X4 Pro profile, from an identical starting state (same settings, same input script) on `develop` and on this branch.

With temporary logging in `storeCoverBuffer()` and in the new branch:

- moving the selection around the home screen without changing orientation — snapshot taken **once**, never dropped, so the cache still does its job and the cover is not re-read from SD per render;
- switching orientation — exactly **one** drop and one re-capture at the new orientation.

Active theme during the runs was Lyra; all four themes set `coverRendered = coverBufferStored` the same way, so the fix is not theme-specific.

Not yet verified on hardware.

### Before / after

Home screen right after switching Portrait -> Landscape CW:

| `develop` | this branch |
|---|---|
| <img width="420" alt="3258-before-develop" src="https://github.com/user-attachments/assets/2eb8cd88-8390-46f9-929a-6283243a5a16" /> | <img width="420" alt="3258-after-fix" src="https://github.com/user-attachments/assets/2ded8ccd-d9f0-46bd-ac1c-afdebc44edd5" /> |

(The menu being cut off in landscape is a separate issue, #3259.)

