### PR TITLE
fix: report the chapter actually on screen, not the spine's first TOC entry

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1737,7 +1737,13 @@ int EpubReaderActivity::currentTocIndex() const {
     if (entry.spineIndex != currentSpineIndex) break;
     if (entry.anchor.empty()) continue;
     const auto anchorPage = section->findAnchor(entry.anchor);
-    if (!anchorPage.has_value() || *anchorPage > section->currentPage) break;
+    // A miss here doesn't prove this chapter is past the current page -- e.g. a
+    // partial build's anchor map may simply not have reached this anchor yet.
+    // Only a *resolved* page past currentPage is a reliable "gone too far"
+    // signal; an unresolved anchor is skipped so later, resolvable entries are
+    // still considered.
+    if (!anchorPage.has_value()) continue;
+    if (*anchorPage > section->currentPage) break;
     resolved = i;
   }
   return resolved;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -728,7 +728,10 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
 
   switch (action) {
     case EpubReaderMenuActivity::MenuAction::SELECT_CHAPTER: {
-      const int spineIdx = currentSpineIndex;
+      // Resolve before the section is released below: currentTocIndex() reads
+      // section->currentPage to pick the right chapter within a spine item that
+      // bundles several (see currentTocIndex()).
+      const int initialTocIndex = currentTocIndex();
       // Release the section while the chapter list is up (mirrors the
       // TEXT_SETTINGS path): picking a chapter resets it anyway, and its
       // tens-of-KB footprint is the difference between the chapter list
@@ -746,7 +749,7 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
         section.reset();
       }
       startActivityForResult(
-          std::make_unique<EpubReaderChapterSelectionActivity>(renderer, mappedInput, epub, spineIdx),
+          std::make_unique<EpubReaderChapterSelectionActivity>(renderer, mappedInput, epub, initialTocIndex),
           [this](const ActivityResult& result) {
             if (result.isCancelled) {
               openReaderMenu();
@@ -912,7 +915,7 @@ bool EpubReaderActivity::launchKOReaderSync() {
 
   CrossPointPosition localPos = getCurrentPosition();
   SavedProgressPosition localKoPos = ProgressMapper::toSavedProgress(epub, localPos);
-  const int tocIdx = epub->getTocIndexForSpineIndex(currentSpineIndex);
+  const int tocIdx = currentTocIndex();
   std::string localChapterName = (tocIdx >= 0) ? epub->getTocItem(tocIdx).title : "";
   const std::string savedEpubPath = epub->getPath();
 
@@ -1687,7 +1690,7 @@ void EpubReaderActivity::renderStatusBar() const {
   } else if (sb.titleMode == CrossPointSettings::STATUS_BAR_TITLE::CHAPTER_TITLE) {
     title = tr(STR_UNNAMED);
     if (epub) {
-      const int tocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
+      const int tocIndex = currentTocIndex();
       if (tocIndex != -1) {
         const auto tocItem = epub->getTocItem(tocIndex);
         title = tocItem.title;
@@ -1720,9 +1723,29 @@ bool EpubReaderActivity::usesToolbarMenu() const {
   return SETTINGS.readerMenuStyle == CrossPointSettings::READER_MENU_TOOLBAR;
 }
 
+int EpubReaderActivity::currentTocIndex() const {
+  if (!epub) return -1;
+  const int startTocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
+  if (startTocIndex < 0 || !section) return startTocIndex;
+
+  // Mirrors the forward walk in Section::startBuild (which collects this spine's
+  // tocAnchors for page-break insertion), but resolves the other direction: which
+  // of those chapters has the reader actually reached.
+  int resolved = startTocIndex;
+  for (int i = startTocIndex + 1; i < epub->getTocItemsCount(); i++) {
+    const auto entry = epub->getTocItem(i);
+    if (entry.spineIndex != currentSpineIndex) break;
+    if (entry.anchor.empty()) continue;
+    const auto anchorPage = section->findAnchor(entry.anchor);
+    if (!anchorPage.has_value() || *anchorPage > section->currentPage) break;
+    resolved = i;
+  }
+  return resolved;
+}
+
 std::string EpubReaderActivity::currentChapterTitle() const {
   if (!epub) return "";
-  const int tocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
+  const int tocIndex = currentTocIndex();
   if (tocIndex != -1) {
     return epub->getTocItem(tocIndex).title;
   }
@@ -1821,7 +1844,7 @@ void EpubReaderActivity::openOverlay(Overlay target) {
       focusedTool = 0;
       break;
     case Overlay::Contents:
-      panelIndex = std::max(0, epub->getTocIndexForSpineIndex(currentSpineIndex));
+      panelIndex = std::max(0, currentTocIndex());
       // Fresh viewport opening on the current chapter, cursor shown or not.
       toolbarUi->nav().reset(panelIndex);
       toolbarUi->nav().top = panelIndex;

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -129,6 +129,12 @@ class EpubReaderActivity final : public ReaderActivity {
   void discardOverlayPage();
   void handleOverlayInput();
   void renderOverlay();
+  // TOC index for the chapter actually on screen. A single spine item can bundle
+  // several TOC entries (e.g. Calibre's HTML splitter packs many chapters into one
+  // file, distinguished only by #anchor) so this walks forward from the spine's
+  // first TOC entry and returns the last one whose anchor page is at or before the
+  // current page, instead of always reporting that first entry.
+  int currentTocIndex() const;
   std::string currentChapterTitle() const;
   // Text panel rows (font, size, line spacing, alignment, focus reading).
   std::string textRowName(int row) const;

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -15,10 +15,10 @@ namespace fui = freeink::ui;
 EpubReaderChapterSelectionActivity::EpubReaderChapterSelectionActivity(GfxRenderer& renderer,
                                                                        MappedInputManager& mappedInput,
                                                                        const std::shared_ptr<Epub>& epub,
-                                                                       const int currentSpineIndex)
+                                                                       const int initialTocIndex)
     : UiListActivity("EpubReaderChapterSelection", renderer, mappedInput),
       epub(epub),
-      currentSpineIndex(currentSpineIndex) {}
+      initialTocIndex(initialTocIndex) {}
 
 void EpubReaderChapterSelectionActivity::onEnter() {
   UiListActivity::onEnter();
@@ -40,10 +40,7 @@ void EpubReaderChapterSelectionActivity::onEnter() {
   // Start with the current chapter at the top of the viewport; the first
   // screen build pulls the viewport to it (ListNav follow-on-build) and
   // materializes the row window there (refreshTocWindow in buildScreen).
-  int tocIndex = epub->getTocIndexForSpineIndex(currentSpineIndex);
-  if (tocIndex == -1) {
-    tocIndex = 0;
-  }
+  const int tocIndex = initialTocIndex >= 0 ? initialTocIndex : 0;
   nav.selected = tocIndex;
 }
 

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.h
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.h
@@ -8,7 +8,10 @@
 
 class EpubReaderChapterSelectionActivity final : public UiListActivity {
   std::shared_ptr<Epub> epub;
-  int currentSpineIndex = 0;
+  // TOC index of the chapter actually on screen, resolved by the caller (a single
+  // spine item can bundle several chapters, distinguished only by #anchor, so this
+  // is not simply derived from the spine index here).
+  int initialTocIndex = 0;
 
   // Windowed row buffers: TOC entries are SD-backed (BookMetadataCache LUT
   // reads), so only the rows around the viewport are materialized. A
@@ -37,6 +40,6 @@ class EpubReaderChapterSelectionActivity final : public UiListActivity {
 
  public:
   explicit EpubReaderChapterSelectionActivity(GfxRenderer& renderer, MappedInputManager& mappedInput,
-                                              const std::shared_ptr<Epub>& epub, int currentSpineIndex);
+                                              const std::shared_ptr<Epub>& epub, int initialTocIndex);
   void onEnter() override;
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix the status bar, chapter overlay, TOC screen, and KOReader sync all showing a stale, earlier chapter title when the reader is deep inside a spine item that bundles multiple logical chapters.
* **What changes are included?**
  - A single spine (XHTML) file can contain several TOC entries distinguished only by `#anchor` — this is common output from tools like Calibre's HTML splitter, which packs many chapters into one physical file purely by output size, not by chapter boundary.
  - `getTocIndexForSpineIndex(spineIndex)` only ever returns the *first* TOC entry mapped to a spine file, so any page past the first chapter in that file reported the wrong (earlier) chapter everywhere "current chapter" is shown.
  - Added `EpubReaderActivity::currentTocIndex()`, which walks forward through the spine's TOC entries (mirroring the anchor collection `Section::startBuild` already does for page-break insertion) and resolves each anchor to a page number via the existing `Section::findAnchor()`, picking the last chapter whose anchor page is at or before the current page.
  - Replaced the four call sites that used to call `getTocIndexForSpineIndex(currentSpineIndex)` directly (status bar, chapter overlay highlight, KOReader sync, and the chapter-list screen's initial position) with this resolver.
  - `EpubReaderChapterSelectionActivity` now takes the already-resolved `initialTocIndex` from its caller instead of re-deriving it from `spineIndex` on its own (it has no access to the current page, so it can't do this resolution itself).

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

Reproduced with a Calibre-generated EPUB where 206 TOC entries (chapters) are packed into 16 physical XHTML files via `#toc_N` anchors. Jumping to a chapter deep inside one of these files loaded the correct page content, but the status bar and TOC screen both reported an earlier chapter (e.g. chapter 16 instead of chapter 25) until now.

Verified on-device: chapter navigation now matches the actual reading position for this book.

No flash/RAM impact — the change is purely logic reused from existing primitives (`Section::findAnchor`, the TOC-entry walk already done in `Section::startBuild`), no new allocations or data structures.

---

### AI Usage

Did you use AI tools to help write this code? **PARTIALLY** — root-caused and implemented with Claude Code (investigated the TOC/spine mapping and anchor-resolution primitives in the existing codebase, designed and wrote the fix); I reviewed the diagnosis, the diff, and verified the fix on-device myself.