### PR TITLE
fix: keep the home screen in portrait

### DIFF
--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -12,7 +12,6 @@
 
 #include "CrossPointSettings.h"
 #include "MappedInputManager.h"
-#include "activities/reader/ReaderUtils.h"
 #include "components/UITheme.h"
 #include "components/UIThemeTokens.h"
 #include "components/icons/customListIcons.h"
@@ -161,17 +160,9 @@ void FrontlightPanelActivity::runTile(const int idx) {
     case 2:  // Cycle the reading orientation
       SETTINGS.orientation = static_cast<uint8_t>((SETTINGS.orientation + 1) % 4);
       SETTINGS.saveToFile();
-      // Nothing else would turn the renderer: ActivityManager::Pop restores the
-      // activity underneath without calling onEnter(), so its
-      // applyInitialOrientation() never runs. Apply it here instead.
-      ReaderUtils::applyOrientation(renderer, SETTINGS.orientation);
-      // Close rather than redraw in place: the turned panel lays out against
-      // the new frame while the old panel's pixels sit in the old frame, so
-      // repeated taps stacked stale panels on screen. The screen underneath
-      // repaints in the new orientation and its refresh carries the cleanup a
-      // whole-frame rewrite needs.
-      renderer.promoteNextRefresh(HalDisplay::FULL_REFRESH);
-      close();
+      // Only the setting changes: turning the renderer cropped the portrait-only
+      // screens the panel opens over. The reader reflows on its next loop().
+      requestUpdate();
       break;
     case 3:  // Touch reader controls (for reading with the palm on the glass)
       // Toggles the existing Settings -> Controls option, nothing lower-level:


### PR DESCRIPTION
Fixes #3258, #3259.

### The bug

The orientation tile in the quick-settings panel cycles `SETTINGS.orientation`, which is the *reading* orientation — it lives under the Reader category in `SettingsList.h`, and `ReaderActivity::onExit()` restores portrait when a book is closed. Every other screen is laid out for portrait.

The panel, however, turns the renderer for whatever screen sits under it. Cycling the orientation from the home screen therefore leaves the home screen itself in landscape, and it does not fit there: the cover tile is a fixed theme metric that does not depend on the screen height (400 for Classic, 350 for RoundedRaff, 300 for Lyra Extended, 242 for Lyra). In portrait's 800 px everything fits; in landscape's 480 px the menu block starts too low and the lower entries — File Transfer, Settings, and OPDS Browser when servers are configured — are pushed past the bottom edge. The home screen has no scrolling, so there is no way to bring them back.

### The fix

Have the home screen claim portrait when it paints, the same way `ReaderActivity`, `XtcReaderActivity` and `SleepActivity` already claim theirs. The reading orientation keeps working where it belongs — it is still saved, and the next book still opens turned.

It has to happen in `render()` rather than `onEnter()`: `ActivityManager::Pop` repaints the screen under a dismissed panel without calling `onEnter()`, which is the exact path this bug takes.

An earlier attempt made the panel skip the turn unless a reader was underneath. That was dropped: it also took the turn away from screens that handle landscape fine — the file browser lays out correctly in landscape — and it made the tile look inert, since nothing on screen moved when it was tapped.

### Verification

Built for `default` (ESP32-C3) and exercised in the desktop simulator on the X4 Pro profile, theme Lyra Extended (three covers — the tightest case).

- Panel over the home screen, tap the orientation tile: the panel dismisses as before, the setting advances and is saved, and the home screen repaints in portrait, complete.
- Open a book with the setting on Landscape CW: the reader opens turned, unchanged.
- Panel over the file browser, tap the tile: the file browser still turns — no capability removed from screens that handle it.

Not yet verified on hardware.

### Before / after

Home screen after cycling the orientation to Landscape CW, theme Lyra Extended. The "before" shot is taken on top of #3260 so the separate cover-cache bug does not obscure the cropped menu.

| `develop` | this branch |
|---|---|
| <img width="420" alt="home screen cropped in landscape" src="https://raw.githubusercontent.com/winst0niuss/crossword/assets/pr-screenshots/3259-before-landscape.png" /> | <img width="420" alt="home screen stays in portrait" src="https://raw.githubusercontent.com/winst0niuss/crossword/assets/pr-screenshots/3259-after-portrait.png" /> |

