### PR TITLE
fix: dismiss the quick-settings sheet with a swipe up

### DIFF
--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -240,6 +240,12 @@ void FrontlightPanelActivity::loop() {
       if (touch.event.dragPermille >= 0) draggingSlider = true;
       return;
     }
+    // Swipe up dismisses the sheet, the way it was pulled down from the top
+    // edge. draggingSlider keeps a fast slider flick from closing it.
+    if (!draggingSlider && mappedInput.wasSwipe() == MappedInputManager::SwipeDir::Up) {
+      close();
+      return;
+    }
     // panelBottom > 0 guards the frame the sheet opens in: the release that
     // opened it (a status-bar tap) is still in the input snapshot when the panel
     // runs its first loop(), and panelBottom is only known once render() has


### PR DESCRIPTION
Fixes #3266.

### The bug

`FrontlightPanelActivity::loop()` dismisses the sheet on a release with `touchY >= panelBottom`, and `computePanelBottom()` counts the grabber band as part of the sheet. So the only way out is the screen *below* the sheet, and the gesture the grabber advertises, pulling the sheet back up the way it was pulled down, does nothing.

In portrait that is invisible: roughly 345 px of free screen sit under the sheet. In landscape the sheet keeps its height on a 480 px screen and the strip shrinks to about 25 px, well under a comfortable touch target. Dismissing it means aiming between the sheet's bottom rule and the screen edge, or pressing "Refresh Screen" to close it as a side effect. Boards with hardware buttons still have Back; touch-only boards do not.

### The fix

Close the sheet on an up-swipe, which is what every phone answers to and what the grabber advertises. Six added lines in `loop()`, no layout change: the sheet, the tiles and the grabber are drawn exactly as before, and the existing release-below-the-sheet path keeps working.

Two details make the gesture safe to accept anywhere on screen:

* a swipe release is reported off-target (`touchY = -1`), so nothing under the finger is activated on the way out;
* `draggingSlider` is already set on the held frames of a slider drag, so a fast flick on the brightness or warmth pill never reads as a dismissal.

The panel is opened by a top-edge *down*-swipe, so the opening gesture cannot close it in the frame it appears in. On boards without a Home key the bottom-edge up-swipe already closed the panel through `handleHomeGesture()`; the behaviour is now the same on every board.

### Verification

Built for `default` (ESP32-C3) and exercised in the desktop simulator on the X4 Pro profile, in landscape (the tight case):

- swipe up over the sheet, from the grabber and from the sheet body alike, and it dismisses;
- drag the brightness slider and release, the sheet stays open, `draggingSlider` doing its job;
- tap below the sheet, it still dismisses, unchanged from `develop`;
- the same swipe on `develop`, the sheet stays up, which is the bug.

Not yet verified on hardware.

### Screenshot

The sheet over the reader in landscape, the grabber is the short bar at the bottom, and the strip under the sheet is all that used to be tappable:

<img width="640" alt="quick-settings sheet in landscape" src="https://raw.githubusercontent.com/winst0niuss/crossword/assets/pr-screenshots/quick-settings-landscape.png" />
