### PR TITLE
chore: ask for the device in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,21 @@ body:
       value: |
         Thanks for taking the time to report this bug! Please fill out the details below.
 
+  - type: dropdown
+    id: device
+    attributes:
+      label: Device
+      description: Which device does this happen on? Pick "Other" for boards CrossPoint does not release firmware for — those are maintained in their own port repositories.
+      options:
+        - Xteink X3
+        - Xteink X4
+        - Xteink X4 Pro
+        - Seeed Sticky
+        - M5Stack Paper Mono
+        - Other / not listed
+    validations:
+      required: true
+
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,6 +16,7 @@ body:
       options:
         - Xteink X3
         - Xteink X4
+        - Xteink X4 Classic
         - Xteink X4 Pro
         - Seeed Sticky
         - M5Stack Paper Mono


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make bug reports routable to whoever owns the affected hardware.
* **What changes are included?** One required `Device` dropdown as the first field of `bug_report.yml`.

Of the 185 open issues filed with the bug template, 87 never name a device model anywhere in the body — the form does not ask, so reporters mention it only when they think of it.

The options match the binaries the release workflow publishes (`firmware.bin` for X3/X4, `firmware-sticky.bin`, `firmware-x4pro.bin`, `firmware-papermono.bin`). X3 and X4 are listed separately even though they share one binary, since the distinction matters for triage. "Other / not listed" carries a note that boards CrossPoint does not release firmware for are maintained in their own port repositories.

No change to `feature_request.yml`: only ~6 of the open feature requests are device-specific, so a device field there would be noise.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. *(N/A — repository metadata only)*

## Additional Context

Repository metadata only: no firmware code, no memory or flash impact. Validated with `yaml.safe_load`.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_