### PR TITLE
chore: expire needs-info reports after three weeks of silence

### DIFF
--- a/.github/workflows/reopen-on-reply.yml
+++ b/.github/workflows/reopen-on-reply.yml
@@ -1,8 +1,10 @@
 name: "Reopen On Reply"
 
-# Makes good on the promise in the automatic closing message. `no-response` is
-# the guard rather than `needs-info`: it is applied only by the stale workflow,
-# so a comment can never reopen an issue that was closed deliberately.
+# Makes good on the promise in the automatic closing message. `no-response-closed`
+# is the guard rather than `needs-info` or `no-response`: the stale workflow stamps
+# it only when *it* closes the issue, so a comment can never reopen an issue that a
+# maintainer closed deliberately. `!issue.pull_request` keeps this to issues —
+# `issue_comment` also fires on pull request comments.
 
 on:
   issue_comment:
@@ -15,8 +17,9 @@ jobs:
   reopen:
     if: >
       github.event.issue.state == 'closed' &&
+      !github.event.issue.pull_request &&
       github.event.comment.user.type != 'Bot' &&
-      contains(github.event.issue.labels.*.name, 'no-response')
+      contains(github.event.issue.labels.*.name, 'no-response-closed')
     runs-on: ubuntu-latest
     steps:
       - name: Reopen and clear the waiting labels
@@ -26,4 +29,5 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh issue reopen "$ISSUE" --repo "$REPO"
-          gh issue edit "$ISSUE" --repo "$REPO" --remove-label no-response --remove-label needs-info
+          gh issue edit "$ISSUE" --repo "$REPO" \
+            --remove-label no-response-closed --remove-label no-response --remove-label needs-info

--- a/.github/workflows/reopen-on-reply.yml
+++ b/.github/workflows/reopen-on-reply.yml
@@ -1,0 +1,29 @@
+name: "Reopen On Reply"
+
+# Makes good on the promise in the automatic closing message. `no-response` is
+# the guard rather than `needs-info`: it is applied only by the stale workflow,
+# so a comment can never reopen an issue that was closed deliberately.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  reopen:
+    if: >
+      github.event.issue.state == 'closed' &&
+      github.event.comment.user.type != 'Bot' &&
+      contains(github.event.issue.labels.*.name, 'no-response')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reopen and clear the waiting labels
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue reopen "$ISSUE" --repo "$REPO"
+          gh issue edit "$ISSUE" --repo "$REPO" --remove-label no-response --remove-label needs-info

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -19,6 +19,19 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
+      # actions/stale cannot apply a label that does not exist, so provision the
+      # three lifecycle labels first. --force makes this idempotent.
+      - name: Ensure the lifecycle labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create needs-info --repo "$REPO" --force \
+            --color d4c5f9 --description "Incomplete report: missing the details needed to act"
+          gh label create no-response --repo "$REPO" --force \
+            --color fbca04 --description "Waiting on the reporter for more information"
+          gh label create no-response-closed --repo "$REPO" --force \
+            --color ededed --description "Closed automatically after no reply"
       - uses: actions/stale@v11
         with:
           only-labels: needs-info

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -1,0 +1,37 @@
+name: "Close Unanswered Reports"
+
+# Only issues someone with triage rights has explicitly marked `needs-info`
+# enter this flow.
+# After 14 quiet days they gain `no-response`, and 7 days later they close.
+# `no-response` is also what marks a close as automatic, so the reopen-on-reply
+# workflow can tell it apart from a deliberate one.
+
+on:
+  schedule:
+    - cron: "30 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          only-labels: needs-info
+          days-before-stale: 14
+          days-before-close: 7
+          stale-issue-label: no-response
+          exempt-issue-labels: accepted,good-first-issue
+          stale-issue-message: >
+            This report is still missing the details needed to act on it. It will
+            close in 7 days without a reply — commenting removes this label and
+            keeps it open.
+          close-issue-message: >
+            Closing because the missing details never arrived. This is not a
+            rejection: comment with them and the issue reopens automatically.
+          # PRs are handled by review, not by this schedule.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -3,8 +3,9 @@ name: "Close Unanswered Reports"
 # Only issues someone with triage rights has explicitly marked `needs-info`
 # enter this flow.
 # After 14 quiet days they gain `no-response`, and 7 days later they close.
-# `no-response` is also what marks a close as automatic, so the reopen-on-reply
-# workflow can tell it apart from a deliberate one.
+# The close also stamps `no-response-closed` — applied only by this action at
+# close time, so the reopen-on-reply workflow can tell an automatic close apart
+# from a deliberate one (a maintainer closing by hand never carries it).
 
 on:
   schedule:
@@ -24,6 +25,7 @@ jobs:
           days-before-stale: 14
           days-before-close: 7
           stale-issue-label: no-response
+          close-issue-label: no-response-closed
           exempt-issue-labels: accepted,good-first-issue
           stale-issue-message: >
             This report is still missing the details needed to act on it. It will


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Give incomplete bug reports an ending, without losing the ones whose reporter comes back.
* **What changes are included?** Two workflows: a scheduled `actions/stale` run over `needs-info` issues, and an `issue_comment` job that reopens the ones it closed.

95 open issues have not been touched in 60 days, and 15 of the 39 crash reports carry no panic address or backtrace. Nothing currently ages a report out, so asking for details and getting no answer leaves the issue open indefinitely.

The lifecycle:

1. Someone with triage rights applies `needs-info` — the only way into the flow, nothing enters automatically.
2. After 14 quiet days the issue gains `no-response` and a comment saying it closes in 7.
3. If the reporter replies first, `remove-stale-when-updated` drops the label and the clock resets.
4. Otherwise it closes, carrying both labels.
5. A later comment from a human reopens it and clears both.

`no-response` is the reopen guard rather than `needs-info`, so a comment can never reopen an issue that was closed deliberately — only the automatic closes are automatically reversible.

Two notes:

* **This needs two new labels before it does anything**: `needs-info` and `no-response`. I avoided reusing the existing `stale` label because its description is about PRs being out of date with master.
* PRs are excluded (`days-before-pr-stale: -1`).

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. *(N/A — repository metadata only)*

## Additional Context

Repository metadata only: no firmware code, no memory or flash impact. Both files validated with `yaml.safe_load`. `actions/stale` pinned to v11.

The policy question is worth deciding before merging, not after: 14+7 days is short enough that a reporter on holiday loses their issue. It is reversible by a comment, but the first few closes will tell you whether the window is right.

---

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_