### PR TITLE
feat: Add support for Xteink X4 Classic board

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -201,7 +201,8 @@ void HalGPIO::setSharedConfirmPowerShortPressEmitsPower(const bool enabled) {
 bool HalGPIO::hasEdgeSideButtons() const {
   return BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX3 ||
          BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX3Uc8279 ||
-         BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX4Pro;
+         BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX4Pro ||
+         BoardConfig::ACTIVE.board == BoardConfig::Board::XteinkX4Classic;
 }
 
 bool HalGPIO::isXteinkDevice() const {

--- a/platformio.ini
+++ b/platformio.ini
@@ -267,6 +267,49 @@ build_flags =
   ; change that stops a lit frontlight from blocking sleep.
   -DFREEINK_FRONTLIGHT_LS
 
+; --- Xteink X4 Classic (X4C) ---------------------------------------------------
+; Same ESP32-S3 board and display stack as the X4 Pro (SSD1677/UC8179/UC8279 auto-
+; detected at boot) but buttons-only: no touchscreen and no frontlight, so the
+; freed pins become four extra front buttons (two side page-turn keys + four bottom
+; keys). Native 1-bit SDMMC + USB-MSC file transfer as on the X4 Pro; drops the
+; frontlight flag. See freeink-sdk/docs/xteink-x4c-support.md.
+;   pio run -e x4c -t upload
+[env:x4c]
+extends = base
+board = esp32-s3-devkitc1-n16r8
+board_build.mcu = esp32s3
+board_build.arduino.memory_type = dio_opi
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_X4CLASSIC=1
+  -DFREEINK_CAP_USB_MSC=1
+  -DBOARD_HAS_PSRAM
+  -DUSB_PRODUCT=\"CrossPoint_X4_Classic\"
+  -DUSB_MANUFACTURER=\"CrossPoint\"
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x4c\"
+  -DENABLE_SERIAL_LOG
+  -DCROSSPOINT_WAIT_FOR_USB_SERIAL
+  -DLOG_LEVEL=2
+  ; X4C SD is native SDMMC (1-bit), mounted through SdFat's block-device API.
+  -DUSE_BLOCK_DEVICE_INTERFACE=1
+
+[env:x4c-gh_release]
+extends = base
+board = esp32-s3-devkitc1-n16r8
+board_build.mcu = esp32s3
+board_build.arduino.memory_type = dio_opi
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_X4CLASSIC=1
+  -DFREEINK_CAP_USB_MSC=1
+  -DBOARD_HAS_PSRAM
+  -DUSB_PRODUCT=\"CrossPoint_X4_Classic\"
+  -DUSB_MANUFACTURER=\"CrossPoint\"
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1 ; Set log level to info for release builds
+  -DUSE_BLOCK_DEVICE_INTERFACE=1
+
 [env:x4pro-gh_release]
 extends = base
 board = esp32-s3-devkitc1-n16r8

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -50,9 +50,7 @@ namespace {
 // (that helper also gates power management). Overlay refresh choices are per-panel:
 // this family runs the grayscale anti-aliasing pass, so chrome painted over a
 // fresh page needs the HALF ghost-cleanup and closing re-renders the page.
-bool xteinkClassPanel() {
-  return gpio.isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isX4Classic();
-}
+bool xteinkClassPanel() { return gpio.isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isX4Classic(); }
 
 constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
 constexpr size_t initialBookmarkCacheCapacity = 16;

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -46,11 +46,13 @@
 #include "util/ScreenshotUtil.h"
 
 namespace {
-// The X4 Pro carries the X4's panel but sits outside isXteinkDevice() (that
-// helper also gates power management). Overlay refresh choices are per-panel:
+// The X4 Pro and X4 Classic carry the X4's panel but sit outside isXteinkDevice()
+// (that helper also gates power management). Overlay refresh choices are per-panel:
 // this family runs the grayscale anti-aliasing pass, so chrome painted over a
 // fresh page needs the HALF ghost-cleanup and closing re-renders the page.
-bool xteinkClassPanel() { return gpio.isXteinkDevice() || BoardConfig::isX4Pro(); }
+bool xteinkClassPanel() {
+  return gpio.isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isX4Classic();
+}
 
 constexpr int PAGE_TURN_RATES[] = {1, 1, 3, 6, 12};
 constexpr size_t initialBookmarkCacheCapacity = 16;

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -57,8 +57,9 @@ void SettingsActivity::rebuildSettingsLists() {
     if (setting.category == StrId::STR_NONE_OPT) continue;
     if (setting.category == StrId::STR_CAT_DISPLAY) {
       // The sunlight fading fix is a grayscale-waveform compensation that does
-      // not apply on the X4 Pro (plain OTP waveform, no custom grayscale LUT).
-      if (setting.valuePtr == &CrossPointSettings::fadingFix && BoardConfig::isX4Pro()) {
+      // not apply on the X4 Pro / X4 Classic (plain OTP waveform, same panels).
+      if (setting.valuePtr == &CrossPointSettings::fadingFix &&
+          (BoardConfig::isX4Pro() || BoardConfig::isX4Classic())) {
         continue;
       }
       displaySettings.push_back(setting);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,8 +377,11 @@ void setup() {
     powerManager.startDeepSleep(gpio);
   }
 
-  const auto recoveryButton =
-      BoardConfig::isX4Pro() ? MappedInputManager::Button::Down : MappedInputManager::Button::Up;
+  // X4 Pro and X4 Classic both map BTN_UP to GPIO0 — an ESP32-S3 boot strap — so
+  // gate recovery on the non-strap Down key (GPIO7) to avoid a stuck-in-recovery loop.
+  const auto recoveryButton = (BoardConfig::isX4Pro() || BoardConfig::isX4Classic())
+                                  ? MappedInputManager::Button::Down
+                                  : MappedInputManager::Button::Up;
   const bool recoveryFirmwareMode = wakeupReason == HalGPIO::WakeupReason::PowerButton && !BoardConfig::isPaperMono() &&
                                     mappedInputManager.isPressed(recoveryButton);
 
@@ -407,7 +410,8 @@ void setup() {
   const bool isPersistedSleepWake = isSleepWake && !APP_STATE.showBootScreen;
 
   if (recoveryFirmwareMode) {
-    LOG_INF("MAIN", "Recovery firmware mode (%s + POWER held at boot)", BoardConfig::isX4Pro() ? "DOWN" : "UP");
+    LOG_INF("MAIN", "Recovery firmware mode (%s + POWER held at boot)",
+            (BoardConfig::isX4Pro() || BoardConfig::isX4Classic()) ? "DOWN" : "UP");
   }
 
   // Touch boards default the reader menu to the toolbar overlay instead of the
@@ -438,7 +442,7 @@ void setup() {
     case HalGPIO::WakeupReason::AfterUSBPower:
       // Most devices return to sleep after a USB-powered cold boot.
       LOG_DBG("MAIN", "Wakeup reason: After USB Power");
-#if FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_EEGO_A4
+#if FREEINK_DEVICE_X4PRO || FREEINK_DEVICE_X4CLASSIC || FREEINK_DEVICE_PAPERMONO || FREEINK_DEVICE_EEGO_A4
       // X4 Pro must stay awake so USB Serial/JTAG remains available after leaving
       // USB Drive and reconnecting the cable. Paper Mono has no armable GPIO wake
       // (its button is behind the PMIC). EEGO A4's post-flash reset reads as

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -379,9 +379,8 @@ void setup() {
 
   // X4 Pro and X4 Classic both map BTN_UP to GPIO0 — an ESP32-S3 boot strap — so
   // gate recovery on the non-strap Down key (GPIO7) to avoid a stuck-in-recovery loop.
-  const auto recoveryButton = (BoardConfig::isX4Pro() || BoardConfig::isX4Classic())
-                                  ? MappedInputManager::Button::Down
-                                  : MappedInputManager::Button::Up;
+  const auto recoveryButton = (BoardConfig::isX4Pro() || BoardConfig::isX4Classic()) ? MappedInputManager::Button::Down
+                                                                                     : MappedInputManager::Button::Up;
   const bool recoveryFirmwareMode = wakeupReason == HalGPIO::WakeupReason::PowerButton && !BoardConfig::isPaperMono() &&
                                     mappedInputManager.isPressed(recoveryButton);
 

--- a/src/network/FirmwareBoardTag.cpp
+++ b/src/network/FirmwareBoardTag.cpp
@@ -10,6 +10,8 @@
 // the release asset suffixes (firmware-<name>.bin; plain firmware.bin for x4).
 #if FREEINK_DEVICE_X4PRO
 #define CROSSPOINT_BOARD_NAME "x4pro"
+#elif FREEINK_DEVICE_X4CLASSIC
+#define CROSSPOINT_BOARD_NAME "x4c"
 #elif FREEINK_DEVICE_X4 || FREEINK_DEVICE_X3
 #define CROSSPOINT_BOARD_NAME "x4"
 #elif FREEINK_DEVICE_PAPERMONO


### PR DESCRIPTION
Adds X4 Classic variant which shares the X4 Pro's ESP32-S3 hardware and display panel but uses buttons-only input (no touchscreen/frontlight). Updates GPIO configuration, panel detection, settings filtering, and recovery mode logic to handle the new board type alongside X4 Pro.
