### PR TITLE
fix(ui): match list row label and value font sizes

### DIFF
--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -190,6 +190,10 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  // Label at the value's font size: both sides of the row read as one unit.
+  // maxLines=2 also marks the style caller-owned (see textStyleUnset).
+  props.labelText = screen.theme().smallText;
+  props.labelText.maxLines = 2;
   syncListViewport(screen, props);
   screen.list(props);
 }

--- a/src/activities/settings/ButtonRemapActivity.cpp
+++ b/src/activities/settings/ButtonRemapActivity.cpp
@@ -173,6 +173,10 @@ void ButtonRemapActivity::buildScreen(UiScreen& screen) {
   if (!mappedInput.hasTouch()) {
     props.rowHeight = static_cast<int16_t>(metrics.listRowHeight);
   }
+  // Label at the value's font size: both sides of the row read as one unit.
+  // maxLines=2 also marks the style caller-owned (see textStyleUnset).
+  props.labelText = screen.theme().smallText;
+  props.labelText.maxLines = 2;
   screen.list(props);
 }
 

--- a/src/activities/settings/KOReaderSettingsActivity.cpp
+++ b/src/activities/settings/KOReaderSettingsActivity.cpp
@@ -162,6 +162,10 @@ void KOReaderSettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  // Label at the value's font size: both sides of the row read as one unit.
+  // maxLines=2 also marks the style caller-owned (see textStyleUnset).
+  props.labelText = screen.theme().smallText;
+  props.labelText.maxLines = 2;
   syncListViewport(screen, props);
   screen.list(props);
 }

--- a/src/activities/settings/LanguageSelectActivity.cpp
+++ b/src/activities/settings/LanguageSelectActivity.cpp
@@ -78,6 +78,10 @@ void LanguageSelectActivity::buildScreen(UiScreen& screen) {
   props.count = static_cast<uint16_t>(totalItems);
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
+  // Label at the value's font size: both sides of the row read as one unit.
+  // maxLines=2 also marks the style caller-owned (see textStyleUnset).
+  props.labelText = screen.theme().smallText;
+  props.labelText.maxLines = 2;
   syncListViewport(screen, props);
   screen.list(props);
 }

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -193,6 +193,10 @@ void OpdsSettingsActivity::buildScreen(UiScreen& screen) {
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in loop()
   props.valueInset = 8;               // air between the value and the row edge
+  // Label at the value's font size: both sides of the row read as one unit.
+  // maxLines=2 also marks the style caller-owned (see textStyleUnset).
+  props.labelText = screen.theme().smallText;
+  props.labelText.maxLines = 2;
   syncListViewport(screen, props);
   screen.list(props);
 }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** In two-column list rows the label was drawn one font size larger than its value ("Night Mode" at 12pt next to "Off" at 10pt). Reported in the 1.6.0rc discussion: https://github.com/crosspoint-reader/crosspoint-reader/discussions/3099#discussioncomment-18197856
* **What changes are included?** `props.labelText = theme().smallText` (plus `maxLines = 2`) on the list screens that were still on the FreeInkUI default.

`Screen::list()` substitutes `bodyText` for an unset `labelText` and `smallText` for an unset `valueText` (`FreeInkApp.h:247-253`), so any screen that did not set `labelText` got two sizes on the same row. #2957 already fixed this in Settings, Status Bar, Text Settings and the File Browser with the same two lines; these screens were missed:

- Reader menu (`EpubReaderMenuActivity`)
- KOReader settings
- OPDS server settings
- Button remap
- Language select

Before FUI, `BaseTheme::drawList` drew label and value with `UI_10_FONT_ID`, so this restores the 1.5.0 look.

Card-style rows are deliberately left alone: the font download list, the OPDS entry browser and the Wi-Fi list keep the larger label because their trailing text is a badge or a glyph, not the row's value (the Wi-Fi screen already states this in a comment).

`maxLines = 2` is required, not cosmetic: an all-default `smallText` fails `textStyleUnset()` (`FreeInkUICore.h:550`) and the list would substitute `bodyText` back.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

No memory or flash impact: same number of draw calls, one `TextStyle` copy per build. Rows keep their height (it comes from the theme metrics, not from the label font); a label that no longer fits on one line now wraps instead of truncating.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
