### PR TITLE
fix: Hide reader menu style setting on button boards & change refresh methods for night mode and frontlight panel

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -262,10 +262,6 @@ build_flags =
   -DLOG_LEVEL=2
   ; X4 Pro SD is native SDMMC (1-bit), mounted through SdFat's block-device API.
   -DUSE_BLOCK_DEVICE_INTERFACE=1
-  ; Frontlight PWM clocked from RC_FAST with KEEP_ALIVE so it survives light
-  ; sleep (freeink-sdk FREEINK_FRONTLIGHT_LS); pairs with the HalPowerManager
-  ; change that stops a lit frontlight from blocking sleep.
-  -DFREEINK_FRONTLIGHT_LS
 
 ; --- Xteink X4 Classic (X4C) ---------------------------------------------------
 ; Same ESP32-S3 board and display stack as the X4 Pro (SSD1677/UC8179/UC8279 auto-
@@ -326,7 +322,6 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
-  -DFREEINK_FRONTLIGHT_LS
 
 [env:x4pro-gh_release_rc]
 extends = base
@@ -344,7 +339,6 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
-  -DFREEINK_FRONTLIGHT_LS
 
 ; --- M5Stack Paper Mono — ESP32-S3, SSD1683 800x480 + FT6336 touch + frontlight
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK

--- a/src/SettingsList.h
+++ b/src/SettingsList.h
@@ -462,8 +462,14 @@ inline std::vector<SettingInfo> getSettingsList(const SdCardFontRegistry* regist
 
   std::vector<SettingInfo> v = baseList;
   if (!BoardConfig::hasTouch()) {
+    // The toolbar reader menu is touch-first chrome: button boards keep the
+    // classic list menu, so the style choice is hidden along with the touch
+    // controls.
     v.erase(std::remove_if(v.begin(), v.end(),
-                           [](const SettingInfo& s) { return s.nameId == StrId::STR_TOUCH_READER_CONTROLS; }),
+                           [](const SettingInfo& s) {
+                             return s.nameId == StrId::STR_TOUCH_READER_CONTROLS ||
+                                    s.nameId == StrId::STR_READER_MENU_STYLE;
+                           }),
             v.end());
   }
   // The reader-menu gesture choice only makes sense where the menu stays

--- a/src/activities/UiTabListActivity.cpp
+++ b/src/activities/UiTabListActivity.cpp
@@ -177,7 +177,11 @@ void UiTabListActivity::buildTabBar(UiScreen& screen) {
   tabStyles.focused = tabStyles.selected;
   tabStyles.active = tabStyles.selected;
   tabProps.tabStyles = tabStyles;
-  const fui::Rect tabRect = screen.takeTop(tabBand);
+  const fui::Rect contentTabRect = screen.takeTop(tabBand);
+  const fui::Rect frameRect = screen.frame().screen();
+  // Tab chrome is a full-width screen band like the legacy GUI tab bar. The
+  // remaining list content still stays inside the device safe area.
+  const fui::Rect tabRect{frameRect.x, contentTabRect.y, frameRect.width, contentTabRect.height};
   // Focused band wash is the Lyra treatment; legacy RoundedRaff keeps the
   // band plain in both states.
   if (tabsFocused && !metrics.tabPillFullSlot) {

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -422,8 +422,8 @@ std::string getFileExtension(const std::string& filename) {
 void FileBrowserActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // Full path band at the bottom: separator on top, left-truncated so the

--- a/src/activities/home/RecentBooksActivity.cpp
+++ b/src/activities/home/RecentBooksActivity.cpp
@@ -150,8 +150,8 @@ void RecentBooksActivity::promptRemoveBook(const std::string& path, const std::s
 void RecentBooksActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (recentBooks.empty()) {

--- a/src/activities/network/NetworkModeSelectionActivity.cpp
+++ b/src/activities/network/NetworkModeSelectionActivity.cpp
@@ -65,8 +65,8 @@ void NetworkModeSelectionActivity::activateIndex(const int index) {
 void NetworkModeSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // rowItems_ was built once in the constructor and is reused here on every

--- a/src/activities/network/UsbDriveActivity.cpp
+++ b/src/activities/network/UsbDriveActivity.cpp
@@ -134,7 +134,7 @@ void UsbDriveActivity::buildDriveScreen(UiScreen& screen) const {
   }
 
   const auto& metrics = UITheme::getInstance().getMetrics();
-  screen.setContentMargin(fui::Insets{
+  screen.setContentMarginFromScreen(fui::Insets{
       static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), static_cast<int16_t>(metrics.contentSidePadding),
       static_cast<int16_t>(metrics.buttonHintsHeight), static_cast<int16_t>(metrics.contentSidePadding)});
 

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -896,7 +896,7 @@ void WifiSelectionActivity::buildListScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content below the header + MAC sub-band, above the legend line.
-  screen.setContentMargin(fui::Insets{
+  screen.setContentMarginFromScreen(fui::Insets{
       static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight +
                            metrics.verticalSpacing),
       static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),

--- a/src/activities/reader/EndOfBookOptions.cpp
+++ b/src/activities/reader/EndOfBookOptions.cpp
@@ -162,7 +162,7 @@ void EndOfBookOptions::buildListScreen(UiScreen& screen) {
   const int titleY = safe.y + safe.height / 8;
   const int subtitleY = titleY + renderer.getLineHeight(UI_12_FONT_ID) + metrics.verticalSpacing;
   const int listTop = subtitleY + renderer.getLineHeight(UI_10_FONT_ID) + metrics.verticalSpacing * 2;
-  screen.setContentMargin(fui::Insets{
+  screen.setContentMarginFromScreen(fui::Insets{
       static_cast<int16_t>(listTop), static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
       static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.verticalSpacing),
       static_cast<int16_t>(safe.x)});

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1346,6 +1346,11 @@ void EpubReaderActivity::renderBook() {
     currentPageVisibleOffset = p->visibleTextOffset;
     currentPageFootnotes = std::move(p->footnotes);
 
+    // The overlay and non-tiled grayscale renderer share the renderer's single
+    // stored-BW slot. Release the old page snapshot before renderContents()
+    // needs that slot, then snapshot the newly rendered page below.
+    discardOverlayPage();
+
     const auto start = millis();
     renderContents(std::move(p), orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft);
     LOG_DBG("ERS", "Rendered page in %dms", millis() - start);
@@ -1380,7 +1385,6 @@ void EpubReaderActivity::renderBook() {
   if (overlay != Overlay::None && usesToolbarMenu()) {
     // The page just re-rendered under the overlay: refresh the snapshot that
     // backs panel->toolbar restores (any previous copy is stale).
-    discardOverlayPage();
     overlayPageStored = renderer.storeBwBuffer();
     renderOverlay();
     // An open option picker rides on top of the freshly drawn panel.

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1385,10 +1385,12 @@ void EpubReaderActivity::renderBook() {
     renderOverlay();
     // An open option picker rides on top of the freshly drawn panel.
     if (overlayPopup.isActive()) overlayPopup.render(renderer);
-    // HALF on the Xteink grayscale panels: the page render above just ran the
-    // anti-aliasing waveform, and a FAST differential leaves the covered text
-    // ghosting gray through the chrome background (see openOverlay).
-    renderer.displayBuffer(xteinkClassPanel() ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
+    // FAST, same as openOverlay: HALF's inverting pass flashes the sheet
+    // (white, in night mode) on every repaint under an open panel. Any AA
+    // residue a FAST differential leaves under the chrome has not shown in
+    // practice; restore a HALF cleanup here if text ever visibly ghosts
+    // through the sheet (see #2190 for the mechanism).
+    renderer.displayBuffer(HalDisplay::FAST_REFRESH);
   }
 }
 

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -1717,7 +1717,9 @@ static_assert(std::size(kAlignIds) == CrossPointSettings::PARAGRAPH_ALIGNMENT_CO
 }  // namespace
 
 bool EpubReaderActivity::usesToolbarMenu() const {
-  return SETTINGS.readerMenuStyle == CrossPointSettings::READER_MENU_TOOLBAR;
+  // Touch-first chrome: button boards always get the classic list menu, even
+  // if a settings file (e.g. an SD card moved from a touch board) says Toolbar.
+  return mappedInput.hasTouch() && SETTINGS.readerMenuStyle == CrossPointSettings::READER_MENU_TOOLBAR;
 }
 
 std::string EpubReaderActivity::currentChapterTitle() const {

--- a/src/activities/reader/EpubReaderBookmarksActivity.cpp
+++ b/src/activities/reader/EpubReaderBookmarksActivity.cpp
@@ -197,10 +197,10 @@ void EpubReaderBookmarksActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the title band render() paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (bookmarks.empty()) {

--- a/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/EpubReaderChapterSelectionActivity.cpp
@@ -129,10 +129,10 @@ void EpubReaderChapterSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band drawChrome paints the title in.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (!epub) {

--- a/src/activities/reader/EpubReaderFootnotesActivity.cpp
+++ b/src/activities/reader/EpubReaderFootnotesActivity.cpp
@@ -58,10 +58,10 @@ void EpubReaderFootnotesActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (footnotes.empty()) {

--- a/src/activities/reader/EpubReaderMenuActivity.cpp
+++ b/src/activities/reader/EpubReaderMenuActivity.cpp
@@ -152,10 +152,10 @@ void EpubReaderMenuActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
 
   // Progress summary where the old sub-header band sat.
   std::string progressLine;

--- a/src/activities/reader/KOReaderSyncActivity.cpp
+++ b/src/activities/reader/KOReaderSyncActivity.cpp
@@ -441,8 +441,8 @@ void KOReaderSyncActivity::buildResultScreen(UiScreen& screen) {
   // Side padding is 0 here (like the other FreeInkApp screens): the action list
   // supplies its own theme side padding, and the raw comparison text is indented
   // to line up with the list rows below (see labelIndent).
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (state == SHOWING_RESULT) {

--- a/src/activities/reader/ReaderToolbarUi.cpp
+++ b/src/activities/reader/ReaderToolbarUi.cpp
@@ -36,6 +36,8 @@ constexpr int kToolCount = 3;
 // Bottom sheet height for the panels. ListNav fits whole rows in the remaining
 // list area; any spare pixels stay between the list and the switcher.
 constexpr int kPanelHeightPercent = 62;
+// Cap the sheet may grow to when rounding the list area up to a whole row.
+constexpr int kPanelHeightMaxPercent = 72;
 }  // namespace
 
 ReaderToolbarUi::ReaderToolbarUi(GfxRenderer& renderer) : UiAppHost(renderer) {}
@@ -97,12 +99,16 @@ void ReaderToolbarUi::screenFn(UiScreen& screen, void* user) {
 // the active one inside an outline pill (the theme's control radius). Each
 // slot is registered as one tap target, so the row stays light (no filled
 // tiles, no labels -- the glyphs carry the meaning).
-void ReaderToolbarUi::buildToolRow(UiScreen& screen, const fui::LayoutAnchor anchor) {
+void ReaderToolbarUi::buildToolRow(UiScreen& screen, const fui::LayoutAnchor anchor, const int16_t sideInset) {
   const auto& tokens = screen.theme();
   const fui::BitmapRef icons[kToolCount] = {fui::bitmapFromIcon(icon_reader_contents_24),
                                             fui::bitmapFromIcon(icon_reader_text_24),
                                             fui::bitmapFromIcon(icon_reader_more_24)};
-  const fui::Rect row = screen.take(anchor, kToolRowH);
+  // sideInset absorbs the difference between the two hosts' content bands
+  // (the toolbar's is spaceLg-inset, the panel's is full width): the slots
+  // must land on the same x either way, or the icons jump when a tap swaps
+  // the toolbar for a panel.
+  const fui::Rect row = screen.take(anchor, kToolRowH).inset(fui::Insets{0, sideInset, 0, sideInset});
   const int16_t slotW = static_cast<int16_t>(row.width / kToolCount);
   // Theme radius as-is (the frontlight panel pattern); the fill clamps to
   // the shape's own height so round themes cannot overshoot.
@@ -200,7 +206,7 @@ void ReaderToolbarUi::buildToolbar(UiScreen& screen) {
     if (model_.pageInfo) screen.target().text(line, model_.pageInfo, infoStyle);
   }
 
-  buildToolRow(screen, fui::LayoutAnchor::Top);
+  buildToolRow(screen, fui::LayoutAnchor::Top, 0);  // content band already spaceLg-inset
 }
 
 void ReaderToolbarUi::buildPanel(UiScreen& screen) {
@@ -214,15 +220,37 @@ void ReaderToolbarUi::buildPanel(UiScreen& screen) {
   sheetProps.grabberMargin = tokens.spaceLg;
   sheetProps.grabberInset = static_cast<int16_t>(tokens.spaceLg + tokens.spaceMd);
 
+  // Size the sheet to an exact number of list rows instead of a fixed screen
+  // share: a percentage leaves up to a row's height of dead space above the
+  // switcher, and a short list (Text, More) leaves empty row slots. Chrome =
+  // everything in the sheet that is not the list; the row count starts from
+  // the target share, grows one row when that still fits the cap, and shrinks
+  // to the item count when the list is shorter than the space.
   const int16_t titleH = screen.target().lineHeight(tokens.titleText.font);
-  screen.sheet(sheetProps, static_cast<int16_t>((safe.height * kPanelHeightPercent) / 100));
-  screen.insetContent(fui::Insets{0, tokens.spaceLg, 0, tokens.spaceLg});
+  const int16_t rowH =
+      model_.denseRows ? static_cast<int16_t>(UITheme::getInstance().getMetrics().listRowHeight) : tokens.rowHeight;
+  const int16_t rowStride = static_cast<int16_t>(rowH + tokens.listRowGap);
+  const int16_t grabberBand =
+      static_cast<int16_t>(sheetProps.grabberMargin + sheetProps.grabberHeight + sheetProps.grabberInset);
+  const int16_t chrome = static_cast<int16_t>(grabberBand + titleH + tokens.spaceMd + tokens.spaceSm +
+                                              std::max(0, model_.bottomReserve) + kToolRowH + tokens.spaceSm);
+  const int16_t target = static_cast<int16_t>((safe.height * kPanelHeightPercent) / 100);
+  const int16_t cap = static_cast<int16_t>((safe.height * kPanelHeightMaxPercent) / 100);
+  int sheetRows = (target - chrome + tokens.listRowGap) / rowStride;
+  if (static_cast<int16_t>(chrome + (sheetRows + 1) * rowStride - tokens.listRowGap) <= cap) ++sheetRows;
+  if (model_.itemCount > 0 && sheetRows > model_.itemCount) sheetRows = model_.itemCount;
+  if (sheetRows < 1) sheetRows = 1;
+  screen.sheet(sheetProps, static_cast<int16_t>(chrome + sheetRows * rowStride - tokens.listRowGap));
+  // No blanket side inset: Screen::list() draws in the content band, and the
+  // scroll track must reach the sheet's edge like a full-screen list's does.
+  // The title insets itself; the rows inset via rowInset below.
 
   // Title line: panel name left, page position right when the list spans pages.
   {
     fui::TextStyle titleStyle = tokens.titleText;
     titleStyle.bold = true;
-    const fui::Rect line = screen.takeTop(titleH, tokens.spaceMd);
+    const fui::Rect line =
+        screen.takeTop(titleH, tokens.spaceMd).inset(fui::Insets{0, tokens.spaceLg, 0, tokens.spaceLg});
     screen.target().text(line, model_.panelTitle, titleStyle);
     // Filled in below once the viewport is known; reserve the rect now.
     pageIndicatorRect_ = line;
@@ -231,14 +259,22 @@ void ReaderToolbarUi::buildPanel(UiScreen& screen) {
   // Switcher row along the sheet's bottom edge (above the button-hint row on
   // button boards); the list takes what is left.
   screen.spacer(static_cast<int16_t>(tokens.spaceSm + std::max(0, model_.bottomReserve)), fui::LayoutAnchor::Bottom);
-  buildToolRow(screen, fui::LayoutAnchor::Bottom);
+  buildToolRow(screen, fui::LayoutAnchor::Bottom, tokens.spaceLg);  // full-width band
   screen.spacer(tokens.spaceSm, fui::LayoutAnchor::Bottom);
 
   listProps_.count = static_cast<uint16_t>(std::max(0, model_.itemCount));
   listProps_.action = ACTION_ROW;
   listProps_.inputMask = fui::InputTouch;  // physical buttons stay with the reader
-  listProps_.rowHeight =
-      model_.denseRows ? static_cast<int16_t>(UITheme::getInstance().getMetrics().listRowHeight) : tokens.rowHeight;
+  listProps_.rowHeight = rowH;
+  // The label column starts flush with the panel title (no list-side padding
+  // on top of the sheet's own inset). Body-size text: small reads condensed
+  // and the taller row doubles as the tap target.
+  listProps_.labelText = tokens.bodyText;
+  listProps_.sidePadding = 0;
+  // The list band spans the sheet's full width -- the scroll track hugs the
+  // panel edge (theme bezel inset included) exactly like a full-screen list.
+  // rowInset pulls the rows back to the title's spaceLg alignment.
+  listProps_.rowInset = tokens.spaceLg;
   const fui::Rect listRect = screen.body();
   const int count = std::max(0, model_.itemCount);
   // The nav owns selection + viewport (same fui::ListNav idiom as the list

--- a/src/activities/reader/ReaderToolbarUi.h
+++ b/src/activities/reader/ReaderToolbarUi.h
@@ -82,7 +82,7 @@ class ReaderToolbarUi : public UiAppHost {
   static void onAction(const freeink::ui::ActionEvent& event, void* user);
   void buildToolbar(UiScreen& screen);
   void buildPanel(UiScreen& screen);
-  void buildToolRow(UiScreen& screen, freeink::ui::LayoutAnchor anchor);
+  void buildToolRow(UiScreen& screen, freeink::ui::LayoutAnchor anchor, int16_t sideInset);
 
   Model model_;
   Routed pending_;

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
@@ -96,10 +96,10 @@ void XtcReaderChapterSelectionActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band drawChrome paints the title in.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (!xtc) {

--- a/src/activities/settings/ButtonRemapActivity.cpp
+++ b/src/activities/settings/ButtonRemapActivity.cpp
@@ -153,7 +153,7 @@ void ButtonRemapActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   const int topOffset = metrics.topPadding + metrics.headerHeight + metrics.tabBarHeight + metrics.verticalSpacing;
-  screen.setContentMargin(
+  screen.setContentMarginFromScreen(
       fui::Insets{static_cast<int16_t>(safe.y + topOffset),
                   static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width) + metrics.verticalSpacing),
                   static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.verticalSpacing),

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -629,8 +629,8 @@ void FontDownloadActivity::activateSelected() {
 void FontDownloadActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   if (state_ == FAMILY_LIST && filteredIndices_.empty()) {

--- a/src/activities/settings/KOReaderSettingsActivity.cpp
+++ b/src/activities/settings/KOReaderSettingsActivity.cpp
@@ -117,8 +117,8 @@ void KOReaderSettingsActivity::activateIndex(const int index) {
 void KOReaderSettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // rowItems_'s labels/actionValue were set once in the constructor; only the

--- a/src/activities/settings/LanguageSelectActivity.cpp
+++ b/src/activities/settings/LanguageSelectActivity.cpp
@@ -66,10 +66,10 @@ void LanguageSelectActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the header band GUI.drawHeader paints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
-                                      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
-                                      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)),
-                                      static_cast<int16_t>(safe.x)});
+  screen.setContentMarginFromScreen(fui::Insets{
+      static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
+      static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
+      static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // rowItems was built once in onEnter() and is reused here on every repaint.

--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -193,7 +193,7 @@ void OpdsServerListActivity::buildScreen(UiScreen& screen) {
   // Content below the GUI.drawHeader band, above the button hints; derived
   // from the safe area so board bezel insets apply (same as LanguageSelect).
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
-  screen.setContentMargin(
+  screen.setContentMarginFromScreen(
       fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
                   static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
                   static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.buttonHintsHeight),

--- a/src/activities/settings/OpdsSettingsActivity.cpp
+++ b/src/activities/settings/OpdsSettingsActivity.cpp
@@ -167,7 +167,7 @@ void OpdsSettingsActivity::buildScreen(UiScreen& screen) {
   // Content below the GUI.drawHeader band, above the button hints; derived
   // from the safe area so board bezel insets apply (same as LanguageSelect).
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
-  screen.setContentMargin(
+  screen.setContentMarginFromScreen(
       fui::Insets{static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight),
                   static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
                   static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height) + metrics.buttonHintsHeight),

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -464,8 +464,8 @@ std::string SettingsActivity::settingValueText(const SettingInfo& setting) {
 void SettingsActivity::buildScreen(UiScreen& screen) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   // Content below the GUI.drawHeader band, above the button hints.
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight), 0});
 
   buildTabBar(screen);
 

--- a/src/activities/settings/StatusBarSettingsActivity.cpp
+++ b/src/activities/settings/StatusBarSettingsActivity.cpp
@@ -243,8 +243,8 @@ void StatusBarSettingsActivity::buildScreen(UiScreen& screen) {
   const int statusBarHeight = UITheme::getInstance().getStatusBarHeight();
   const auto previewFooter =
       static_cast<int16_t>(statusBarHeight + verticalPreviewTextPadding + metrics.verticalSpacing);
-  screen.setContentMargin(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
-                                      static_cast<int16_t>(metrics.buttonHintsHeight + previewFooter), 0});
+  screen.setContentMarginFromScreen(fui::Insets{static_cast<int16_t>(metrics.topPadding + metrics.headerHeight), 0,
+                                                static_cast<int16_t>(metrics.buttonHintsHeight + previewFooter), 0});
   screen.spacer(static_cast<int16_t>(metrics.verticalSpacing));
 
   // rowItems_'s labels/actionValue were set once in onEnter(); only the live

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -196,7 +196,7 @@ void TextSettingsActivity::buildScreen(UiScreen& screen) {
   // directly) and above the caption band + button hints.
   const int tabTop = afterHeader + previewHeight;
   const int captionHeight = renderer.getTextHeight(UI_10_FONT_ID) + metrics_.verticalSpacing;
-  screen.setContentMargin(
+  screen.setContentMarginFromScreen(
       fui::Insets{static_cast<int16_t>(tabTop), 0, static_cast<int16_t>(bottomReserved + captionHeight), 0});
 
   buildTabBar(screen);

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -428,9 +428,10 @@ void FrontlightPanelActivity::render(RenderLock&&) {
   renderUi();
 
   // A tile that rewrote the whole frame (night mode) re-drives every pixel
-  // once; ordinary repaints stay on the fast path. FULL, not HALF: HALF is the
-  // balanced-speed waveform and leaves some ghost behind, which is exactly what
-  // the tile that sets this flag is asked to remove.
-  renderer.displayBuffer(cleanRefreshPending ? HalDisplay::FULL_REFRESH : HalDisplay::FAST_REFRESH);
+  // once; ordinary repaints stay on the fast path. HALF: strong enough to
+  // flip the whole frame's polarity without the FULL waveform's blackout
+  // flash. Any faint residue clears with the panel's dedicated refresh tile
+  // or the next scheduled clean refresh.
+  renderer.displayBuffer(cleanRefreshPending ? HalDisplay::HALF_REFRESH : HalDisplay::FAST_REFRESH);
   cleanRefreshPending = false;
 }

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -4,7 +4,6 @@
 #include <GfxRenderer.h>
 #include <HalFrontlight.h>
 #include <HalGPIO.h>
-#include <HalPowerManager.h>
 #include <I18n.h>
 
 #include <algorithm>
@@ -343,35 +342,18 @@ void FrontlightPanelActivity::buildPanelScreen(UiScreen& screen) {
   screen.sheet(sheetProps, static_cast<int16_t>(panelBottom));
   screen.insetContent(fui::Insets{0, kPanelSideMargin, 0, kPanelSideMargin});
 
-  // Slim status band: just the battery in the top-right corner, so the
-  // indicator stays visible while the panel is open. No title, no full
-  // header band -- the glyph/percent height plus theme air is enough.
+  // Reuse the exact battery renderer and header rectangle used by Home. Call
+  // the base implementation directly because RoundedRaff suppresses its
+  // untitled Home header.
   {
     const auto& metrics = UITheme::getInstance().getMetrics();
     screen.spacer(theme.spaceMd);
     const int16_t bandH = std::max<int16_t>(static_cast<int16_t>(metrics.batteryHeight),
                                             screen.target().lineHeight(theme.smallText.font));
-    const fui::Rect band = screen.takeTop(bandH, theme.spaceMd);
-    const uint16_t percent = powerManager.getBatteryPercentage();
-    const bool showPercent = SETTINGS.hideBatteryPercentage != CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_ALWAYS;
-    char percentText[8];
-    snprintf(percentText, sizeof(percentText), "%u%%", static_cast<unsigned>(percent));
-    constexpr int16_t kBatteryNubWidth = 2;  // glyph terminal nub past glyphWidth
-    constexpr int16_t kBatteryGap = 4;       // BaseTheme::batteryPercentSpacing
-    const int16_t labelW =
-        showPercent ? screen.target().measureText(theme.smallText.font, percentText, theme.smallText).width : 0;
-    const int16_t reserve =
-        static_cast<int16_t>(metrics.batteryWidth + kBatteryNubWidth + (showPercent ? labelW + kBatteryGap : 0));
-    fui::BatteryIndicatorProps battery;
-    battery.percent = static_cast<uint8_t>(percent > 100 ? 100 : percent);
-    battery.charging = gpio.isUsbConnected();
-    battery.label = showPercent ? percentText : nullptr;
-    battery.text = theme.smallText;
-    battery.glyphWidth = static_cast<int16_t>(metrics.batteryWidth);
-    battery.glyphHeight = static_cast<int16_t>(metrics.batteryHeight);
-    battery.gap = kBatteryGap;
-    fui::batteryIndicator(screen.frame(),
-                          fui::Rect{static_cast<int16_t>(band.right() - reserve), band.y, reserve, bandH}, battery);
+    screen.takeTop(bandH, theme.spaceMd);
+    UITheme::getInstance().getTheme().BaseTheme::drawHeader(
+        renderer, Rect{0, metrics.topPadding, renderer.getScreenWidth(), metrics.homeTopPadding - metrics.topPadding},
+        nullptr);
   }
 
   if (Frontlight.present()) {

--- a/src/activities/util/FrontlightPanelActivity.cpp
+++ b/src/activities/util/FrontlightPanelActivity.cpp
@@ -4,6 +4,7 @@
 #include <GfxRenderer.h>
 #include <HalFrontlight.h>
 #include <HalGPIO.h>
+#include <HalPowerManager.h>
 #include <I18n.h>
 
 #include <algorithm>
@@ -263,8 +264,11 @@ void FrontlightPanelActivity::loop() {
 
 int FrontlightPanelActivity::computePanelBottom() const {
   const auto tokens = uiThemeTokens(uiTarget);
+  const auto& metrics = UITheme::getInstance().getMetrics();
   const int16_t lineHeight = uiTarget.lineHeight(tokens.smallText.font);
-  int y = tokens.spaceLg + tokens.spaceMd;  // top padding
+  // Slim battery band + the air around it (mirrors buildPanelScreen).
+  const int y0 = std::max<int>(metrics.batteryHeight, lineHeight);
+  int y = tokens.spaceMd + y0 + tokens.spaceMd;
   if (Frontlight.present()) {
     // Screen::sliderRow reserves caption + spaceMd + control band, then a
     // spaceMd gap; addSliderRow() adds one more spaceMd of air after each row.
@@ -339,10 +343,36 @@ void FrontlightPanelActivity::buildPanelScreen(UiScreen& screen) {
   screen.sheet(sheetProps, static_cast<int16_t>(panelBottom));
   screen.insetContent(fui::Insets{0, kPanelSideMargin, 0, kPanelSideMargin});
 
-  // The sheet hangs from the very top of the screen, so its content needs a
-  // real top inset of its own — nothing above it reserves space the way a
-  // header band did.
-  screen.spacer(static_cast<int16_t>(theme.spaceLg + theme.spaceMd));
+  // Slim status band: just the battery in the top-right corner, so the
+  // indicator stays visible while the panel is open. No title, no full
+  // header band -- the glyph/percent height plus theme air is enough.
+  {
+    const auto& metrics = UITheme::getInstance().getMetrics();
+    screen.spacer(theme.spaceMd);
+    const int16_t bandH = std::max<int16_t>(static_cast<int16_t>(metrics.batteryHeight),
+                                            screen.target().lineHeight(theme.smallText.font));
+    const fui::Rect band = screen.takeTop(bandH, theme.spaceMd);
+    const uint16_t percent = powerManager.getBatteryPercentage();
+    const bool showPercent = SETTINGS.hideBatteryPercentage != CrossPointSettings::HIDE_BATTERY_PERCENTAGE::HIDE_ALWAYS;
+    char percentText[8];
+    snprintf(percentText, sizeof(percentText), "%u%%", static_cast<unsigned>(percent));
+    constexpr int16_t kBatteryNubWidth = 2;  // glyph terminal nub past glyphWidth
+    constexpr int16_t kBatteryGap = 4;       // BaseTheme::batteryPercentSpacing
+    const int16_t labelW =
+        showPercent ? screen.target().measureText(theme.smallText.font, percentText, theme.smallText).width : 0;
+    const int16_t reserve =
+        static_cast<int16_t>(metrics.batteryWidth + kBatteryNubWidth + (showPercent ? labelW + kBatteryGap : 0));
+    fui::BatteryIndicatorProps battery;
+    battery.percent = static_cast<uint8_t>(percent > 100 ? 100 : percent);
+    battery.charging = gpio.isUsbConnected();
+    battery.label = showPercent ? percentText : nullptr;
+    battery.text = theme.smallText;
+    battery.glyphWidth = static_cast<int16_t>(metrics.batteryWidth);
+    battery.glyphHeight = static_cast<int16_t>(metrics.batteryHeight);
+    battery.gap = kBatteryGap;
+    fui::batteryIndicator(screen.frame(),
+                          fui::Rect{static_cast<int16_t>(band.right() - reserve), band.y, reserve, bandH}, battery);
+  }
 
   if (Frontlight.present()) {
     addSliderRow(screen, tr(STR_BRIGHTNESS), brightness, ACTION_BRIGHTNESS, ACTION_BRIGHTNESS_STEP,
@@ -394,7 +424,7 @@ void FrontlightPanelActivity::render(RenderLock&&) {
   panelBottom = computePanelBottom();
 
   // fui::sheet draws the card body, its bottom rule, and the grabber during
-  // renderUi(); nothing is hand-drawn around it any more.
+  // renderUi(); the battery band at the card's top is part of the screen build.
   renderUi();
 
   // A tile that rewrote the whole frame (night mode) re-drives every pixel

--- a/src/components/UIThemeTokens.h
+++ b/src/components/UIThemeTokens.h
@@ -21,13 +21,12 @@ inline freeink::ui::ThemeTokens uiThemeTokens(const freeink::ui::GfxRendererTarg
   tokens.listSelectionStyle = static_cast<fui::SelectionStyle>(metrics.listSelectionStyle);
   tokens.listScrollWidth = static_cast<int16_t>(metrics.listScrollWidth);
   tokens.listScrollSide = static_cast<uint8_t>(metrics.listScrollSide);
-  // The scroll track hugs the band edge; on boards whose panel sits recessed
-  // behind the bezel the edge columns are covered, so push the indicator
-  // inward past the covered side. Bezel truth is per-board data
-  // (BoardConfig::ViewableInsets); lists render in the portrait UI frame, so
-  // the panel-native portrait insets apply directly.
-  const auto& vi = BoardConfig::ACTIVE.viewableInsets;
-  tokens.listScrollInset = static_cast<int16_t>(metrics.listScrollSide == 1 ? vi.left : vi.right);
+  // No extra scroll-track inset: the bezel is already compensated once at the
+  // frame level (GfxRendererTarget::deviceContext() feeds the board's
+  // viewable insets into the fui safe area, and every list band derives from
+  // safeRect()). Adding the same inset here doubled the compensation and
+  // floated the track a full bezel-width inside the visible edge.
+  tokens.listScrollInset = 0;
   // Screen::header()/status() band height. Without this the SDK's
   // line-height-derived default applies and fui-drawn headers (OPDS) come out
   // a different height than every GUI.drawHeader band.

--- a/src/components/UiSliderDialog.h
+++ b/src/components/UiSliderDialog.h
@@ -32,7 +32,7 @@ inline void buildSliderDialogScreen(UiAppHost::UiScreen& screen, const GfxRender
   const Rect safe = UITheme::getInstance().getScreenSafeArea(renderer, true, false);
   // Content: the safe area minus the title band render() paints, dropped down
   // to where the legacy fixed layout placed the readout.
-  screen.setContentMargin(fui::Insets{
+  screen.setContentMarginFromScreen(fui::Insets{
       static_cast<int16_t>(safe.y + metrics.topPadding + metrics.headerHeight + metrics.verticalSpacing * 4),
       static_cast<int16_t>(renderer.getScreenWidth() - (safe.x + safe.width)),
       static_cast<int16_t>(renderer.getScreenHeight() - (safe.y + safe.height)), static_cast<int16_t>(safe.x)});

--- a/src/components/themes/roundedraff/RoundedRaffTheme.h
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.h
@@ -7,12 +7,10 @@ class GfxRenderer;
 namespace RoundedRaffMetrics {
 constexpr ThemeMetrics values = {.batteryWidth = 15,
                                  .batteryHeight = 12,
-                                 // Legacy value was 0 (the old header drew its content 5px into the
-                                 // band, so it never showed). 15 drops the band clear of the X4 Pro
-                                 // bezel and centers the battery strip on the same line as Lyra's
-                                 // (5 + 40/2 == 15 + 20/2), so the header doesn't hug the top edge.
-                                 .topPadding = 15,
-                                 .batteryBarHeight = 20,
+                                 // Fit the 23px SMALL_FONT_ID line box and lift it one pixel while
+                                 // keeping the 12px battery glyph at y=19, aligned with Lyra.
+                                 .topPadding = 13,
+                                 .batteryBarHeight = 24,
                                  .headerHeight = 45,
                                  .verticalSpacing = 10,
                                  .previewPadding = 12,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -724,7 +724,11 @@ void loop() {
 
   // Refresh the battery icon when USB is plugged or unplugged.
   // Placed after sleep guards so we never queue a render that won't be processed.
-  if (gpio.wasUsbStateChanged()) {
+  // Not while reading: there a repaint is a full page re-render (visible
+  // flash, the AA pass re-running, and a frontlight dip under the refresh
+  // load); the reader's status bar picks the charging state up on the next
+  // page turn instead.
+  if (gpio.wasUsbStateChanged() && !activityManager.isReaderActivity()) {
     activityManager.requestUpdate();
   }
 


### PR DESCRIPTION
Instead of a bunch of code to fix the new touch menu on button boards, for now, I'm just disabling it, defaulting all button only boards to the existing menu. I also fixed #3282 #3281 

Closes #3236 

May also reduce #3275

Also fixes some issues with FUI margins effecting this new menu and tab bars