### PR TITLE
fix: drop section caches when the CSS rule set behind them is gone

### DIFF
--- a/lib/Epub/Epub.cpp
+++ b/lib/Epub/Epub.cpp
@@ -455,11 +455,9 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
           LOG_ERR("EBP", "Failed to reload cache after CSS rebuild");
           return false;
         }
-        const bool cssCacheChanged =
-            cssParseResult == CssParser::ParseResult::Complete ||
-            (cssParseResult == CssParser::ParseResult::Partial && cacheStatus != CssParser::CacheStatus::Partial);
-        if (cssCacheChanged) {
-          // The CSS cache changed, so section caches must use the same rule set.
+        if (CssParser::sectionCacheIsStale(cacheStatus, cacheLoadResult, cssParseResult)) {
+          // Section caches hold styles already resolved against the previous rule set, and
+          // that rule set is either gone or replaced.
           Storage.removeDir((cachePath + "/sections").c_str());
         }
       }
@@ -562,9 +560,10 @@ bool Epub::load(const bool buildIfMissing, const bool skipLoadingCss) {
   if (!skipLoadingCss) {
     // Parse CSS before reloading book.bin to leave more heap for CSS rule-table growth.
     bookMetadataCache.reset();
-    if (parseCssFiles(cssParser->inspectCache()) != CssParser::ParseResult::Error) {
-      Storage.removeDir((cachePath + "/sections").c_str());
-    }
+    parseCssFiles(cssParser->inspectCache());
+    // book.bin was just rebuilt, so any surviving section files were laid out against a
+    // different spine and rule set whatever the parse returned.
+    Storage.removeDir((cachePath + "/sections").c_str());
   }
 
   // Reload the cache from disk so it's in the correct state

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -943,6 +943,28 @@ void CssParser::deleteCache() const {
   Storage.remove((cachePath + rulesCacheBackup).c_str());
 }
 
+bool CssParser::sectionCacheIsStale(const CacheStatus statusBefore, const CacheLoadResult loadResult,
+                                    const ParseResult parseResult) {
+  // The complete cache hydrated: sections were laid out against this exact file.
+  if (loadResult == CacheLoadResult::Complete) return false;
+
+  // Too little heap to hydrate. The file is untouched and no reparse ran, so whatever the
+  // sections were built from is still on disk for the next attempt.
+  if (loadResult == CacheLoadResult::LowMemory) return false;
+
+  // A complete parse always rewrites the cache.
+  if (parseResult == ParseResult::Complete) return true;
+
+  // A partial parse replaces the cache unless a partial one was already there, in which
+  // case parseCssFiles() keeps the existing file rather than writing a shorter one.
+  if (parseResult == ParseResult::Partial) return statusBefore != CacheStatus::Partial;
+
+  // The parse failed, so nothing was written. Sections are stale only when the rule set
+  // they were built from was deleted on the way in: an unreadable or wrong-version cache
+  // (Invalid), or a Complete header that failed to hydrate. Both call deleteCache().
+  return statusBefore == CacheStatus::Invalid || statusBefore == CacheStatus::Complete;
+}
+
 CssParser::CacheStatus CssParser::inspectCache() const {
   if (cachePath.empty() || (!hasCache() && !restoreCacheBackupIfNeeded())) {
     return CacheStatus::Missing;

--- a/lib/Epub/Epub/css/CssParser.h
+++ b/lib/Epub/Epub/css/CssParser.h
@@ -116,6 +116,19 @@ class CssParser {
   CacheStatus inspectCache() const;
 
   /**
+   * Whether section caches built against the previous CSS rule set must be dropped.
+   *
+   * Section files store styles already resolved against the rule set that was loaded when
+   * they were laid out, and their header carries no CSS identity to check later. They stay
+   * valid only while the cache file behind them is the one still on disk.
+   *
+   * @param statusBefore  inspectCache() result taken before any rebuild attempt
+   * @param loadResult    loadFromCache() result (Invalid when it was never called)
+   * @param parseResult   parseCssFiles() result (Error when it never ran)
+   */
+  static bool sectionCacheIsStale(CacheStatus statusBefore, CacheLoadResult loadResult, ParseResult parseResult);
+
+  /**
    * Delete CSS rules cache file exists
    */
   void deleteCache() const;

--- a/test/css_parser/CssParserTest.cpp
+++ b/test/css_parser/CssParserTest.cpp
@@ -289,4 +289,64 @@ TEST_F(CssParserTest, CacheHydrationRejectsNonFiniteStyleLengths) {
   }
 }
 
+// Section caches store styles already resolved against a CSS rule set, and their header
+// carries no CSS identity. sectionCacheIsStale() is the single place that decides whether
+// they survive an EPUB open, so every combination of the three inputs is pinned here.
+
+using CacheStatus = CssParser::CacheStatus;
+using CacheLoadResult = CssParser::CacheLoadResult;
+using ParseResult = CssParser::ParseResult;
+
+TEST(CssSectionCacheInvalidation, HydratedCompleteCacheKeepsSections) {
+  for (const CacheStatus status :
+       {CacheStatus::Missing, CacheStatus::Complete, CacheStatus::Partial, CacheStatus::Invalid}) {
+    SCOPED_TRACE(static_cast<int>(status));
+    EXPECT_FALSE(CssParser::sectionCacheIsStale(status, CacheLoadResult::Complete, ParseResult::Error));
+    EXPECT_FALSE(CssParser::sectionCacheIsStale(status, CacheLoadResult::Complete, ParseResult::Complete));
+  }
+}
+
+TEST(CssSectionCacheInvalidation, LowMemoryRetryKeepsSections) {
+  // The cache file is left untouched for a later retry, so the sections built from it
+  // are still consistent with what is on disk.
+  for (const CacheStatus status :
+       {CacheStatus::Missing, CacheStatus::Complete, CacheStatus::Partial, CacheStatus::Invalid}) {
+    SCOPED_TRACE(static_cast<int>(status));
+    EXPECT_FALSE(CssParser::sectionCacheIsStale(status, CacheLoadResult::LowMemory, ParseResult::Error));
+  }
+}
+
+TEST(CssSectionCacheInvalidation, CompleteReparseDropsSections) {
+  for (const CacheStatus status :
+       {CacheStatus::Missing, CacheStatus::Complete, CacheStatus::Partial, CacheStatus::Invalid}) {
+    SCOPED_TRACE(static_cast<int>(status));
+    EXPECT_TRUE(CssParser::sectionCacheIsStale(status, CacheLoadResult::Invalid, ParseResult::Complete));
+  }
+}
+
+TEST(CssSectionCacheInvalidation, PartialReparseDropsSectionsUnlessCacheWasAlreadyPartial) {
+  EXPECT_TRUE(CssParser::sectionCacheIsStale(CacheStatus::Missing, CacheLoadResult::Invalid, ParseResult::Partial));
+  EXPECT_TRUE(CssParser::sectionCacheIsStale(CacheStatus::Invalid, CacheLoadResult::Invalid, ParseResult::Partial));
+  EXPECT_TRUE(CssParser::sectionCacheIsStale(CacheStatus::Complete, CacheLoadResult::Invalid, ParseResult::Partial));
+  // parseCssFiles() preserves an existing partial cache rather than writing a shorter one.
+  EXPECT_FALSE(CssParser::sectionCacheIsStale(CacheStatus::Partial, CacheLoadResult::Invalid, ParseResult::Partial));
+}
+
+TEST(CssSectionCacheInvalidation, FailedReparseDropsSectionsWhenTheOldRuleSetWasDeleted) {
+  // Version bump path: inspectCache() reports Invalid, deleteCache() removes the old file,
+  // then the reparse fails (an SD hiccup, or free heap under MIN_HEAP_FOR_CSS_PARSING).
+  // Sections laid out against the deleted rule set must not survive.
+  EXPECT_TRUE(CssParser::sectionCacheIsStale(CacheStatus::Invalid, CacheLoadResult::Invalid, ParseResult::Error));
+  // A Complete header that failed to hydrate is deleted the same way.
+  EXPECT_TRUE(CssParser::sectionCacheIsStale(CacheStatus::Complete, CacheLoadResult::Invalid, ParseResult::Error));
+}
+
+TEST(CssSectionCacheInvalidation, FailedReparseKeepsSectionsWhenNothingWasDeleted) {
+  // Nothing was on disk and nothing was written: no rule set changed hands, so rebuilding
+  // sections on every open of a book with no parseable CSS would be pure churn.
+  EXPECT_FALSE(CssParser::sectionCacheIsStale(CacheStatus::Missing, CacheLoadResult::Invalid, ParseResult::Error));
+  // A partial cache is preserved for a later retry.
+  EXPECT_FALSE(CssParser::sectionCacheIsStale(CacheStatus::Partial, CacheLoadResult::Invalid, ParseResult::Error));
+}
+
 }  // namespace


### PR DESCRIPTION
### Problem

Section files store styles already resolved against the CSS rule set that was loaded when they were laid out, and their header (`Section.cpp:122-158`) carries `spec.embeddedStyle` but no CSS rule-set identity — so nothing detects a mismatch later. #3005 made the `sections/` wipe conditional on the CSS cache having been rewritten, which opens a window the previous unconditional wipe did not have.

First boot after a `CSS_CACHE_VERSION` bump (9→10 shipped in #3005 itself, because `interpretAlignment()` now maps `text-align: start/end` to `Start`/`End` rather than `Left`/`Right`):

1. `inspectCache()` reads version 9 → `CacheStatus::Invalid`
2. `deleteCache()` (`Epub.cpp:440`) destroys the v9 cache
3. `parseCssFiles()` returns `Error` — from an SD hiccup, or far more plausibly from free heap under `MIN_HEAP_FOR_CSS_PARSING`, which skips every stylesheet and yields a `Partial` with zero rules that `Epub.cpp` converts to `Error`
4. `cssCacheChanged` is false, so `sections/` **survives**

Already-cached chapters keep rendering with v9 alignment while newly built chapters get no CSS at all. It self-heals only on a later successful open. This affects every device on upgrade.

### Fix

Move the decision into `CssParser::sectionCacheIsStale()`, a pure predicate over the three states that drive it, and drop `sections/` whenever the rule set they were built from was **deleted** on the way in, as well as whenever it was **replaced**.

What #3005 was protecting still holds: the low-memory retry and the already-partial-cache retry both leave the cache file untouched, so their section caches survive. A `Missing` cache with a failed parse also keeps its sections — nothing changed hands, so wiping would be churn on every open of a book with no parseable CSS.

The build-from-scratch path returns to an unconditional wipe: `book.bin` has just been rebuilt there, so any surviving section file was laid out against a different spine whatever the CSS parse returned.

### Notes

No format version bump. The header gains no field — the bug is in the invalidation decision, not in what the file stores, and adding CSS identity to every section header would cost disk bytes plus a one-shot global cache wipe to fix something the predicate fixes for free.

### Testing

Six new cases covering every combination of `CacheStatus` × `CacheLoadResult` × `ParseResult`, including both regression paths (`Invalid`+`Error`, `Complete`-header-fails-to-hydrate+`Error`) and both no-churn paths. Full host suite green; four board builds green.
