### PR TITLE
fix(reader): give the overlay and the end-of-book menu input precedence

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -403,6 +403,35 @@ void EpubReaderActivity::loop() {
 
   const auto touch = ReaderUtils::detectTouchPageTurn(renderer, mappedInput);
 
+  if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
+    showBookmarkMessage = false;
+    requestUpdate();
+  }
+
+  if (showDictionaryMessage && (millis() - dictionaryMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
+    showDictionaryMessage = false;
+    requestUpdate();
+  }
+
+  // The toolbar reader menu owns all input while shown, ahead of the automatic page turn
+  // below: the More panel's rate popup switches automatic turning on and leaves the panel
+  // open, so the timer must neither flip the page under it nor eat the panel's next
+  // Confirm/Back release.
+  if (overlay != Overlay::None) {
+    if (usesToolbarMenu()) {
+      // Hold the interval at zero elapsed so closing the panel starts a fresh one.
+      lastPageTurnTime = millis();
+      handleOverlayInput();
+      return;
+    }
+    // The style was switched off while an overlay was up (Settings reached via
+    // the More panel); fall back to the clean page.
+    overlay = Overlay::None;
+    discardOverlayPage();
+    requestUpdate();
+    return;
+  }
+
   if (automaticPageTurnActive) {
     if (mappedInput.wasReleased(MappedInputManager::Button::Confirm) ||
         mappedInput.wasReleased(MappedInputManager::Button::Back) ||
@@ -429,33 +458,21 @@ void EpubReaderActivity::loop() {
     }
   }
 
-  if (showBookmarkMessage && (millis() - bookmarkMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
-    showBookmarkMessage = false;
-    requestUpdate();
-  }
-
-  if (showDictionaryMessage && (millis() - dictionaryMessageTime) >= ReaderUtils::BOOKMARK_MESSAGE_DURATION_MS) {
-    showDictionaryMessage = false;
-    requestUpdate();
-  }
-
-  // The toolbar reader menu owns all input while shown.
-  if (overlay != Overlay::None) {
-    if (usesToolbarMenu()) {
-      handleOverlayInput();
-      return;
-    }
-    // The style was switched off while an overlay was up (Settings reached via
-    // the More panel); fall back to the clean page.
-    overlay = Overlay::None;
-    discardOverlayPage();
-    requestUpdate();
+  // While the end-of-book suggestion menu is up it owns Confirm/Back/navigation, so it
+  // gets this tick's input first and the long-press shortcuts below stay inert behind it
+  // -- a hold there must not drop a bookmark onto the suggestion screen or paint the
+  // dictionary word picker over it. Anything the menu does not handle (long-press Back to
+  // the file browser, say) still falls through to the regular handlers.
+  if (handleEndOfBookMenu()) {
     return;
   }
+  const bool endOfBookMenuOpen = endOfBookMenuActive();
 
   const unsigned long confirmHoldMs = confirmLongPressThreshold();
-  const bool confirmLongPressed =
-      confirmHoldMs != 0 && mappedInput.wasLongPressed(MappedInputManager::Button::Confirm, confirmHoldMs);
+  // wasLongPressed() suppresses the release that follows it, so leave it unpolled while
+  // the end-of-book menu owns Confirm -- otherwise the menu never sees that release.
+  const bool confirmLongPressed = !endOfBookMenuOpen && confirmHoldMs != 0 &&
+                                  mappedInput.wasLongPressed(MappedInputManager::Button::Confirm, confirmHoldMs);
   const bool confirmReleased = mappedInput.wasReleased(MappedInputManager::Button::Confirm);
   if (confirmLongPressed) {
     switch (SETTINGS.longPressMenuFunction) {
@@ -483,7 +500,7 @@ void EpubReaderActivity::loop() {
   // Home-key boards have no front Confirm button, so a Home-key hold runs the
   // same user-selected long-press action. The SDK emits this event once per
   // hold and suppresses the short Home tap for the same contact.
-  if (mappedInput.wasHomeKeyHold()) {
+  if (mappedInput.wasHomeKeyHold() && !endOfBookMenuOpen) {
     switch (SETTINGS.longPressMenuFunction) {
       case CrossPointSettings::LP_MENU_BOOKMARK:
         if (!showBookmarkMessage) {
@@ -512,10 +529,6 @@ void EpubReaderActivity::loop() {
       default:
         break;
     }
-  }
-
-  if (handleEndOfBookMenu()) {
-    return;
   }
 
   if (confirmReleased || ReaderUtils::isTouchMenuGesture(renderer, mappedInput)) {

--- a/src/activities/reader/ReaderActivity.cpp
+++ b/src/activities/reader/ReaderActivity.cpp
@@ -93,9 +93,12 @@ void ReaderActivity::clearEndOfBookOptionsIfNeeded() {
   endOfBookOptions.reset();
 }
 
+bool ReaderActivity::endOfBookMenuActive() const {
+  return isAtEndOfBook() && endOfBookOptionsReady.load(std::memory_order_acquire) && endOfBookOptions->menuActive();
+}
+
 bool ReaderActivity::handleEndOfBookMenu(const bool suppressConfirmRelease) {
-  if (!isAtEndOfBook() || !endOfBookOptionsReady.load(std::memory_order_acquire) || !endOfBookOptions->menuActive() ||
-      suppressConfirmRelease) {
+  if (suppressConfirmRelease || !endOfBookMenuActive()) {
     return false;
   }
 

--- a/src/activities/reader/ReaderActivity.h
+++ b/src/activities/reader/ReaderActivity.h
@@ -36,6 +36,8 @@ class ReaderActivity : public Activity {
   virtual void onEndOfBookRendered() {}
 
   bool handleBackNavigation();
+  /** True while the end-of-book suggestion menu is on screen and owning input. */
+  bool endOfBookMenuActive() const;
   bool handleEndOfBookMenu(bool suppressConfirmRelease = false);
   bool handleEndOfBookPageTurn(bool prevTriggered, bool nextTriggered);
   void clearEndOfBookOptionsIfNeeded();


### PR DESCRIPTION
Two ordering problems in `EpubReaderActivity::loop()`, each letting a handler act on input that a screen already on top of the page owns.

### 1. The automatic page turn runs ahead of the toolbar overlay guard

#3182's More panel reaches automatic page turning through a rate popup whose callback calls `toggleAutoPageTurn()` — setting `automaticPageTurnActive = true` and `lastPageTurnTime = millis()` — and returns with `overlay == Overlay::More` still set. On the next tick the panel's first Confirm/Back release (or centre-third menu tap) is consumed as "cancel auto page turn" instead of acting on the panel, and once `pageTurnDuration` elapses `pageTurn(true)` flips the page underneath the still-open panel.

The classic drawer never hit this: it only reached `toggleAutoPageTurn()` from the drawer's *result* handler, after the menu activity had already popped, so `loop()` never ran with both states live.

### 2. The end-of-book suggestion menu lost its precedence in #2973

That change moved the long-press dispatch above `handleEndOfBookMenu()`. With the menu on screen, a Confirm hold now runs the bound shortcut — `LP_MENU_BOOKMARK` drops a bookmark and paints a confirmation over the suggestion screen, `LP_MENU_DICTIONARY` opens the word picker on top of it. `ReaderActivity::loop()` still has the intended order, so the two readers disagree.

### Fix

Move the overlay guard above the timer and hold `lastPageTurnTime` while a panel is up, so closing the panel starts a fresh interval rather than firing a turn immediately.

Restore `handleEndOfBookMenu()` ahead of the long-press dispatch and leave the hold polls out while the menu owns Confirm. That second part matters: `wasLongPressed()` calls `suppressNextRelease()`, so merely reordering would still take the release away from the menu. Removing `ignoreNextConfirmRelease` in #2973 was itself sound — `ActivityManager.cpp:102` consumes the suppression centrally — the reorder is the defect.

Factors the menu-active test into `ReaderActivity::endOfBookMenuActive()` so the guard and `handleEndOfBookMenu()` cannot drift apart.

### Testing

Host suite green, four board builds green. Both fixes are control-flow ordering inside a method bound to `GfxRenderer`/`MappedInputManager`/FreeRTOS with no pure logic to extract, so they **need on-device verification** on a touch board: open More → set an auto-turn rate → confirm the panel stays put and the first tap lands on the panel; and reach end-of-book, hold Confirm, confirm nothing paints over the suggestion menu.
