### PR TITLE
fix(reader): allocate ReaderToolbarUi without abort()ing on OOM

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -248,7 +248,11 @@ void EpubReaderActivity::openReaderMenu() {
     focusedTool = 0;
     panelHoldJumped = false;
     panelCursorShown = !mappedInput.hasTouch();
-    if (!toolbarUi) toolbarUi = std::make_unique<ReaderToolbarUi>(renderer);
+    if (!ensureToolbarUi()) {
+      // Nothing to draw the menu with; leave the page as it is rather than aborting.
+      overlay = Overlay::None;
+      return;
+    }
     toolbarUi->begin();
     discardOverlayPage();
     requestUpdate();
@@ -1809,10 +1813,24 @@ void EpubReaderActivity::discardOverlayPage() {
   overlayPageStored = false;
 }
 
+bool EpubReaderActivity::ensureToolbarUi() {
+  // ~2 KB claimed only while the menu is open, which is peak heap pressure with an EPUB
+  // section resident. A throwing new would abort() here rather than return null.
+  if (!toolbarUi) {
+    toolbarUi = makeUniqueNoThrow<ReaderToolbarUi>(renderer);
+    if (!toolbarUi) LOG_ERR("EPUBREADER", "OOM: ReaderToolbarUi");
+  }
+  return toolbarUi != nullptr;
+}
+
 void EpubReaderActivity::openOverlay(Overlay target) {
   const Overlay previous = overlay;
   overlay = target;
-  if (!toolbarUi) toolbarUi = std::make_unique<ReaderToolbarUi>(renderer);
+  if (!ensureToolbarUi()) {
+    // Nothing to draw the panel with; stay on the page instead of resetting the device.
+    overlay = previous;
+    return;
+  }
   if (previous == Overlay::None) toolbarUi->begin();
   // Buttons show a cursor from the start; touch boards only once a button moves it.
   panelCursorShown = !mappedInput.hasTouch();

--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -249,8 +249,11 @@ void EpubReaderActivity::openReaderMenu() {
     panelHoldJumped = false;
     panelCursorShown = !mappedInput.hasTouch();
     if (!ensureToolbarUi()) {
-      // Nothing to draw the menu with; leave the page as it is rather than aborting.
+      // Nothing to draw the menu with; repaint the page rather than aborting --
+      // openReaderMenu() can run right after a child activity returned, so the
+      // framebuffer may still hold that child's screen.
       overlay = Overlay::None;
+      requestUpdate();
       return;
     }
     toolbarUi->begin();

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -124,6 +124,8 @@ class EpubReaderActivity final : public ReaderActivity {
   void openReaderMenu();
   // Toolbar reader menu (see Overlay above).
   bool usesToolbarMenu() const;
+  /** Allocates toolbarUi on first use. False when the heap could not spare it. */
+  bool ensureToolbarUi();
   void openOverlay(Overlay target);
   void closeOverlayToPage();
   void discardOverlayPage();


### PR DESCRIPTION
### Problem

`ReaderToolbarUi` is roughly 2 KB (32 `std::string`s, 16 `ListItem`s, two 324-byte `StyleSet`-carrying prop structs, `FreeInkApp<24,6>`) and is allocated on demand at exactly the wrong moment: the reader menu opens with an EPUB section resident, which is peak heap pressure.

Under `-fno-exceptions` the throwing `new` inside `std::make_unique` calls `abort()` rather than returning null, so an allocation failure there **resets the device** instead of failing to open a menu. Neither call site (`EpubReaderActivity.cpp:251`, `:1815`) checked the result.

`AGENTS.md` mandates `makeUniqueNoThrow<T>()` for exactly this, and `ReaderActivity.cpp` already uses it three lines away.

### Fix

Route both sites through `ensureToolbarUi()`, which uses `makeUniqueNoThrow` and `LOG_ERR`s on failure. `openOverlay()` restores the previous overlay state and `openReaderMenu()` returns to the clean page, so the menu simply does not open. `renderOverlay()` and `handleOverlayInput()` already tolerate a null `toolbarUi`, so nothing downstream needed changing.

### Note for a separate change

`EpubReaderActivity.cpp` still has 11 bare `std::make_unique` sites for child activities (lines 514, 593, 972, 1243, 1270, 1284, 1335, 1354, 1456, 1500, 3060) — every one aborts on OOM. Converting those is bigger than a search-and-replace: child activities are handed to `startActivityForResult()` / `replaceActivity()`, so `ActivityManager` needs a defined null contract first. Happy to follow up if you'd like that shape decided.
