### PR TITLE
feat: add support for M5Paper v1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
             asset: firmware-x4pro.bin
           - pio_env: papermono-gh_release
             asset: firmware-papermono.bin
+          - pio_env: m5paper-gh_release
+            asset: firmware-m5paper.bin
     steps:
       - uses: actions/checkout@v6
         with:

--- a/platformio.ini
+++ b/platformio.ini
@@ -419,6 +419,7 @@ extends = base
 board = esp32dev
 board_build.mcu = esp32
 board_build.flash_mode = qio
+upload_speed = 460800
 build_unflags =
   ${base.build_unflags}
   -DARDUINO_USB_MODE=1
@@ -441,6 +442,7 @@ extends = base
 board = esp32dev
 board_build.mcu = esp32
 board_build.flash_mode = qio
+upload_speed = 460800
 build_unflags =
   ${base.build_unflags}
   -DARDUINO_USB_MODE=1
@@ -463,6 +465,7 @@ extends = base
 board = esp32dev
 board_build.mcu = esp32
 board_build.flash_mode = qio
+upload_speed = 460800
 build_unflags =
   ${base.build_unflags}
   -DARDUINO_USB_MODE=1

--- a/platformio.ini
+++ b/platformio.ini
@@ -406,3 +406,76 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+
+; --- M5Paper v1.1 — classic ESP32 (D0WDQ6-V3), IT8951E 960x540 ED047TC1 ------
+; 16MB flash + 8MB Quad SPI PSRAM. The framebuffer does not fit in classic-ESP32
+; DRAM, so the SDK auto-enables FREEINK_FB_PSRAM; that needs BOARD_HAS_PSRAM.
+; [base] assumes an ESP32-S3 with USB CDC, so those defines are unset here or the
+; link fails. The Arduino core leaves i2cInit/i2cSlaveInit weak and GT911 touch
+; init loses them, hence -Wl,-u. No front buttons, so button hints are off.
+;   pio run -e m5paper -t upload
+[env:m5paper]
+extends = base
+board = esp32dev
+board_build.mcu = esp32
+board_build.flash_mode = qio
+build_unflags =
+  ${base.build_unflags}
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+  ${base.build_flags}
+  -UARDUINO_USB_MODE
+  -UARDUINO_USB_CDC_ON_BOOT
+  -DFREEINK_DEVICE_M5PAPER=1
+  -DBOARD_HAS_PSRAM
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-m5paper\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2
+  -DCROSSPOINT_SHOW_BUTTON_HINTS=0
+  -Wl,-u,i2cInit
+  -Wl,-u,i2cSlaveInit
+
+[env:m5paper-gh_release]
+extends = base
+board = esp32dev
+board_build.mcu = esp32
+board_build.flash_mode = qio
+build_unflags =
+  ${base.build_unflags}
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+  ${base.build_flags}
+  -UARDUINO_USB_MODE
+  -UARDUINO_USB_CDC_ON_BOOT
+  -DFREEINK_DEVICE_M5PAPER=1
+  -DBOARD_HAS_PSRAM
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1 ; Set log level to info for release builds
+  -DCROSSPOINT_SHOW_BUTTON_HINTS=0
+  -Wl,-u,i2cInit
+  -Wl,-u,i2cSlaveInit
+
+[env:m5paper-gh_release_rc]
+extends = base
+board = esp32dev
+board_build.mcu = esp32
+board_build.flash_mode = qio
+build_unflags =
+  ${base.build_unflags}
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+  ${base.build_flags}
+  -UARDUINO_USB_MODE
+  -UARDUINO_USB_CDC_ON_BOOT
+  -DFREEINK_DEVICE_M5PAPER=1
+  -DBOARD_HAS_PSRAM
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-rc+${sysenv.CROSSPOINT_RC_HASH}\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
+  -DCROSSPOINT_SHOW_BUTTON_HINTS=0
+  -Wl,-u,i2cInit
+  -Wl,-u,i2cSlaveInit


### PR DESCRIPTION
Adds build environments for the original M5Stack M5Paper v1.1 - classic ESP32 (D0WDQ6-V3), 16MB flash, 8MB Quad SPI PSRAM, IT8951E driving a 960x540 ED047TC1 panel.

The hardware layer already exists in freeink-sdk (FREEINK_DEVICE_M5PAPER, hand-rolled IT8951 driver), and OtaUpdater derives its release asset name from board_tag, so no firmware code changes were required - FirmwareBoardTag.cpp already maps FREEINK_DEVICE_M5PAPER to the "m5paper" board name.

What this PR adds is the CrossPoint-side build configuration, which needed two things beyond the SDK's sample env:

- USB CDC: the shared [base] env assumes an ESP32-S3 and defines ARDUINO_USB_MODE / ARDUINO_USB_CDC_ON_BOOT. Classic ESP32 needs both unflagged and undefined or the link fails.
- I2C: the Arduino core leaves i2cInit / i2cSlaveInit weak, so GT911 touch init loses them. Pulled in with -Wl,-u.
Button hints are disabled - the device has no front buttons.

Envs: m5paper, m5paper-gh_release, m5paper-gh_release_rc
Release asset: firmware-m5paper.bin

Verified on hardware (M5Paper v1.1): builds, flashes, boots, mounts SD, opens and renders EPUB including Korean text, no watchdog reboots on large books.