### PR TITLE
fix: Four small UX fixes

### DIFF
--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -21,11 +21,10 @@ void MappedInputManager::update() const {
 }
 
 bool MappedInputManager::isNavDirectionSwapped() const {
-  // Key the swap on the orientation the screen is *actually* rendered at, not the persisted reader
-  // setting. The reader (and its modal menus) render rotated, so navigation/labels flip there; the
-  // home and settings UI render in portrait, so they never flip even when a rotated reader is configured.
+  // Touch boards always follow the rendered orientation; button-only boards keep the user toggle.
+  // Home and settings render in portrait, so neither path swaps them.
   const auto orientation = renderer.getOrientation();
-  return SETTINGS.frontButtonFollowOrientation &&
+  return (gpio.hasTouch() || SETTINGS.frontButtonFollowOrientation) &&
          (orientation == GfxRenderer::PortraitInverted || orientation == GfxRenderer::LandscapeCounterClockwise);
 }
 
@@ -90,9 +89,9 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       // Reader page navigation uses side buttons and can be swapped via settings.
       switch (sideLayout) {
         case CrossPointSettings::PREV_NEXT:
-          return (gpio.*fn)(HalGPIO::BTN_UP);
+          return (gpio.*fn)(isNavDirectionSwapped() ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP);
         case CrossPointSettings::NEXT_PREV:
-          return (gpio.*fn)(HalGPIO::BTN_DOWN);
+          return (gpio.*fn)(isNavDirectionSwapped() ? HalGPIO::BTN_UP : HalGPIO::BTN_DOWN);
         case CrossPointSettings::SIDE_BUTTONS_DISABLED:
         default:
           return false;
@@ -101,16 +100,16 @@ bool MappedInputManager::mapButton(const Button button, bool (HalGPIO::*fn)(uint
       // Reader page navigation uses side buttons and can be swapped via settings.
       switch (sideLayout) {
         case CrossPointSettings::PREV_NEXT:
-          return (gpio.*fn)(HalGPIO::BTN_DOWN);
+          return (gpio.*fn)(isNavDirectionSwapped() ? HalGPIO::BTN_UP : HalGPIO::BTN_DOWN);
         case CrossPointSettings::NEXT_PREV:
-          return (gpio.*fn)(HalGPIO::BTN_UP);
+          return (gpio.*fn)(isNavDirectionSwapped() ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP);
         case CrossPointSettings::SIDE_BUTTONS_DISABLED:
         default:
           return false;
       }
     case Button::NavNext:
       // Logical "next item" navigation: side Down + front Right, with the control axis flipped in
-      // INVERTED / LANDSCAPE_CCW (frontButtonFollowOrientation) so it matches the rotated hint labels.
+      // INVERTED / LANDSCAPE_CCW under the live orientation policy, matching the rotated hint labels.
       return isNavDirectionSwapped() ? (mapButton(Button::Up, fn) || mapButton(Button::Left, fn))
                                      : (mapButton(Button::Down, fn) || mapButton(Button::Right, fn));
     case Button::NavPrevious:

--- a/src/MappedInputManager.h
+++ b/src/MappedInputManager.h
@@ -111,10 +111,8 @@ class MappedInputManager {
   // Returns the raw front button index that was pressed this frame (or -1 if none).
   int getPressedFrontButton() const;
 
-  // True when the control axis is flipped relative to the physical buttons: the user opted into
-  // orientation-following front buttons AND the screen is *currently rendered* rotated (INVERTED /
-  // LANDSCAPE_CCW). Keyed on the live renderer orientation rather than the persisted reader setting,
-  // so portrait UI (home, settings) never swaps while the reader and its menus do.
+  // True when the control axis is flipped relative to the physical buttons: always on touch boards,
+  // or when button-only boards opt in, while the screen is currently INVERTED / LANDSCAPE_CCW.
   [[nodiscard]] bool isNavDirectionSwapped() const;
 
  private:

--- a/src/activities/UiTabListActivity.cpp
+++ b/src/activities/UiTabListActivity.cpp
@@ -9,6 +9,10 @@
 
 namespace fui = freeink::ui;
 
+namespace {
+constexpr int16_t TOUCH_TAB_BAR_HEIGHT = 50;
+}
+
 UiTabListActivity::UiTabListActivity(const char* name, GfxRenderer& renderer, MappedInputManager& mappedInput)
     : UiListActivity(name, renderer, mappedInput) {}
 
@@ -123,9 +127,8 @@ void UiTabListActivity::buildTabBar(UiScreen& screen) {
   tabProps.count = static_cast<uint16_t>(count);
   tabProps.action = ACTION_TAB;
   tabProps.inputMask = fui::InputTouch;
-  // Pill shape and label size are theme-driven. Label-hugging (Lyra): small
-  // text so the pill wraps a compact label, kept tight horizontally so wide
-  // labels (e.g. "Controls") still fit their slot at large UI scales.
+  // Pill shape and label size are theme-driven. Lyra uses equal-width slots
+  // with small labels so wide text (e.g. "Controls") still fits at large UI scales.
   // Full-slot (RoundedRaff): the pill fills its slot like the legacy layout
   // (slot minus a 4px frame, 8px clearance above the divider) with
   // body-size labels; zero horizontal contentInset disables the tabBar's
@@ -137,18 +140,17 @@ void UiTabListActivity::buildTabBar(UiScreen& screen) {
     tabProps.contentInset = fui::Insets{2, 0, 2, 0};
   } else {
     tabProps.text = screen.theme().smallText;
-    tabProps.layout = fui::TabBarLayout::ContentWidth;
-    tabProps.leadingInset = static_cast<int16_t>(metrics.contentSidePadding);
     tabProps.gap = static_cast<int16_t>(metrics.tabSpacing);
     // Unfocused state: no bottom inset, so the pill (and the 2px selected
     // underline drawn along its bottom edge) reaches the band's 1px divider —
     // legacy Lyra drew the underline sitting on that rule, not floating above.
-    tabProps.tabInset = tabsFocused ? fui::Insets{2, 0, 4, 0} : fui::Insets{2, 0, 0, 0};
-    tabProps.contentInset = fui::Insets{2, 8, 2, 8};
+    tabProps.tabInset = tabsFocused ? fui::Insets{2, 4, 4, 4} : fui::Insets{2, 4, 0, 4};
+    tabProps.contentInset = fui::Insets{2, 0, 2, 0};
   }
   const int16_t tabLineHeight = screen.target().lineHeight(tabProps.text.font);
-  const int16_t tabBand =
-      static_cast<int16_t>(metrics.tabBarHeight > tabLineHeight + 10 ? metrics.tabBarHeight : tabLineHeight + 10);
+  const int16_t preferredTabHeight =
+      mappedInput.hasTouch() ? TOUCH_TAB_BAR_HEIGHT : static_cast<int16_t>(metrics.tabBarHeight);
+  const int16_t tabBand = preferredTabHeight > tabLineHeight + 10 ? preferredTabHeight : tabLineHeight + 10;
   // Legacy Lyra two-state treatment: with the selection on the tab band, the
   // band fills gray and the active tab is a solid pill; with the selection
   // down in the list, the band is plain and the active tab keeps a gray box

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -17,6 +17,8 @@
 namespace {
 
 constexpr unsigned long POPUP_DURATION_MS = 1500;
+constexpr unsigned long WORD_REPEAT_START_MS = 500;
+constexpr unsigned long WORD_REPEAT_INTERVAL_MS = 500;
 
 // A token is selectable when it has an ASCII alphanumeric or a non-ASCII
 // codepoint outside U+2000-U+206F (dashes, bullets and other General
@@ -269,11 +271,20 @@ void DictionaryWordSelectActivity::loop() {
   }
 
   const bool hasNextWord = selected + 1 < static_cast<int>(words.size());
-  if (mappedInput.wasPressed(MappedInputManager::Button::ScreenLeft) && selected > 0) {
+  const unsigned long now = millis();
+  const bool repeat =
+      mappedInput.getHeldTime() >= WORD_REPEAT_START_MS && now - lastHorizontalMoveTime >= WORD_REPEAT_INTERVAL_MS;
+  const bool moveLeft = mappedInput.wasPressed(MappedInputManager::Button::ScreenLeft) ||
+                        (repeat && mappedInput.isPressed(MappedInputManager::Button::ScreenLeft));
+  const bool moveRight = mappedInput.wasPressed(MappedInputManager::Button::ScreenRight) ||
+                         (repeat && mappedInput.isPressed(MappedInputManager::Button::ScreenRight));
+  if (moveLeft && selected > 0) {
     selected--;
+    lastHorizontalMoveTime = now;
     requestUpdate();
-  } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenRight) && hasNextWord) {
+  } else if (moveRight && hasNextWord) {
     selected++;
+    lastHorizontalMoveTime = now;
     requestUpdate();
   } else if (mappedInput.wasPressed(MappedInputManager::Button::ScreenUp)) {
     moveVertical(-1);

--- a/src/activities/reader/DictionaryWordSelectActivity.h
+++ b/src/activities/reader/DictionaryWordSelectActivity.h
@@ -57,6 +57,7 @@ class DictionaryWordSelectActivity final : public Activity {
   std::vector<WordBox> words;
   int selected = 0;
   uint16_t rowCount = 0;
+  unsigned long lastHorizontalMoveTime = 0;
 
   Dictionary dict;
   bool dictOpenAttempted = false;

--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -2,6 +2,8 @@
 
 #include <GfxRenderer.h>
 #include <I18n.h>
+#include <Logging.h>
+#include <Memory.h>
 
 #include <cstring>
 
@@ -45,11 +47,8 @@ StrId opdsFormatLabel(uint8_t format) {
 
 int OpdsServerListActivity::getItemCount() const {
   int count = static_cast<int>(OPDS_STORE.getCount());
-  // Settings mode appends three virtual items: "Add Server", "Download folder"
-  // and "Filename format".
-  if (!pickerMode) {
-    count += 3;
-  }
+  // Picker mode appends "Add Server"; Settings also adds folder and format.
+  count += pickerMode ? 1 : 3;
   return count;
 }
 
@@ -86,12 +85,12 @@ void OpdsServerListActivity::rebuildRowItems() {
     item.actionValue = static_cast<int16_t>(i);
     rowItems_.push_back(item);
   }
-  if (!pickerMode) {
-    fui::ListItem addServer;
-    addServer.label = tr(STR_ADD_SERVER);
-    addServer.actionValue = static_cast<int16_t>(serverCount);
-    rowItems_.push_back(addServer);
+  fui::ListItem addServer;
+  addServer.label = tr(STR_ADD_SERVER);
+  addServer.actionValue = static_cast<int16_t>(serverCount);
+  rowItems_.push_back(addServer);
 
+  if (!pickerMode) {
     fui::ListItem folder;
     folder.label = tr(STR_OPDS_DOWNLOAD_FOLDER);
     folder.actionValue = static_cast<int16_t>(serverCount + 1);
@@ -137,6 +136,16 @@ void OpdsServerListActivity::handleSelection() {
       if (server) {
         activityManager.replaceActivity(std::make_unique<OpdsBookBrowserActivity>(renderer, mappedInput, *server));
       }
+    } else {
+      auto editor = makeUniqueNoThrow<OpdsSettingsActivity>(renderer, mappedInput, -1);
+      if (!editor) {
+        LOG_ERR("OPS", "OOM: OPDS settings activity");
+        return;
+      }
+      startActivityForResult(std::move(editor), [this](const ActivityResult&) {
+        OPDS_STORE.loadFromFile();
+        rebuildRowItems();
+      });
     }
     return;
   }


### PR DESCRIPTION
## Summary

I implemented four requests from #2964

- Hold Left/Right 500ms to move repeatedly through dictionary words
- Wider, taller, evenly spaced Lyra tabs
- Rotated controls automatically follow orientation on touch devices 
- “Add Server” directly from the OPDS server picker

All tested on x4 and sticky apart from the last one - I dont use OPDS server...

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< PARTIALLY >**_
