### PR TITLE
fix: Decouple reader menu gestures from touch controls

### DIFF
--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -141,11 +141,9 @@ inline bool isTouchMenuTap(const GfxRenderer& renderer, const MappedInputManager
 // Reader menu opens on the menu edge-swipe or a center-third tap. On home-key
 // boards a long press of the capacitive key runs the user-selected long-press
 // function instead (SETTINGS.longPressMenuFunction), not the menu.
-// With touch reader controls Off the reading surface ignores touch entirely,
-// menu included, so a stray brush of the screen can't open it; the menu stays
-// reachable via the Confirm button.
+// Menu gestures honor showReaderMenu independently of touchReaderControls,
+// which only gates page-turn touch zones in detectTouchPageTurn().
 inline bool isTouchMenuGesture(const GfxRenderer& renderer, const MappedInputManager& input) {
-  if (!SETTINGS.touchReaderControls) return false;
   if (!input.hasTouch()) return false;
   if (input.wasMenuGesture()) return true;
   // Bottom-edge up-swipe variant: only selectable on home-key boards, where


### PR DESCRIPTION
## Summary

Fixes #2868 and #3011. The issue was if you didn't want to have touch page turns enabled, then you couldn't open the reader menu touch gesture. This PR decouples those two settings and user can enable reader menu touch gesture without enabling touch for page turning.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [X] I have read SCOPE.md and ROADMAP.md.
- [X] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [X] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [X] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [X] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [X] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
