### PR TITLE
feat: add configurable X3 damaged-screen safe area

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Conversion runs the firmware repo's `lib/EpdFont/scripts/fontconvert_sdcard.py` 
 - [User Guide](./USER_GUIDE.md)
 - [Web server usage](./docs/webserver.md)
 - [Web server endpoints](./docs/webserver-endpoints.md)
-- [X3 damaged-screen safe area](./docs/x3-damaged-top-band.md)
+- [X3 configurable damaged-screen safe area](./docs/x3-damaged-top-band.md)
 - [Project scope](./SCOPE.md)
 - [Contributing docs](./docs/contributing/README.md)
 - [Touch and UI development](./docs/contributing/touch-and-ui.md) - how to build new screens on the FreeInkUI activity bases (UiListActivity and friends), plus build envs for the non-Xteink touch devices

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Conversion runs the firmware repo's `lib/EpdFont/scripts/fontconvert_sdcard.py` 
 - [User Guide](./USER_GUIDE.md)
 - [Web server usage](./docs/webserver.md)
 - [Web server endpoints](./docs/webserver-endpoints.md)
+- [X3 damaged-screen safe area](./docs/x3-damaged-top-band.md)
 - [Project scope](./SCOPE.md)
 - [Contributing docs](./docs/contributing/README.md)
 - [Touch and UI development](./docs/contributing/touch-and-ui.md) - how to build new screens on the FreeInkUI activity bases (UiListActivity and friends), plus build envs for the non-Xteink touch devices

--- a/docs/x3-damaged-top-band.md
+++ b/docs/x3-damaged-top-band.md
@@ -1,10 +1,19 @@
 # Xteink X3: reserve a damaged top band
 
-The `x3_damaged_top` PlatformIO environment reserves the upper 13% of an X3
-in portrait orientation. The physical band is painted black; CrossPoint lays
-out its UI and books in the remaining `528 x 688` logical viewport. Because
-the framebuffer is byte-packed, the requested percentage is rounded up and
-byte-aligned: 13% becomes 104 of the panel's 792 physical rows (about 13.1%).
+The `x3_reserved_top` PlatformIO environment reserves a configurable percentage
+of an X3 in portrait orientation. The physical band is painted black; CrossPoint
+lays out its UI and books below it. There is no baked-in percentage: set
+`CROSSPOINT_RESERVED_TOP_PERCENT` to an integer from 1 through 50 for each build.
+
+For example, this reserves 13%:
+
+```sh
+CROSSPOINT_RESERVED_TOP_PERCENT=13 pio run -e x3_reserved_top
+```
+
+Because the framebuffer is byte-packed, the requested percentage is rounded up
+and byte-aligned. On the X3, 13% becomes 104 of the panel's 792 physical rows
+(about 13.1%) and leaves a `528 x 688` logical viewport.
 
 This is intentionally an opt-in build, so normal builds are unaffected.  It
 also locks the device to portrait: rotating the UI would turn the physical
@@ -12,16 +21,10 @@ damaged top edge into a side edge and make a rectangular safe viewport invalid.
 The renderer mechanism itself is panel-agnostic; the build environment scopes
 it to the X3 by pairing the percentage with its 792-pixel panel width.
 
-Build the firmware from a recursive clone:
-
-```sh
-pio run -e x3_damaged_top
-```
-
 The resulting image is:
 
 ```text
-.pio/build/x3_damaged_top/firmware.bin
+.pio/build/x3_reserved_top/firmware.bin
 ```
 
 Flash it with CrossPoint's web installer by selecting X3 and **Custom .bin**,
@@ -29,7 +32,7 @@ or with a known-good serial connection:
 
 ```sh
 esptool.py --chip esp32c3 --port /dev/ttyACM0 --baud 921600 write_flash \
-  0x10000 .pio/build/x3_damaged_top/firmware.bin
+  0x10000 .pio/build/x3_reserved_top/firmware.bin
 ```
 
 Use a data-capable USB-C cable. Some third-party X3 units are USB locked; use

--- a/docs/x3-damaged-top-band.md
+++ b/docs/x3-damaged-top-band.md
@@ -1,0 +1,42 @@
+# Xteink X3: reserve a damaged top band
+
+The `x3_damaged_top` PlatformIO environment reserves the upper 13% of an X3
+in portrait orientation. The physical band is painted black; CrossPoint lays
+out its UI and books in the remaining `528 x 688` logical viewport. Because
+the framebuffer is byte-packed, the requested percentage is rounded up and
+byte-aligned: 13% becomes 104 of the panel's 792 physical rows (about 13.1%).
+
+This is intentionally an opt-in build, so normal builds are unaffected.  It
+also locks the device to portrait: rotating the UI would turn the physical
+damaged top edge into a side edge and make a rectangular safe viewport invalid.
+The renderer mechanism itself is panel-agnostic; the build environment scopes
+it to the X3 by pairing the percentage with its 792-pixel panel width.
+
+Build the firmware from a recursive clone:
+
+```sh
+pio run -e x3_damaged_top
+```
+
+The resulting image is:
+
+```text
+.pio/build/x3_damaged_top/firmware.bin
+```
+
+Flash it with CrossPoint's web installer by selecting X3 and **Custom .bin**,
+or with a known-good serial connection:
+
+```sh
+esptool.py --chip esp32c3 --port /dev/ttyACM0 --baud 921600 write_flash \
+  0x10000 .pio/build/x3_damaged_top/firmware.bin
+```
+
+Use a data-capable USB-C cable. Some third-party X3 units are USB locked; use
+the Xteink Unlocker only when required by the device and only with its supported
+firmware choices.
+
+If CrossPoint is already installed, an SD card is also sufficient: copy the
+image to the card, then select **Settings → System → SD Card Firmware Update**
+and choose the `.bin` file. CrossPoint validates the ESP32 image before writing
+the inactive OTA slot and restarts into it when complete.

--- a/lib/Epub/Epub/converters/DirectPixelWriter.h
+++ b/lib/Epub/Epub/converters/DirectPixelWriter.h
@@ -24,6 +24,9 @@ struct DirectPixelWriter {
   // (originY 0, clipRows panelHeight) so the clip doubles as a bounds guard.
   int originY;
   int clipRows;
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  int topReservedRows;
+#endif
 
   // Orientation is collapsed into a linear transform:
   //   phyX = phyXBase + x * phyXStepX + y * phyXStepY
@@ -39,6 +42,9 @@ struct DirectPixelWriter {
     fb = renderer.getWriteTarget();
     originY = renderer.getWriteOriginY();
     clipRows = renderer.getWriteRows();
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+    topReservedRows = renderer.getTopReservedRows();
+#endif
     mode = renderer.getRenderMode();
     displayWidthBytes = renderer.getDisplayWidthBytes();
 
@@ -97,6 +103,9 @@ struct DirectPixelWriter {
   // Call once per row before the column loop.
   // Pre-computes the Y-dependent portion so writePixel() only needs the X part.
   inline void beginRow(int logicalY) {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+    logicalY += topReservedRows;
+#endif
     rowPhyXBase = phyXBase + logicalY * phyXStepY;
     rowPhyYBase = phyYBase + logicalY * phyYStepY;
   }
@@ -143,7 +152,7 @@ struct DirectPixelWriter {
 
   // Write a single 2-bit dithered pixel value to the framebuffer.
   // Must be called after beginRow() for the current row.
-  // No bounds checking — caller guarantees coordinates are valid.
+  // Reserved-viewport builds retain a physical-X bounds check because this path writes raw memory.
   inline void writePixel(int logicalX, uint8_t pixelValue, bool writeWhiteInBw = false) const {
     // Determine whether to draw based on render mode
     bool draw;
@@ -174,6 +183,9 @@ struct DirectPixelWriter {
     // mode) and any out-of-frame row (full-frame mode) in one branch.
     const int sy = phyY - originY;
     if (static_cast<unsigned>(sy) >= static_cast<unsigned>(clipRows)) return;
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+    if (static_cast<unsigned>(phyX) >= static_cast<unsigned>(displayWidthBytes) * 8u) return;
+#endif
 
     const uint16_t byteIndex = static_cast<uint16_t>(sy * displayWidthBytes + (phyX >> 3));
     const uint8_t bitMask = 1 << (7 - (phyX & 7));

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -277,34 +277,55 @@ void GfxRenderer::ensureSdGlyphsResident(const int fontId, const char* text, con
 }
 
 // Translate logical (x,y) coordinates to physical panel coordinates based on current orientation
+static inline int reservedTopRowsForPanel(const uint16_t panelWidth) {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT) != defined(CROSSPOINT_RESERVED_TOP_PANEL_WIDTH)
+#error "reserved top percentage and panel width must be configured together"
+#elif defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  static_assert(CROSSPOINT_RESERVED_TOP_PERCENT > 0 && CROSSPOINT_RESERVED_TOP_PERCENT <= 50,
+                "reserved top percentage must be between 1 and 50");
+  static_assert(CROSSPOINT_RESERVED_TOP_PANEL_WIDTH > 0, "reserved top panel width must be positive");
+  if (panelWidth != CROSSPOINT_RESERVED_TOP_PANEL_WIDTH) return 0;
+  constexpr int roundedRows = (CROSSPOINT_RESERVED_TOP_PANEL_WIDTH * CROSSPOINT_RESERVED_TOP_PERCENT + 99) / 100;
+  return (roundedRows + 7) & ~0x7;
+#else
+  (void)panelWidth;
+  return 0;
+#endif
+}
+
 // This should always be inlined for better performance
 static inline void rotateCoordinates(const GfxRenderer::Orientation orientation, const int x, const int y, int* phyX,
                                      int* phyY, const uint16_t panelWidth, const uint16_t panelHeight) {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  const int safeY = y + reservedTopRowsForPanel(panelWidth);
+#else
+  const int safeY = y;
+#endif
   switch (orientation) {
     case GfxRenderer::Portrait: {
       // Logical portrait (480x800) → panel (800x480)
       // Rotation: 90 degrees clockwise
-      *phyX = y;
+      *phyX = safeY;
       *phyY = panelHeight - 1 - x;
       break;
     }
     case GfxRenderer::LandscapeClockwise: {
       // Logical landscape (800x480) rotated 180 degrees (swap top/bottom and left/right)
       *phyX = panelWidth - 1 - x;
-      *phyY = panelHeight - 1 - y;
+      *phyY = panelHeight - 1 - safeY;
       break;
     }
     case GfxRenderer::PortraitInverted: {
       // Logical portrait (480x800) → panel (800x480)
       // Rotation: 90 degrees counter-clockwise
-      *phyX = panelWidth - 1 - y;
+      *phyX = panelWidth - 1 - safeY;
       *phyY = x;
       break;
     }
     case GfxRenderer::LandscapeCounterClockwise: {
       // Logical landscape (800x480) aligned with panel orientation
       *phyX = x;
-      *phyY = y;
+      *phyY = safeY;
       break;
     }
   }
@@ -1632,7 +1653,22 @@ void GfxRenderer::clearScreen(const uint8_t color) const {
     return;
   }
   display.clearScreen(color);
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  paintReservedTopBand();
+#endif
 }
+
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+void GfxRenderer::paintReservedTopBand() const {
+  const int reservedRows = getTopReservedRows();
+  if (reservedRows <= 0 || !frameBuffer) return;
+
+  const int reservedBytes = reservedRows / 8;
+  for (int row = 0; row < panelHeight; ++row) {
+    memset(frameBuffer + static_cast<uint32_t>(row) * panelWidthBytes, 0x00, reservedBytes);
+  }
+}
+#endif
 
 void GfxRenderer::beginStripTarget(uint8_t* scratch, int stripY0, int stripRows) const {
   // Band is caller-guaranteed in-bounds (the reader's grayscale loop computes
@@ -1682,11 +1718,17 @@ HalDisplay::RefreshMode GfxRenderer::applyPromotedRefresh(const HalDisplay::Refr
 void GfxRenderer::displayBuffer(HalDisplay::RefreshMode refreshMode) const {
   auto elapsed = millis() - start_ms;
   LOG_DBG("GFX", "Time = %lu ms from clearScreen to displayBuffer", elapsed);
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  paintReservedTopBand();
+#endif
   refreshMode = applyPromotedRefresh(refreshMode);
   display.displayBuffer(refreshMode, fadingFix);
 }
 
 void GfxRenderer::displayBufferAsync(HalDisplay::RefreshMode refreshMode) const {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  paintReservedTopBand();
+#endif
   refreshMode = applyPromotedRefresh(refreshMode);
   // The async path has no turn-off-screen hook, which the sunlight fading fix
   // relies on; keep those users on the blocking path.
@@ -1838,7 +1880,11 @@ int GfxRenderer::getScreenHeight() const {
     case Portrait:
     case PortraitInverted:
       // 800px tall in portrait logical coordinates
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+      return panelWidth - getTopReservedRows();
+#else
       return panelWidth;
+#endif
     case LandscapeClockwise:
     case LandscapeCounterClockwise:
       // 480px tall in landscape logical coordinates
@@ -1846,6 +1892,8 @@ int GfxRenderer::getScreenHeight() const {
   }
   return panelWidth;
 }
+
+int GfxRenderer::getTopReservedRows() const { return reservedTopRowsForPanel(panelWidth); }
 
 void GfxRenderer::tapToLogical(float nx, float ny, int& outX, int& outY) const {
   int phyX = static_cast<int>(nx * panelWidth);
@@ -1874,6 +1922,13 @@ void GfxRenderer::tapToLogical(float nx, float ny, int& outX, int& outY) const {
       outY = phyY;
       break;
   }
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  if (getTopReservedRows() > 0 && (orientation == Portrait || orientation == PortraitInverted)) {
+    outY -= getTopReservedRows();
+    if (outY < 0) outY = 0;
+    if (outY >= getScreenHeight()) outY = getScreenHeight() - 1;
+  }
+#endif
 }
 
 // Translate a logical rect through rotateCoordinates and take the bounding
@@ -2201,6 +2256,9 @@ size_t GfxRenderer::getBufferSize() const { return frameBufferSize; }
 // void GfxRenderer::grayscaleRevert() const { display.grayscaleRevert(); }
 
 void GfxRenderer::displayGrayscaleBase(HalDisplay::RefreshMode fallback) const {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  paintReservedTopBand();
+#endif
   display.displayGrayscaleBase(fallback, fadingFix);
 }
 

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1650,6 +1650,16 @@ void GfxRenderer::clearScreen(const uint8_t color) const {
   if (_stripActive) {
     // Clear only the active band's scratch, not the shared framebuffer.
     memset(_stripBuf, color, static_cast<size_t>(panelWidthBytes) * _stripRows);
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+    // Strip planes bypass the shared framebuffer, so preserve the physical
+    // black exclusion band in every controller row they will replace.
+    const int reservedBytes = getTopReservedRows() / 8;
+    if (reservedBytes > 0) {
+      for (int row = 0; row < _stripRows; ++row) {
+        memset(_stripBuf + static_cast<size_t>(row) * panelWidthBytes, 0x00, reservedBytes);
+      }
+    }
+#endif
     return;
   }
   display.clearScreen(color);

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -121,6 +121,9 @@ class GfxRenderer {
   // per-pixel rotation, no per-pixel RMW.
   template <Color color>
   void fillRectImpl(int x, int y, int width, int height) const;
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+  void paintReservedTopBand() const;
+#endif
 
  public:
   explicit GfxRenderer(HalDisplay& halDisplay)
@@ -183,7 +186,13 @@ class GfxRenderer {
                              uint8_t styleMask = 0x0F) const;
 
   // Orientation control (affects logical width/height and coordinate transforms)
-  void setOrientation(const Orientation o) { orientation = o; }
+  void setOrientation(const Orientation o) {
+#if defined(CROSSPOINT_RESERVED_TOP_PERCENT)
+    orientation = getTopReservedRows() > 0 ? Portrait : o;
+#else
+    orientation = o;
+#endif
+  }
   Orientation getOrientation() const { return orientation; }
 
   // Fading fix control
@@ -192,6 +201,9 @@ class GfxRenderer {
   // Screen ops
   int getScreenWidth() const;
   int getScreenHeight() const;
+  // Logical rows reserved at the top of the portrait X3 view. This is zero
+  // in ordinary builds and on every other panel.
+  int getTopReservedRows() const;
   void tapToLogical(float nx, float ny, int& outX, int& outY) const;
   void displayBuffer(HalDisplay::RefreshMode refreshMode = HalDisplay::FAST_REFRESH) const;
   // One-shot: the next displayBuffer()/displayBufferAsync() call uses `mode`

--- a/platformio.ini
+++ b/platformio.ini
@@ -197,22 +197,24 @@ build_flags =
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
 
-; --- Xteink X3 damaged top band ---------------------------------------------
-; Reserves the upper 13% of the portrait X3 screen (104 of 792 physical rows
-; after byte alignment), paints it black, and lays out the firmware in the
-; remaining 528x688 viewport.
+; --- Xteink X3 configurable damaged top band --------------------------------
+; Set CROSSPOINT_RESERVED_TOP_PERCENT to an integer from 1 through 50 when
+; building. The requested portrait-height percentage is rounded up to the next
+; framebuffer-byte boundary, painted black, and excluded from layout.
 ; This image also contains X4 support, but the reservation is enabled only when
 ; the runtime-selected panel has X3's 792px physical width.
-[env:x3_damaged_top]
+[env:x3_reserved_top]
 extends = base, firmware_tuned
+extra_scripts =
+  ${base.extra_scripts}
+  pre:scripts/configure_reserved_top.py
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
   -DFREEINK_DEVICE_X3=1
-  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x3-damaged-top\"
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x3-reserved-top\"
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1
-  -DCROSSPOINT_RESERVED_TOP_PERCENT=13
   -DCROSSPOINT_RESERVED_TOP_PANEL_WIDTH=792
 
 ; --- Seeed Sticky — ESP32-S3R8, 3.97" 800x480 SSD1677 + GT911 touch -----------

--- a/platformio.ini
+++ b/platformio.ini
@@ -197,6 +197,24 @@ build_flags =
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
 
+; --- Xteink X3 damaged top band ---------------------------------------------
+; Reserves the upper 13% of the portrait X3 screen (104 of 792 physical rows
+; after byte alignment), paints it black, and lays out the firmware in the
+; remaining 528x688 viewport.
+; This image also contains X4 support, but the reservation is enabled only when
+; the runtime-selected panel has X3's 792px physical width.
+[env:x3_damaged_top]
+extends = base, firmware_tuned
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_X4=1
+  -DFREEINK_DEVICE_X3=1
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-x3-damaged-top\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=1
+  -DCROSSPOINT_RESERVED_TOP_PERCENT=13
+  -DCROSSPOINT_RESERVED_TOP_PANEL_WIDTH=792
+
 ; --- Seeed Sticky — ESP32-S3R8, 3.97" 800x480 SSD1677 + GT911 touch -----------
 ; Different MCU family than the C3 envs (one binary per family). The SDK
 ; auto-enables CAP_TOUCH (GT911) and the BQ27220 gauge for this device; PSRAM is

--- a/scripts/configure_reserved_top.py
+++ b/scripts/configure_reserved_top.py
@@ -1,0 +1,20 @@
+"""Validate and inject the optional damaged-screen reservation percentage."""
+
+import os
+
+Import("env")  # noqa: F821  -- provided by PlatformIO at script load
+
+
+VARIABLE = "CROSSPOINT_RESERVED_TOP_PERCENT"
+raw_percent = os.environ.get(VARIABLE, "").strip()
+
+try:
+    percent = int(raw_percent)
+except ValueError as exc:
+    raise ValueError(f"{VARIABLE} must be an integer from 1 through 50") from exc
+
+if not 1 <= percent <= 50:
+    raise ValueError(f"{VARIABLE} must be an integer from 1 through 50")
+
+env.Append(CPPDEFINES=[(VARIABLE, percent)])  # noqa: F821
+print(f"CrossPoint reserved top band: {percent}%")


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Allow an Xteink X3 with a damaged upper display band to keep the damaged area black and use the rest of the screen normally.
* **What changes are included?**
  * Adds an opt-in `x3_reserved_top` PlatformIO environment whose reserved percentage is supplied through `CROSSPOINT_RESERVED_TOP_PERCENT` at build time.
  * Adds a compile-time, panel-width-scoped renderer safe area. It shifts normal and direct image rendering, reduces the logical height, remaps touch input, and repaints the reserved band before every refresh path.
  * Validates percentages from 1 through 50 and byte-aligns the result to the framebuffer. For example, 13% becomes 104 of 792 physical rows, leaving a `528 x 688` logical viewport.
  * Locks this build to portrait so the physical top-edge exclusion remains a rectangular viewport.
  * Documents building and flashing the opt-in image.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (Not applicable: none of those areas are changed.)

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

Not applicable; this is a new contribution.

## Additional Context

The setting is compile-time opt-in with no baked-in percentage. Build it with, for example, `CROSSPOINT_RESERVED_TOP_PERCENT=13 pio run -e x3_reserved_top`. A missing, non-integer, or out-of-range value stops the build with a validation error. Feature-specific hot-path work compiles out of standard builds, and the 792-pixel panel-width guard keeps the shared X3/X4 firmware from reserving space on an X4.

Hardware validation was performed on the affected Xteink X3. The 13% setting completed an SD-card firmware update successfully and was confirmed to align almost pixel-perfectly with the damaged band.

Validation performed:

* `CROSSPOINT_RESERVED_TOP_PERCENT=13 pio run -e x3_reserved_top` — passed (17.1% RAM, 82.0% flash)
* `pio run -e default` — passed, verifying the no-feature compile path
* `CROSSPOINT_RESERVED_TOP_PERCENT=13 pio check -e x3_reserved_top` — no defects found
* Missing percentage validation — build stops with the documented 1–50 error
* Host CTest suite — 168/168 passed
* `esptool image-info` — valid ESP32-C3, 16 MB, 80 MHz DIO image with valid checksum and hash
* Exhaustive coordinate check — all 363,264 usable pixels and the full reserved band remain in framebuffer bounds; zero out-of-bounds mappings

The resulting firmware image is 5,386,496 bytes, within the 6,553,600-byte application slot.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_
