### PR TITLE
fix: Paper Mono cold boot from USB power

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -265,7 +265,12 @@ bool HalGPIO::coldBootImpliesPowerButton() const {
   // post-flash boots as battery button boots, and STAT-only boards like the
   // EEGO A4 misread them the same way once the charger terminates at 100%
   // (STAT inactive reads as "no USB").
-  return isXteinkDevice() || BoardConfig::isPaperMono() || BoardConfig::isSticky();
+  // Paper Mono: the button sits behind the PMIC and the board has no USB/charge
+  // telemetry at all (no gauge, no usbDetect pin), so isUsbConnected() is always
+  // false here. Gating it in would misread every USB/post-flash cold boot as a
+  // power-button boot and leave the display dark. Treat it like the other
+  // detection-blind boards: any cold boot is a normal boot.
+  return isXteinkDevice() || BoardConfig::isSticky();
 }
 
 HalGPIO::WakeupReason HalGPIO::getWakeupReason() const {


### PR DESCRIPTION
## Summary

The Paper Mono (m5stack_paper_mono, ESP32-S3-R8) release builds do not boot to the UI when the device is cold-plugged into USB power. One-line classification fix in `HalGPIO::coldBootImpliesPowerButton()`, verified on hardware.

`coldBootImpliesPowerButton()` listed Paper Mono among boards whose cold boot should be treated as a power-button boot. Paper Mono has no USB/charge telemetry at all (button behind the PMIC, no gauge, no `usbDetect` pin), so `isUsbConnected()` is always false there. Every USB / post-flash cold boot was misclassified as a power-button boot and the firmware refused to continue to the UI — the device sat dark until unplugged.

This is the same failure class the gate already handles for the other detection-blind boards, so Paper Mono is simply removed from that list.

## Verification (Paper Mono, ESP32-S3-R8)

With this change the device boots straight to the home screen on USB cold plug, and `getWakeupReason()` reports the expected values on subsequent power-button boots.

## Note on a second, deeper Paper Mono issue

While verifying on hardware I hit a separate problem: the display driver's PSRAM frame buffers never allocate (`psram=0/0`, `alloc FAIL psramTotal=0`). Root cause and analysis here: #3326. It needs a build-system decision (the env deliberately avoids `[firmware_tuned]` for TinyUSB reasons), so I kept it out of this PR.

## CI

`Build papermono`, `clang-format`, `Build default` and `Test Status` fail on `develop` itself (e.g. run 32668504092 fails in `SleepActivity.cpp: ProgressFile has not been declared`), so those red marks are pre-existing and unrelated to this change. `Build sticky` and `Build x4pro` pass on this branch.