### PR TITLE
fix(epub): lower below-baseline marks clear of descenders

### DIFF
--- a/lib/EpdFont/EpdFont.cpp
+++ b/lib/EpdFont/EpdFont.cpp
@@ -1,5 +1,6 @@
 #include "EpdFont.h"
 
+#include <BidiUtils.h>
 #include <Utf8.h>
 
 #include <algorithm>
@@ -19,11 +20,16 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
   int lastBaseLeft = 0;
   int lastBaseWidth = 0;
   int lastBaseTop = 0;
+  int lastBaseHeight = 0;
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
   uint32_t cp;
   uint32_t prevCp = 0;
   while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&string)))) {
-    const bool isCombining = utf8IsCombiningMark(cp);
+    // Match drawText()'s mark predicate: utf8IsCombiningMark() misses RTL NSM
+    // marks (Arabic harakat, Hebrew niqqud), which BidiUtils::isTransparentMark
+    // catches. Measurement must treat the same codepoints as marks that
+    // rendering overlays, or it records them as base glyphs and mismeasures.
+    const bool isCombining = utf8IsCombiningMark(cp) || BidiUtils::isTransparentMark(cp);
 
     if (!isCombining) {
       cp = applyLigatures(cp, string);
@@ -40,12 +46,16 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
         lastBaseLeft = 0;
         lastBaseWidth = 0;
         lastBaseTop = 0;
+        lastBaseHeight = 0;
       }
       continue;
     }
 
     const combiningMark::Anchor anchor = combiningMark::anchorFor(cp);
     const int raiseBy = isCombining ? combiningMark::raiseAboveBase(anchor, glyph->top, glyph->height, lastBaseTop) : 0;
+    const int lowerBy = isCombining ? combiningMark::lowerBelowBase(anchor, glyph->top, glyph->height, lastBaseTop,
+                                                                    lastBaseHeight, data->descender)
+                                    : 0;
 
     if (!isCombining && prevCp != 0) {
       const auto kernFP = getKerning(prevCp, cp);  // 4.4 fixed-point kern
@@ -55,7 +65,7 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
     const int glyphBaseX = isCombining ? combiningMark::anchorOver(anchor, lastBaseX, lastBaseLeft, lastBaseWidth,
                                                                    glyph->left, glyph->width)
                                        : lastBaseX;
-    const int glyphBaseY = startY - raiseBy;
+    const int glyphBaseY = startY - raiseBy + lowerBy;
 
     *minX = std::min(*minX, glyphBaseX + glyph->left);
     *maxX = std::max(*maxX, glyphBaseX + glyph->left + glyph->width);
@@ -66,6 +76,7 @@ void EpdFont::getTextBounds(const char* string, const int startX, const int star
       lastBaseLeft = glyph->left;
       lastBaseWidth = glyph->width;
       lastBaseTop = glyph->top;
+      lastBaseHeight = glyph->height;
       prevAdvanceFP = glyph->advanceX;  // 12.4 fixed-point
       prevCp = cp;
     }

--- a/lib/EpdFont/EpdFontData.h
+++ b/lib/EpdFont/EpdFontData.h
@@ -106,6 +106,24 @@ constexpr int raiseAboveBase(const Anchor anchor, const int markTop, const int m
   return (gap < MIN_GAP_PX) ? (MIN_GAP_PX - gap) : 0;
 }
 
+/// Lower a below-baseline combining mark clear of a base glyph that descends
+/// past it. `lineDescent` (negative) clamps the mark inside the line box.
+/// Returns 0 for above-baseline marks (see raiseAboveBase), non-default
+/// anchors, bases that don't reach the mark, and when there is no base glyph
+/// (baseHeight 0, e.g. a leading mark or a mark after a zero-height space).
+constexpr int lowerBelowBase(const Anchor anchor, const int markTop, const int markHeight, const int baseTop,
+                             const int baseHeight, const int lineDescent) {
+  if (anchor != Anchor::CenterRaised) return 0;
+  if (markTop > 0) return 0;
+  if (baseHeight == 0) return 0;  // no base glyph to clear
+  const int wantTop = (baseTop - baseHeight) - MIN_GAP_PX;
+  if (markTop <= wantTop) return 0;
+  int lower = markTop - wantTop;
+  const int markBottomAfter = markTop - lower - markHeight;
+  if (markBottomAfter < lineDescent) lower -= (lineDescent - markBottomAfter);  // keep inside line box
+  return lower < 0 ? 0 : lower;
+}
+
 }  // namespace combiningMark
 
 /// GCC/Clang (the ESP32 firmware toolchain) pack structs with __attribute__((packed)).

--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -653,6 +653,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
   int lastBaseLeft = 0;
   int lastBaseWidth = 0;
   int lastBaseTop = 0;
+  int lastBaseHeight = 0;
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
   if (fontCacheManager_ && fontCacheManager_->isScanning()) {
@@ -690,9 +691,12 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
       const auto anchor = combiningMark::anchorFor(cp);
       const int raiseBy =
           combiningMark::raiseAboveBase(anchor, combiningGlyph->top, combiningGlyph->height, lastBaseTop);
+      const int lowerBy = combiningMark::lowerBelowBase(anchor, combiningGlyph->top, combiningGlyph->height,
+                                                        lastBaseTop, lastBaseHeight, font.getData(style)->descender);
       const int combiningX = combiningMark::anchorOver(anchor, lastBaseX, lastBaseLeft, lastBaseWidth,
                                                        combiningGlyph->left, combiningGlyph->width);
-      renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, combiningX, yPos - raiseBy, black, style);
+      renderCharImpl<TextRotation::None>(*this, renderMode, font, cp, combiningX, yPos - raiseBy + lowerBy, black,
+                                         style);
       continue;
     }
 
@@ -711,6 +715,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     lastBaseLeft = glyph ? glyph->left : 0;
     lastBaseWidth = glyph ? glyph->width : 0;
     lastBaseTop = glyph ? glyph->top : 0;
+    lastBaseHeight = glyph ? glyph->height : 0;
     prevAdvanceFP = glyph ? glyph->advanceX : 0;  // 12.4 fixed-point
 
     const bool isSupSub = (style & (EpdFontFamily::SUP | EpdFontFamily::SUB)) != 0;
@@ -2147,6 +2152,7 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
   int lastBaseLeft = 0;
   int lastBaseWidth = 0;
   int lastBaseTop = 0;
+  int lastBaseHeight = 0;
   int32_t prevAdvanceFP = 0;  // 12.4 fixed-point: prev glyph's advance + next kern for snap
 
   uint32_t cp;
@@ -2165,7 +2171,9 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
       const auto anchor = combiningMark::anchorFor(cp);
       const int raiseBy =
           combiningMark::raiseAboveBase(anchor, combiningGlyph->top, combiningGlyph->height, lastBaseTop);
-      const int combiningX = x - raiseBy;
+      const int lowerBy = combiningMark::lowerBelowBase(anchor, combiningGlyph->top, combiningGlyph->height,
+                                                        lastBaseTop, lastBaseHeight, font.getData(style)->descender);
+      const int combiningX = x - raiseBy + lowerBy;
       const int combiningY = combiningMark::anchorOverRotated90CW(anchor, lastBaseY, lastBaseLeft, lastBaseWidth,
                                                                   combiningGlyph->left, combiningGlyph->width);
       renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, combiningX, combiningY, black, style);
@@ -2186,6 +2194,7 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
     lastBaseLeft = glyph ? glyph->left : 0;
     lastBaseWidth = glyph ? glyph->width : 0;
     lastBaseTop = glyph ? glyph->top : 0;
+    lastBaseHeight = glyph ? glyph->height : 0;
     prevAdvanceFP = glyph ? glyph->advanceX : 0;  // 12.4 fixed-point
 
     renderCharImpl<TextRotation::Rotated90CW>(*this, renderMode, font, cp, x, lastBaseY, black, style);

--- a/test/combining_marks/CombiningMarkAnchorTest.cpp
+++ b/test/combining_marks/CombiningMarkAnchorTest.cpp
@@ -15,6 +15,7 @@ using combiningMark::Anchor;
 using combiningMark::anchorFor;
 using combiningMark::anchorOver;
 using combiningMark::anchorOverRotated90CW;
+using combiningMark::lowerBelowBase;
 using combiningMark::raiseAboveBase;
 
 TEST(AnchorFor, PositionSensitiveNiqqud) {
@@ -70,4 +71,35 @@ TEST(RaiseAboveBase, CentreRaisedBehaviourUnchanged) {
   EXPECT_EQ(raiseAboveBase(Anchor::CenterRaised, 16, 3, 12), 0);
   // Below-baseline mark (kasra, cedilla): stays at font-native position.
   EXPECT_EQ(raiseAboveBase(Anchor::CenterRaised, 2, 4, 12), 0);
+}
+
+// A below-baseline mark (top -3, height 6) lowered clear of a base glyph that
+// descends past it. Font descender -18. Values from a real 16px face.
+TEST(LowerBelowBase, ClearsDescendingBase) {
+  // Base bottom -8, no clamp: lower = -3 - (-8 - 1) = 6.
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, -3, 6, 12, 20, -18), 6);
+}
+
+TEST(LowerBelowBase, ClampsToLineDescender) {
+  // Deep base (bottom -12): ideal lower 10 puts the mark at -19, clamped to 9.
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, -3, 6, 22, 34, -18), 9);
+}
+
+TEST(LowerBelowBase, NoLowerWhenBaseDoesNotDescendIntoMark) {
+  // Base sitting on the baseline: mark already clear.
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, -3, 6, 20, 20, -18), 0);
+}
+
+TEST(LowerBelowBase, NoLowerWithoutBaseGlyph) {
+  // No base glyph (baseHeight 0): a leading mark, or a mark after a zero-height
+  // space. Nothing to clear, so the mark must not be pushed against a phantom
+  // baseline. E.g. a leading U+0318 (combining tack below).
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, 0, 3, 0, 0, -18), 0);
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, -3, 6, 0, 0, -18), 0);
+}
+
+TEST(LowerBelowBase, IgnoresAboveBaselineMarksAndNativeAnchors) {
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterRaised, 23, 5, 22, 34, -18), 0);  // above-baseline: raiseAboveBase owns it
+  EXPECT_EQ(lowerBelowBase(Anchor::CenterNative, -3, 6, 22, 34, -18), 0);  // native anchors keep font height
+  EXPECT_EQ(lowerBelowBase(Anchor::RightNative, -3, 6, 22, 34, -18), 0);
 }

--- a/test/differential_rounding/CMakeLists.txt
+++ b/test/differential_rounding/CMakeLists.txt
@@ -2,11 +2,15 @@ add_executable(DifferentialRoundingTest
   DifferentialRoundingTest.cpp
   ${REPO_ROOT}/lib/EpdFont/EpdFont.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+  ${REPO_ROOT}/lib/MiniBidi/BidiUtils.cpp  # EpdFont::getTextBounds uses BidiUtils::isTransparentMark
+  ${REPO_ROOT}/lib/MiniBidi/minibidi.c
 )
 
 target_include_directories(DifferentialRoundingTest PRIVATE
+  ${REPO_ROOT}/test/minibidi_arabic/stubs  # no-op Logging.h (real one needs Arduino)
   ${REPO_ROOT}/lib/EpdFont
   ${REPO_ROOT}/lib/Utf8
+  ${REPO_ROOT}/lib/MiniBidi
 )
 
 target_link_libraries(DifferentialRoundingTest PRIVATE

--- a/test/ligature_guard/CMakeLists.txt
+++ b/test/ligature_guard/CMakeLists.txt
@@ -2,11 +2,15 @@ add_executable(LigatureGuardTest
   LigatureGuardTest.cpp
   ${REPO_ROOT}/lib/EpdFont/EpdFont.cpp
   ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+  ${REPO_ROOT}/lib/MiniBidi/BidiUtils.cpp  # EpdFont::getTextBounds uses BidiUtils::isTransparentMark
+  ${REPO_ROOT}/lib/MiniBidi/minibidi.c
 )
 
 target_include_directories(LigatureGuardTest PRIVATE
+  ${REPO_ROOT}/test/minibidi_arabic/stubs  # no-op Logging.h (real one needs Arduino)
   ${REPO_ROOT}/lib/EpdFont
   ${REPO_ROOT}/lib/Utf8
+  ${REPO_ROOT}/lib/MiniBidi
 )
 
 target_link_libraries(LigatureGuardTest PRIVATE


### PR DESCRIPTION
## Summary

Below-baseline combining marks (Arabic kasra, etc.)
were pinned at a fixed baseline-relative position, so any base glyph
that descends past the baseline overlapped them. Add lowerBelowBase(),
symmetric to raiseAboveBase(): lower the mark clear of the base's
descent, clamped to the font descender so it stays inside the line box.
Track lastBaseHeight in the draw and measure paths.

NOTE:
Heuristic, not GPOS (CrossPoint has none): it fixes only the vertical overlap — the mark stays centered, not at the font's real anchor — and when a base descends deeper than the mark can clear, it clamps to the descender (touching, not overlapping) rather than spilling into the next line.

Closes #3328 

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? Yes.
