### PR TITLE
fix(epub): render Arabic AE (U+06D5) connected

### DIFF
--- a/lib/MiniBidi/minibidi.c
+++ b/lib/MiniBidi/minibidi.c
@@ -327,6 +327,28 @@ static uchar stype(ucschar c) {
   return SU;
 }
 
+/* Visual fallback forms for joining characters that have no encoded Unicode
+ * presentation form, so the lookups in shape_form cannot shape them.  The
+ * connected (final) form borrows a visually compatible donor glyph; every
+ * other context keeps the base codepoint (these are right-joining, so only
+ * ISOLATED and FINAL occur).  These are renderer compatibility substitutions,
+ * not Unicode character equivalences.  Sorted by cp. */
+typedef struct {
+  ucschar cp;
+  ucschar final_form;
+} contextual_fallback;
+
+static const contextual_fallback contextual_fallbacks[] = {
+    {0x06D5, 0xFEEA}, /* ARABIC LETTER AE -> visually compatible HEH final form */
+};
+
+static ucschar fallback_shape_form(ucschar c, uchar form) {
+  if (form != SHAPE_FINAL) return c;
+  for (int i = 0; i < lengthof(contextual_fallbacks); i++)
+    if (c == contextual_fallbacks[i].cp) return contextual_fallbacks[i].final_form;
+  return c;
+}
+
 /* SISOLATED/SFINAL/SINITIAL/SMEDIAL equivalent.
    form is one of the SHAPE_* offsets; returns c unchanged when the letter
    has no presentation form allocated for that context. */
@@ -346,7 +368,7 @@ static ucschar shape_form(ucschar c, uchar form) {
     else
       return form < xshapeforms[k].forms ? xshapeforms[k].isolated + form : c;
   }
-  return c;
+  return fallback_shape_form(c, form);
 }
 
 /* CrossPoint deviation 1: NSM marks (harakat) sit between letters in our

--- a/test/minibidi_arabic/MiniBidiArabicTest.cpp
+++ b/test/minibidi_arabic/MiniBidiArabicTest.cpp
@@ -234,6 +234,32 @@ TEST(Regression, HebrewUntouchedByShaper) {
 // Pure Latin text passes through unchanged.
 TEST(Regression, LatinPassthrough) { EXPECT_EQ(shapeVisual({'h', 'e', 'l', 'l', 'o'}), (CP{'h', 'e', 'l', 'l', 'o'})); }
 
+/* ── AE (U+06D5) final-form fallback ─────────────────────────────────────
+ * AE has no encoded presentation form; its connected (final) shape falls back
+ * to the final-form Heh (U+FEEA) so a preceding letter joins into it, while
+ * the isolated form keeps the base codepoint. AE is right-joining, so it never
+ * joins forward. Expectations are visual order (left to right). */
+
+// Standalone AE keeps its base codepoint (isolated).
+TEST(ArabicAe, IsolatedKeepsBase) { EXPECT_EQ(shapeVisual({0x06D5}), (CP{0x06D5})); }
+
+// A dual-joining letter before AE joins into it; AE takes the fallback final form.
+TEST(ArabicAe, ConnectsAfterJoiningLetter) {
+  EXPECT_EQ(shapeVisual({0x0628, 0x06D5}), (CP{0xFEEA, 0xFE91}));                  // بە
+  EXPECT_EQ(shapeVisual({0x0628, 0x06D5, 0x062A}), (CP{0xFE95, 0xFEEA, 0xFE91}));  // بەت
+  EXPECT_EQ(shapeVisual({0x0645, 0x06D5, 0x0646}), (CP{0xFEE5, 0xFEEA, 0xFEE3}));  // مەن
+}
+
+// A right-joining-only letter (alef) does not join forward, so AE stays isolated.
+TEST(ArabicAe, StaysIsolatedAfterNonForwardJoiner) {
+  EXPECT_EQ(shapeVisual({0x0627, 0x06D5}), (CP{0x06D5, 0xFE8D}));  // اە
+}
+
+// ZWNJ blocks the join: AE stays isolated (the ZWNJ is dropped from output).
+TEST(ArabicAe, StaysIsolatedAcrossZwnj) {
+  EXPECT_EQ(shapeVisual({0x0628, 0x200C, 0x06D5}), (CP{0x06D5, 0xFE8F}));  // ب‌ە
+}
+
 /* ── isTransparentMark ───────────────────────────────────────────────── */
 
 TEST(TransparentMark, RtlMarksAreTransparent) {


### PR DESCRIPTION

## Summary

* **What is the goal of this PR?** (e.g., Implements the new feature for file uploading.)
* **What changes are included?**

U+06D5 (Arabic AE, used in Kurdish/Uyghur/Kazakh/Kyrgyz/Ottoman) has
no encoded Unicode presentation form, so the codepoint-based shaper could not
produce its connected shape: it stayed in its isolated form even when the
preceding letter joined into it. Neighbours already shaped correctly (AE is
right-joining); only AE itself was wrong.

Add a small contextual-fallback table in shape_form: AE's final form borrows
the visually compatible final-form Heh (U+FEEA); the isolated form keeps the
base codepoint. This is a renderer compatibility substitution, not a Unicode
equivalence. Runs only as a fallback after the normal presentation-form
lookups miss, so no other codepoint is affected.

Closes #2909

Fixes https://github.com/crosspoint-reader/crosspoint-reader/issues/2909

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

**If this PR was opened against the previous (broader) scope and was already in flight under Phase 0, link the
relevant Discussion or issue so reviewers can see the history.**

## Additional Context

* Add any other information that might be helpful for the reviewer (e.g., performance implications, potential risks,
  specific areas to focus on).
* Memory / flash impact, if known.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? Yes
