### PR TITLE
fix(x4pro): shut down SD card before deep sleep

### DIFF
--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -44,6 +44,28 @@ class HalStorage::StorageLock {
   ~StorageLock() { xSemaphoreGiveRecursive(HalStorage::getInstance().storageMutex); }
 };
 
+bool HalStorage::prepareForDeepSleep() {
+#if FREEINK_SD_SDMMC
+  StorageLock lock;
+  if (!SDCard.ready()) return true;
+
+  // Sleep preparation runs after all filesystem users have stopped. Detach the
+  // volume, synchronize the device, then stop the native host before its
+  // external rail is disabled.
+  FsBlockDeviceInterface* blockDevice = SDCard.detachFilesystemForRawAccess();
+  if (!blockDevice) {
+    LOG_ERR("STORAGE", "Failed to detach SD volume before deep sleep");
+    return false;
+  }
+  const bool synced = blockDevice->syncDevice();
+  if (!synced) LOG_ERR("STORAGE", "Failed to synchronize SD device before deep sleep");
+  blockDevice->end();
+  LOG_DBG("STORAGE", "SD volume and host stopped for deep sleep");
+  return synced;
+#endif
+  return true;
+}
+
 #if FREEINK_CAP_USB_MSC && !FREEINK_SD_SDMMC
 #error "USB Drive requires an SDMMC-backed storage profile"
 #endif

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -24,6 +24,10 @@ class HalStorage {
   HalStorage();
   bool begin();
   bool ready() const;
+  // Release the mounted volume and its block device before deep sleep. Call
+  // only after all file users have stopped; existing HalFiles become invalid.
+  // A deep-sleep wake resets the MCU and mounts storage again through begin().
+  bool prepareForDeepSleep();
   // USB Drive exclusively owns the SD card while active. Callers must stop
   // all filesystem work before beginUsbDrive(), then reboot after endUsbDrive().
   bool beginUsbDrive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,6 +289,7 @@ void enterDeepSleep(bool fromTimeout = false) {
 
   halTiltSensor.deepSleep();
   display.deepSleep();
+  Storage.prepareForDeepSleep();
   LOG_DBG("MAIN", "Entering deep sleep");
 
   powerManager.startDeepSleep(gpio);
@@ -450,6 +451,7 @@ void setup() {
       // the device in a USB-replug boot loop (or sleep right after a flash).
       break;
 #else
+      Storage.prepareForDeepSleep();
       powerManager.startDeepSleep(gpio);
       break;
 #endif


### PR DESCRIPTION
## Summary

This fixes an X4 Pro sleep-power regression exposed after #3215 made battery-only fast wake reliable.

On the RC03/develop baseline, I observed approximately 2% battery loss per hour while using the `Cover` sleep screen. The mounted filesystem and SDMMC host remained active until deep sleep, even though the SD power gate was
disabled later in the sleep sequence.

After sleep-screen storage access finishes, this change unmounts the filesystem, and stops the SDMMC host before SD power is disabled. A deep-sleep wake mounts the card normally during boot.

I tested an earlier version containing the same SD teardown on an X4 Pro for 24 hours with the `Cover` sleep screen. The battery indicator showed minimal to no loss, compared with approximately 2% per hour on the RC03/develop baseline.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

Stock/fork context: #3215 documents that stock firmware does not reliably provide battery-only fast wake on affected hardware. This PR fixes the SD power regression in CrossPoint's fast-wake implementation. No popular fork
is known to solve this combination.

## Additional Context

- Applies only to native-SDMMC targets; SPI-backed storage retains its existing behavior.
- `pio run -e x4pro`: passed.
- `pio run -e default`: passed.

### AI Usage

Did you use AI tools to help write this code? _**YES**_

