### PR TITLE
fix: sd not shutting down on deep sleep & restores single click power on

### DIFF
--- a/lib/hal/HalStorage.cpp
+++ b/lib/hal/HalStorage.cpp
@@ -44,6 +44,11 @@ class HalStorage::StorageLock {
   ~StorageLock() { xSemaphoreGiveRecursive(HalStorage::getInstance().storageMutex); }
 };
 
+void HalStorage::prepareForDeepSleep() {
+  StorageLock lock;
+  SDCard.shutdown();
+}
+
 #if FREEINK_CAP_USB_MSC && !FREEINK_SD_SDMMC
 #error "USB Drive requires an SDMMC-backed storage profile"
 #endif

--- a/lib/hal/HalStorage.h
+++ b/lib/hal/HalStorage.h
@@ -24,6 +24,11 @@ class HalStorage {
   HalStorage();
   bool begin();
   bool ready() const;
+  // Stop the SD card for deep sleep: unmount, stop the SDMMC host, and release
+  // the bus pads (no-op on SPI boards). Call only after all file users have
+  // stopped; open HalFiles become invalid. A deep-sleep wake resets the MCU and
+  // mounts storage again through begin().
+  void prepareForDeepSleep();
   // USB Drive exclusively owns the SD card while active. Callers must stop
   // all filesystem work before beginUsbDrive(), then reboot after endUsbDrive().
   bool beginUsbDrive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -372,10 +372,11 @@ void setup() {
   powerManager.begin();
 
   const auto wakeupReason = gpio.getWakeupReason();
-  if (wakeupReason == HalGPIO::WakeupReason::PowerButton && !gpio.verifyPowerButtonWakeup()) {
-    LOG_DBG("MAIN", "Power-button wake not held through verification, sleeping");
-    powerManager.startDeepSleep(gpio);
-  }
+  // Sample the wake hold now — a click wake is released within milliseconds of
+  // boot — but defer the sleep-or-boot decision until SETTINGS is loaded below:
+  // click-to-wake is a setting, and an X4 battery power-off cuts all power, so
+  // only SD state survives to the next boot.
+  const bool wakeHoldVerified = wakeupReason != HalGPIO::WakeupReason::PowerButton || gpio.verifyPowerButtonWakeup();
 
   // X4 Pro and X4 Classic both map BTN_UP to GPIO0 — an ESP32-S3 boot strap — so
   // gate recovery on the non-strap Down key (GPIO7) to avoid a stuck-in-recovery loop.
@@ -436,6 +437,12 @@ void setup() {
 
   switch (wakeupReason) {
     case HalGPIO::WakeupReason::PowerButton:
+      // With Short Power Button Press = Sleep, a single click wakes on any
+      // device; otherwise the button must still be held (ghost-wake debounce).
+      if (!wakeHoldVerified && SETTINGS.shortPwrBtn != CrossPointSettings::SHORT_PWRBTN::SLEEP) {
+        LOG_DBG("MAIN", "Power-button wake not held through verification, sleeping");
+        powerManager.startDeepSleep(gpio);
+      }
       wakePowerReleasePending = true;
       break;
     case HalGPIO::WakeupReason::AfterUSBPower:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,6 +289,7 @@ void enterDeepSleep(bool fromTimeout = false) {
 
   halTiltSensor.deepSleep();
   display.deepSleep();
+  Storage.prepareForDeepSleep();
   LOG_DBG("MAIN", "Entering deep sleep");
 
   powerManager.startDeepSleep(gpio);
@@ -441,6 +442,7 @@ void setup() {
       // device; otherwise the button must still be held (ghost-wake debounce).
       if (!wakeHoldVerified && SETTINGS.shortPwrBtn != CrossPointSettings::SHORT_PWRBTN::SLEEP) {
         LOG_DBG("MAIN", "Power-button wake not held through verification, sleeping");
+        Storage.prepareForDeepSleep();
         powerManager.startDeepSleep(gpio);
       }
       wakePowerReleasePending = true;
@@ -457,6 +459,7 @@ void setup() {
       // the device in a USB-replug boot loop (or sleep right after a flash).
       break;
 #else
+      Storage.prepareForDeepSleep();
       powerManager.startDeepSleep(gpio);
       break;
 #endif


### PR DESCRIPTION
With Short Power Button Press = Sleep, a single click wakes the device again on every board. The held-button verification still samples the power pin early in setup() (a click is released within milliseconds of boot), but the sleep-or-boot decision now waits until SETTINGS is loaded: click-to-wake is a setting, and on the C3 Xteink boards a battery power-off cuts all power, so only SD state survives to the next boot. Regression from #3191, which required the button to be held through boot regardless of the setting.

Also fixes the issue identified by @jfmyers9 where the SD card wasn't shutting down on the x4pro on sleep

Closes #3332 