### PR TITLE
feat(board): add OnePage ESP32-C61 board target and UI mapping support

### DIFF
--- a/boards/onepage-c61.json
+++ b/boards/onepage-c61.json
@@ -1,0 +1,36 @@
+{
+  "build": {
+    "core": "esp32",
+    "f_cpu": "160000000L",
+    "f_flash": "80000000L",
+    "flash_mode": "dio",
+    "mcu": "esp32c61",
+    "variant": "esp32c61"
+  },
+  "connectivity": [
+    "bluetooth",
+    "wifi"
+  ],
+  "debug": {
+    "openocd_target": "esp32c61.cfg"
+  },
+  "frameworks": [
+    "arduino",
+    "espidf"
+  ],
+  "name": "OnePage (ESP32-C61HR2, 16 MB Flash, 2 MB PSRAM @40MHz)",
+  "upload": {
+    "flash_size": "16MB",
+    "maximum_ram_size": 327680,
+    "maximum_size": 16777216,
+    "require_upload_port": true,
+    "speed": 460800
+  },
+  "espidf": {
+    "custom_sdkconfig": [
+      "CONFIG_IDF_TARGET=\"esp32c61\""
+    ]
+  },
+  "url": "https://github.com/MoveCall/onepage-reader",
+  "vendor": "OnePage"
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,7 @@ extra_scripts =
   pre:scripts/gen_i18n.py
   pre:scripts/git_branch.py
   pre:scripts/patch_jpegdec.py
+  pre:scripts/patch_pngdec.py
   post:scripts/register_unit_tests_target.py
 
 ; Libraries
@@ -400,3 +401,50 @@ build_flags =
   -DENABLE_SERIAL_LOG
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
   -DUSE_BLOCK_DEVICE_INTERFACE=1
+
+; --- OnePage Reader — ESP32-C61, SSD1677 800x480, 4-key ADC ladder + 3 side keys -
+; Open-hardware DIY e-reader ecosystem (ESP32-C61HR2, 16MB flash, 2MB PSRAM @40MHz).
+; MicroSD shares SPI bus with EPD (20MHz). BLE HID host support for page-turner remotes.
+[env:onepage]
+extends = base
+board = onepage-c61
+board_build.mcu = esp32c61
+extra_scripts =
+  ${base.extra_scripts}
+  pre:scripts/patch_ld_sleep_clock.py
+custom_sdkconfig =
+  CONFIG_SPIRAM=y
+  CONFIG_SPIRAM_MODE_QUAD=y
+  CONFIG_SPIRAM_SPEED_40M=y
+  CONFIG_SPIRAM_USE_MALLOC=y
+  CONFIG_SPIRAM_BOOT_INIT=y
+  CONFIG_SPIRAM_BOOT_HW_INIT=y
+  CONFIG_SPIRAM_PRE_CONFIGURE_MEMORY_PROTECTION=y
+  CONFIG_SPIRAM_MALLOC_RESERVE_INTERNAL=65536
+  CONFIG_BT_NIMBLE_TRANSPORT_ACL_FROM_LL_COUNT=8
+  CONFIG_BT_NIMBLE_MSYS_1_BLOCK_COUNT=16
+  CONFIG_BT_LE_SLEEP_ENABLE=y
+  CONFIG_BT_LE_LP_CLK_SRC_MAIN_XTAL=n
+  CONFIG_BT_LE_LP_CLK_SRC_DEFAULT=y
+  CONFIG_RTC_CLK_SRC_INT_RC=n
+  CONFIG_RTC_CLK_SRC_EXT_CRYS=y
+  CONFIG_ESPTOOLPY_FLASHFREQ_40M=n
+  CONFIG_ESPTOOLPY_FLASHFREQ_80M=y
+custom_component_remove =
+  espressif/esp_rainmaker
+  espressif/rmaker_common
+  espressif/esp_insights
+  espressif/esp_diag_data_store
+  espressif/esp_diagnostics
+  espressif/esp-modbus
+  espressif/esp-serial-flasher
+  espressif/esp-zboss-lib
+  espressif/esp-zigbee-lib
+  espressif/cbor
+build_flags =
+  ${base.build_flags}
+  -DFREEINK_DEVICE_ONEPAGE=1
+  -DCROSSPOINT_VERSION=\"${crosspoint.version}-onepage\"
+  -DENABLE_SERIAL_LOG
+  -DCROSSPOINT_WAIT_FOR_USB_SERIAL
+  -DLOG_LEVEL=2

--- a/scripts/patch_ld_sleep_clock.py
+++ b/scripts/patch_ld_sleep_clock.py
@@ -1,0 +1,93 @@
+"""
+PlatformIO pre-build script: fix an upstream linker-script omission that makes
+CONFIG_BT_LE_SLEEP_ENABLE unbuildable on the ESP32-C61 Arduino framework.
+
+Background
+----------
+Enabling the BLE controller's modem-sleep (CONFIG_BT_LE_SLEEP_ENABLE=y) links in
+`sleep_clock_modem_retention_init` from libesp_hw_support.a. The C61 linker
+script `ld/sections.ld` places `sleep_clock.*` .text via an *explicit* rule that
+lists only two sections:
+
+    *libesp_hw_support.a:sleep_clock.*(.text
+        .text.__esp_system_init_fn_sleep_clock_startup_init
+        .text.sleep_clock_system_retention_init)
+
+and the generic `.text.*` collector in `.flash.text` EXCLUDE_FILEs
+`sleep_clock.*`. So `.text.sleep_clock_modem_retention_init` matches neither the
+explicit list nor the generic collector. It falls through to an output section
+with no 4-byte alignment, landing at an odd flash address (e.g. 0x421e9b62).
+esptool then rejects the image: "Invalid .text.sleep_clock_modem_retention_init
+segment length ... has to be multiple of 4".
+
+With BLE sleep disabled (the Arduino default) that section is never linked, so
+the omission is invisible — it only bites once we enable BT_LE_SLEEP_ENABLE.
+
+Fix
+---
+Add `.text.sleep_clock_modem_retention_init` to the explicit sleep_clock rule so
+it is collected alongside the other retention-init sections in the properly
+aligned .flash.text output section.
+
+This patches a file inside the PlatformIO package cache (outside the repo). It
+is idempotent and refuses to act if the upstream rule text has changed, so a
+framework update that restructures the script won't be silently corrupted.
+"""
+
+Import("env")  # noqa: F821 (SCons-injected global)
+import os
+
+RULE_OLD = (
+    "*libesp_hw_support.a:sleep_clock.*(.text "
+    ".text.__esp_system_init_fn_sleep_clock_startup_init "
+    ".text.sleep_clock_system_retention_init)"
+)
+RULE_NEW = (
+    "*libesp_hw_support.a:sleep_clock.*(.text "
+    ".text.__esp_system_init_fn_sleep_clock_startup_init "
+    ".text.sleep_clock_system_retention_init "
+    ".text.sleep_clock_modem_retention_init)"
+)
+
+
+def _framework_libs_dir(env):
+    # e.g. ~/.platformio/packages/framework-arduinoespressif32-libs
+    for pkg in ("framework-arduinoespressif32-libs",):
+        d = env.PioPlatform().get_package_dir(pkg)
+        if d and os.path.isdir(d):
+            return d
+    return None
+
+
+def patch_sections_ld(env):
+    libs_dir = _framework_libs_dir(env)
+    if not libs_dir:
+        return  # not the C61-from-source build; nothing to patch
+
+    ld_path = os.path.join(libs_dir, "esp32c61", "ld", "sections.ld")
+    if not os.path.isfile(ld_path):
+        return
+
+    with open(ld_path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    if ".text.sleep_clock_modem_retention_init" in text:
+        return  # already patched
+
+    if RULE_OLD not in text:
+        # Upstream layout changed — do not risk corrupting it. If BT_LE_SLEEP is
+        # enabled the build will still fail loudly at esptool, which is the
+        # correct signal to revisit this patch.
+        print(
+            "WARN: patch_ld_sleep_clock: expected sleep_clock rule not found in "
+            "%s; skipping (framework may have fixed or restructured this)." % ld_path
+        )
+        return
+
+    text = text.replace(RULE_OLD, RULE_NEW, 1)
+    with open(ld_path, "w", encoding="utf-8") as f:
+        f.write(text)
+    print("Patched sections.ld: collect .text.sleep_clock_modem_retention_init (%s)" % ld_path)
+
+
+patch_sections_ld(env)  # noqa: F821

--- a/scripts/patch_pngdec.py
+++ b/scripts/patch_pngdec.py
@@ -1,0 +1,74 @@
+"""
+PlatformIO pre-build script: guard PNGdec's ESP32-S3 SIMD assembly so it
+compiles on targets whose Arduino framework build lacks the esp-dsp component.
+
+PNGdec 1.1.6 ships `s3_simd_rgb565.S` which, under `#ifdef ARDUINO_ARCH_ESP32`,
+unconditionally does `#include "dsps_fft2r_platform.h"`. That header is provided
+by the espressif/esp-dsp component. The ESP32-C61 Arduino framework is built
+from source via custom_sdkconfig and does NOT include esp-dsp, so the raw
+include is a fatal "No such file or directory" — it only ever built on C3/S3
+because their prebuilt arduino-libs happen to carry the header.
+
+JPEGDEC's equivalent `.S` files already guard the include with
+`#if __has_include("dsps_fft2r_platform.h")`. This script retrofits the same
+guard onto PNGdec's file so the block is skipped cleanly when the header is
+absent (the SIMD path is an ESP32-S3-only optimization; C61 does not use it).
+
+Idempotent: if the guard is already present, the file is left untouched.
+"""
+
+Import("env")  # noqa: F821 (SCons-injected global)
+import os
+
+RAW_INCLUDE = '#include "dsps_fft2r_platform.h"'
+GUARDED_INCLUDE = (
+    '#if __has_include("dsps_fft2r_platform.h")\n'
+    '#include "dsps_fft2r_platform.h"'
+)
+# Matching #endif is appended after the existing include-guarded block. The
+# upstream file already closes its `#ifdef ARDUINO_ARCH_ESP32` with an #endif;
+# we only need to balance the __has_include we introduce, so we append one
+# #endif right before that final one via a sentinel comment match.
+
+
+def patch_pngdec(env):
+    libdeps_dir = os.path.join(env["PROJECT_DIR"], ".pio", "libdeps")
+    if not os.path.isdir(libdeps_dir):
+        return
+    for env_dir in os.listdir(libdeps_dir):
+        s_file = os.path.join(libdeps_dir, env_dir, "PNGdec", "src", "s3_simd_rgb565.S")
+        if os.path.isfile(s_file):
+            _patch_one(s_file)
+
+
+def _patch_one(path):
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    if "__has_include" in text:
+        return  # already guarded
+
+    if RAW_INCLUDE not in text:
+        return  # upstream layout changed — leave it alone rather than corrupt it
+
+    # Wrap the include in a __has_include guard and close it right before the
+    # final trailing #endif that closes the ARDUINO_ARCH_ESP32 block.
+    text = text.replace(RAW_INCLUDE, GUARDED_INCLUDE, 1)
+
+    # Close the __has_include we opened. The file ends with the
+    # `#endif // dsps_fft2r_sc16_aes3_enabled` line followed by the outer
+    # `#endif` for ARDUINO_ARCH_ESP32. Insert our closing #endif after the
+    # inner sc16 #endif.
+    marker = "#endif // dsps_fft2r_sc16_aes3_enabled"
+    if marker in text:
+        text = text.replace(marker, marker + "\n#endif // __has_include dsps_fft2r_platform.h", 1)
+    else:
+        # Fallback: append at EOF (still balances the guard).
+        text = text.rstrip() + "\n#endif // __has_include dsps_fft2r_platform.h\n"
+
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    print("Guarded PNGdec S3 SIMD include: %s" % path)
+
+
+patch_pngdec(env)  # noqa: F821

--- a/src/MappedInputManager.cpp
+++ b/src/MappedInputManager.cpp
@@ -404,6 +404,12 @@ MappedInputManager::Labels MappedInputManager::mapFrontLabels(const char* back, 
     return "";
   };
 
+  if (BoardConfig::isOnePage()) {
+    // OnePage physical layout from left to right: Back, Left, Right, Confirm (K1-K4)
+    return {labelForHardware(HalGPIO::BTN_BACK), labelForHardware(HalGPIO::BTN_LEFT),
+            labelForHardware(HalGPIO::BTN_RIGHT), labelForHardware(HalGPIO::BTN_CONFIRM)};
+  }
+
   return {labelForHardware(HalGPIO::BTN_BACK), labelForHardware(HalGPIO::BTN_CONFIRM),
           labelForHardware(HalGPIO::BTN_LEFT), labelForHardware(HalGPIO::BTN_RIGHT)};
 }

--- a/src/network/FirmwareBoardTag.cpp
+++ b/src/network/FirmwareBoardTag.cpp
@@ -28,6 +28,8 @@
 #define CROSSPOINT_BOARD_NAME "murphy"
 #elif FREEINK_DEVICE_DELINK
 #define CROSSPOINT_BOARD_NAME "delink"
+#elif FREEINK_DEVICE_ONEPAGE
+#define CROSSPOINT_BOARD_NAME "onepage"
 #else
 #error "FirmwareBoardTag: no FREEINK_DEVICE_* flag set; cannot derive board name"
 #endif


### PR DESCRIPTION
### Summary                                                                                                                  
Adds board support and build configuration for the **OnePage** DIY e-reader (ESP32-C61, SSD1677 800×480 e-paper, 4-key front ADC ladder + 3 side keys).                                                                                                     
                                                                                                                                 
Hardware repo: https://github.com/MoveCall/onepage-reader                                                                    
SDK dependency: merged upstream in freeink-project/freeink-sdk#68 and #70.                                                   
                                                                                                                                 
### Changes                                                                                                                  
- Added `boards/onepage-c61.json` and `[env:onepage]` in `platformio.ini`                                                    
- Added build helper scripts (`patch_pngdec.py`, `patch_ld_sleep_clock.py`) for C61                                          
- Added physical button hint order (`Back, Left, Right, Confirm`) in `MappedInputManager`                                    
- Added `onepage` firmware tag in `FirmwareBoardTag.cpp`                                                                     
                                                                                                                                 
### Verification                                                                                                             
- Successfully built `[env:onepage]` with PlatformIO                                                                         
- Tested and verified on physical OnePage hardware (display, buttons, SD card, USB) 

<img width="4032" height="3024" alt="IMG_1980" src="https://github.com/user-attachments/assets/027a08a0-0997-43ce-a24e-6b5a209a5e4b" />
