### PR TITLE
fix(reader): wrap long unbreakable words instead of dropping them

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 
 #include "FontCacheManager.h"
+#include "TextWrap.h"
 
 namespace {
 
@@ -1756,66 +1757,11 @@ std::string GfxRenderer::truncatedText(const int fontId, const char* text, const
 
 std::vector<std::string> GfxRenderer::wrappedText(const int fontId, const char* text, const int maxWidth,
                                                   const int maxLines, const EpdFontFamily::Style style) const {
-  std::vector<std::string> lines;
-
-  if (!text || maxWidth <= 0 || maxLines <= 0) return lines;
-
-  std::string remaining = text;
-  std::string currentLine;
-
-  while (!remaining.empty()) {
-    if (static_cast<int>(lines.size()) == maxLines - 1) {
-      // Last available line: combine any word already started on this line with
-      // the rest of the text, then let truncatedText fit it with an ellipsis.
-      std::string lastContent = currentLine.empty() ? remaining : currentLine + " " + remaining;
-      lines.push_back(truncatedText(fontId, lastContent.c_str(), maxWidth, style));
-      return lines;
-    }
-
-    // Find next word
-    size_t spacePos = remaining.find(' ');
-    std::string word;
-
-    if (spacePos == std::string::npos) {
-      word = remaining;
-      remaining.clear();
-    } else {
-      word = remaining.substr(0, spacePos);
-      remaining.erase(0, spacePos + 1);
-    }
-
-    std::string testLine = currentLine.empty() ? word : currentLine + " " + word;
-
-    if (getTextWidth(fontId, testLine.c_str(), style) <= maxWidth) {
-      currentLine = testLine;
-    } else {
-      if (!currentLine.empty()) {
-        lines.push_back(currentLine);
-        // If the carried-over word itself exceeds maxWidth, truncate it and
-        // push it as a complete line immediately — storing it in currentLine
-        // would allow a subsequent short word to be appended after the ellipsis.
-        if (getTextWidth(fontId, word.c_str(), style) > maxWidth) {
-          lines.push_back(truncatedText(fontId, word.c_str(), maxWidth, style));
-          currentLine.clear();
-          if (static_cast<int>(lines.size()) >= maxLines) return lines;
-        } else {
-          currentLine = word;
-        }
-      } else {
-        // Single word wider than maxWidth: truncate and stop to avoid complicated
-        // splitting rules (different between languages). Results in an aesthetically
-        // pleasing end.
-        lines.push_back(truncatedText(fontId, word.c_str(), maxWidth, style));
-        return lines;
-      }
-    }
-  }
-
-  if (!currentLine.empty() && static_cast<int>(lines.size()) < maxLines) {
-    lines.push_back(currentLine);
-  }
-
-  return lines;
+  // Line-breaking logic lives in textwrap::wrapLines (header-only, unit-tested);
+  // here we bind it to this renderer's font measurement and ellipsis truncation.
+  return textwrap::wrapLines(
+      text, maxWidth, maxLines, [&](const std::string& s) { return getTextWidth(fontId, s.c_str(), style); },
+      [&](const std::string& s) { return truncatedText(fontId, s.c_str(), maxWidth, style); });
 }
 
 // Note: Internal driver treats screen in command orientation; this library exposes a logical orientation

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -303,8 +303,9 @@ class GfxRenderer {
   std::string truncatedText(int fontId, const char* text, int maxWidth,
                             EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
   /// Word-wrap \p text into at most \p maxLines lines, each no wider than
-  /// \p maxWidth pixels. Overflowing words and excess lines are UTF-8-safely
-  /// truncated with an ellipsis (U+2026).
+  /// \p maxWidth pixels. A word wider than \p maxWidth is hard-broken at a
+  /// UTF-8 codepoint boundary rather than dropped. Only the final line is
+  /// truncated with an ellipsis (U+2026), when \p maxLines is exhausted.
   std::vector<std::string> wrappedText(int fontId, const char* text, int maxWidth, int maxLines,
                                        EpdFontFamily::Style style = EpdFontFamily::REGULAR) const;
 

--- a/lib/GfxRenderer/TextWrap.h
+++ b/lib/GfxRenderer/TextWrap.h
@@ -2,8 +2,11 @@
 
 #include <Utf8.h>
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <string_view>
 #include <vector>
 
 // Greedy word-wrap for GfxRenderer::wrappedText(), header-only so the pure
@@ -13,6 +16,8 @@
 // Breaks on ASCII spaces; a token wider than maxWidth is hard-broken at UTF-8
 // codepoint boundaries rather than dropped (#2949). This is codepoint-level, not
 // full Unicode line-breaking/grapheme segmentation (future work).
+// Every emitted line is a contiguous slice of the input, so traversal is
+// allocation-free: the only heap use is the returned line strings.
 namespace textwrap {
 
 template <typename Measure, typename TruncateToWidth>
@@ -21,73 +26,85 @@ std::vector<std::string> wrapLines(const char* text, const int maxWidth, const i
   std::vector<std::string> lines;
   if (!text || maxWidth <= 0 || maxLines <= 0) return lines;
 
-  std::string remaining = text;
-  std::string currentLine;
+  const std::string_view in(text);
+  // No line is emptier than one codepoint, so lines can't exceed the byte count;
+  // cap the reservation so a huge maxLines on short text can't over-allocate.
+  lines.reserve(std::min(static_cast<size_t>(maxLines), in.size()));
+  std::string scratch;  // reused for width probes; capacity is retained across calls
 
-  // Longest prefix of s (>= 1 codepoint) that fits maxWidth, as a byte length on
-  // a UTF-8 boundary. Takes one codepoint even if it overflows, to make progress.
-  const auto prefixWithinWidth = [&](const std::string& s) -> size_t {
-    const char* base = s.c_str();
-    const uint8_t* p = reinterpret_cast<const uint8_t*>(base);
+  // Width of the byte range in[start, start+len), via the reused scratch buffer.
+  const auto measureRange = [&](const size_t start, const size_t len) -> int {
+    scratch.assign(in.data() + start, len);
+    return measure(scratch);
+  };
+
+  // Longest prefix of in[start, start+len) (>= 1 codepoint) that fits maxWidth,
+  // as a byte length on a UTF-8 boundary. Takes one codepoint even if it
+  // overflows, to make progress. Walks boundaries via the lead byte only, so it
+  // never reads past the range even on truncated/invalid input.
+  const auto prefixWithinWidth = [&](const size_t start, const size_t len) -> size_t {
+    size_t consumed = 0;
     size_t lastFit = 0;
-    while (*p) {
-      const uint8_t* q = p;
-      utf8NextCodepoint(&q);
-      const size_t cand = static_cast<size_t>(reinterpret_cast<const char*>(q) - base);
-      if (measure(s.substr(0, cand)) <= maxWidth) {
+    while (consumed < len) {
+      size_t step = static_cast<size_t>(utf8CodepointLen(static_cast<uint8_t>(in[start + consumed])));
+      if (step > len - consumed) step = len - consumed;  // clamp to the range end
+      const size_t cand = consumed + step;
+      if (measureRange(start, cand) <= maxWidth) {
         lastFit = cand;
-        p = q;
+        consumed = cand;
       } else {
         break;
       }
     }
     if (lastFit == 0) {
-      const uint8_t* q = reinterpret_cast<const uint8_t*>(base);
-      utf8NextCodepoint(&q);
-      lastFit = static_cast<size_t>(reinterpret_cast<const char*>(q) - base);
+      lastFit = static_cast<size_t>(utf8CodepointLen(static_cast<uint8_t>(in[start])));
+      if (lastFit > len) lastFit = len;
     }
     return lastFit;
   };
 
-  while (!remaining.empty()) {
+  size_t pos = 0;         // start of the next unprocessed word
+  size_t lineStart = 0;   // start of the current line's committed content
+  size_t lineLen = 0;     // its byte length
+  bool haveLine = false;  // whether the current line has any content
+
+  while (pos < in.size()) {
     if (static_cast<int>(lines.size()) == maxLines - 1) {
       // Last available line: fold in the rest and ellipsize.
-      lines.push_back(truncateToWidth(currentLine.empty() ? remaining : currentLine + " " + remaining));
+      const size_t start = haveLine ? lineStart : pos;
+      scratch.assign(in.data() + start, in.size() - start);
+      lines.push_back(truncateToWidth(scratch));
       return lines;
     }
 
-    size_t spacePos = remaining.find(' ');
-    std::string word;
-    if (spacePos == std::string::npos) {
-      word = remaining;
-      remaining.clear();
-    } else {
-      word = remaining.substr(0, spacePos);
-      remaining.erase(0, spacePos + 1);
-    }
+    const size_t space = in.find(' ', pos);
+    const size_t wordEnd = (space == std::string_view::npos) ? in.size() : space;
+    const size_t candStart = haveLine ? lineStart : pos;
 
-    std::string testLine = currentLine.empty() ? word : currentLine + " " + word;
-
-    if (measure(testLine) <= maxWidth) {
-      currentLine = testLine;
-    } else if (!currentLine.empty()) {
-      // Doesn't fit: flush and re-queue `word` so it's handled fresh next line.
-      lines.push_back(currentLine);
-      currentLine.clear();
-      if (static_cast<int>(lines.size()) >= maxLines) return lines;
-      remaining = remaining.empty() ? word : word + " " + remaining;
+    if (measureRange(candStart, wordEnd - candStart) <= maxWidth) {
+      lineStart = candStart;
+      lineLen = wordEnd - candStart;
+      haveLine = true;
+      pos = (space == std::string_view::npos) ? in.size() : space + 1;  // consume word (+ space)
+    } else if (haveLine) {
+      // Doesn't fit: flush and re-examine `word` fresh on the next line.
+      lines.emplace_back(in.data() + lineStart, lineLen);
+      haveLine = false;
+      lineLen = 0;
     } else {
-      // currentLine empty, so testLine == word and word alone exceeds maxWidth:
-      // hard-break at a codepoint boundary and re-queue the rest (#2949).
-      const size_t take = prefixWithinWidth(word);
-      lines.push_back(word.substr(0, take));
-      const std::string rest = word.substr(take);
-      remaining = remaining.empty() ? rest : rest + " " + remaining;
+      // Empty line and the word alone exceeds maxWidth: hard-break at a
+      // codepoint boundary and leave the rest for the next line (#2949).
+      const size_t take = prefixWithinWidth(pos, wordEnd - pos);
+      lines.emplace_back(in.data() + pos, take);
+      pos += take;
+      // If the break consumed the whole word, step past its trailing space so
+      // the next iteration does not see it as an empty word.
+      if (pos == wordEnd && space != std::string_view::npos) ++pos;
     }
   }
 
-  if (!currentLine.empty() && static_cast<int>(lines.size()) < maxLines) {
-    lines.push_back(currentLine);
+  if (haveLine && static_cast<int>(lines.size()) < maxLines) {
+    lines.emplace_back(in.data() + lineStart, lineLen);
   }
 
   return lines;

--- a/lib/GfxRenderer/TextWrap.h
+++ b/lib/GfxRenderer/TextWrap.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <Utf8.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Greedy word-wrap for GfxRenderer::wrappedText(), header-only so the pure
+// line-breaking is unit-testable with a mock width (no GfxRenderer/display/font).
+//   measure(s)         -> width of s, in the same units as maxWidth
+//   truncateToWidth(s) -> s ellipsized to maxWidth (final line only)
+// Breaks on ASCII spaces; a token wider than maxWidth is hard-broken at UTF-8
+// codepoint boundaries rather than dropped (#2949). This is codepoint-level, not
+// full Unicode line-breaking/grapheme segmentation (future work).
+namespace textwrap {
+
+template <typename Measure, typename TruncateToWidth>
+std::vector<std::string> wrapLines(const char* text, const int maxWidth, const int maxLines, Measure measure,
+                                   TruncateToWidth truncateToWidth) {
+  std::vector<std::string> lines;
+  if (!text || maxWidth <= 0 || maxLines <= 0) return lines;
+
+  std::string remaining = text;
+  std::string currentLine;
+
+  // Longest prefix of s (>= 1 codepoint) that fits maxWidth, as a byte length on
+  // a UTF-8 boundary. Takes one codepoint even if it overflows, to make progress.
+  const auto prefixWithinWidth = [&](const std::string& s) -> size_t {
+    const char* base = s.c_str();
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(base);
+    size_t lastFit = 0;
+    while (*p) {
+      const uint8_t* q = p;
+      utf8NextCodepoint(&q);
+      const size_t cand = static_cast<size_t>(reinterpret_cast<const char*>(q) - base);
+      if (measure(s.substr(0, cand)) <= maxWidth) {
+        lastFit = cand;
+        p = q;
+      } else {
+        break;
+      }
+    }
+    if (lastFit == 0) {
+      const uint8_t* q = reinterpret_cast<const uint8_t*>(base);
+      utf8NextCodepoint(&q);
+      lastFit = static_cast<size_t>(reinterpret_cast<const char*>(q) - base);
+    }
+    return lastFit;
+  };
+
+  while (!remaining.empty()) {
+    if (static_cast<int>(lines.size()) == maxLines - 1) {
+      // Last available line: fold in the rest and ellipsize.
+      lines.push_back(truncateToWidth(currentLine.empty() ? remaining : currentLine + " " + remaining));
+      return lines;
+    }
+
+    size_t spacePos = remaining.find(' ');
+    std::string word;
+    if (spacePos == std::string::npos) {
+      word = remaining;
+      remaining.clear();
+    } else {
+      word = remaining.substr(0, spacePos);
+      remaining.erase(0, spacePos + 1);
+    }
+
+    std::string testLine = currentLine.empty() ? word : currentLine + " " + word;
+
+    if (measure(testLine) <= maxWidth) {
+      currentLine = testLine;
+    } else if (!currentLine.empty()) {
+      // Doesn't fit: flush and re-queue `word` so it's handled fresh next line.
+      lines.push_back(currentLine);
+      currentLine.clear();
+      if (static_cast<int>(lines.size()) >= maxLines) return lines;
+      remaining = remaining.empty() ? word : word + " " + remaining;
+    } else {
+      // currentLine empty, so testLine == word and word alone exceeds maxWidth:
+      // hard-break at a codepoint boundary and re-queue the rest (#2949).
+      const size_t take = prefixWithinWidth(word);
+      lines.push_back(word.substr(0, take));
+      const std::string rest = word.substr(take);
+      remaining = remaining.empty() ? rest : rest + " " + remaining;
+    }
+  }
+
+  if (!currentLine.empty() && static_cast<int>(lines.size()) < maxLines) {
+    lines.push_back(currentLine);
+  }
+
+  return lines;
+}
+
+}  // namespace textwrap

--- a/lib/GfxRenderer/TextWrap.h
+++ b/lib/GfxRenderer/TextWrap.h
@@ -38,6 +38,14 @@ std::vector<std::string> wrapLines(const char* text, const int maxWidth, const i
     return measure(scratch);
   };
 
+  // Length of in[start, start+len) with any trailing spaces dropped, so a line
+  // that swallowed a separator run does not carry blanks that would offset a
+  // centred draw.
+  const auto trimTrailingSpaces = [&](const size_t start, size_t len) -> size_t {
+    while (len > 0 && in[start + len - 1] == ' ') --len;
+    return len;
+  };
+
   // Longest prefix of in[start, start+len) (>= 1 codepoint) that fits maxWidth,
   // as a byte length on a UTF-8 boundary. Takes one codepoint even if it
   // overflows, to make progress. Walks boundaries via the lead byte only, so it
@@ -69,6 +77,14 @@ std::vector<std::string> wrapLines(const char* text, const int maxWidth, const i
   bool haveLine = false;  // whether the current line has any content
 
   while (pos < in.size()) {
+    // Collapse a run of separators. Without this a zero-length "word" between
+    // two spaces (or at the start) would start a line, and flushing it emits an
+    // empty or whitespace-only line.
+    if (in[pos] == ' ' && !haveLine) {
+      ++pos;
+      continue;
+    }
+
     if (static_cast<int>(lines.size()) == maxLines - 1) {
       // Last available line: fold in the rest and ellipsize.
       const size_t start = haveLine ? lineStart : pos;
@@ -88,7 +104,7 @@ std::vector<std::string> wrapLines(const char* text, const int maxWidth, const i
       pos = (space == std::string_view::npos) ? in.size() : space + 1;  // consume word (+ space)
     } else if (haveLine) {
       // Doesn't fit: flush and re-examine `word` fresh on the next line.
-      lines.emplace_back(in.data() + lineStart, lineLen);
+      lines.emplace_back(in.data() + lineStart, trimTrailingSpaces(lineStart, lineLen));
       haveLine = false;
       lineLen = 0;
     } else {
@@ -104,7 +120,7 @@ std::vector<std::string> wrapLines(const char* text, const int maxWidth, const i
   }
 
   if (haveLine && static_cast<int>(lines.size()) < maxLines) {
-    lines.emplace_back(in.data() + lineStart, lineLen);
+    lines.emplace_back(in.data() + lineStart, trimTrailingSpaces(lineStart, lineLen));
   }
 
   return lines;

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -5,6 +5,9 @@
 #define REPLACEMENT_GLYPH 0xFFFD
 
 uint32_t utf8NextCodepoint(const unsigned char** string);
+// Byte length of the UTF-8 sequence a lead byte starts (1 for an invalid lead).
+// Reads only the lead byte, so it is safe to call at a buffer end.
+int utf8CodepointLen(unsigned char lead);
 // Appends a Unicode codepoint to a std::string in UTF-8 encoding.
 void utf8AppendCodepoint(uint32_t cp, std::string& out);
 // Remove the last UTF-8 codepoint from a std::string and return the new size.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -56,5 +56,6 @@ add_subdirectory(chapter_html_slim_parser)
 add_subdirectory(ligature_guard)
 add_subdirectory(page_link)
 add_subdirectory(chapter_position)
+add_subdirectory(text_wrap)
 
 add_subdirectory(inflate_stream)

--- a/test/text_wrap/CMakeLists.txt
+++ b/test/text_wrap/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(TextWrapTest
+  TextWrapTest.cpp
+  ${REPO_ROOT}/lib/Utf8/Utf8.cpp
+)
+
+target_include_directories(TextWrapTest PRIVATE
+  ${REPO_ROOT}/lib/Utf8
+  ${REPO_ROOT}/lib/GfxRenderer
+)
+
+target_link_libraries(TextWrapTest PRIVATE
+  crosspoint_test_common
+  GTest::gtest_main
+)
+
+gtest_discover_tests(TextWrapTest)

--- a/test/text_wrap/TextWrapTest.cpp
+++ b/test/text_wrap/TextWrapTest.cpp
@@ -108,6 +108,20 @@ TEST(TextWrap, ForcedBreakConsumingWordSwallowsSeparator) {
   EXPECT_EQ(out, (Lines{"W", "x", "y"}));
 }
 
+// Separator runs must not start a line: a zero-length word between two spaces
+// would otherwise be flushed as an empty line.
+TEST(TextWrap, RepeatedSpacesDoNotEmitEmptyLines) {
+  EXPECT_EQ(wrap("aaaa  bbbb", 4, 5), (Lines{"aaaa", "bbbb"}));
+  EXPECT_EQ(wrap("aa   bb", 4, 5), (Lines{"aa", "bb"}));
+}
+
+TEST(TextWrap, LeadingAndTrailingSpacesAreDropped) {
+  EXPECT_EQ(wrap(" aaaa", 4, 5), (Lines{"aaaa"}));
+  EXPECT_EQ(wrap("  aaaa", 4, 5), (Lines{"aaaa"}));
+  EXPECT_EQ(wrap("aaaa ", 4, 5), (Lines{"aaaa"}));
+  EXPECT_TRUE(wrap("   ", 4, 5).empty());
+}
+
 TEST(TextWrap, EmptyAndNullInputs) {
   EXPECT_TRUE(wrap("", 10, 3).empty());
   EXPECT_TRUE(wrap(nullptr, 10, 3).empty());

--- a/test/text_wrap/TextWrapTest.cpp
+++ b/test/text_wrap/TextWrapTest.cpp
@@ -94,6 +94,20 @@ TEST(TextWrap, GlyphWiderThanLineStillEmitted) {
   EXPECT_EQ(out, (Lines{"W", "x", "W"}));
 }
 
+// A forced single-glyph break that consumes a whole word must swallow the
+// following space, not emit it as an empty line on the next line.
+TEST(TextWrap, ForcedBreakConsumingWordSwallowsSeparator) {
+  // 'W' has width 2; everything else width 1; line width 1.
+  auto measure = [](const std::string& s) {
+    int w = 0;
+    for (char c : s) w += (c == 'W') ? 2 : 1;
+    return w;
+  };
+  auto trunc = [&](const std::string& s) { return s; };
+  const Lines out = textwrap::wrapLines("W xy", 1, 5, measure, trunc);
+  EXPECT_EQ(out, (Lines{"W", "x", "y"}));
+}
+
 TEST(TextWrap, EmptyAndNullInputs) {
   EXPECT_TRUE(wrap("", 10, 3).empty());
   EXPECT_TRUE(wrap(nullptr, 10, 3).empty());

--- a/test/text_wrap/TextWrapTest.cpp
+++ b/test/text_wrap/TextWrapTest.cpp
@@ -1,0 +1,102 @@
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "Utf8.h"
+#include "lib/GfxRenderer/TextWrap.h"
+
+namespace {
+
+using Lines = std::vector<std::string>;
+
+// Mock width: one unit per codepoint (so maxWidth is "codepoints per line").
+int codepointWidth(const std::string& s) {
+  int n = 0;
+  auto* p = reinterpret_cast<const unsigned char*>(s.c_str());
+  while (*p) {
+    if (!utf8NextCodepoint(&p)) break;
+    ++n;
+  }
+  return n;
+}
+
+// First n codepoints of s (UTF-8 safe).
+std::string firstCodepoints(const std::string& s, int n) {
+  auto* base = reinterpret_cast<const unsigned char*>(s.c_str());
+  auto* p = base;
+  while (n-- > 0 && *p) utf8NextCodepoint(&p);
+  return s.substr(0, static_cast<size_t>(reinterpret_cast<const char*>(p) - reinterpret_cast<const char*>(base)));
+}
+
+// Wrap with the codepoint mock; "~" stands in for the ellipsis (width 1).
+Lines wrap(const char* text, int maxWidth, int maxLines) {
+  return textwrap::wrapLines(text, maxWidth, maxLines, codepointWidth, [&](const std::string& s) {
+    return codepointWidth(s) <= maxWidth ? s : firstCodepoints(s, maxWidth - 1) + "~";
+  });
+}
+
+}  // namespace
+
+// Ordinary space-separated text wraps on spaces exactly as before.
+TEST(TextWrap, NormalWordWrapUnchanged) {
+  EXPECT_EQ(wrap("the quick brown fox", 9, 4), (Lines{"the quick", "brown fox"}));
+}
+
+TEST(TextWrap, ShortTextOneLine) { EXPECT_EQ(wrap("hello", 10, 3), (Lines{"hello"})); }
+
+// The #2949 bug: a single token wider than the line used to be truncated to an
+// ellipsis and the rest dropped. It must now hard-break and keep all the text.
+TEST(TextWrap, LongTokenHardBreaksInsteadOfDropping) {
+  EXPECT_EQ(wrap("AAAAAAAAAAAAAAAA", 5, 4), (Lines{"AAAAA", "AAAAA", "AAAAA", "A"}));
+}
+
+// A long token followed by a normal word: break the token, then flow the word.
+TEST(TextWrap, LongTokenThenWordFlows) {
+  EXPECT_EQ(wrap("supercalifragilistic ok", 6, 4), (Lines{"superc", "alifra", "gilist", "ic ok"}));
+}
+
+// A short word first, then a long token: exercises the flush-and-requeue path
+// (the started line is flushed and the over-long word is re-handled fresh).
+TEST(TextWrap, ShortWordThenLongTokenRequeues) {
+  EXPECT_EQ(wrap("ok supercalifragilistic", 6, 4), (Lines{"ok", "superc", "alifra", "gilis~"}));
+}
+
+// maxLines is respected and only the final line is ellipsized. The mock
+// ellipsis keeps maxWidth-1 codepoints then "~", so line 2 is "bbb~".
+TEST(TextWrap, MaxLinesEllipsizesFinalLine) {
+  EXPECT_EQ(wrap("aaaa bbbb cccc dddd eeee", 4, 2), (Lines{"aaaa", "bbb~"}));
+}
+
+// A hard-broken token that runs past maxLines ellipsizes the last line and stops.
+TEST(TextWrap, LongTokenHittingMaxLinesEllipsizesAndStops) {
+  EXPECT_EQ(wrap("AAAAAAAAAAAA end", 5, 3), (Lines{"AAAAA", "AAAAA", "AA e~"}));
+}
+
+// Multi-byte scripts (no spaces): hard-break must land on codepoint boundaries
+// so every emitted line is valid UTF-8, and no character is dropped.
+TEST(TextWrap, CjkHardBreakOnCodepointBoundaries) {
+  // 7 CJK codepoints (3 bytes each), 3 per line.
+  EXPECT_EQ(wrap("日本語テキスト", 3, 5), (Lines{"日本語", "テキス", "ト"}));
+}
+
+// Progress guarantee: even when a single glyph is wider than the whole line, it
+// is emitted on its own line rather than looping forever or being dropped.
+TEST(TextWrap, GlyphWiderThanLineStillEmitted) {
+  // 'W' has width 2; everything else width 1; line width 1.
+  auto measure = [](const std::string& s) {
+    int w = 0;
+    for (char c : s) w += (c == 'W') ? 2 : 1;
+    return w;
+  };
+  auto trunc = [&](const std::string& s) { return s; };
+  const Lines out = textwrap::wrapLines("WxW", 1, 5, measure, trunc);
+  EXPECT_EQ(out, (Lines{"W", "x", "W"}));
+}
+
+TEST(TextWrap, EmptyAndNullInputs) {
+  EXPECT_TRUE(wrap("", 10, 3).empty());
+  EXPECT_TRUE(wrap(nullptr, 10, 3).empty());
+  EXPECT_TRUE(wrap("hello", 0, 3).empty());
+  EXPECT_TRUE(wrap("hello", 10, 0).empty());
+}


### PR DESCRIPTION
## Problem

`GfxRenderer::wrappedText()` drops content when a single token is wider than the wrap width. Instead of breaking the long token across lines, the current code truncates it to an ellipsis and discards the remainder — so any text after the over-long token disappears from the label.

This is most visible with long unbreakable strings that have no spaces to wrap on:

- long file names / titles (`this_is_a_really_long_download_name.epub`)
- URLs
- spaceless scripts (CJK), where the whole run is effectively one token

Closes #2949.

## Fix

Extract the pure line-breaking out of `GfxRenderer` into a small header-only helper, `lib/GfxRenderer/TextWrap.h` (`textwrap::wrapLines`), parameterised on a `measure()` and a `truncateToWidth()` callback. `wrappedText()` becomes a thin wrapper that binds those to `getTextWidth()` / `truncatedText()`.

Behaviour change: a token that is wider than `maxWidth` on its own is now **hard-broken at UTF-8 codepoint boundaries** and the remainder re-queued, instead of being ellipsized-and-dropped. Normal space-based wrapping is unchanged. `maxLines` is still respected and only the final line is ellipsized.

### Before / after (wrap width ~6 units)

```
"supercalifragilistic ok", maxLines 4

before: {"super~"}                         // rest dropped
after:  {"superc","alifra","gilist","ic ok"}
```

## Notes

- Hard-breaking is at the **codepoint** level, not full Unicode line-breaking / grapheme-cluster segmentation (UAX #14/#29). That keeps it dependency-free and small for the C3 target; combining marks could in theory split from their base. Called out as future work in the header comment.
- A progress guarantee ensures at least one codepoint is emitted per line even if a single glyph is wider than the whole line, so it can never loop or drop input.

## Tests

New `test/text_wrap/` gtest suite (10 cases) with a mock codepoint-width measure: normal wrapping unchanged, long-token hard-break, long-token-then-word, short-word-then-long-token requeue, maxLines ellipsis, CJK codepoint-boundary breaks, glyph-wider-than-line progress, and empty/null guards. Full suite passes locally (cmake + ninja + ctest).