### PR TITLE
fix: classify X4 Pro cold boots as power-button boots

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -260,12 +260,14 @@ bool HalGPIO::coldBootImpliesPowerButton() const {
   // Xteink-style power topology: the power button energizes the rail until
   // firmware latches it, so a no-USB POWERON can only be a still-held button
   // boot, and plugging USB into an off device should charge-sleep, not boot.
+  // The S3 X4 Pro shares that topology but sits outside isXteinkDevice(),
+  // which covers only the C3 Xteink boards.
   // Everything else boots on any cold boot: boards with no USB detection at
   // all (M5Paper v1.1, PaperColor, Murphy, de-link) would misread USB and
   // post-flash boots as battery button boots, and STAT-only boards like the
   // EEGO A4 misread them the same way once the charger terminates at 100%
   // (STAT inactive reads as "no USB").
-  return isXteinkDevice() || BoardConfig::isPaperMono() || BoardConfig::isSticky();
+  return isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isPaperMono() || BoardConfig::isSticky();
 }
 
 HalGPIO::WakeupReason HalGPIO::getWakeupReason() const {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Restore `WakeupReason::PowerButton` on X4 Pro
  cold boots, which #3248 unintentionally turned into `WakeupReason::Other`. The visible
  consequence is that **DOWN + POWER held from a true cold boot no longer enters recovery
  firmware mode** on that board.

* **What changes are included?** One predicate, in `lib/hal/HalGPIO.cpp`:

  ```cpp
  return isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isPaperMono() || BoardConfig::isSticky();
  ```

  plus two lines of comment. 4 insertions, 1 deletion, one file.

### Why the X4 Pro fell out

`coldBootImpliesPowerButton()` (added in #3248) is built on `isXteinkDevice()`, which
matches only the **C3** Xteink boards — `XteinkX3`, `XteinkX3Uc8279`, `XteinkX4`. The
S3 X4 Pro and the X4 Classic added a day later in #3279 are not in that set;
`EpubReaderActivity.cpp` already documents the same gap for the panel case and works
around it locally:

```cpp
// The X4 Pro and X4 Classic carry the X4's panel but sit outside isXteinkDevice()
bool xteinkClassPanel() { return gpio.isXteinkDevice() || BoardConfig::isX4Pro() || BoardConfig::isX4Classic(); }
```

The X4 Pro does have the topology `coldBootImpliesPowerButton()` is describing: the master
peripheral rail is firmware-latched on GPIO1 (`power.latch0`, held through deep sleep since
#3215), and a power-on from battery requires a long physical hold gated by the
**vendor bootloader** — by the time `setup()` samples the button it is still down. A cold
boot there genuinely is a power-button press, so classifying it as one is truthful,
not a heuristic.

### What breaks today without it

On develop, an X4 Pro cold boot resolves to `Other` (on battery: `!usbConnected` and
`coldBootImpliesPowerButton() == false`) or `AfterUSBPower` (on charger, STAT active).
Two consumers of the classification are affected:

1. **`recoveryFirmwareMode`** (`src/main.cpp`) requires `wakeupReason == PowerButton`.
   DOWN + POWER at a cold boot is therefore dead on the X4 Pro — and a cold
   boot is exactly the state in which you most want a recovery affordance.
2. **`isPersistedSleepWake`** is false, so a cold power-on falls back to
   `BootResume::Splash` instead of resuming splashlessly. Cosmetic but user-visible.

**Why nobody noticed:** #3215 holds the power-latch pins HIGH through deep sleep, so the
ordinary X4 Pro power-on is `ESP_RST_DEEPSLEEP` + EXT1 — matched by the *first* branch of
`getWakeupReason()`, which still returns `PowerButton`. Recovery mode and splashless resume
therefore still work from a sleep wake. Only a genuine cold boot (latch dropped: battery
pulled, post-flash, long power-off) takes the broken path, and that is the least-exercised
one in daily use.

### Reproduction

1. Flash stock `develop` to an X4 Pro.
2. Fully power the device off (long power hold to power-off, so the GPIO1 latch drops).
3. From that cold state, hold **DOWN + POWER**.
4. Observed: normal boot. Expected (and the behaviour before #3248): recovery firmware
   mode, with `Recovery firmware mode (DOWN + POWER held at boot)` in the log.

With the patch, the same steps take the recovery branch (by code inspection — see
"Verification NOT performed" below; happy to flash and confirm on device).

### Scope of the change / non-regression

* `isXteinkDevice()` itself is **not** touched, so #3248's target boards, `xteinkClassPanel()`
  and the C3-only battery-MOSFET block in `HalPowerManager::startDeepSleep()` all behave
  exactly as before.
* Deep-sleep wakes are unaffected on every board: the `ESP_RST_DEEPSLEEP` branch of
  `getWakeupReason()` runs before `coldBootImpliesPowerButton()` is ever consulted.
* The `AfterFlash` / `AfterUSBPower` branches are unchanged; the X4 Pro / X4 Classic
  `AfterUSBPower` arm is already `break` (stay awake), so there is no plug-in boot loop.
* On the X4 Pro a cold boot now runs `verifyPowerButtonWakeup()` again — which is what it
  did for the entire life of the board before #3248, and which the vendor bootloader's own
  long-hold gate makes a formality. It is additionally skipped when
  `shortPwrBtn == SHORT_PWRBTN::SLEEP`.
* #3248's stated worry about STAT-only boards is that a post-flash reset misreads as a
  battery button boot. Empirically that does not apply here: before #3248 the X4 Pro
  classified *every* cold boot as `PowerButton` and flashing never dropped it into sleep,
  i.e. an X4 Pro post-flash reset does not report `ESP_RST_POWERON`.

### The X4 Classic

The X4 Classic almost certainly shares this gap: it was added in #3279 one day *after*
#3248 (so that PR never considered it), and it carries the identical power section (GPIO1
`power.latch0`, GPIO21 STAT, CW2017, `usbDetect` unassigned). I only have X4 Pro hardware,
so this PR deliberately covers just the X4 Pro; happy to add `isX4Classic()` here or in a
follow-up if you'd like it included without waiting for hardware confirmation.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

> **`lib/hal/` + recovery-path coordination:** this PR changes one predicate in
> `lib/hal/HalGPIO.cpp` and it does affect whether recovery firmware mode is reachable, so
> it is squarely in the "coordinate first" bucket. `freeink-sdk/` is **not** touched (the
> submodule pointer is unchanged at develop's `fad70f2`), no bootloader or OTA code is
> touched. Flagging it here for a maintainer look rather than claiming prior sign-off —
> please treat the PR itself as the coordination request.

## Additional Context

* **Memory / flash impact:** two extra inline board comparisons on a boot-time path. No
  measurable flash or RAM change; nothing here runs in a loop.
* **Risk areas to focus review on:** the board list in `coldBootImpliesPowerButton()`, and
  whether you want the X4 Classic included (see "One thing to confirm").
* **Verification performed on this branch:** `pio run -e x4pro` and `pio run -e default`
  both green; `pio check --fail-on-defect low` clean (`lib/hal/HalGPIO.cpp` reports no
  defects — note that `lib/` is outside the default `check_patterns`, so I ran it
  explicitly; the only hits there are two pre-existing low-severity findings in
  `HalStorage.cpp` that this PR does not touch). `./bin/clang-format-fix -g` clean.
* **Verification NOT performed:** this exact branch has **not** been flashed to hardware.
  The X4 Pro cold-boot / recovery-mode behaviour described above was established by reading
  the code against a device whose bootloader long-hold gate and GPIO1 latch behaviour are
  hardware-verified from earlier work on a downstream fork. That fork's daily-driver build
  predates #3248 and therefore still classifies X4 Pro cold boots as `PowerButton` — the
  behaviour this PR restores — but I have not deliberately exercised recovery mode from a
  cold boot on it either, so treat the repro above as derived from the code, not as a
  recorded hardware run. I can flash this branch and confirm it on device if that helps.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — analysis, patch and this PR body
were produced with Claude (Claude Code), reviewed and tested by me.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzWKHRsQp7usMAcyPA1Mc
