### PR TITLE
fix(reader): release the section before Text Settings opens, not in its handler

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -804,21 +804,24 @@ void EpubReaderActivity::onReaderMenuConfirm(EpubReaderMenuActivity::MenuAction 
       break;
     }
     case EpubReaderMenuActivity::MenuAction::TEXT_SETTINGS: {
+      // Release the section before the settings screen opens, like
+      // SELECT_CHAPTER above, rather than in the result handler: an external
+      // pop skips a handler whose activity set no result, and a section that
+      // survives a size change is re-drawn at the old layout's word positions
+      // with the new size's glyphs.
+      {
+        RenderLock lock;
+        if (section) {
+          rememberCurrentContentOffset();
+          cachedSpineIndex = currentSpineIndex;
+          cachedChapterTotalPageCount = section->pageCount;
+          nextPageNumber = section->currentPage;
+        }
+        section.reset();
+      }
       startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
                                                                     TextSettingsActivity::Tab::Family),
-                             [this](const ActivityResult&) {
-                               {
-                                 RenderLock lock;
-                                 if (section) {
-                                   rememberCurrentContentOffset();
-                                   cachedSpineIndex = currentSpineIndex;
-                                   cachedChapterTotalPageCount = section->pageCount;
-                                   nextPageNumber = section->currentPage;
-                                 }
-                                 section.reset();
-                               }
-                               openReaderMenu();
-                             });
+                             [this](const ActivityResult&) { openReaderMenu(); });
       break;
     }
     case EpubReaderMenuActivity::MenuAction::NIGHT_MODE:
@@ -2122,6 +2125,19 @@ void EpubReaderActivity::handleOverlayInput() {
         overlay = Overlay::None;
         overlayPopup.dismiss();
         discardOverlayPage();
+        // Same up-front release as the classic menu's TEXT_SETTINGS branch:
+        // applyReaderTextSettings() below resets the section too, but only on
+        // the paths that run the result handler.
+        {
+          RenderLock lock;
+          if (section) {
+            rememberCurrentContentOffset();
+            cachedSpineIndex = currentSpineIndex;
+            cachedChapterTotalPageCount = section->pageCount;
+            nextPageNumber = section->currentPage;
+          }
+          section.reset();
+        }
         startActivityForResult(std::make_unique<TextSettingsActivity>(renderer, mappedInput, &sdFontSystem.registry(),
                                                                       TextSettingsActivity::Tab::Family),
                                [this](const ActivityResult&) {


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make the reader's laid-out `Section` be released **before**
  `TextSettingsActivity` opens rather than inside its result handler, on both routes into it,
  so no exit path can leave a stale layout installed after a font/size change.

* **What changes are included?** `src/activities/reader/EpubReaderActivity.cpp` only, both
  reader routes into Text Settings:
  * the classic reader menu's `MenuAction::TEXT_SETTINGS` case — the existing five-statement
    release block is **moved** out of the result lambda to just before
    `startActivityForResult`, leaving `[this](const ActivityResult&) { openReaderMenu(); }`;
  * the toolbar Text panel's row 0 ("Font", added by #3182) — the same block is added ahead
    of `startActivityForResult`. `applyReaderTextSettings()` still runs in the handler; its
    own `section.reset()` is then a no-op.

  29 insertions, 13 deletions, one file. The third `TextSettingsActivity` construction site in
  the tree (`SettingsActivity.cpp`) is outside the reader and has no Section to stale, so it
  is untouched.

### The bug

`renderBook()` trusts any installed `Section`: if one is present it draws it, without
re-validating that the layout was built with the current text spec. The Section's word
x-positions are baked at layout time, so drawing an old-size layout with new-size glyphs
gives visibly wrong spacing — crowded after a size increase, gaping after a decrease — until
something else forces a re-pagination (in practice, reopening the book).

`TextSettingsActivity` persists every change as it is made and never sets an
`ActivityResult`, and it does not override `handleHomeGesture()`. So any exit that does not
run the result handler leaves the new size persisted **and** the old Section installed. Both
reader routes released the Section only in that handler, which makes the invariant depend on
"every exit path runs the handler" — an assumption nothing in the reader enforces.

### Framing this honestly

* **On today's develop this is latent.** Every current way out of Text Settings runs the
  result handler, so there is no user-visible bug to reproduce on `develop` as it stands.
* **It goes live the moment any external-pop path exists.** Open PR #3224 (configurable
  Home-key gestures) makes "Go Back" the default Home-key tap; `ActivityManager` skips the
  result handler of an activity that set no result on an external pop, which is exactly this
  case. A downstream fork carrying #3224 shipped that combination and the bug was
  **reproduced and then fixed on hardware** (2026-09-01): change text size in-book, tap Home
  to leave Text Settings, and the page comes back mis-spaced until the book is reopened.
  Upstream's own toolbar route (#3182) reproduced it independently in the same fork after a
  rebase, which is why this PR fixes both routes rather than one.
* **It is worth doing regardless** as defence in depth, because the correctness of the
  reader's layout should not rest on the exit path taken out of a settings screen.

### Precedent

This is exactly the pattern `SELECT_CHAPTER` already uses a few cases above in the same
function — it releases the Section before the chapter list opens and lets the cached-position
rebuild restore it on cancel. Its comment even describes the TEXT_SETTINGS case as the
sibling it mirrors; after this PR that is true in both directions.

### Behaviour cost

Cancelling out of Text Settings **without changing anything** now re-paginates the chapter
once on return, instead of returning to the already-laid-out page. That is the same trade
`SELECT_CHAPTER` has always accepted, and it comes with the same upside: the picker gets the
Section's tens of KB back while it is open, which matters for its live font previews (and on
the toolbar route it is now the default reader menu path on touch boards, so it is the more
visible of the two).

### Alternative considered

A follow-up could fold the now-four copies of the release block (SELECT_CHAPTER, both
TEXT_SETTINGS routes, `applyReaderTextSettings()`) into one small private helper —
`releaseSectionForRelayout()` — which would make the invariant greppable and give the next
new route into `TextSettingsActivity` something obvious to call. I kept it out of this PR to
keep the diff a pure behaviour fix; happy to add it here if you'd prefer it in one go.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

> Last box is a no-op for this PR: it touches only `src/activities/reader/EpubReaderActivity.cpp`.
> No `lib/hal/`, no `freeink-sdk/` (submodule pointer unchanged at develop's `fad70f2`), no
> bootloader, OTA or recovery code.

## Additional Context

* **Memory / flash impact:** none meaningful — one block relocated, one block duplicated.
  While Text Settings is open the reader now holds *less* RAM (the Section is freed), which
  is the same headroom the chapter list already gets.
* **Concurrency:** both release blocks take a scoped `RenderLock`, matching the surrounding
  code. The toolbar site is reached from `EpubReaderActivity::loop()` via
  `handleOverlayInput()`, which `ActivityManager::loop()` calls with no lock held, and the
  sibling `Overlay::Contents` branch in the same lambda already takes its own `RenderLock` —
  so there is no nesting.
* **Re-entry:** on the toolbar route the handler still sets `overlay = Overlay::Text` and
  calls `toolbarUi->begin()` / `requestUpdate()` against a now-null Section; `renderBook()`
  is the single funnel that reconstructs a null Section and the toolbar is drawn on top
  afterwards, so the panel comes back over a freshly paginated page. On an external pop
  `overlay` was already set to `None` before the picker opened, so the reader simply
  repaints the page.
* **Areas to focus review on:** whether re-paginating on an unchanged cancel is an acceptable
  cost on the toolbar route (it is now the default menu on touch boards), and whether you'd
  rather take the helper refactor described above in the same change.
* **Verification performed on this branch:** `pio run -e x4pro` and `pio run -e default` both
  green; `pio check --fail-on-defect low` reports no defects; `./bin/clang-format-fix -g`
  clean.
* **Verification NOT performed:** this exact branch has **not** been flashed to hardware. The
  on-hardware reproduction and fix-confirmation described above were on a downstream fork's
  build (which carries #3224, the thing that makes the bug reachable), not on this branch;
  on stock `develop` the change is latent by construction, so there is nothing on-device to
  observe beyond "Text Settings still works and the page re-paginates on return".

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_ — analysis, patch and this PR body
were produced with Claude (Claude Code), reviewed and tested by me.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014BzWKHRsQp7usMAcyPA1Mc
