### PR TITLE
fix(reader): turn dictionary pages with short power-button press

### DIFF
--- a/src/activities/reader/DictionaryDefinitionActivity.cpp
+++ b/src/activities/reader/DictionaryDefinitionActivity.cpp
@@ -203,6 +203,17 @@ void DictionaryDefinitionActivity::loop() {
     return;
   }
 
+  // Short power-button press turns the page here too, matching the reader
+  // (ReaderUtils::detectPageTurn) when the setting is Page Turn.
+  if (SETTINGS.shortPwrBtn == CrossPointSettings::SHORT_PWRBTN::PAGE_TURN &&
+      mappedInput.wasReleased(MappedInputManager::Button::Power)) {
+    if (currentPage + 1 < totalPages) {
+      currentPage++;
+      requestUpdate();
+    }
+    return;
+  }
+
   // Same tap zones as the reader page turns: left third = previous page,
   // the rest = next. Back is the usual left-edge swipe.
   int tx = 0;


### PR DESCRIPTION
## Problem

Setting the short power-button action to **Page Turn** turns the page while reading a book, but does nothing inside the dictionary. Steps (issue #3262):

1. Set short power-button press = Page Turn.
2. Look up a word.
3. Press the power button → nothing happens.

## Cause

The reader turns pages via `ReaderUtils::detectPageTurn`, which treats a `Button::Power` release as "next page" when `SETTINGS.shortPwrBtn == SHORT_PWRBTN::PAGE_TURN`. The dictionary definition viewer (`DictionaryDefinitionActivity::loop()`) has its **own** input loop that only handled Back, tap zones, and the Left/Right buttons — it never checked the power button.

## Fix

Handle `Button::Power` in the dictionary loop the same way the reader does: when the short-power-button action is Page Turn, a release advances one page. Next-only, mirroring the reader; no-op on the last page. Back / taps / Left-Right unchanged.

## Testing

- [ ] Xteink X4: short-press = Page Turn, look up a word, press power → advances a page; last page is a no-op; other input unaffected.

Closes #3262