### PR TITLE
refactor: convert compile-time settings lookup tables to constexpr

### DIFF
--- a/src/activities/settings/OpdsServerListActivity.cpp
+++ b/src/activities/settings/OpdsServerListActivity.cpp
@@ -171,8 +171,8 @@ void OpdsServerListActivity::handleSelection() {
 
   // "Filename format": picker like every other multi-option setting.
   if (nav.selected == serverCount + 2) {
-    static const StrId formatLabels[] = {StrId::STR_FMT_AUTHOR_TITLE, StrId::STR_FMT_TITLE_AUTHOR,
-                                         StrId::STR_FMT_TITLE};
+    static constexpr StrId formatLabels[] = {StrId::STR_FMT_AUTHOR_TITLE, StrId::STR_FMT_TITLE_AUTHOR,
+                                             StrId::STR_FMT_TITLE};
     optionPopup.show(StrId::STR_OPDS_FILENAME_FORMAT, formatLabels, static_cast<int>(OpdsFilenameFormat::Count),
                      SETTINGS.opdsFilenameFormat, [this](int idx) {
                        SETTINGS.opdsFilenameFormat = static_cast<uint8_t>(idx);

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -34,9 +34,6 @@
 
 namespace fui = freeink::ui;
 
-const StrId SettingsActivity::categoryNames[categoryCount] = {StrId::STR_CAT_DISPLAY, StrId::STR_CAT_READER,
-                                                              StrId::STR_CAT_CONTROLS, StrId::STR_CAT_SYSTEM};
-
 SettingsActivity::SettingsActivity(GfxRenderer& renderer, MappedInputManager& mappedInput)
     : UiTabListActivity("Settings", renderer, mappedInput) {}
 

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -177,7 +177,8 @@ class SettingsActivity final : public UiTabListActivity {
   void rebuildRowItems();
 
   static constexpr int categoryCount = 4;
-  static const StrId categoryNames[categoryCount];
+  static constexpr StrId categoryNames[categoryCount] = {StrId::STR_CAT_DISPLAY, StrId::STR_CAT_READER,
+                                                         StrId::STR_CAT_CONTROLS, StrId::STR_CAT_SYSTEM};
 
   // --- UiTabListActivity contract ---
   int listCount() const override { return settingsCount; }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make two settings-screen lookup tables' compile-time/flash placement standard-guaranteed instead of compiler-observed, per this repo's "`constexpr` First" coding standard (CLAUDE.md rule #6).
* **What changes are included?**
  - `SettingsActivity::categoryNames` and `OpdsServerListActivity`'s `formatLabels` converted from `static const` to `static constexpr`
  - Removed the now-unnecessary out-of-line `.cpp` definition for `categoryNames` (replaced by an inline `constexpr` initializer in the header)

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (n/a — this is an internal code-quality refactor, not a user-facing feature).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (n/a — this PR only touches `src/activities/settings/`.)

## Additional Context

* No behavior, control flow, or memory layout change. `static const` already landed in flash in practice on this
  toolchain; `constexpr` makes that guaranteed by the standard instead of compiler-observed, and enables
  compile-time evaluation for these two small (12-byte and 16-byte) literal `StrId` tables.
* Verified via `pio run` (build succeeds) and `pio check` (cppcheck: no defects found).

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? **YES** — implemented with Claude Code (Sonnet 5): code analysis, the
edits, build/check verification, and this PR description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnQV6onyMxKHxpRAjnuLL6
