### PR TITLE
perf: navigate folders in the web file manager without reloading the page

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1842,12 +1842,15 @@
 
 <script>
   // get current path from query parameter
-  const currentPath = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
+  let currentPath = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
 
-  if (currentPath !== '/') {
+  // Base title from <title>; re-applied on every navigation so returning to the root resets it.
+  const baseTitle = document.title;
+  function applyPathTitle() {
     const leaf = currentPath.split('/').filter(Boolean).pop();
-    if (leaf) document.title = leaf + ' - Files - CrossPoint Reader';
+    document.title = leaf ? leaf + ' - ' + baseTitle : baseTitle;
   }
+  applyPathTitle();
 
   // Network status monitoring
   let isNetworkOnline = navigator.onLine;
@@ -1933,26 +1936,13 @@
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)).toLocaleString() + ' ' + sizes[i];
   }
 
+  // A newer hydrate() call owns the DOM: an older one still awaiting its listing must not
+  // go on to write a table it no longer represents (rapid folder clicks, Back-button mashing -
+  // scanFiles() yields during long scans, so per-folder fetch latency genuinely varies).
+  let hydrateGeneration = 0;
+
   async function hydrate() {
-    // Fetch CrossPoint version
-    fetchVersion();
-
-    // Close modals when clicking overlay - call proper cleanup functions
-    document.querySelectorAll('.modal-overlay').forEach(function(overlay) {
-      overlay.addEventListener('click', function(e) {
-        if (e.target === overlay) {
-          // Call the appropriate close function for each modal to ensure cleanup
-          if (overlay.id === 'uploadModal') return closeUploadModal();
-          if (overlay.id === 'folderModal') return closeFolderModal();
-          if (overlay.id === 'deleteModal') return closeDeleteModal();
-          if (overlay.id === 'renameModal') return closeRenameModal();
-          if (overlay.id === 'moveModal') return closeMoveModal();
-          if (overlay.id === 'imagePreviewModal') return closeImagePreview();
-          overlay.classList.remove('open');
-        }
-      });
-    });
-
+    const generation = ++hydrateGeneration;
     const breadcrumbs = document.getElementById('directory-breadcrumbs');
     const fileTable = document.getElementById('file-table');
 
@@ -1998,12 +1988,17 @@
     let files = [];
     try {
       const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + '&_=' + Date.now());
+      // A newer hydrate() may already be in flight (or done) by the time this resolves - bail
+      // rather than render a listing for a path the UI no longer points at.
+      if (generation !== hydrateGeneration) return;
       if (!response.ok) {
         throw new Error('Failed to load files: ' + response.status + ' ' + response.statusText);
       }
       files = await response.json();
+      if (generation !== hydrateGeneration) return;
     } catch (e) {
       console.error(e);
+      if (generation !== hydrateGeneration) return;
       fileTable.innerHTML = '<div class="no-files">An error occurred while loading the files</div>';
       return;
     }
@@ -2082,6 +2077,32 @@
       fileTableContent += '</table>';
       fileTable.innerHTML = fileTableContent;
     }
+  }
+
+  // Navigate to a folder without a full page reload: updates history and title, then re-hydrates the listing.
+  async function navigateTo(path, { push = true } = {}) {
+    currentPath = path;
+    applyPathTitle();
+    if (push) {
+      // Root keeps the page's canonical URL so history entries match a direct /files load.
+      const url = path === '/' ? '/files' : '/files?path=' + encodeURIComponent(path);
+      history.pushState({ path: path }, '', url);
+    }
+    await hydrate();
+    window.scrollTo(0, 0);
+  }
+
+  // Delegated click handler: intercepts a plain left-click on a `selector` link inside the
+  // listener's container and routes it through navigateTo() instead of a full page load.
+  // Modifier-clicks and non-primary buttons are left alone so the browser's normal link
+  // handling (new tab, copy link, etc.) still applies.
+  function handleNavLinkClick(e, selector) {
+    const link = e.target.closest(selector);
+    if (!link) return;
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+    e.preventDefault();
+    const url = new URL(link.href);
+    navigateTo(decodeURIComponent(url.searchParams.get('path') || '/'));
   }
 
   // Image preview
@@ -2968,12 +2989,53 @@
 
   // Initialize quality settings handlers
   document.addEventListener('DOMContentLoaded', function() {
+    // Fetch CrossPoint version once. hydrate() re-runs on every folder navigation now, and this
+    // data (device/version) doesn't depend on currentPath, so fetching it there would just add a
+    // redundant /api/status round-trip to every folder click.
+    fetchVersion();
+
+    // Close modals when clicking overlay - call proper cleanup functions.
+    // Bound once here, not inside hydrate(): the overlay elements live outside #file-table and
+    // #directory-breadcrumbs (the only containers hydrate() rewrites), so they persist across every
+    // hydrate() call. Re-adding this listener from inside hydrate() would pile up one extra
+    // listener per folder navigation, each firing the close function again on the next click.
+    document.querySelectorAll('.modal-overlay').forEach(function(overlay) {
+      overlay.addEventListener('click', function(e) {
+        if (e.target === overlay) {
+          // Call the appropriate close function for each modal to ensure cleanup
+          if (overlay.id === 'uploadModal') return closeUploadModal();
+          if (overlay.id === 'folderModal') return closeFolderModal();
+          if (overlay.id === 'deleteModal') return closeDeleteModal();
+          if (overlay.id === 'renameModal') return closeRenameModal();
+          if (overlay.id === 'moveModal') return closeMoveModal();
+          if (overlay.id === 'imagePreviewModal') return closeImagePreview();
+          overlay.classList.remove('open');
+        }
+      });
+    });
+
     // Delegated so it survives file-table re-renders (avoids inline onclick with untrusted names).
     document.getElementById('file-table').addEventListener('click', function(e) {
       const link = e.target.closest('.image-preview-link');
       if (!link) return;
       e.preventDefault();
       openImagePreview(link.getAttribute('href'), link.textContent);
+    });
+
+    // Folder rows and breadcrumb segments are rebuilt by hydrate() on every navigation, but their
+    // containers are static, so this delegation is set up exactly once. '.folder-link' scopes the
+    // file-table delegate to folder rows only (file links / action buttons in the same table are
+    // untouched); the breadcrumb container only ever holds breadcrumb links, so 'a' is safe there.
+    document.getElementById('file-table').addEventListener('click', function(e) {
+      handleNavLinkClick(e, '.folder-link');
+    });
+    document.getElementById('directory-breadcrumbs').addEventListener('click', function(e) {
+      handleNavLinkClick(e, 'a');
+    });
+
+    window.addEventListener('popstate', function() {
+      const path = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
+      navigateTo(path, { push: false });
     });
 
     const qualitySlider = document.getElementById('qualitySlider');

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1938,6 +1938,16 @@
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)).toLocaleString() + ' ' + sizes[i];
   }
 
+  // Where the user is in each folder they have visited, so Back and Forward return them there.
+  // Held in memory rather than on the history entry: an entry's state can only be rewritten with
+  // replaceState(), which browsers rate-limit, and keeping it current would mean calling it on
+  // every scroll frame. Scroll events already fire at most once per frame, so this is one Map
+  // write per frame while scrolling.
+  const scrollOffsets = new Map();
+  window.addEventListener('scroll', function() {
+    scrollOffsets.set(currentPath, window.scrollY);
+  }, { passive: true });
+
   // Mirrors the loader markup the server renders inside #file-table. A full page load got it for
   // free; in-page navigation has to put it back itself.
   const LOADER_MARKUP = '<div class="loader-container"><span class="loader"></span></div>';
@@ -2105,21 +2115,15 @@
     closeOpenModals();
     dismissFailedUploads();
 
-    if (push) {
-      // Remember where the user was in the folder being left. The browser cannot restore it on
-      // Back by itself: at that point the document holds only a loader, so there is nothing to
-      // scroll to yet and the offset is clamped away. On a popstate the entry has already
-      // changed, so its stored offset is the one to restore rather than to overwrite.
-      history.replaceState({ path: currentPath, scrollY: window.scrollY }, '');
-    }
-    const scrollY = push ? 0 : (history.state && history.state.scrollY) || 0;
+    // Entering a folder starts at the top; returning to one restores where the user was.
+    const scrollY = push ? 0 : scrollOffsets.get(path) || 0;
 
     currentPath = path;
     applyPathTitle();
     if (push) {
       // Root keeps the page's canonical URL so history entries match a direct /files load.
       const url = path === '/' ? '/files' : '/files?path=' + encodeURIComponent(path);
-      history.pushState({ path: path, scrollY: 0 }, '', url);
+      history.pushState({ path: path }, '', url);
     }
     // Only once the listing is up, and never for a hydrate() that a newer navigation superseded -
     // that one would pull the user out of the listing which replaced it.
@@ -6269,9 +6273,13 @@ function retryAllFailedUploads() {
 
     xhr.send(formData);
   }
-  // Seed the entry the page was loaded on so a Back into it carries a scroll offset, like every
-  // entry navigateTo() pushes.
-  history.replaceState({ path: currentPath, scrollY: 0 }, '');
+  // The listing arrives after the navigation, so the browser's own scroll restoration runs while
+  // the document is still just a loader: it cannot land on the right offset, and the scroll events
+  // it fires would overwrite the offset recorded for the folder being left. navigateTo() restores
+  // the remembered one once the rows are up instead.
+  if ('scrollRestoration' in history) {
+    history.scrollRestoration = 'manual';
+  }
 
   // Once, not from hydrate(): device/version don't depend on currentPath, so fetching them per
   // navigation would add a redundant /api/status round-trip to every folder click. Issued ahead of

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1938,13 +1938,18 @@
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)).toLocaleString() + ' ' + sizes[i];
   }
 
-  // A newer hydrate() call owns the DOM: an older one still awaiting its listing must not
-  // go on to write a table it no longer represents (rapid folder clicks, Back-button mashing -
-  // scanFiles() yields during long scans, so per-folder fetch latency genuinely varies).
-  let hydrateGeneration = 0;
+  // Mirrors the loader markup the server renders inside #file-table. A full page load got it for
+  // free; in-page navigation has to put it back itself.
+  const LOADER_MARKUP = '<div class="loader-container"><span class="loader"></span></div>';
 
+  // Listing request owned by the hydrate() call that currently owns the DOM, so a newer call can
+  // supersede it. Rapid folder clicks and Back-button mashing genuinely reorder responses
+  // (scanFiles() yields during long scans), and without a full page load nothing aborts them.
+  let listingRequest = null;
+
+  // Renders the breadcrumbs and the listing for currentPath.
+  // Returns false if a newer hydrate() superseded this one before it could render.
   async function hydrate() {
-    const generation = ++hydrateGeneration;
     const breadcrumbs = document.getElementById('directory-breadcrumbs');
     const fileTable = document.getElementById('file-table');
 
@@ -1987,22 +1992,32 @@
       });
     }
 
+    // The breadcrumbs above now point at the new folder, so the outgoing listing has to go in the
+    // same frame: its rows carry absolute paths in their delete / move / rename handlers, and
+    // leaving them on screen would let the user act on the folder they just left.
+    fileTable.innerHTML = LOADER_MARKUP;
+    document.getElementById('folder-summary').textContent = '';
+
+    if (listingRequest) listingRequest.abort();
+    const request = new AbortController();
+    listingRequest = request;
+
     let files = [];
     try {
-      const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + '&_=' + Date.now());
-      // A newer hydrate() may already be in flight (or done) by the time this resolves - bail
-      // rather than render a listing for a path the UI no longer points at.
-      if (generation !== hydrateGeneration) return;
+      const response = await fetch('/api/files?path=' + encodeURIComponent(currentPath) + '&_=' + Date.now(),
+                                   { signal: request.signal });
       if (!response.ok) {
         throw new Error('Failed to load files: ' + response.status + ' ' + response.statusText);
       }
       files = await response.json();
-      if (generation !== hydrateGeneration) return;
     } catch (e) {
+      // Aborted means a newer hydrate() owns the DOM and has already drawn its own loader.
+      if (request.signal.aborted) return false;
       console.error(e);
-      if (generation !== hydrateGeneration) return;
       fileTable.innerHTML = '<div class="no-files">An error occurred while loading the files</div>';
-      return;
+      return true;
+    } finally {
+      if (listingRequest === request) listingRequest = null;
     }
 
     let folderCount = 0;
@@ -2079,19 +2094,38 @@
       fileTableContent += '</table>';
       fileTable.innerHTML = fileTableContent;
     }
+    return true;
   }
 
   // Navigate to a folder without a full page reload: updates history and title, then re-hydrates the listing.
   async function navigateTo(path, { push = true } = {}) {
+    // A full page load discarded everything scoped to the folder being left. In-page navigation
+    // has to do it explicitly: an open modal still holds the paths it captured there, and the
+    // failed-upload banner retries into whatever folder is current when it is clicked.
+    closeOpenModals();
+    dismissFailedUploads();
+
+    if (push) {
+      // Remember where the user was in the folder being left. The browser cannot restore it on
+      // Back by itself: at that point the document holds only a loader, so there is nothing to
+      // scroll to yet and the offset is clamped away. On a popstate the entry has already
+      // changed, so its stored offset is the one to restore rather than to overwrite.
+      history.replaceState({ path: currentPath, scrollY: window.scrollY }, '');
+    }
+    const scrollY = push ? 0 : (history.state && history.state.scrollY) || 0;
+
     currentPath = path;
     applyPathTitle();
     if (push) {
       // Root keeps the page's canonical URL so history entries match a direct /files load.
       const url = path === '/' ? '/files' : '/files?path=' + encodeURIComponent(path);
-      history.pushState({ path: path }, '', url);
+      history.pushState({ path: path, scrollY: 0 }, '', url);
     }
-    await hydrate();
-    window.scrollTo(0, 0);
+    // Only once the listing is up, and never for a hydrate() that a newer navigation superseded -
+    // that one would pull the user out of the listing which replaced it.
+    if (await hydrate()) {
+      window.scrollTo(0, scrollY);
+    }
   }
 
   // Delegated click handler: intercepts a plain left-click on a `selector` link inside the
@@ -2989,6 +3023,23 @@
     return labels[state] || 'Normal';
   }
 
+  // Each modal owns cleanup beyond hiding itself (revoking a preview URL, clearing the paths a
+  // confirm would act on), so every close routes through this dispatch rather than just dropping
+  // the .open class.
+  function closeModalOverlay(overlay) {
+    if (overlay.id === 'uploadModal') return closeUploadModal();
+    if (overlay.id === 'folderModal') return closeFolderModal();
+    if (overlay.id === 'deleteModal') return closeDeleteModal();
+    if (overlay.id === 'renameModal') return closeRenameModal();
+    if (overlay.id === 'moveModal') return closeMoveModal();
+    if (overlay.id === 'imagePreviewModal') return closeImagePreview();
+    overlay.classList.remove('open');
+  }
+
+  function closeOpenModals() {
+    document.querySelectorAll('.modal-overlay.open').forEach(closeModalOverlay);
+  }
+
   // Initialize quality settings handlers
   document.addEventListener('DOMContentLoaded', function() {
     // Fetch CrossPoint version once. hydrate() re-runs on every folder navigation now, and this
@@ -3004,14 +3055,7 @@
     document.querySelectorAll('.modal-overlay').forEach(function(overlay) {
       overlay.addEventListener('click', function(e) {
         if (e.target === overlay) {
-          // Call the appropriate close function for each modal to ensure cleanup
-          if (overlay.id === 'uploadModal') return closeUploadModal();
-          if (overlay.id === 'folderModal') return closeFolderModal();
-          if (overlay.id === 'deleteModal') return closeDeleteModal();
-          if (overlay.id === 'renameModal') return closeRenameModal();
-          if (overlay.id === 'moveModal') return closeMoveModal();
-          if (overlay.id === 'imagePreviewModal') return closeImagePreview();
-          overlay.classList.remove('open');
+          closeModalOverlay(overlay);
         }
       });
     });
@@ -6230,6 +6274,10 @@ function retryAllFailedUploads() {
 
     xhr.send(formData);
   }
+  // Seed the entry the page was loaded on so a Back into it carries a scroll offset, like every
+  // entry navigateTo() pushes.
+  history.replaceState({ path: currentPath, scrollY: 0 }, '');
+
   hydrate();
 </script>
 </body>

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -3042,11 +3042,6 @@
 
   // Initialize quality settings handlers
   document.addEventListener('DOMContentLoaded', function() {
-    // Fetch CrossPoint version once. hydrate() re-runs on every folder navigation now, and this
-    // data (device/version) doesn't depend on currentPath, so fetching it there would just add a
-    // redundant /api/status round-trip to every folder click.
-    fetchVersion();
-
     // Close modals when clicking overlay - call proper cleanup functions.
     // Bound once here, not inside hydrate(): the overlay elements live outside #file-table and
     // #directory-breadcrumbs (the only containers hydrate() rewrites), so they persist across every
@@ -6277,6 +6272,12 @@ function retryAllFailedUploads() {
   // Seed the entry the page was loaded on so a Back into it carries a scroll offset, like every
   // entry navigateTo() pushes.
   history.replaceState({ path: currentPath, scrollY: 0 }, '');
+
+  // Once, not from hydrate(): device/version don't depend on currentPath, so fetching them per
+  // navigation would add a redundant /api/status round-trip to every folder click. Issued ahead of
+  // the first listing because the device handles one request at a time and the detected device
+  // sets the upload converter's target dimensions.
+  fetchVersion();
 
   hydrate();
 </script>

--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -1842,7 +1842,9 @@
 
 <script>
   // get current path from query parameter
-  let currentPath = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
+  // URLSearchParams.get() already percent-decodes; a second decode would turn a literal '%2F' into '/'
+  // and throw on a folder name containing '%'.
+  let currentPath = new URLSearchParams(window.location.search).get('path') || '/';
 
   // Base title from <title>; re-applied on every navigation so returning to the root resets it.
   const baseTitle = document.title;
@@ -2102,7 +2104,7 @@
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     e.preventDefault();
     const url = new URL(link.href);
-    navigateTo(decodeURIComponent(url.searchParams.get('path') || '/'));
+    navigateTo(url.searchParams.get('path') || '/');
   }
 
   // Image preview
@@ -3034,7 +3036,7 @@
     });
 
     window.addEventListener('popstate', function() {
-      const path = decodeURIComponent(new URLSearchParams(window.location.search).get('path') || '/');
+      const path = new URLSearchParams(window.location.search).get('path') || '/';
       navigateTo(path, { push: false });
     });
 


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Make folder browsing in the web File Manager feel instant. Today every folder click (and every breadcrumb click) is a plain `<a href="/files?path=...">`, i.e. a full page navigation: the browser re-downloads and re-parses the whole Files page just to show a different directory listing, even though `/api/files` already serves that listing on its own. On the device this is the difference between "instant" and "a couple of seconds" per click, and it is what makes the file manager feel slow.
* **What changes are included?** `src/network/html/FilesPage.html` only. No server, build-script or endpoint changes.

**Navigation.** A delegated click handler on `#file-table` (scoped to `.folder-link`) and on `#directory-breadcrumbs` intercepts plain left-clicks, calls `history.pushState()` and re-runs `hydrate()` in place. Modifier-clicks and non-primary buttons are left alone, so open-in-new-tab / copy-link keep working (the anchors keep their real `href`). `popstate` re-hydrates from the URL, so Back/Forward walk through the visited folders without a reload. Root navigations push the canonical `/files` URL so history entries match a direct load.

**`hydrate()` owns the listing lifecycle.** It restores the loader into `#file-table` and clears `#folder-summary` in the same frame it rewrites the breadcrumbs, then fetches. Doing it up front matters: the rows of the outgoing folder carry absolute paths in their delete / move / rename handlers and their checkboxes feed `getSelectedItems()`, so leaving them on screen under the new folder's breadcrumbs would let the user act on a folder they had already left. It also means a failed listing no longer shows the previous folder's counts next to the error message.

**Superseded listings are aborted.** Navigation can outpace the fetch (rapid clicks, Back-button mashing, and `scanFiles()` yields during long scans, so per-folder latency genuinely varies). An `AbortController` per navigation supersedes the one in flight, so an obsolete response is dropped rather than read to the end. The device has no client-disconnect hook — `handleFileListData()` streams `scanFiles()` through `sendContent()` — so the scan itself still runs to completion; what this saves is transferring a listing that will be discarded, on a server that starts the next request only once the current one returns.

**State that the page used to lose on reload.** `navigateTo()` closes any open modal and dismisses the failed-upload banner. Both capture state in the folder being left: a modal holds the paths its confirm acts on, and "Retry All Failed Uploads" re-sends through `uploadFileHTTP()` / `uploadFileWebSocket()`, which read `currentPath` at send time — so after a folder change the retry landed in the wrong directory. The overlay-click handler's id-to-close-function dispatch is extracted into `closeModalOverlay()` so navigation reuses each modal's own cleanup instead of just dropping the `.open` class; `closeUploadModal()` still refuses to close while an upload is in progress.

**Scroll position is remembered per folder.** A passive scroll listener records `window.scrollY` against the current folder path in a `Map`, and `navigateTo()` reapplies it once `hydrate()` has rendered: clicking into a folder still starts at the top, while Back and Forward return the user where they were. It is deliberately not carried on the history entry — an entry's state can only be rewritten with `replaceState()`, which browsers rate-limit, so keeping it current would mean calling that on every scroll frame. `history.scrollRestoration` is set to `'manual'`, because the browser's own restoration runs while the document is still only a loader and the scroll events it fires would overwrite the offset recorded for the folder being left. A `hydrate()` that a newer navigation superseded renders nothing and scrolls nothing, instead of pulling the user out of the listing that replaced it.

**One-time setup.** `hydrate()` now runs on every navigation, so its one-time work moves out of it: the `/api/status` version fetch is issued at parse time, ahead of the first listing (the device handles one request at a time, and the detected device sets `MAX_WIDTH`/`MAX_HEIGHT` for the upload image converter, so an upload started while it was still queued behind a slow root scan converted against the default profile). The modal-overlay close listeners move to `DOMContentLoaded`; left inside `hydrate()` they would stack one extra listener per navigation.

**Path parsing.** The `path` query parameter is read once, without a second `decodeURIComponent()`: `URLSearchParams.get()` already percent-decodes, so the extra decode turned a literal `%2F` into `/` and threw `URIError` for a folder name containing `%`.

## Changes since first submission

A self-review of the first version found that removing the reload also removed the implicit reset it performed, with nothing put in its place. The listing lifecycle, modal/banner reset, scroll handling and `/api/status` ordering described above are the result; the generation counter that guarded against out-of-order responses is replaced by the `AbortController`, which covers the same case and stops the wasted transfer as well. A subsequent review comment caught that the first form of the scroll handling only recorded an offset on a forward navigation, so scrolling done after arriving via Back or Forward was lost; that is what the per-folder `Map` above replaces.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does. CrossInk has shipped an earlier form of this change since its v1.5.20; these corrections are being ported back to it. Stock CrossPoint still reloads the page on every folder click.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer. (It touches none of them.)

## Additional Context

* **Relationship to #2560.** That PR adds `Cache-Control`/`ETag` so a *reload* of the page becomes a cheap 304. This PR removes the reload for folder browsing altogether. The two are complementary and independent: with both, a folder click costs one `/api/files` request, and a manual page refresh costs one 304.
* **Memory / flash impact.** Firmware-side: none beyond the HTML payload. Measured with `scripts/build_html.py`, `FilesPageHtml` gzipped goes from **51 336 → 53 870 bytes (+2 534)**. (The first version of this PR quoted +111 bytes against a 52 601-byte baseline; that baseline was measured against a dirty tree and was wrong — the real figure for that version was 52 712, i.e. +1 376.) The page is now fetched once per session rather than once per folder click, so this trades ~2.3 KB on a single transfer against ~52 KB saved on every subsequent folder click. Runtime: each folder click sends exactly one `/api/files` request instead of `/files` + `/api/files` + `/api/status`.
* **Known limitation.** Focus is not moved after an in-page navigation: a folder link activated with Enter is removed by the table rewrite and focus falls back to `<body>`, with no announcement for screen-reader users. A full page load used to reset focus with a fresh title announcement. Left out of this PR deliberately, to keep it to the navigation change.
* **Still full reloads.** Delete, upload, mkdir, rename and move still call `window.location.reload()`. `hydrate()` is now a general "refresh the current listing" mechanism they could route through, but converting them needs the same state-reset review as above and belongs in its own PR.

## What was verified

* `pio run -e default` builds (ESP32-C3).
* `node --check` on the inline script passes.
* Browser run against a mock of `/files`, `/api/files` and `/api/status`, with a 1.5 s artificial delay on two folders to open the race windows, and a folder that returns 500. A `window` marker set at parse time is read at the end of the whole session: **`__PAGE_LOADS === 1`**, so no full page load happened at any point. Measured in that run:
  * During a slow scan: breadcrumbs and title already on the new folder, `#file-table` showing the loader with **0 rows**, `#folder-summary` empty.
  * A checkbox ticked in one folder: `getSelectedItems()` returns 1 before the navigation and **0** after.
  * Failing folder: the error message replaces the listing and `#folder-summary` is **empty** (previously it kept `4 folders, 36 files, 35,77 KB`).
  * Delete modal opened in `/Comics`, then Back: modal **closed**, root listing rendered.
  * Failed-upload banner shown, then a folder click: banner **hidden**, `failedUploadsGlobal.length === 0`.
  * Scrolled to y=400 in a long folder, into a subfolder, then Back: **y=400** restored. Then scrolled to y=500 in that folder, Forward, and Back again: **y=500** restored. Clicking into an already-visited folder still starts at the top.
  * Slow folder clicked, then a breadcrumb that resolves first: after the slow response would have arrived, breadcrumbs, row count and scroll offset are **unchanged**; the server log shows the superseded `/api/files` request **aborted** by the client.
  * Resource timings confirm `/api/status` is issued **before** the first `/api/files`.
  * A synthetic Ctrl-click on a folder link is **not** intercepted (`defaultPrevented === false`) and the browser follows the link.
  * Console shows no `AbortError` and no unexpected errors — only the deliberate 500.
* Suggested on-device test: open `/files`, click into a folder and back a few times while watching the DevTools Network tab. Only `/api/files?...` requests should appear after the initial load, Back should return you to where you were in the list, and Ctrl/Cmd-click on a folder should still open it in a new tab. Also worth exercising on a large directory: click a folder and confirm the table clears to the spinner immediately instead of showing the old folder's files.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_ — written and self-reviewed with Claude Code; the build, syntax check and the browser scenarios above were run by the author.
