### PR TITLE
fix: Improve font download memory handling and free OPDS catalogs on download

### DIFF
--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -9,6 +9,9 @@
 #include "esp_private/esp_cpu_internal.h"
 #include "esp_private/esp_system_attr.h"
 #include "esp_private/panic_internal.h"
+#if !__riscv
+#include <xtensa_context.h>  // XtExcFrame for the stack capture below
+#endif
 
 #define MAX_PANIC_STACK_DEPTH 32
 #define PANIC_CAPTURE_MAGIC 0x50414E49u
@@ -44,27 +47,24 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
     return;
   }
 
-#if !__riscv
-  __real_panic_print_backtrace(frame, core);
-  return;
-#else
   for (size_t i = 0; i < MAX_PANIC_STACK_DEPTH; i++) {
     panicStack[i].sp = 0;
   }
 
-  // Copied from components/esp_system/port/arch/riscv/panic_arch.c
-  uint32_t sp = (uint32_t)((RvExcFrame*)frame)->sp;
+  // Stack window dump, mirroring components/esp_system/port/arch/*/panic_arch.c.
+  // Hardware exceptions never reach __wrap_panic_abort, so on both
+  // architectures this dump is the only diagnostic a crash leaves on-device.
+#if __riscv
+  const uint32_t sp = (uint32_t)((RvExcFrame*)frame)->sp;
+#else
+  const uint32_t sp = (uint32_t)((XtExcFrame*)frame)->a1;
+#endif
   const int per_line = 8;
   int depth = 0;
   for (int x = 0; x < 1024; x += per_line * sizeof(uint32_t)) {
     uint32_t* spp = (uint32_t*)(sp + x);
-    // panic_print_hex(sp + x);
-    // panic_print_str(": ");
     panicStack[depth].sp = sp + x;
     for (int y = 0; y < per_line; y++) {
-      // panic_print_str("0x");
-      // panic_print_hex(spp[y]);
-      // panic_print_str(y == per_line - 1 ? "\r\n" : " ");
       panicStack[depth].spp[y] = spp[y];
     }
 
@@ -76,7 +76,6 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
   panicCaptureMarker = PANIC_CAPTURE_MAGIC;
 
   __real_panic_print_backtrace(frame, core);
-#endif
 }
 }
 
@@ -128,6 +127,31 @@ void clearPanic() {
   clearLastLogs();
 }
 
+static const char* resetReasonName(esp_reset_reason_t reason) {
+  switch (reason) {
+    case ESP_RST_PANIC:
+      return "PANIC (exception/abort)";
+    case ESP_RST_CPU_LOCKUP:
+      return "CPU_LOCKUP";
+    case ESP_RST_INT_WDT:
+      return "INT_WDT";
+    case ESP_RST_TASK_WDT:
+      return "TASK_WDT";
+    case ESP_RST_WDT:
+      return "WDT (other)";
+    case ESP_RST_BROWNOUT:
+      return "BROWNOUT";
+    case ESP_RST_POWERON:
+      return "POWERON";
+    case ESP_RST_SW:
+      return "SW";
+    case ESP_RST_DEEPSLEEP:
+      return "DEEPSLEEP";
+    default:
+      return "OTHER";
+  }
+}
+
 std::string getPanicInfo(bool full) {
   if (!full) {
     return panicMessage;
@@ -135,6 +159,10 @@ std::string getPanicInfo(bool full) {
     std::string info;
 
     info += "CrossPoint version: " CROSSPOINT_VERSION;
+    // A lockup or hardware watchdog resets without running any panic hook, so
+    // the reason and stack come back empty; the reset cause is then the only
+    // way to tell those apart from a true panic.
+    info += "\n\nReset reason: " + std::string(resetReasonName(esp_reset_reason()));
     info += "\n\nPanic reason: " + std::string(panicMessage);
     info += "\n\nLast logs:\n" + getLastLogs();
     info += "\n\nStack memory:\n";

--- a/lib/hal/HalSystem.cpp
+++ b/lib/hal/HalSystem.cpp
@@ -6,6 +6,7 @@
 #include "HalStorage.h"
 #include "Logging.h"
 #include "esp_debug_helpers.h"
+#include "esp_memory_utils.h"
 #include "esp_private/esp_cpu_internal.h"
 #include "esp_private/esp_system_attr.h"
 #include "esp_private/panic_internal.h"
@@ -59,9 +60,15 @@ void IRAM_ATTR __wrap_panic_print_backtrace(const void* frame, int core) {
 #else
   const uint32_t sp = (uint32_t)((XtExcFrame*)frame)->a1;
 #endif
+  constexpr uint32_t captureBytes = 1024;
+  if (!esp_stack_ptr_is_sane(sp) || sp > UINT32_MAX - captureBytes ||
+      !esp_ptr_in_dram(reinterpret_cast<const void*>(sp + captureBytes - 1))) {
+    __real_panic_print_backtrace(frame, core);
+    return;
+  }
   const int per_line = 8;
   int depth = 0;
-  for (int x = 0; x < 1024; x += per_line * sizeof(uint32_t)) {
+  for (int x = 0; x < captureBytes; x += per_line * sizeof(uint32_t)) {
     uint32_t* spp = (uint32_t*)(sp + x);
     panicStack[depth].sp = sp + x;
     for (int y = 0; y < per_line; y++) {

--- a/platformio.ini
+++ b/platformio.ini
@@ -57,6 +57,11 @@ build_flags =
   -DHAVE_FFDHE_2048
   -DHAVE_CURVE25519
   -DHAVE_SNI
+# RFC 6066 max_fragment_length: SecureClient asks the peer for 2KB TLS records
+# so the receive path never needs the default ~17KB contiguous buffer -- the
+# MEMORY_E mid-download failure at the ~20KB free heap font downloads leave.
+# Servers that ignore the extension keep 16KB records and behave as before.
+  -DHAVE_MAX_FRAGMENT
   -Wno-bidi-chars
   -Wl,--wrap=panic_print_backtrace,--wrap=panic_abort,--wrap=bootloader_common_check_efuse_blk_validity
   -fno-exceptions

--- a/src/activities/browser/OpdsBookBrowserActivity.cpp
+++ b/src/activities/browser/OpdsBookBrowserActivity.cpp
@@ -1,6 +1,7 @@
 #include "OpdsBookBrowserActivity.h"
 
 #include <Arduino.h>
+#include <FontCacheManager.h>
 #include <FreeInkUIIcon.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
@@ -425,7 +426,7 @@ void OpdsBookBrowserActivity::releaseEntries() {
   // entries; stop routing touches against it until the next render.
   closeRouting();
   std::vector<OpdsEntry>().swap(entries);
-  rebuildRowItems();
+  std::vector<fui::ListItem>().swap(rowItems);
 }
 
 void OpdsBookBrowserActivity::navigateToEntry(const OpdsEntry& entry) {
@@ -490,6 +491,28 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
   filename += opdsBookFilename(book.author, book.title, static_cast<OpdsFilenameFormat>(SETTINGS.opdsFilenameFormat));
   LOG_DBG("OPDS", "Downloading: %s -> %s", downloadUrl.c_str(), filename.c_str());
 
+  // The selected book data is now copied into the download URL, filename, and
+  // status line. Reclaim the catalog while TLS owns its record buffers; reload
+  // the current feed when the transfer finishes.
+  releaseEntries();
+
+  // Rebuildable SD-font caches can hold tens of KB the TLS session needs for
+  // a multi-MB book; release them up front (they repopulate on demand) and
+  // refuse to start below the floor — a doomed transfer otherwise dies
+  // mid-stream with MEMORY_E, or abort()s on an interior allocation.
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+  }
+  LOG_DBG("OPDS", "Download heap: %u free, %u max block", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+  if (ESP.getFreeHeap() < HttpDownloader::MIN_TLS_FREE_HEAP ||
+      ESP.getMaxAllocHeap() < HttpDownloader::MIN_TLS_MAX_ALLOC) {
+    LOG_ERR("OPDS", "Low heap for download (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+    state = BrowserState::ERROR;
+    errorMessage = tr(STR_DOWNLOAD_FAILED);
+    requestUpdate();
+    return;
+  }
+
   int lastRenderedPercent = -1;
   unsigned long lastProgressUpdateMs = 0;
   const auto result = HttpDownloader::downloadToFile(
@@ -523,16 +546,22 @@ void OpdsBookBrowserActivity::downloadBook(const OpdsEntry& book) {
 
   if (result == HttpDownloader::OK) {
     clearBookCache(filename);
-    state = BrowserState::BROWSING;
+    state = BrowserState::LOADING;
+    statusMessage = tr(STR_LOADING);
+    fetchFeed(currentPath);
+    return;
   } else if (result == HttpDownloader::ABORTED) {
-    // User cancelled; the partial file is already removed. Back to the list,
-    // or straight home when the abort came from the home gesture.
+    // The partial file is already removed. Reload the released catalog unless
+    // the cancel came from the home gesture.
     LOG_INF("OPDS", "Download cancelled");
     if (goHomeAfterCancel) {
       onGoHome();
       return;
     }
-    state = BrowserState::BROWSING;
+    state = BrowserState::LOADING;
+    statusMessage = tr(STR_LOADING);
+    fetchFeed(currentPath);
+    return;
   } else {
     LOG_ERR("OPDS", "Download failed: %d", static_cast<int>(result));
     state = BrowserState::ERROR;

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -127,6 +127,16 @@ bool FontDownloadActivity::fetchAndParseManifest() {
   // TLS buffers and the full JSON string in RAM simultaneously.
   static constexpr const char* MANIFEST_TMP = "/fonts_manifest.tmp";
 
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+  }
+  if (ESP.getFreeHeap() < HttpDownloader::MIN_TLS_FREE_HEAP ||
+      ESP.getMaxAllocHeap() < HttpDownloader::MIN_TLS_MAX_ALLOC) {
+    LOG_ERR("FONT", "Low heap for manifest (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+    errorMessage_ = tr(STR_MEMORY_ERROR);
+    return false;
+  }
+
   auto result = HttpDownloader::downloadToFile(FONT_MANIFEST_URL, MANIFEST_TMP, nullptr);
   if (result != HttpDownloader::OK) {
     LOG_ERR("FONT", "Failed to fetch manifest from %s", FONT_MANIFEST_URL);
@@ -435,6 +445,17 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
     LOG_DBG("FONT", "Free heap after SD font cache release: %d bytes", ESP.getFreeHeap());
   }
 
+  // Check before touching the family directory so a failed update leaves the
+  // installed family unchanged.
+  if (ESP.getFreeHeap() < HttpDownloader::MIN_TLS_FREE_HEAP ||
+      ESP.getMaxAllocHeap() < HttpDownloader::MIN_TLS_MAX_ALLOC) {
+    LOG_ERR("FONT", "Low heap for download (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+    RenderLock lock(*this);
+    state_ = ERROR;
+    errorMessage_ = tr(STR_MEMORY_ERROR);
+    return;
+  }
+
   if (!fontInstaller_.ensureFamilyDir(family.name.c_str())) {
     RenderLock lock(*this);
     state_ = ERROR;
@@ -451,21 +472,6 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
       fileTotal_ = file.size;
     }
     requestUpdateAndWait();
-
-    // Fail while failure is still clean: starting a TLS transfer under this
-    // floor ends in a mid-body MEMORY_E or an allocation abort() instead of
-    // this error screen.
-    if (ESP.getFreeHeap() < HttpDownloader::MIN_TLS_FREE_HEAP ||
-        ESP.getMaxAllocHeap() < HttpDownloader::MIN_TLS_MAX_ALLOC) {
-      LOG_ERR("FONT", "Low heap for download (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
-      fontInstaller_.deleteFamily(family.name.c_str());
-      family.installed = false;
-      family.hasUpdate = false;
-      RenderLock lock(*this);
-      state_ = ERROR;
-      errorMessage_ = "Not enough free memory - try again after a restart";
-      return;
-    }
 
     char destPath[128];
     FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -1,6 +1,7 @@
 #include "FontDownloadActivity.h"
 
 #include <ArduinoJson.h>
+#include <FontCacheManager.h>
 #include <GfxRenderer.h>
 #include <HalStorage.h>
 #include <I18n.h>
@@ -426,6 +427,14 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
   }
   requestUpdateAndWait();
 
+  // Rebuildable SD-font caches (glyph/kern arenas, CJK fallback tables) can
+  // hold tens of KB the TLS session needs; release them up front rather than
+  // starving the transfer. They repopulate on demand after the download.
+  if (auto* fcm = renderer.getFontCacheManager()) {
+    fcm->releaseSdFontCaches();
+    LOG_DBG("FONT", "Free heap after SD font cache release: %d bytes", ESP.getFreeHeap());
+  }
+
   if (!fontInstaller_.ensureFamilyDir(family.name.c_str())) {
     RenderLock lock(*this);
     state_ = ERROR;
@@ -442,6 +451,20 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
       fileTotal_ = file.size;
     }
     requestUpdateAndWait();
+
+    // Fail while failure is still clean: starting a TLS transfer under this
+    // floor ends in a mid-body MEMORY_E or an allocation abort() instead of
+    // this error screen.
+    if (ESP.getFreeHeap() < MIN_DOWNLOAD_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_DOWNLOAD_MAX_ALLOC) {
+      LOG_ERR("FONT", "Low heap for download (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
+      fontInstaller_.deleteFamily(family.name.c_str());
+      family.installed = false;
+      family.hasUpdate = false;
+      RenderLock lock(*this);
+      state_ = ERROR;
+      errorMessage_ = "Not enough free memory - try again after a restart";
+      return;
+    }
 
     char destPath[128];
     FontInstaller::buildFontPath(family.name.c_str(), file.name.c_str(), destPath, sizeof(destPath));
@@ -467,7 +490,11 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
           }
           requestUpdate(true);
         },
-        &cancelRequested_);
+        // Bulk font transfers follow GitHub's release-asset redirect over plain
+        // HTTP: the CRC check below (manifest fetched over TLS) covers
+        // integrity, and skipping the second TLS session keeps the C3 heap out
+        // of MEMORY_E territory.
+        &cancelRequested_, "", "", /*downgradeRedirectsToHttp=*/true);
 
     if (result == HttpDownloader::ABORTED) {
       fontInstaller_.deleteFamily(family.name.c_str());

--- a/src/activities/settings/FontDownloadActivity.cpp
+++ b/src/activities/settings/FontDownloadActivity.cpp
@@ -455,7 +455,8 @@ void FontDownloadActivity::downloadFamily(ManifestFamily& family) {
     // Fail while failure is still clean: starting a TLS transfer under this
     // floor ends in a mid-body MEMORY_E or an allocation abort() instead of
     // this error screen.
-    if (ESP.getFreeHeap() < MIN_DOWNLOAD_FREE_HEAP || ESP.getMaxAllocHeap() < MIN_DOWNLOAD_MAX_ALLOC) {
+    if (ESP.getFreeHeap() < HttpDownloader::MIN_TLS_FREE_HEAP ||
+        ESP.getMaxAllocHeap() < HttpDownloader::MIN_TLS_MAX_ALLOC) {
       LOG_ERR("FONT", "Low heap for download (%u free, %u max block)", ESP.getFreeHeap(), ESP.getMaxAllocHeap());
       fontInstaller_.deleteFamily(family.name.c_str());
       family.installed = false;

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -65,7 +65,7 @@ struct WifiPowerSaveGuard {
 
 #if defined(FREEINK_NET_WOLFSSL)
 HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std::string& username,
-                                         const std::string& password, Sink& sink) {
+                                         const std::string& password, Sink& sink, bool downgradeRedirectsToHttp) {
   WifiPowerSaveGuard psGuard;
   std::string url = startUrl;
 
@@ -109,6 +109,15 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
       if (location.empty() || !freeink::SecureHttpClient::resolveUrl(url, location, url)) {
         LOG_ERR("HTTP", "wolfSSL bad redirect: %d", status);
         return HttpDownloader::HTTP_ERROR;
+      }
+      if (downgradeRedirectsToHttp && url.rfind("https://", 0) == 0) {
+        // Fetch the redirect target over plain HTTP. GitHub's release-asset
+        // CDN serves its signed URLs on both schemes, and skipping the second
+        // TLS session removes its ~17KB record buffer — the MEMORY_E /
+        // OOM-abort site on C3 heaps that sit near 45KB free. Callers opting
+        // in must verify content integrity themselves (e.g. the font
+        // manifest's per-file checksum, fetched over TLS).
+        url.replace(0, 8, "http://");
       }
       continue;
     }
@@ -241,10 +250,14 @@ HttpDownloader::DownloadError runGet(const std::string& url, const std::string& 
 // mbedTLS path fails to connect or stalls mid-stream. Plain-http URLs still use a
 // WiFiClient inside runGetWolf, so this is safe for non-TLS targets too.
 HttpDownloader::DownloadError runGetSecure(const std::string& url, const std::string& username,
-                                           const std::string& password, Sink& sink) {
+                                           const std::string& password, Sink& sink,
+                                           bool downgradeRedirectsToHttp = false) {
 #if defined(FREEINK_NET_WOLFSSL)
-  return runGetWolf(url, username, password, sink);
+  return runGetWolf(url, username, password, sink, downgradeRedirectsToHttp);
 #else
+  // esp_http_client follows redirects internally; the downgrade only exists on
+  // the wolfSSL path, where the manual hop loop exposes the Location URL.
+  (void)downgradeRedirectsToHttp;
   return runGet(url, username, password, sink);
 #endif
 }
@@ -280,7 +293,8 @@ bool HttpDownloader::fetchUrl(const std::string& url, const DataCallback& onData
 
 HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url, const std::string& destPath,
                                                              ProgressCallback progress, bool* cancelFlag,
-                                                             const std::string& username, const std::string& password) {
+                                                             const std::string& username, const std::string& password,
+                                                             bool downgradeRedirectsToHttp) {
   LOG_DBG("HTTP", "Downloading: %s -> %s", url.c_str(), destPath.c_str());
 
   if (Storage.exists(destPath.c_str())) {
@@ -297,7 +311,7 @@ HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& 
   sink.cancelFlag = cancelFlag;
   sink.write = [&file](const uint8_t* data, size_t len) { return file.write(data, len) == len; };
 
-  const DownloadError result = runGetSecure(url, username, password, sink);
+  const DownloadError result = runGetSecure(url, username, password, sink, downgradeRedirectsToHttp);
   // Close before any remove() on the same path; DESTRUCTOR_CLOSES_FILE would
   // otherwise close only after the remove.
   file.close();

--- a/src/network/HttpDownloader.cpp
+++ b/src/network/HttpDownloader.cpp
@@ -114,9 +114,7 @@ HttpDownloader::DownloadError runGetWolf(const std::string& startUrl, const std:
         // Fetch the redirect target over plain HTTP. GitHub's release-asset
         // CDN serves its signed URLs on both schemes, and skipping the second
         // TLS session removes its ~17KB record buffer — the MEMORY_E /
-        // OOM-abort site on C3 heaps that sit near 45KB free. Callers opting
-        // in must verify content integrity themselves (e.g. the font
-        // manifest's per-file checksum, fetched over TLS).
+        // OOM-abort site on C3 heaps that sit near 45KB free.
         url.replace(0, 8, "http://");
       }
       continue;

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -23,6 +23,13 @@ class HttpDownloader {
     ABORTED,
   };
 
+  // Pre-flight floor for starting a TLS transfer. Below this the session or
+  // its ~17KB record buffer fails mid-stream (wolfSSL MEMORY_E) — or an
+  // interior allocation abort()s the device. Callers should check before
+  // downloadToFile() and fail into their error UI instead.
+  static constexpr uint32_t MIN_TLS_FREE_HEAP = 40000;
+  static constexpr uint32_t MIN_TLS_MAX_ALLOC = 20000;
+
   /**
    * Fetch text content from a URL with optional credentials.
    */
@@ -40,8 +47,14 @@ class HttpDownloader {
 
   /**
    * Download a file to the SD card with optional credentials.
+   *
+   * downgradeRedirectsToHttp rewrites followed redirect targets from https to
+   * http so the bulk transfer skips a second TLS session (and its ~17KB record
+   * buffer — the OOM site on low-heap C3 boards). Only for callers that verify
+   * content integrity themselves against a checksum obtained over TLS.
    */
   static DownloadError downloadToFile(const std::string& url, const std::string& destPath,
                                       ProgressCallback progress = nullptr, bool* cancelFlag = nullptr,
-                                      const std::string& username = "", const std::string& password = "");
+                                      const std::string& username = "", const std::string& password = "",
+                                      bool downgradeRedirectsToHttp = false);
 };

--- a/src/network/HttpDownloader.h
+++ b/src/network/HttpDownloader.h
@@ -50,8 +50,7 @@ class HttpDownloader {
    *
    * downgradeRedirectsToHttp rewrites followed redirect targets from https to
    * http so the bulk transfer skips a second TLS session (and its ~17KB record
-   * buffer — the OOM site on low-heap C3 boards). Only for callers that verify
-   * content integrity themselves against a checksum obtained over TLS.
+   * buffer — the OOM site on low-heap C3 boards).
    */
   static DownloadError downloadToFile(const std::string& url, const std::string& destPath,
                                       ProgressCallback progress = nullptr, bool* cancelFlag = nullptr,


### PR DESCRIPTION
Add heap checks before font downloads to prevent mid-transfer failures. Release SD font caches to free memory for TLS sessions. Improve crash diagnostics by adding reset reason names and extending stack dumps to both RISC-V and Xtensa architectures. Allow HTTP downgrades for GitHub redirects to reduce memory pressure. Also releases the opds catalog from DRAM before a download to free up memory needed for TLS transfers

Fixes #3315 
