### PR TITLE
test: add X3 and X4 simulator smoke checks

### DIFF
--- a/.github/workflows/simulator.yml
+++ b/.github/workflows/simulator.yml
@@ -1,0 +1,88 @@
+name: Simulator smoke
+
+on:
+  pull_request:
+  push:
+    branches: [develop, 'ci/simulator-*']
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: 'Optional upstream commit SHA or refs/pull/NUMBER/head to test with this harness'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: simulator-${{ github.workflow }}-${{ github.ref }}-${{ inputs.upstream_ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    name: Simulator ${{ matrix.device }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [x3, x4]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          path: harness
+          persist-credentials: false
+
+      - uses: actions/checkout@v6
+        with:
+          repository: ${{ inputs.upstream_ref && 'crosspoint-reader/crosspoint-reader' || github.repository }}
+          ref: ${{ inputs.upstream_ref || github.sha }}
+          path: firmware
+          submodules: recursive
+          persist-credentials: false
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsdl2-dev libssl-dev xvfb xauth
+          python -m pip install platformio==6.1.19 PyYAML==6.0.3 Pillow==12.3.0
+
+      - name: Record provenance and install build-only configuration
+        run: |
+          mkdir -p artifacts
+          git -C harness rev-parse HEAD > artifacts/harness-sha.txt
+          git -C firmware rev-parse HEAD > artifacts/firmware-sha.txt
+          git -C firmware submodule status --recursive > artifacts/submodules.txt
+          cp harness/platformio.simulator.ini firmware/platformio.simulator.ini
+          cp harness/scripts/simulator_platform.py firmware/scripts/simulator_platform.py
+          cp harness/platformio.simulator.ini artifacts/
+
+      - name: Build simulator
+        working-directory: firmware
+        env:
+          DEVICE: ${{ matrix.device }}
+        run: |
+          set -o pipefail
+          pio run -c platformio.simulator.ini -e "simulator_$DEVICE" -j 2 2>&1 | tee ../artifacts/build.log
+
+      - name: Exercise reader and saved progress
+        env:
+          DEVICE: ${{ matrix.device }}
+          LIBGL_ALWAYS_SOFTWARE: '1'
+        run: |
+          xvfb-run -a -s '-screen 0 1280x1024x24' python harness/scripts/simulator_smoke.py \
+            --binary "firmware/.pio/build/simulator_$DEVICE/program" \
+            --device "$DEVICE" --output artifacts/smoke
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: simulator-${{ matrix.device }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: artifacts/
+          retention-days: 14
+          if-no-files-found: error

--- a/docs/contributing/testing-debugging.md
+++ b/docs/contributing/testing-debugging.md
@@ -42,6 +42,73 @@ python3 scripts/debugging_monitor.py
 - Serial logs from boot through failure
 - Whether issue reproduces after clearing `.crosspoint/` cache on SD card
 
+## Simulator smoke checks
+
+`Simulator smoke` builds the real firmware against a pinned revision of the
+[official simulator](https://github.com/crosspoint-reader/crosspoint-simulator)
+on GitHub-hosted Ubuntu, for both X3 and X4. Its standalone
+`platformio.simulator.ini` does not change device or release environments.
+
+The check generates a small original EPUB and an isolated virtual SD card. It
+captures Home, resumes that book through the normal persisted-state path,
+presses next/previous/next, and restarts the process to reopen the saved page.
+It checks screenshot dimensions and content, round-trip page equality, logged
+page transitions, and the actual persisted progress record. This is not yet a
+file-browser selection test or a comprehensive visual-regression suite.
+
+Each device uploads logs, PNG/BMP screenshots, a machine-readable result, the
+generated EPUB, and exact firmware/harness/SDK revisions. Artifacts are retained
+for 14 days. Preserve useful evidence in a PR before it expires. A missing
+screenshot, crash, timeout, wrong page, or failed persistence check fails the job;
+a successful launch alone is not a pass.
+
+### Reproduce on Linux
+
+```sh
+git submodule update --init --recursive
+sudo apt-get install libsdl2-dev libssl-dev xvfb xauth
+python3 -m pip install platformio==6.1.19 PyYAML==6.0.3 Pillow==12.3.0
+pio run -c platformio.simulator.ini -e simulator_x4 -j 2
+LIBGL_ALWAYS_SOFTWARE=1 xvfb-run -a -s '-screen 0 1280x1024x24' \
+  python3 scripts/simulator_smoke.py --device x4 \
+  --binary .pio/build/simulator_x4/program --output build/smoke-x4
+```
+
+Use `simulator_x3` and `--device x3` for X3. The output directory must be new:
+the runner deliberately refuses to overwrite previous results or a developer's
+virtual SD card. The build configuration also supports macOS with SDL2 installed;
+the screenshot assertions currently target the 1x Linux CI display, not Retina.
+
+### Test a selected PR without changing its branch
+
+Run the workflow manually and set `upstream_ref` to an upstream 40-character
+commit SHA or `refs/pull/NUMBER/head`. Prefer a SHA for repeatable reviews. An
+empty value tests the selected workflow branch. The workflow records the
+resolved SHA and overlays only its native build configuration/helper; it does
+not merge the harness into the selected PR. Run the same harness against the
+PR's base and head, then compare the two device artifact sets. These are
+separate smoke results, not an automated base-versus-head image verdict.
+
+On a contribution fork, pushes to `ci/simulator-*` also run the demonstration,
+without needing to open a draft upstream PR just to debug the test setup.
+
+### Limits and safety
+
+- The simulator recompiles firmware for the host; it does not execute the ESP32
+  firmware binary or validate real heap limits, page-turn speed, power, SD timing,
+  e-ink waveforms, ghosting, or flashing. Hardware testing remains necessary.
+- The default simulator uses compatibility image decoders. This text fixture
+  does not establish device image-decoder correctness.
+- Input and capture schedules use fixed milliseconds with bounded process/job
+  timeouts. Missing the expected state fails; the runner does not retry failures
+  into passes. If CI timings prove unreliable, use simulator state-aware waits
+  rather than weakening the assertions.
+- PR builds execute untrusted code. Use disposable GitHub-hosted runners,
+  read-only permissions, no secrets and no persisted checkout credentials.
+  Never move this workflow to `pull_request_target` or a personal self-hosted
+  runner. Do not use personal books, Wi-Fi credentials, or live network accounts
+  in test fixtures. Simulator success does not approve a PR for merging.
+
 ## Common troubleshooting references
 
 - [User Guide troubleshooting section](../../USER_GUIDE.md#7-troubleshooting-issues--escaping-bootloop)

--- a/platformio.simulator.ini
+++ b/platformio.simulator.ini
@@ -31,6 +31,8 @@ build_flags =
   -DPNG_MAX_BUFFERED_PIXELS=16416
   -DDISABLE_FS_H_WARNING=1
   -DDESTRUCTOR_CLOSES_FILE=1
+  ; Native hosts have no separate flash address space (AnimatedGIF readFLASH).
+  -Dmemcpy_P=memcpy
   -Isrc
 lib_ignore = hal, PNGdec, JPEGDEC, WebSockets
 extra_scripts =

--- a/platformio.simulator.ini
+++ b/platformio.simulator.ini
@@ -1,0 +1,58 @@
+# Standalone native configuration; does not change device/release builds.
+# Based on crosspoint-simulator's macOS and Linux/WSL sample environments.
+[platformio]
+default_envs = simulator_x4, simulator_x3
+
+[env]
+platform = native@1.2.1
+lib_ldf_mode = deep+
+lib_compat_mode = off
+build_src_filter =
+  +<*>
+  -<network/FirmwareFlasher.cpp>
+  -<network/OtaBootSwitch.cpp>
+  -<network/OtaUpdater.cpp>
+  -<platform/skip_efuse_blk_check.c>
+build_flags =
+  -std=gnu++2a
+  !sdl2-config --cflags --libs
+  -Wno-narrowing
+  -Wno-deprecated-declarations
+  -DSIMULATOR
+  -DCROSSPOINT_SIMULATOR_PROJECT_WEBSERVER
+  -DCROSSPOINT_VERSION=\"ci-simulator\"
+  -DENABLE_SERIAL_LOG
+  -DLOG_LEVEL=2
+  -DEINK_DISPLAY_SINGLE_BUFFER_MODE=1
+  -DMINIZ_NO_ZLIB_COMPATIBLE_NAMES=1
+  -DXML_GE=0
+  -DXML_CONTEXT_BYTES=1024
+  -DUSE_UTF8_LONG_NAMES=1
+  -DPNG_MAX_BUFFERED_PIXELS=16416
+  -DDISABLE_FS_H_WARNING=1
+  -DDESTRUCTOR_CLOSES_FILE=1
+  -Isrc
+lib_ignore = hal, PNGdec, JPEGDEC, WebSockets
+extra_scripts =
+  pre:scripts/simulator_platform.py
+  pre:scripts/gen_i18n.py
+  pre:scripts/build_html.py
+lib_deps =
+  simulator=https://github.com/crosspoint-reader/crosspoint-simulator#c55f168bc0e677fdb32312c8be4b5874469465e6
+  FreeInkUI=symlink://freeink-sdk/libs/ui/FreeInkUI
+  Icons=symlink://freeink-sdk/libs/assets/Icons
+  bblanchon/ArduinoJson @ 7.4.2
+  ricmoo/QRCode @ 0.0.1
+  https://github.com/bitbank2/AnimatedGIF.git#d01888f0255fd0781fc2b8600b9111b14c999584
+  links2004/WebSockets @ 2.7.3
+
+[env:simulator_x4]
+build_flags =
+  ${env.build_flags}
+  -DFREEINK_DEVICE_X4=1
+
+[env:simulator_x3]
+build_flags =
+  ${env.build_flags}
+  -DSIMULATOR_DEVICE_X3
+  -DFREEINK_DEVICE_X3=1

--- a/scripts/simulator_platform.py
+++ b/scripts/simulator_platform.py
@@ -1,0 +1,10 @@
+"""Host libraries for the standalone native simulator configuration."""
+
+import sys
+
+Import("env")  # noqa: F821 -- supplied by PlatformIO/SCons
+
+if sys.platform.startswith("linux"):
+    env.Append(LIBS=["ssl", "crypto"])  # noqa: F821
+elif sys.platform != "darwin":
+    raise RuntimeError("The simulator requires macOS or Linux (including WSL)")

--- a/scripts/simulator_smoke.py
+++ b/scripts/simulator_smoke.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Exercise the real reader through the official simulator's scripted buttons.
+
+Requires Pillow. Run under xvfb-run on Linux. Every invocation owns a fresh
+output directory; it never reads or deletes a developer's simulated SD card.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import struct
+import subprocess
+import sys
+import zipfile
+
+from PIL import Image, ImageChops
+
+
+def require(condition, message):
+    if not condition:
+        raise RuntimeError(message)
+
+
+def make_book(path):
+    """Generate original, deterministic EPUB 2 text without external assets."""
+    paragraphs = "".join(
+        f"<p>Paragraph {n:03d}. Reading should be calm and predictable. "
+        "Turn the page to find another numbered paragraph. "
+        "This original text exercises pagination, navigation and saved progress.</p>"
+        for n in range(1, 81)
+    )
+    entries = {
+        "mimetype": "application/epub+zip",
+        "META-INF/container.xml": '<?xml version="1.0"?>'
+        '<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+        '<rootfiles><rootfile full-path="OEBPS/content.opf" '
+        'media-type="application/oebps-package+xml"/></rootfiles></container>',
+        "OEBPS/content.opf": '<?xml version="1.0"?>'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="id">'
+        '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+        '<dc:identifier id="id">crosspoint-ci-smoke</dc:identifier>'
+        '<dc:title>CrossPoint CI Reading Test</dc:title><dc:creator>CrossPoint contributors</dc:creator>'
+        '<dc:language>en</dc:language></metadata><manifest>'
+        '<item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>'
+        '<item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/>'
+        '</manifest><spine toc="ncx"><itemref idref="chapter"/></spine></package>',
+        "OEBPS/toc.ncx": '<?xml version="1.0"?>'
+        '<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">'
+        '<head><meta name="dtb:uid" content="crosspoint-ci-smoke"/></head>'
+        '<docTitle><text>CrossPoint CI Reading Test</text></docTitle><navMap>'
+        '<navPoint id="chapter" playOrder="1"><navLabel><text>Reading test</text></navLabel>'
+        '<content src="chapter.xhtml"/></navPoint></navMap></ncx>',
+        "OEBPS/chapter.xhtml": '<?xml version="1.0" encoding="utf-8"?>'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Reading test</title></head>'
+        f'<body><h1>Reading test</h1>{paragraphs}</body></html>',
+    }
+    with zipfile.ZipFile(path, "w") as book:
+        for name, text in entries.items():
+            info = zipfile.ZipInfo(name, date_time=(2020, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED if name == "mimetype" else zipfile.ZIP_DEFLATED
+            book.writestr(info, text.encode("utf-8"))
+
+
+def run_phase(binary, output, name, buttons, screenshots):
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CROSSPOINT_SIM_")}
+    env.update({
+        "CROSSPOINT_SIM_INPUT_SCRIPT": buttons,
+        "CROSSPOINT_SIM_SCREENSHOTS": ";".join(f"{ms}:{filename}.bmp" for ms, filename in screenshots),
+        "TZ": "UTC",
+    })
+    with (output / f"{name}.log").open("w", encoding="utf-8") as log:
+        result = subprocess.run([str(binary)], cwd=output, env=env, stdout=log,
+                                stderr=subprocess.STDOUT, timeout=45, check=False)
+    require(result.returncode == 0, f"{name}: simulator exited {result.returncode}; see {name}.log")
+    return (output / f"{name}.log").read_text(encoding="utf-8", errors="replace")
+
+
+def load_screen(output, name, size):
+    path = output / f"{name}.bmp"
+    require(path.is_file(), f"Missing screenshot: {name}")
+    with Image.open(path) as source:
+        image = source.convert("RGB")
+    require(image.size == size, f"{name}: expected {size}, got {image.size}")
+    require(image.convert("L").getextrema()[0] < 100 and image.convert("L").getextrema()[1] > 200,
+            f"{name}: blank or invalid display")
+    image.save(output / f"{name}.png")
+    # Exclude the status bar, whose clock is not a rendering regression.
+    return image.crop((0, 0, size[0], size[1] - 80))
+
+
+def smoke(binary, output, device):
+    books = output / "fs_" / "books"
+    books.mkdir(parents=True)
+    cache = output / "fs_" / ".crosspoint"
+    cache.mkdir()
+    make_book(books / "smoke.epub")
+    size = (528, 792) if device == "x3" else (480, 800)
+
+    run_phase(binary, output, "home", "5000:QUIT", [(4000, "home")])
+    load_screen(output, "home", size)
+
+    # Use the firmware's persisted resume path, without a test-only reader API.
+    (cache / "state.json").write_text(json.dumps({
+        "openEpubPath": "/books/smoke.epub", "lastSleepFromReader": True,
+        "readerActivityLoadCount": 0, "showBootScreen": False,
+    }), encoding="utf-8")
+    log = run_phase(binary, output, "reading",
+                    "7000:DOWN;10000:UP;13000:DOWN;17000:QUIT",
+                    [(6000, "page-1"), (9000, "page-2"), (12000, "page-1-back"), (16000, "page-2-again")])
+    pages = {name: load_screen(output, name, size)
+             for name in ("page-1", "page-2", "page-1-back", "page-2-again")}
+    require(ImageChops.difference(pages["page-1"], pages["page-2"]).getbbox() is not None,
+            "Page-forward did not change the reading content")
+    for first, second in (("page-1", "page-1-back"), ("page-2", "page-2-again")):
+        require(ImageChops.difference(pages[first], pages[second]).getbbox() is None,
+                f"Round-trip navigation changed content: {first} / {second}")
+    saved = re.findall(r"Progress saved: spine=(\d+) offset=\d+ page=(\d+)", log)
+    transitions = [position for i, position in enumerate(saved) if i == 0 or position != saved[i - 1]]
+    require(transitions == [("0", "0"), ("0", "1"), ("0", "0"), ("0", "1")],
+            f"Unexpected page transitions: {transitions}")
+    progress_files = list(cache.glob("epub_*/progress.bin"))
+    require(len(progress_files) == 1, "Expected one persisted EPUB progress file")
+    data = progress_files[0].read_bytes()
+    require(len(data) in (6, 10), f"Unexpected progress record size: {len(data)}")
+    spine, page, count = struct.unpack_from("<HHH", data)
+    require(spine == 0 and page == 1 and count > 1, f"Wrong saved progress: {(spine, page, count)}")
+
+    log = run_phase(binary, output, "reopen", "7000:QUIT", [(6000, "page-2-reopened")])
+    reopened = load_screen(output, "page-2-reopened", size)
+    require("Loaded cache: 0, 1" in log, "Reopen did not load the saved page")
+    require(ImageChops.difference(pages["page-2"], reopened).getbbox() is None,
+            "Reopening the book did not reproduce its saved page")
+    return {"device": device, "screen_size": size, "transitions": transitions,
+            "saved_progress": {"spine": spine, "page": page, "page_count": count},
+            "book_sha256": hashlib.sha256((books / "smoke.epub").read_bytes()).hexdigest()}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--device", choices=("x3", "x4"), required=True)
+    parser.add_argument("--output", type=Path, required=True, help="New directory; must not already exist")
+    args = parser.parse_args()
+    binary = args.binary.resolve(strict=True)
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    report = {"status": "failed", "device": args.device}
+    try:
+        report.update(smoke(binary, output, args.device))
+        report["status"] = "passed"
+    except (OSError, RuntimeError, subprocess.TimeoutExpired) as error:
+        report["error"] = str(error)
+    (output / "result.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/simulator_smoke.py
+++ b/scripts/simulator_smoke.py
@@ -107,8 +107,10 @@ def smoke(binary, output, device):
         "openEpubPath": "/books/smoke.epub", "lastSleepFromReader": True,
         "readerActivityLoadCount": 0, "showBootScreen": False,
     }), encoding="utf-8")
+    # Leave the activity before QUIT: killing an active reader intentionally
+    # leaves its crash-loop guard set, so the next boot goes Home instead.
     log = run_phase(binary, output, "reading",
-                    "7000:DOWN;10000:UP;13000:DOWN;17000:QUIT",
+                    "7000:DOWN;10000:UP;13000:DOWN;17000:BACK;20000:QUIT",
                     [(6000, "page-1"), (9000, "page-2"), (12000, "page-1-back"), (16000, "page-2-again")])
     pages = {name: load_screen(output, name, size)
              for name in ("page-1", "page-2", "page-1-back", "page-2-again")}
@@ -128,6 +130,8 @@ def smoke(binary, output, device):
     spine, page, count = struct.unpack_from("<HHH", data)
     require(spine == 0 and page == 1 and count > 1, f"Wrong saved progress: {(spine, page, count)}")
 
+    state = json.loads((cache / "state.json").read_text(encoding="utf-8"))
+    require(state.get("readerActivityLoadCount") == 0, "Reader did not exit cleanly before restart")
     log = run_phase(binary, output, "reopen", "7000:QUIT", [(6000, "page-2-reopened")])
     reopened = load_screen(output, "page-2-reopened", size)
     require("Loaded cache: 0, 1" in log, "Reopen did not load the saved page")


### PR DESCRIPTION
## Summary

Add a small X3/X4 simulator smoke check for PR review, using the official external simulator rather than another emulator implementation.

- A separate `platformio.simulator.ini` pins the simulator revision and supplies Linux/macOS host settings without changing device/release environments. Runtime verification below is on Linux only.
- `.github/workflows/simulator.yml` runs on disposable Ubuntu runners, with read-only permissions, no secrets and no persisted checkout credentials. Manual runs can test an upstream SHA or PR ref with the same harness.
- `scripts/simulator_smoke.py` generates an original EPUB in a fresh virtual SD card, checks Home, opens via persisted resume state, turns next/previous/next, exits the reader normally and restarts to reopen the saved page.
- Failures include wrong dimensions, blank/missing screens, incorrect page transitions, changed round-trip content, wrong persisted progress, crashes and timeouts. Logs, screenshots, the fixture, results and exact revisions are uploaded.

This complements #1870 rather than replacing its developer-facing integration. It leaves the SDL/HAL implementation in `crosspoint-simulator`, does not add an allocator/OOM simulator, and does not change branch protection or replace existing firmware/unit checks.

## Where to view the screenshots

1. Open the [successful upstream X3/X4 simulator run](https://github.com/crosspoint-reader/crosspoint-reader/actions/runs/33939859185).
2. Scroll to **Artifacts** and download `simulator-x3-33939859185-1` or `simulator-x4-33939859185-1` (GitHub sign-in is required).
3. Unzip the download and open the PNGs in `smoke/`:
   - `home.png` — Home screen.
   - `page-1.png` and `page-2.png` — rendered book and page-forward result.
   - `page-1-back.png` and `page-2-again.png` — next/previous round trip.
   - `page-2-reopened.png` — saved page after restarting.

`smoke/result.json` contains the assertions' results; `home.log`, `reading.log` and `reopen.log` contain the execution logs. These are **simulator captures, not device photos**. GitHub provides artifact ZIP downloads rather than inline image previews; retention is **14 days from each run**.

## Verification

Successful hosted run: https://github.com/marcusquinn/crosspoint-reader/actions/runs/33937839330

Firmware/harness head: `59bda6bc38fa074d2b2b3b2b03dd877c7fc5464d` (production source based on `9d2f234e`). Simulator: `c55f168bc0e677fdb32312c8be4b5874469465e6`.

| Profile | Display | Page transitions (zero-based) | Persisted/reopened page | Result |
| --- | --- | --- | --- | --- |
| X3 | 528×792 | 0 → 1 → 0 → 1 | 1 of 26 | Pass |
| X4 | 480×800 | 0 → 1 → 0 → 1 | 1 of 28 | Pass |

Both used the same generated EPUB SHA-256: `78fbeec2c40051d75a17ea8a6335e50482abeadd55aa8266d6d68e7cb7a4276c`. Artifacts contain the screenshots and `result.json` per device (14-day retention).

Additional checks: `actionlint`, Python syntax compilation, generated XML validation and `git diff --check` passed. A local negative probe returning exit zero without a screenshot was rejected as intended. The initial hosted run also caught a test lifecycle mistake: quitting inside the reader correctly leaves its crash-loop guard set; the runner now presses Back before restarting instead of bypassing that guard.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This addresses development/PR verification, not an existing stock-firmware reading feature; it reuses the official simulator.
- [x] No changes to `freeink-sdk/`, `lib/hal/`, bootloader, OTA or recovery implementations.

## Additional Context / Runtime Testing

Simulator runtime verified on hosted Linux; **not tested on physical hardware**. No firmware RAM/flash impact. This does not establish ESP32 memory limits, real page-turn speed, e-ink ghosting/waveforms, SD timing, power behaviour or firmware flashing safety. Default simulator image shims are unchanged; the fixture tests text.

The test uses fixed-time input/capture schedules and fails if expected states are missed; it does not retry failures into passes. Screenshot equality is within a device run, excluding the status bar, not a cross-platform golden-image gate. Reopening uses real saved progress; initial opening is seeded through the normal resume path, not file-browser selection. The separate macOS build path is available, but screenshot assertions target 1x Linux rather than Retina.

### AI Usage

**YES.** AI-assisted implementation and source review. The verification above is from actual commands and hosted simulator runs; no hardware results are claimed.
