### PR TITLE
fix: skip image resources in EPUB spines

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -6,10 +6,13 @@ All POD fields are written in the ESP32 little-endian representation used by
 
 ## `book.bin`
 
-### Version 10
+### Version 11
 
 `book.bin` stores EPUB metadata plus lookup tables for spine and TOC entries.
 The current firmware writes this version from `BookMetadataCache`.
+Version 11 rebuilds older metadata caches so raw image resources incorrectly
+listed in an EPUB spine are no longer treated as chapters. The binary layout
+is unchanged.
 
 ImHex pattern:
 
@@ -18,7 +21,7 @@ import std.mem;
 import std.string;
 import std.core;
 
-#define EXPECTED_VERSION 10
+#define EXPECTED_VERSION 11
 #define MAX_STRING_LENGTH 65535
 
 struct String {

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -11,7 +11,7 @@
 #include "FsHelpers.h"
 
 namespace {
-constexpr uint8_t BOOK_CACHE_VERSION = 10;  // v10: ignore ambiguous guide text references
+constexpr uint8_t BOOK_CACHE_VERSION = 11;  // v11: exclude raw images from the spine
 constexpr char bookBinFile[] = "/book.bin";
 constexpr char tmpSpineBinFile[] = "/spine.bin.tmp";
 constexpr char tmpTocBinFile[] = "/toc.bin.tmp";

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -196,18 +196,21 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
       }
     }
 
-    // Record index entry for fast lookup later
-    if (self->tempItemStore) {
-      ItemIndexEntry entry;
-      entry.idHash = fnvHash(itemId);
-      entry.idLen = static_cast<uint16_t>(itemId.size());
-      entry.fileOffset = static_cast<uint32_t>(self->tempItemStore.position());
-      self->itemIndex.push_back(entry);
-    }
+    // This lookup feeds the spine, not cover/image discovery below. Some
+    // malformed books reference a raw image as a page; never send it to the
+    // chapter XML parser. XHTML cover wrappers remain readable spine entries.
+    if (!startsWithImageMediaType(mediaType)) {
+      if (self->tempItemStore) {
+        ItemIndexEntry entry;
+        entry.idHash = fnvHash(itemId);
+        entry.idLen = static_cast<uint16_t>(itemId.size());
+        entry.fileOffset = static_cast<uint32_t>(self->tempItemStore.position());
+        self->itemIndex.push_back(entry);
+      }
 
-    // Write items down to SD card
-    serialization::writeString(self->tempItemStore, itemId);
-    serialization::writeString(self->tempItemStore, href);
+      serialization::writeString(self->tempItemStore, itemId);
+      serialization::writeString(self->tempItemStore, href);
+    }
 
     if (itemId == self->coverItemId) {
       // Some EPUBs set meta name="cover" to an XHTML wrapper item.


### PR DESCRIPTION
## Summary

Resolves #2994.

Keep manifest `image/*` resources out of the temporary lookup used to build the EPUB spine. A malformed book can otherwise pass a raw image to the chapter XML parser, then repeatedly fail to render any readable content beyond it.

- `ContentOpfParser.cpp`: reuse `startsWithImageMediaType()` before adding an item to the spine lookup. Cover-image discovery below that block is unchanged, and XHTML cover wrappers still enter the lookup.
- `BookMetadataCache.cpp`: bump metadata cache version to 11 so a previously cached image spine is rebuilt.
- `docs/file-formats.md`: document the version change; the serialized layout itself is unchanged.

This narrowly filters image resources, rather than rejecting every unfamiliar or missing media type. It adds no per-manifest heap fields or allocations. Old metadata caches rebuild on next open.

## Where to view the before/after screenshots

- **Before:** [failing baseline run](https://github.com/marcusquinn/crosspoint-reader/actions/runs/33938253047) → **Artifacts** → download the `simulator-x3-...` or `simulator-x4-...` ZIP.
- **After:** [passing fix run](https://github.com/marcusquinn/crosspoint-reader/actions/runs/33938637299) → **Artifacts** → download the matching device's ZIP.
- Unzip and compare `smoke/page-1.png` and `smoke/page-2.png`. The baseline shows **“Failed to index - invalid book”**; the fixed run renders the original numbered-paragraph text. The passing run also includes `smoke/page-2-reopened.png` to demonstrate saved-page restoration.
- `smoke/reading.log` contains the XML-parser failure before the fix; `smoke/result.json` provides the test verdict. The input EPUB is `smoke/fs_/books/smoke.epub` in both downloads.

GitHub sign-in is required to download artifacts. These are simulator captures, not physical-device photos, and artifacts expire **14 days after each run**.

## Reproduction and Runtime Testing

Original generated fixture: a valid PNG is incorrectly referenced before an XHTML chapter in the OPF spine. No third-party book was downloaded.

Before: https://github.com/marcusquinn/crosspoint-reader/actions/runs/33938253047

- Both X3 and X4 native builds succeed, but the test fails to turn a page.
- The captured reader log shows `Loading file: OEBPS/image.png, index: 0`, followed by `Parse error at line 1` and `Failed during incremental section build` on each attempted page turn.

After, at the exact fix head `2e6368d109096d8408fff93e44cfee3f3175fb7c`: https://github.com/marcusquinn/crosspoint-reader/actions/runs/33938637299

- Both devices open the XHTML chapter, turn next/previous/next, persist page 1, and reopen that same page.
- The before/after fixture SHA-256 is identical: `8533c2ed51a3900517f9eac1014b21c1012a6e72c388de1fdcaeb798e85da1b0`.
- The harness is unchanged between the two runs. Its branch is `ci/simulator-spine-regression` in the contribution fork; the generator, logs, input book and screenshots are available there/in the run artifacts.

Ordinary text-book regression at the same fix head also passes on X3 and X4: https://github.com/marcusquinn/crosspoint-reader/actions/runs/33938638937

`./bin/clang-format-fix -g` (clang-format 21) and `git diff --check` pass. Simulator runtime verified; **not yet verified on physical devices**. No ESP32 performance, memory-limit, or display-waveform claims.

## Scope Check

- [x] Read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme or external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This repairs the reported core EPUB-reading failure rather than adding a stock-firmware feature.
- [x] No SDK, HAL, bootloader, OTA or recovery changes.

### AI Usage

**YES.** AI-assisted implementation and source review. The report's diagnosis was independently reproduced using original fixture content in actual hosted simulator runs; no hardware testing is implied.
