### PR TITLE
fix: preserve all packages when optimizing EPUBs

### DIFF
--- a/src/network/html/FilesPage.html
+++ b/src/network/html/FilesPage.html
@@ -4132,11 +4132,11 @@ const FONT_MEDIA_TYPE_REGEX = /^(font\/|application\/font-|application\/x-font-|
 
 // Returns a Set of zip-root-relative paths of embedded font files, detected by
 // file extension and by OPF manifest media-type (catches odd extensions).
-function collectFontPaths(zip, opfContent, opfPath) {
+function collectFontPaths(zip, opfFiles) {
   const fontPaths = new Set();
   zip.forEach(p => { if (FONT_EXT_REGEX.test(p.toLowerCase())) fontPaths.add(p); });
 
-  if (opfContent && opfPath) {
+  for (const [opfPath, opfContent] of opfFiles) {
     try {
       const doc = new DOMParser().parseFromString(opfContent, 'application/xml');
       if (!doc.querySelector('parsererror')) {
@@ -5060,7 +5060,7 @@ async function convertEpubFile(file, progressCallback) {
   const entries = Object.entries(zip.files);
   const splitImages = {};
   const xhtmlFiles = {};
-  let opfPath = null, opfContent = null;
+  const opfFiles = [];
   let mainIdentifier = null;
 
   // Write mimetype FIRST per EPUB OCF spec
@@ -5154,8 +5154,7 @@ async function convertEpubFile(file, progressCallback) {
     } else if (low.match(/\.(xhtml|html|htm)$/)) {
       xhtmlFiles[path] = await safeReadText(fileObj);
     } else if (low.endsWith('.opf')) {
-      opfPath = path;
-      opfContent = await safeReadText(fileObj);
+      opfFiles.push([path, await safeReadText(fileObj)]);
     }
 
     if (progressCallback) progressCallback((i / entries.length) * 60);
@@ -5165,7 +5164,7 @@ async function convertEpubFile(file, progressCallback) {
   // Counters cover font files, @font-face rules (incl. data: URI fonts), and
   // encryption.xml shrinkage; they count uncompressed content bytes removed
   // (the final archive-size delta is reported separately by logSummary).
-  const fontPaths = collectFontPaths(zip, opfContent, opfPath);
+  const fontPaths = collectFontPaths(zip, opfFiles);
   let removedFontCount = 0;
   let removedFontBytes = 0;
   let removedFontFaceRules = 0;
@@ -5347,13 +5346,15 @@ async function convertEpubFile(file, progressCallback) {
     out.file(xhtmlPath, t, { compression: 'DEFLATE', compressionOptions: { level: 8 }, createFolders: false });
   }
 
-  // Extract main identifier from OPF using DOMParser with regex fallback
-  if (opfContent) {
-    mainIdentifier = extractIdentifier(opfContent);
+  // With multiple packages, each NCX can have its own identifier. Preserve
+  // those identifiers rather than assigning every NCX the last package's ID.
+  if (opfFiles.length === 1) {
+    mainIdentifier = extractIdentifier(opfFiles[0][1]);
   }
 
-  // Third pass: update OPF using fixOPF (DOMParser with regex fallback)
-  if (opfContent) {
+  // Third pass: update every package, preserving container.xml rootfile targets.
+  for (const [opfPath, opfContent] of opfFiles) {
+    if (operationCancelled) throw new Error('Cancelled by user');
     let t = opfContent;
     for (const [o, n] of Object.entries(renamed)) {
       t = t.split(o.split('/').pop()).join(n.split('/').pop());


### PR DESCRIPTION
## Summary

Resolves #3117.

Preserve every OPF when **Optimize EPUB** rebuilds the archive, rather than retaining whichever package happened to be iterated last.

The change is limited to `src/network/html/FilesPage.html`:

- Collect every OPF with its path and run the existing `fixOPF()` transformation on each, relative to that package's directory.
- Collect embedded font paths from every package, including manifest-declared fonts with non-font extensions, so retained OPFs do not reference removed files.
- Preserve existing per-package NCX identifiers when multiple OPFs exist. Single-OPF NCX identifier repair remains unchanged; a multi-package archive must not have every NCX reassigned to the last package's identifier.
- Preserve `META-INF/container.xml` unchanged and retain its target regardless of ZIP entry order.

## Where to inspect the before/after evidence

Open the [browser regression run](https://github.com/marcusquinn/crosspoint-reader/actions/runs/33939267008), scroll to **Artifacts**, and download both `optimizer-broken-33939267008` and `optimizer-working-33939267008`.

After unzipping, inspect `results/result.json` and compare `results/case-0-output.epub` from each artifact: the baseline loses the root `content.opf`; the fix retains all three OPFs. Cases 1 and 2 vary ZIP entry order; case 3 is the single-package control. Each case also includes its original `case-N-input.epub` and input/output SHA-256 values.

**This PR's decisive evidence is archive contents and browser test results, not a screenshot of the page.** No optimizer UI screenshots are claimed. GitHub sign-in is required for artifact downloads; retention is **14 days from the run**.

## Reproduction and Runtime Testing

Hosted before/after browser demonstration: https://github.com/marcusquinn/crosspoint-reader/actions/runs/33939267008

The same harness runs the real `convertEpubFile()` from:

- Base `9d2f234e1d20a875347d3a339b73d5d539fd945c`
- Fix `3eb6deb6ab3a371d4a5eed07542189ef5bfb5659`

Four original synthetic fixtures exercise three-package archives with the root OPF first, last and in the middle, plus a single-package control. Every fixture contains an image conversion, an embedded font detected by media type, and package-specific NCX identifiers.

| Case | Base | Fix |
| --- | --- | --- |
| Root OPF first | Drops root + one auxiliary OPF; container target missing | All 3 OPFs retained |
| Root OPF last | Drops both auxiliary OPFs | All 3 OPFs retained |
| Root OPF in middle | Drops root + one auxiliary OPF; container target missing | All 3 OPFs retained |
| Single OPF | Pass | Pass |

The fixed cases also check XML parsing, manifest resource existence, updated JPEG paths/media types, font removal and NCX identifiers. The baseline job only succeeds when it observes the specific expected missing-OPF failures and the passing single-package control; it does not treat arbitrary errors as a successful reproduction.

The artifact sets include exact revisions, generated input/output EPUBs and JSON results with input SHA-256 values. The harness lives on the fork's `ci/optimizer-regression` demonstration branch; this PR does not introduce a new browser-test framework into the firmware repository.

Local verification also passed using isolated Brave/Playwright, `python3 scripts/build_html.py`, the repository formatting wrapper and `git diff --check`. Browser page assets are real; only the unrelated file-list/status endpoints are intercepted. No actual device upload or physical-reader result is claimed, and these are targeted structural checks rather than EPUBCheck certification.

## Scope Check

- [x] Read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme or external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Fixes the existing EPUB optimizer's data-loss bug, not a new stock-firmware feature.
- [x] No SDK, HAL, bootloader, OTA or recovery changes.

## Additional Context

Processing and OPF retention happen in the browser, not the ESP32 reader heap. The generated Files page compressed from 51,336 to 51,424 bytes in the local build (+88 bytes); generated headers are not committed. Multiple packages now use browser memory for their OPF text instead of overwriting one string.

### AI Usage

**YES.** AI-assisted implementation and source review, with the before/after result verified through the real optimizer in a browser and hosted CI.
