### PR TITLE
chore: update pioarduino to 55.03.311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
           key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
           restore-keys: pio-${{ runner.os }}-
 
+      - name: Install cppcheck runtime dependency
+        run: |
+          # pioarduino's Linux cppcheck binary links against libpcre.so.3.
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libpcre3
+
       - name: Run cppcheck
         run: pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high
 

--- a/lib/Xtc/Xtc/XtcParser.h
+++ b/lib/Xtc/Xtc/XtcParser.h
@@ -71,8 +71,8 @@ class XtcParser {
                              size_t chunkSize = 1024);
 
   // Get title/author from metadata
-  std::string getTitle() const { return m_title; }
-  std::string getAuthor() const { return m_author; }
+  const std::string& getTitle() const { return m_title; }
+  const std::string& getAuthor() const { return m_author; }
 
   bool hasChapters() const { return m_hasChapters; }
   const std::vector<ChapterInfo>& getChapters();

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,19 @@ check_tool = cppcheck
 ; missingInclude (project headers) is suppressed alongside missingIncludeSystem: on a
 ; fresh CI checkout cppcheck has no resolved include paths, so it reports every
 ; project header as missing (~400 information-level lines) and fails the job.
-check_flags = --enable=all --suppress=missingIncludeSystem --suppress=missingInclude --suppress=unusedFunction --suppress=unmatchedSuppression --suppress=*:*/.pio/* --inline-suppr
+check_flags =
+  --enable=all
+  --check-level=exhaustive
+  --suppress=missingIncludeSystem
+  --suppress=missingInclude
+  --suppress=unusedFunction
+  --suppress=unmatchedSuppression
+  --suppress=*:*/.pio/*
+  ; The SDK is maintained separately; keep this check scoped to reader-owned code.
+  --suppress=*:*/freeink-sdk/*
+  ; Analyzer status output is not a source-code defect.
+  --suppress=checkersReport
+  --inline-suppr
 check_skip_packages = yes
 
 board_upload.flash_size = 16MB

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,7 +7,7 @@ extra_configs = platformio.local.ini
 version = 1.6.0
 
 [base]
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.37/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.311/platform-espressif32.zip
 board = esp32-c3-devkitm-1
 framework = arduino
 monitor_speed = 115200
@@ -83,6 +83,7 @@ extra_scripts =
   pre:scripts/git_branch.py
   pre:scripts/patch_jpegdec.py
   post:scripts/register_unit_tests_target.py
+  post:scripts/patch_arduino_rom_libc.py
 
 ; Libraries
 lib_deps =
@@ -146,6 +147,8 @@ custom_sdkconfig =
   ; ESP_I2S.h, which the isolated core rebuild can't resolve. Unused here anyway,
   ; so drop it or the sticky env fails to build.
   CONFIG_ARDUINO_SELECTIVE_ESP_SR=n
+  ; esp-modbus requires its API blocking limit to cover the response timeout.
+  CONFIG_FMB_MASTER_MAX_API_BLOCKING_TIME_MS=10000
 
 ; Drop unused cloud components from the core rebuild. esp_insights/rainmaker
 ; require embedded server certs the lib builder can't generate
@@ -160,8 +163,26 @@ custom_component_remove =
   espressif/esp_secure_cert_mgr
   espressif/cbor
 
+; Keep C3-specific defaults separate from the S3 firmware profiles.
+[firmware_tuned_c3]
+extends = firmware_tuned
+custom_sdkconfig =
+  ${firmware_tuned.custom_sdkconfig}
+  ; Use ROM libc routines to preserve the C3's shared instruction/data RAM.
+  CONFIG_LIBC_OPTIMIZED_MISALIGNED_ACCESS=n
+  ; Match the configurable defaults from the Arduino 3.3.7 build.
+  CONFIG_BT_NIMBLE_CRYPTO_STACK_MBEDTLS=y
+  CONFIG_BT_NIMBLE_EXT_SCAN=y
+  CONFIG_ESP_IPC_TASK_STACK_SIZE=1024
+  CONFIG_ESP_RMAKER_WORK_QUEUE_TASK_STACK=4096
+  CONFIG_ESP_WIFI_GCMP_SUPPORT=n
+  CONFIG_FMB_MASTER_TIMEOUT_MS_RESPOND=3000
+  CONFIG_FMB_QUEUE_LENGTH=20
+  CONFIG_FMB_TCP_CONNECTION_TOUT_SEC=20
+
+
 [env:default]
-extends = base, firmware_tuned
+extends = base, firmware_tuned_c3
 build_flags =
   ${base.build_flags}
   ; CROSSPOINT_VERSION is set by scripts/git_branch.py (includes branch + short SHA)
@@ -173,7 +194,7 @@ build_flags =
 
 
 [env:gh_release]
-extends = base, firmware_tuned
+extends = base, firmware_tuned_c3
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
@@ -183,7 +204,7 @@ build_flags =
   -DLOG_LEVEL=1 ; Set log level to info for release builds
 
 [env:gh_release_rc]
-extends = base, firmware_tuned
+extends = base, firmware_tuned_c3
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1
@@ -193,7 +214,7 @@ build_flags =
   -DLOG_LEVEL=1 ; Set log level to info for release candidate builds
 
 [env:slim]
-extends = base, firmware_tuned
+extends = base, firmware_tuned_c3
 build_flags =
   ${base.build_flags}
   -DFREEINK_DEVICE_X4=1

--- a/scripts/patch_arduino_rom_libc.py
+++ b/scripts/patch_arduino_rom_libc.py
@@ -1,0 +1,54 @@
+"""Work around pioarduino's custom-SDK libc linker configuration gap.
+
+In pioarduino 55.03.311, custom_sdkconfig rebuilds SDK libraries and configuration
+headers, but the Arduino application still uses the packaged libc LINKFLAGS from
+esp32c3/pioarduino-build.py. Selecting ROM libc therefore also requires updating
+those flags. Remove this hook once pioarduino derives the application's libc
+linker flags from the rebuilt SDK configuration.
+"""
+from pathlib import Path
+
+
+def configure_rom_libc(env):
+    if env.BoardConfig().get("build.mcu") != "esp32c3":
+        return
+    # The outer core-generation pass has not installed its new sdkconfig yet.
+    if env.get("ARDUINO_LIB_COMPILE_FLAG") == "Build":
+        return
+    requested = env.GetProjectOption("custom_sdkconfig", "")
+    libc_setting = None
+    for line in requested.splitlines():
+        key, separator, value = line.strip().partition("=")
+        if separator and key == "CONFIG_LIBC_OPTIMIZED_MISALIGNED_ACCESS":
+            libc_setting = value.strip()
+    if libc_setting != "n":
+        return
+
+    libs = Path(env.PioPlatform().get_package_dir("framework-arduinoespressif32-libs")) / "esp32c3"
+    config = (libs / "sdkconfig").read_text(encoding="utf-8").splitlines()
+    if "# CONFIG_LIBC_OPTIMIZED_MISALIGNED_ACCESS is not set" not in config:
+        raise RuntimeError("C3 framework sdkconfig does not match the requested ROM libc configuration")
+    rom = libs / "ld" / "esp32c3.rom.libc-suboptimal_for_misaligned_mem.ld"
+    if not rom.is_file():
+        raise RuntimeError(f"Missing C3 ROM libc linker script: {rom}")
+
+    # pioarduino keeps the prebuilt package's -u anchors after a custom SDK rebuild.
+    # Mirror ESP-IDF's esp_rom selection so flash-off callers still reach ROM.
+    functions = ("memcpy", "memmove", "memcmp", "strcpy", "strncpy", "strncmp", "strcmp")
+    anchors = {f"esp_libc_include_{name}_impl" for name in functions}
+    flags = list(env["LINKFLAGS"])
+    filtered = []
+    index = 0
+    while index < len(flags):
+        if flags[index] == "-u" and index + 1 < len(flags) and flags[index + 1] in anchors:
+            index += 2
+        else:
+            filtered.append(flags[index])
+            index += 1
+    if str(rom) not in filtered:
+        filtered.extend(["-T", str(rom)])
+    env.Replace(LINKFLAGS=filtered)
+
+
+Import("env")  # noqa: F821 -- provided by PlatformIO
+configure_rom_libc(env)  # noqa: F821

--- a/scripts/patch_pioarduino_cache.py
+++ b/scripts/patch_pioarduino_cache.py
@@ -1,4 +1,5 @@
 import hashlib
+import importlib.util
 import sys
 from pathlib import Path
 
@@ -26,6 +27,10 @@ new_check = '''flag_any_custom_sdkconfig = (
     and exists(str(Path(FRAMEWORK_LIB_DIR) / chip_variant / "sdkconfig.orig"))
 )'''
 
+# pioarduino 55.03.39 removed trailing whitespace from the same expression.
+if old_check not in source:
+    old_check = old_check.replace("and \n", "and\n")
+
 if old_check in source:
     builder.write_text(source.replace(old_check, new_check, 1), encoding="utf-8")
 elif new_check not in source:
@@ -35,18 +40,28 @@ requested = env.GetProjectOption("custom_sdkconfig", "")
 board = env.BoardConfig()
 mcu = board.get("build.mcu", "esp32")
 chip_variant = board.get("build.chip_variant", "").lower() or mcu
+component_spec = importlib.util.spec_from_file_location(
+    "crosspoint_pio_components", builder.with_name("component_manager.py")
+)
+components = importlib.util.module_from_spec(component_spec)
+component_spec.loader.exec_module(components)
+fingerprint_fn = getattr(components, "board_memory_fingerprint", None)
+memory_fingerprint = fingerprint_fn(env, board) if fingerprint_fn else ""
+cache_request = requested.strip() + memory_fingerprint if requested.strip() else ""
 framework_libs = Path(platform.get_package_dir("framework-arduinoespressif32-libs"))
 target_sdkconfig = framework_libs / chip_variant / "sdkconfig"
 original_sdkconfig = framework_libs / chip_variant / "sdkconfig.orig"
 request_file = framework_libs / chip_variant / "sdkconfig.crosspoint"
 
+rebuild = bool(requested.strip())
 if original_sdkconfig.is_file():
     cached_request = (
         request_file.read_text(encoding="utf-8") if request_file.is_file() else ""
     )
-    if cache_matches(requested, cached_request):
+    if cache_matches(cache_request, cached_request):
+        rebuild = False
         marker = "# TASMOTA__" + hashlib.md5(
-            (requested.strip() + mcu).encode("utf-8")
+            (requested.strip() + mcu + memory_fingerprint).encode("utf-8")
         ).hexdigest()[:16]
         defaults = Path(env.subst("$PROJECT_DIR")) / "sdkconfig.defaults"
         lines = (
@@ -59,8 +74,19 @@ if original_sdkconfig.is_file():
                 "\n".join([marker, *lines[1:]]) + "\n", encoding="utf-8"
             )
             print(f"Restored cached Arduino framework for {mcu}")
-    else:
+    elif requested.strip():
         # Recompile only this chip from its original template after config changes.
         original_sdkconfig.replace(target_sdkconfig)
+    # With no custom request, retain .orig so upstream reinstalls prebuilt archives.
 
-request_file.write_text(requested.strip() + "\n", encoding="utf-8")
+if rebuild and not board.get("build.esp-idf.sdkconfig_path", ""):
+    # Resolved Kconfig values override sdkconfig.defaults, even across SDK upgrades.
+    # Only reset the generated file for this environment; explicit paths are user-owned.
+    resolved = Path(env.subst("$PROJECT_DIR")) / f"sdkconfig.{env.subst('$PIOENV')}"
+    if resolved.is_file() and "# Automatically generated file. DO NOT EDIT." in (
+        resolved.read_text(encoding="utf-8").splitlines()[:5]
+    ):
+        resolved.unlink()
+        print(f"Reset generated SDK configuration: {resolved.name}")
+
+request_file.write_text(cache_request + "\n", encoding="utf-8")

--- a/src/activities/Activity.h
+++ b/src/activities/Activity.h
@@ -61,10 +61,10 @@ class Activity {
   void setResult(ActivityResult&& result);
 
   // Finish this activity and return to the previous one on the stack (if any)
-  void finish();
+  static void finish();
 
   // Convenience method to facilitate API transition to ActivityManager
   // TODO: remove this in near future
-  void onGoHome(HomeMenuItem item = HomeMenuItem::NONE);
-  void onSelectBook(const std::string& path);
+  static void onGoHome(HomeMenuItem item = HomeMenuItem::NONE);
+  static void onSelectBook(const std::string& path);
 };

--- a/src/activities/home/FileBrowserActivity.cpp
+++ b/src/activities/home/FileBrowserActivity.cpp
@@ -522,7 +522,6 @@ void FileBrowserActivity::drawFooter() {
 }
 
 size_t FileBrowserActivity::findEntry(const std::string& name) const {
-  for (size_t i = 0; i < files.size(); i++)
-    if (files[i] == name) return i;
-  return 0;
+  const auto entry = std::find(files.begin(), files.end(), name);
+  return entry != files.end() ? static_cast<size_t>(entry - files.begin()) : 0;
 }

--- a/src/activities/home/HomeActivity.cpp
+++ b/src/activities/home/HomeActivity.cpp
@@ -250,8 +250,6 @@ void HomeActivity::loop() {
   }
 
   const int menuTop = metrics.homeTopPadding + metrics.homeCoverTileHeight + metrics.homeMenuTopOffset;
-  const int renderedMenuSelection =
-      metrics.homeContinueReadingInMenu ? selectorIndex : selectorIndex - recentBooks.size();
   const int renderedMenuCount =
       menuCount - (metrics.homeContinueReadingInMenu ? 0 : static_cast<int>(recentBooks.size()));
   int menuRow = -1;

--- a/src/activities/network/WifiSelectionActivity.cpp
+++ b/src/activities/network/WifiSelectionActivity.cpp
@@ -812,7 +812,7 @@ void WifiSelectionActivity::loop() {
   }
 }
 
-std::string WifiSelectionActivity::getSignalStrengthIndicator(const int32_t rssi) const {
+std::string WifiSelectionActivity::getSignalStrengthIndicator(const int32_t rssi) {
   // Convert RSSI to signal bars representation
   if (rssi >= -50) {
     return "||||";  // Excellent

--- a/src/activities/network/WifiSelectionActivity.h
+++ b/src/activities/network/WifiSelectionActivity.h
@@ -136,7 +136,7 @@ class WifiSelectionActivity final : public Activity, private UiAppHost {
   void handleAutoConnectFailure();
   void showNetworkListFromAutoConnect();
   bool hasAttemptedAutoSsid(const std::string& ssid) const;
-  std::string getSignalStrengthIndicator(int32_t rssi) const;
+  static std::string getSignalStrengthIndicator(int32_t rssi);
 
   void onComplete(bool connected);
 

--- a/src/activities/reader/ReaderUtils.h
+++ b/src/activities/reader/ReaderUtils.h
@@ -74,7 +74,7 @@ struct TouchPageTurn {
   unsigned long heldMs;
 };
 
-inline TouchPageTurn detectTouchPageTurn(GfxRenderer& renderer, const MappedInputManager& input) {
+inline TouchPageTurn detectTouchPageTurn(const GfxRenderer& renderer, const MappedInputManager& input) {
   TouchPageTurn result{false, false, 0};
   if (!SETTINGS.touchReaderControls || !input.hasTouch()) {
     return result;

--- a/src/activities/reader/TxtReaderActivity.cpp
+++ b/src/activities/reader/TxtReaderActivity.cpp
@@ -118,7 +118,7 @@ void TxtReaderActivity::buildPageIndex(GfxRenderer& renderer) {
   LOG_DBG("TRS", "Built page index: %d pages", totalPages);
 }
 
-bool TxtReaderActivity::loadPageAtOffset(GfxRenderer& renderer, size_t offset, std::vector<std::string>& outLines,
+bool TxtReaderActivity::loadPageAtOffset(const GfxRenderer& renderer, size_t offset, std::vector<std::string>& outLines,
                                          size_t& nextOffset) {
   outLines.clear();
   const size_t fileSize = txt->getFileSize();

--- a/src/activities/reader/TxtReaderActivity.h
+++ b/src/activities/reader/TxtReaderActivity.h
@@ -33,7 +33,8 @@ class TxtReaderActivity final : public ReaderActivity {
 
   void renderPage(GfxRenderer& renderer);
   void initializeReader(GfxRenderer& renderer);
-  bool loadPageAtOffset(GfxRenderer& renderer, size_t offset, std::vector<std::string>& outLines, size_t& nextOffset);
+  bool loadPageAtOffset(const GfxRenderer& renderer, size_t offset, std::vector<std::string>& outLines,
+                        size_t& nextOffset);
   void buildPageIndex(GfxRenderer& renderer);
   bool loadPageIndexCache();
   void savePageIndexCache() const;

--- a/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
+++ b/src/activities/reader/XtcReaderChapterSelectionActivity.cpp
@@ -3,6 +3,7 @@
 #include <GfxRenderer.h>
 #include <I18n.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "MappedInputManager.h"
@@ -23,12 +24,10 @@ int XtcReaderChapterSelectionActivity::findChapterIndexForPage(const uint32_t pa
   }
 
   const auto& chapters = xtc->getChapters();
-  for (size_t i = 0; i < chapters.size(); i++) {
-    if (page >= chapters[i].startPage && page <= chapters[i].endPage) {
-      return static_cast<int>(i);
-    }
-  }
-  return 0;
+  const auto chapter = std::find_if(chapters.begin(), chapters.end(), [page](const auto& candidate) {
+    return page >= candidate.startPage && page <= candidate.endPage;
+  });
+  return chapter != chapters.end() ? static_cast<int>(chapter - chapters.begin()) : 0;
 }
 
 void XtcReaderChapterSelectionActivity::onEnter() {

--- a/src/activities/settings/ButtonRemapActivity.cpp
+++ b/src/activities/settings/ButtonRemapActivity.cpp
@@ -200,7 +200,7 @@ bool ButtonRemapActivity::validateUnassigned(const uint8_t pressedButton) {
   return true;
 }
 
-const char* ButtonRemapActivity::getRoleName(const uint8_t roleIndex) const {
+const char* ButtonRemapActivity::getRoleName(const uint8_t roleIndex) {
   switch (roleIndex) {
     case 0:
       return tr(STR_BACK);

--- a/src/activities/settings/ButtonRemapActivity.h
+++ b/src/activities/settings/ButtonRemapActivity.h
@@ -33,6 +33,6 @@ class ButtonRemapActivity final : public Activity, private UiAppHost {
   // Returns false if a hardware button is already assigned to a different role.
   bool validateUnassigned(uint8_t pressedButton);
   // Labels for UI display.
-  const char* getRoleName(uint8_t roleIndex) const;
+  static const char* getRoleName(uint8_t roleIndex);
   const char* getHardwareName(uint8_t buttonIndex) const;
 };

--- a/src/activities/settings/SettingsActivity.cpp
+++ b/src/activities/settings/SettingsActivity.cpp
@@ -52,7 +52,7 @@ void SettingsActivity::rebuildSettingsLists() {
   std::vector<DictionaryEntry> dictionaries;
   DictionaryRegistry::discover(dictionaries);
 
-  for (auto& setting : getSettingsList(&sdFontSystem.registry(), &dictionaries)) {
+  for (const auto& setting : getSettingsList(&sdFontSystem.registry(), &dictionaries)) {
     if (setting.category == StrId::STR_NONE_OPT) continue;
     if (setting.category == StrId::STR_CAT_DISPLAY) {
       // The sunlight fading fix is a grayscale-waveform compensation that does

--- a/src/activities/settings/SettingsActivity.h
+++ b/src/activities/settings/SettingsActivity.h
@@ -110,7 +110,7 @@ struct SettingInfo {
     return s;
   }
 
-  static SettingInfo String(StrId nameId, char* ptr, size_t maxLen, const char* key = nullptr,
+  static SettingInfo String(StrId nameId, const char* ptr, size_t maxLen, const char* key = nullptr,
                             StrId category = StrId::STR_NONE_OPT) {
     SettingInfo s;
     s.nameId = nameId;

--- a/src/activities/settings/TextSettingsActivity.cpp
+++ b/src/activities/settings/TextSettingsActivity.cpp
@@ -32,10 +32,11 @@ constexpr StrId STYLE_ROW_NAME_IDS[] = {StrId::STR_FOCUS_READING, StrId::STR_HYP
 int findCurrentFontIndex(const SdCardFontRegistry* registry, const char* sdFontFamilyName, uint8_t fontFamily) {
   if (sdFontFamilyName[0] != '\0' && registry) {
     const auto& families = registry->getFamilies();
-    for (int i = 0; i < static_cast<int>(families.size()); i++) {
-      if (families[i].name == sdFontFamilyName) {
-        return CrossPointSettings::BUILTIN_FONT_COUNT + i;
-      }
+    const auto family = std::find_if(families.begin(), families.end(), [sdFontFamilyName](const auto& candidate) {
+      return candidate.name == sdFontFamilyName;
+    });
+    if (family != families.end()) {
+      return CrossPointSettings::BUILTIN_FONT_COUNT + static_cast<int>(family - families.begin());
     }
   }
 

--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -57,11 +57,9 @@ void BmpViewerActivity::loadSiblingImages() {
 
   FsHelpers::sortFileList(siblingImages);
 
-  for (size_t i = 0; i < siblingImages.size(); ++i) {
-    if (siblingImages[i] == fileName) {
-      currentImageIndex = static_cast<int>(i);
-      break;
-    }
+  const auto image = std::find(siblingImages.begin(), siblingImages.end(), fileName);
+  if (image != siblingImages.end()) {
+    currentImageIndex = static_cast<int>(image - siblingImages.begin());
   }
 }
 

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -112,8 +112,7 @@ void BaseTheme::drawBatteryLeft(const GfxRenderer& renderer, Rect rect, const bo
   fillBatteryIcon(renderer, iconRect, percentage);
 }
 
-void BaseTheme::drawProgressBar(const GfxRenderer& renderer, Rect rect, const size_t current,
-                                const size_t total) const {
+void BaseTheme::drawProgressBar(const GfxRenderer& renderer, Rect rect, const size_t current, const size_t total) {
   if (total == 0) {
     return;
   }
@@ -141,7 +140,7 @@ void BaseTheme::drawProgressBar(const GfxRenderer& renderer, Rect rect, const si
 // and run into the neighbouring hint, and now wraps to at most two centred lines
 // (wrappedText() ellipsises anything that still doesn't fit). Shared so every
 // theme's drawButtonHints() gets the same behaviour.
-void BaseTheme::drawHintLabel(GfxRenderer& renderer, const int fontId, const char* label, const int x,
+void BaseTheme::drawHintLabel(const GfxRenderer& renderer, const int fontId, const char* label, const int x,
                               const int boxWidth, const int boxTop, const int boxHeight, const int singleLineYOffset) {
   constexpr int textPadding = 4;  // keeps a wrapped label off the button's border
   const int maxTextWidth = boxWidth - (textPadding * 2);
@@ -722,7 +721,7 @@ void BaseTheme::fillPopupProgress(const GfxRenderer& renderer, const Rect& layou
 
 void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage,
                               const int pageCount, std::string title, const int paddingBottom, const int textYOffset,
-                              const bool fillMargin, const bool isPageBookmarked, const bool pageCountEstimated) const {
+                              const bool fillMargin, const bool isPageBookmarked, const bool pageCountEstimated) {
   auto metrics = UITheme::getInstance().getMetrics();
   int orientedMarginTop, orientedMarginRight, orientedMarginBottom, orientedMarginLeft;
   renderer.getOrientedViewableTRBL(&orientedMarginTop, &orientedMarginRight, &orientedMarginBottom,
@@ -868,7 +867,7 @@ void BaseTheme::drawStatusBar(GfxRenderer& renderer, const float bookProgress, c
   }
 }
 
-void BaseTheme::drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label) const {
+void BaseTheme::drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label) {
   const auto& metrics = UITheme::getInstance().getMetrics();
   auto truncatedLabel =
       renderer.truncatedText(SMALL_FONT_ID, label, rect.width - metrics.contentSidePadding * 2, EpdFontFamily::REGULAR);

--- a/src/components/themes/BaseTheme.h
+++ b/src/components/themes/BaseTheme.h
@@ -220,7 +220,7 @@ class BaseTheme {
   virtual ~BaseTheme() = default;
 
   // Component drawing methods
-  void drawProgressBar(const GfxRenderer& renderer, Rect rect, size_t current, size_t total) const;
+  static void drawProgressBar(const GfxRenderer& renderer, Rect rect, size_t current, size_t total);
   void drawBatteryLeft(const GfxRenderer& renderer, Rect rect,
                        bool showPercentage = true) const;  // Left aligned (reader mode)
   virtual void fillBatteryIcon(const GfxRenderer& renderer, Rect rect, uint16_t percentage) const;
@@ -228,7 +228,7 @@ class BaseTheme {
                                const char* btn4) const;
   // Shared by every theme's drawButtonHints(): centres a hint label in its box,
   // wrapping to two lines rather than overflowing when it's too wide to fit.
-  static void drawHintLabel(GfxRenderer& renderer, int fontId, const char* label, int x, int boxWidth, int boxTop,
+  static void drawHintLabel(const GfxRenderer& renderer, int fontId, const char* label, int x, int boxWidth, int boxTop,
                             int boxHeight, int singleLineYOffset);
   virtual void drawSideButtonHints(const GfxRenderer& renderer, const char* topBtn, const char* bottomBtn) const;
   // Menu row height as DRAWN by drawButtonMenu. HomeActivity builds its touch
@@ -247,11 +247,11 @@ class BaseTheme {
                               const std::function<UIIcon(int index)>& rowIcon) const;
   virtual Rect drawPopup(const GfxRenderer& renderer, const char* message) const;
   virtual void fillPopupProgress(const GfxRenderer& renderer, const Rect& layout, const int progress) const;
-  void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage, const int pageCount,
-                     std::string title, const int paddingBottom = 0, const int textYOffset = 0,
-                     const bool fillMargin = true, const bool isPageBookmarked = false,
-                     const bool pageCountEstimated = false) const;
-  void drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label) const;
+  static void drawStatusBar(GfxRenderer& renderer, const float bookProgress, const int currentPage, const int pageCount,
+                            std::string title, const int paddingBottom = 0, const int textYOffset = 0,
+                            const bool fillMargin = true, const bool isPageBookmarked = false,
+                            const bool pageCountEstimated = false);
+  static void drawHelpText(const GfxRenderer& renderer, Rect rect, const char* label);
   virtual void drawTextField(const GfxRenderer& renderer, Rect rect, const int textWidth, bool cursorMode = false,
                              int contentStartX = 0, int contentWidth = 0) const;
   virtual bool showsFileIcons() const { return false; }

--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -798,7 +798,7 @@ bool WebDAVHandler::getOverwrite(WebServer& s) const {
   return true;  // Default is T
 }
 
-String WebDAVHandler::getMimeType(const String& path) const {
+String WebDAVHandler::getMimeType(const String& path) {
   if (FsHelpers::hasEpubExtension(path)) return "application/epub+zip";
   if (FsHelpers::checkFileExtension(path, ".pdf")) return "application/pdf";
   if (FsHelpers::hasTxtExtension(path)) return "text/plain";

--- a/src/network/WebDAVHandler.h
+++ b/src/network/WebDAVHandler.h
@@ -39,5 +39,5 @@ class WebDAVHandler : public RequestHandler {
   int getDepth(WebServer& s) const;
   bool getOverwrite(WebServer& s) const;
   void sendPropEntry(WebServer& s, const String& href, bool isDir, size_t size, const String& lastModified) const;
-  String getMimeType(const String& path) const;
+  static String getMimeType(const String& path);
 };

--- a/src/util/ButtonNavigator.h
+++ b/src/util/ButtonNavigator.h
@@ -26,9 +26,9 @@ class ButtonNavigator final {
   void onPrevious(const Callback& callback);
   void onPressAndContinuous(const Buttons& buttons, const Callback& callback);
 
-  void onNextPress(const Callback& callback);
-  void onPreviousPress(const Callback& callback);
-  void onPress(const Buttons& buttons, const Callback& callback);
+  static void onNextPress(const Callback& callback);
+  static void onPreviousPress(const Callback& callback);
+  static void onPress(const Buttons& buttons, const Callback& callback);
 
   void onNextRelease(const Callback& callback);
   void onPreviousRelease(const Callback& callback);

--- a/src/util/DictHtmlPages.cpp
+++ b/src/util/DictHtmlPages.cpp
@@ -161,7 +161,7 @@ bool writeNormalizedXhtml(const std::string& html, HalFile& file) {
       const bool closing = html[i + 1] == '/';
       const size_t nameStart = i + (closing ? 2 : 1);
       size_t nameEnd = nameStart;
-      char nameBuf[16];
+      char nameBuf[16] = {};
       size_t nameLen = 0;
       while (nameEnd < j && std::isalnum(static_cast<unsigned char>(html[nameEnd]))) {
         if (nameLen < sizeof(nameBuf) - 1) {

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -165,13 +165,13 @@ class Dictionary {
   // source entry is a NUL-terminated word followed by suffixBytes fixed bytes
   // (8 for .idx: offset+size; 4 for .syn: ordinal). magic tags the sidecar.
   // *outResult (if provided) reports why a failed pass failed.
-  bool buildSidecar(const std::string& sourcePath, const std::string& sidecarPath, uint32_t magic, uint32_t suffixBytes,
-                    void (*yieldFn)(void*), void* ctx, IndexResult* outResult);
+  static bool buildSidecar(const std::string& sourcePath, const std::string& sidecarPath, uint32_t magic,
+                           uint32_t suffixBytes, void (*yieldFn)(void*), void* ctx, IndexResult* outResult);
 
   // True when sidecarPath must be (re)built from sourcePath: missing/unreadable/
   // wrong-version sidecar, or a source-size mismatch. Shared by needsIndex() and
   // buildIndex() so each sidecar is rebuilt only when actually stale.
-  bool sidecarIsStale(const std::string& sourcePath, const std::string& sidecarPath, uint32_t magic);
+  static bool sidecarIsStale(const std::string& sourcePath, const std::string& sidecarPath, uint32_t magic);
 
   // Read the definition at location. On failure returns false and, if outResult
   // is given, sets it to the specific reason (Decompress / LowMemory / ReadError).


### PR DESCRIPTION
## Summary

While preparing automated on-device testing for future font-rendering improvements, I tested the existing serial screenshot command on an Xteink X3 and found that transfers were being truncated.

The investigation pointed to an upstream HWCDC transmit bug. [espressif/arduino-esp32#12606](https://github.com/espressif/arduino-esp32/pull/12606) addresses data loss and transmit hangs during sustained writes. See the original report, [#12494](https://github.com/espressif/arduino-esp32/issues/12494).

This PR updates pioarduino from **55.03.37 to 55.03.311**, bringing Arduino-ESP32 **3.3.7 → 3.3.11** and ESP-IDF **5.5.2 → 5.5.5**, including that fix. I chose 3.3.11 to include the intervening maintenance updates as well, and validated its build compatibility and X3 heap impact. [Release notes](https://github.com/pioarduino/platform-espressif32/releases/tag/55.03.311).

On X3, the final configuration reduces total heap capacity by **720 bytes** compared with develop; the largest free block at Home is unchanged.

The build integration also needs updating so cached framework libraries, generated SDK configuration, and application linker flags remain consistent after the upgrade:

- Update framework caching to account for board memory settings. Clear stale generated SDK configuration on rebuilds so old values do not override the requested configuration, and restore prebuilt libraries when switching from a custom-framework profile.
- Align application linker flags with the rebuilt C3 SDK to work around a limitation in pioarduino 55.03.311's `custom_sdkconfig` support. It rebuilds SDK libraries and configuration headers but retains the packaged libc linker flags for the Arduino application. ESP-IDF 5.5.5 enables RAM-resident optimized libc by default, consuming SRAM that would otherwise be available to the C3 heap. Restoring the ROM libc configuration used with 3.3.7 recovers **1,024 bytes of heap on X3** compared with the new default, and requires adjusting both the SDK setting and the application linker flags. The hook supplies that missing linker adjustment.
- Preserve existing C3 configuration values where supported by the newer SDK, keep C3-specific settings separate from S3 profiles, and satisfy the newer Modbus configuration constraint.

## Cppcheck compatibility

pioarduino also updates the bundled cppcheck package from **2.11.0 to 2.20.1**. This project's CI fails on any unsuppressed low-, medium-, or high-severity finding, including style and performance diagnostics. The newer checker flags existing reader code, so the platform upgrade requires a code cleanup to pass those checks.

The cleanup is isolated in a **separate commit**. It makes stateless helpers static, tightens const interfaces, returns stored metadata by const reference, replaces search loops with standard algorithms, removes an unused local, and explicitly initializes the dictionary tag buffer. These changes preserve reader behavior and add no heap allocations.

The analyzer uses exhaustive analysis to avoid branch-limit notices. Diagnostics owned by the separately maintained FreeInk SDK are excluded, and cppcheck's checker-status summary is suppressed because it is informational output about the analyzer itself. CI retains its existing failure thresholds and installs `libpcre3`, which the packaged Linux cppcheck executable requires.

## Memory impact

Serial measurements on the same X3 at Home after a fresh boot, compared with pristine `develop` at `54337e6d`. The Arduino 3.3.11 values were reconfirmed on cleanup commit `13def4c3`:

| Metric (bytes) | Arduino 3.3.7 | Arduino 3.3.11, this configuration | Delta |
|---|---:|---:|---:|
| Total heap capacity | 268,560 | 267,840 | −720 |
| Free heap at Home | 101,488 | 100,724 | −764 |
| Minimum free since boot | 98,580 | 97,836 | −744 |
| Largest free block | 94,196 | 94,196 | 0 |

On C3, instruction RAM and data RAM share SRAM. Keeping libc in ROM avoids the additional RAM-resident implementations introduced by the newer SDK configuration. The 720-byte heap-capacity decrease consists of 512 bytes of additional IRAM reservation and 208 bytes of static data and alignment. Linker symbols confirm that the affected memory and string functions resolve to ROM.

Heap measurements were taken at Home; rendering performance was not benchmarked.

## Validation

- On the cleanup commit, cppcheck reports **zero findings locally and in Linux CI**. All four CI firmware builds (`default`, `sticky`, `x4pro`, and `papermono`), unit tests, and formatting checks pass. Local C3 and S3 builds also pass; the S3 SDK build emits const-qualifier warnings in ESP-IDF and its managed components.
- Before the cppcheck cleanup, builds passed for `default`, `gh_release`, `sticky`, and `x4pro`. The C3 framework rebuild and application link completed in one invocation. Switching from `sticky` to `x4pro` correctly restored prebuilt framework libraries. The Sticky SDK build emitted USB const-qualifier warnings.
- Flashed and booted the C3 platform-upgrade build on X3 before the cppcheck cleanup. It passed **200 consecutive screenshot captures** using the unchanged handler's single `logSerial.write(buf, bufferSize)` call. Every raw serial payload was exactly 52,272 bytes with its expected end marker. On the unchanged Home screen, all 200 received payloads had the same SHA-256 hash. Six serial heap samples before and after the batch were identical to the 3.3.11 column above.

- Flashed and booted cleanup commit `13def4c3` on the same X3. Six serial heap samples over 60 seconds matched all four Arduino 3.3.11 values above exactly. A Home-screen screenshot also transferred successfully with the expected 52,272-byte payload and end marker.

- I also performed basic manual smoke testing on my X3 with `13def4c3`; the functionality I tested appeared to work normally.

Hardware validation was limited to X3.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- Stock/fork feature comparison: not applicable to this dependency update for CrossPoint's existing serial interface.
- No changes to `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery source. The SDK/toolchain upgrade warrants the usual device smoke testing before merge.

### AI Usage

**YES** — AI tools assisted with investigation, build-hook changes, cppcheck cleanup, and validation.
