### PR TITLE
fix: restore Spanish controls category label

### DIFF
--- a/lib/I18n/translations/spanish.yaml
+++ b/lib/I18n/translations/spanish.yaml
@@ -87,7 +87,7 @@ STR_CALIBRE_INSTRUCTION_3: "3) Desde Calibre, seleccione \"Enviar a dispositivo\
 STR_CALIBRE_INSTRUCTION_4: "\"Permanezca en esta pantalla mientras se envía\""
 STR_CAT_DISPLAY: "Pantalla"
 STR_CAT_READER: "Lector"
-STR_CAT_CONTROLS: "Mandos"
+STR_CAT_CONTROLS: "Controles"
 STR_CAT_SYSTEM: "Sistema"
 STR_SLEEP_SCREEN: "Fondo de pantalla de suspensión"
 STR_TOUCH_TOGGLE: "Táctil"


### PR DESCRIPTION
## Summary

Restore `STR_CAT_CONTROLS` from "Mandos" to "Controles", its Spanish wording before #3137. The shortened label was incorrect in this settings context, as reported in [Discussion #3402](https://github.com/crosspoint-reader/crosspoint-reader/discussions/3402). "Controles" covers the category's button, touch and tilt settings.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

One translation value changed. The I18n generator passes; Spanish, Catalan and Valencian retain 460/460 strings with no fallbacks. Catalan and Valencian already use "Controls". No code or layout changes.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_
