### PR TITLE
fix(webdav): GET sends one byte per file, since HalFile wrapped FsFile

### DIFF
--- a/src/network/WebDAVHandler.cpp
+++ b/src/network/WebDAVHandler.cpp
@@ -324,12 +324,29 @@ void WebDAVHandler::handleGet(WebServer& s) {
   }
 
   String contentType = getMimeType(path);
-  s.setContentLength(file.size());
+  const size_t fileSize = file.size();
+  file.close();
+
+  s.setContentLength(fileSize);
   s.send(200, contentType.c_str(), "");
 
+  // **This used to be `client.write(file)`, and it sent exactly one byte.**
+  //
+  // It worked while `Storage.open()` returned an SdFat `FsFile`, which derives
+  // from `Stream`: the call matched `NetworkClient::write(Stream&)` and streamed
+  // the file. `HalFile` derives from `Print`, not `Stream` (lib/hal/HalStorage.h),
+  // so that overload stopped matching, the compiler took `HalFile::operator bool()`
+  // instead, promoted the `true` to `uint8_t`, and wrote a single `0x01`. **The
+  // call site never changed; its meaning did**, and nothing warned because every
+  // step is a legal conversion.
+  //
+  // The reply still carried the real Content-Length, so a client waited for a
+  // body that never arrived and reported a truncated transfer rather than an
+  // error, which is why this reads as a flaky network rather than a server bug.
   NetworkClient client = s.client();
-  client.write(file);
-  file.close();
+  if (!Storage.readFileToStream(path.c_str(), client)) {
+    LOG_ERR("DAV", "GET %s: failed to stream file", path.c_str());
+  }
 }
 
 // ── HEAD ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What happens

Every WebDAV `GET` returns HTTP 200 with a correct `Content-Length` and a body of exactly one byte, `0x01`.

Reproduced against a device over WebDAV with a 54 822-byte file:

```
HTTP/1.1 200 OK
Content-Length: 54822
```

one byte on the wire. `curl`, `curl --http1.0`, a Range request and `wget` all behave identically, which is what moved suspicion from the client to the server.

## Why

`handleGet()` ended in:

```cpp
NetworkClient client = s.client();
client.write(file);
```

That matched `NetworkClient::write(Stream&)` while `Storage.open()` returned an SdFat `FsFile`, which derives from `Stream`, and it streamed the file correctly.

`6ff5fcd9` (2026-02-28, "make file system operations thread-safe") wrapped the handle in `HalFile`, and `HalFile` derives from `Print`, not `Stream` (`lib/hal/HalStorage.h:81`). The `Stream&` overload stopped matching. Overload resolution then found `HalFile::operator bool()`, promoted the resulting `true` to `uint8_t`, and selected `Print::write(uint8_t)` -- writing a single `0x01`.

The call site never changed; its meaning did. Nothing warned, because every step is a legal implicit conversion.

Because the reply still carries the real `Content-Length`, a client waits for a body that never arrives and reports a truncated transfer rather than an error. That is why this presents as a flaky network rather than a server fault, and why it has gone unnoticed.

This is the only site in the tree that fed a `HalFile` to a `Stream&` parameter.

## The change

Use `Storage.readFileToStream()`, which takes a `Print&` and is what the rest of the tree already uses to stream a file. `file.close()` moves ahead of the send, since `readFileToStream()` opens the path itself; the size is captured first.

## Verification, and its limits

The identical change is running on real hardware in a fork of this project (a LilyGo T5 S3 Pro build). After it, `GET` of a 7401-byte file returns exactly 7401 bytes, and a 732 765-byte file returns all 732 765 bytes with two consecutive downloads byte-for-byte identical.

**This branch itself was not compiled**, and I would rather say so than imply otherwise. `pio run -e default` on `develop` fails here before reaching any source file, in `scripts/patch_pioarduino_cache.py` after `idf_tools.py installation failed (rc=1)`. That is a toolchain-install problem in this environment, present with or without the patch. CI on this PR will cover it.

## One thing worth knowing before you take this

Fixing this makes large transfers actually happen for the first time, and on our board that immediately exposed a second, separate defect: a 733 kB `GET` reset the device 16 s in with `task_wdt: - loopTask (CPU 1)`, because `SDCardManager::readFileToStream()` streams in a loop that never yields, so `loopTask` cannot feed the task watchdog. That one lives in the SDK, not here, and is filed as Free-Ink/freeink-sdk#83. Small files are unaffected either way.