### PR TITLE
fix(reader): synchronize end-of-book menu selection

### DIFF
--- a/src/activities/reader/EndOfBookOptions.cpp
+++ b/src/activities/reader/EndOfBookOptions.cpp
@@ -36,7 +36,7 @@ void EndOfBookOptions::loadOnce(const std::string& currentBookPath) {
   }
   folder = FsHelpers::extractFolderPath(currentBookPath);
   names = NextBookFinder::findNextBooks(currentBookPath, MAX_SUGGESTIONS);
-  selector = 0;
+  selector.store(0, std::memory_order_relaxed);
   if (!names.empty()) {
     // One-time app setup on the render task, before the first render/route.
     resetUi();
@@ -84,7 +84,7 @@ std::string EndOfBookOptions::fullPath(const size_t index) const {
 void EndOfBookOptions::onRowEvent(const fui::ActionEvent& event, void* user) {
   auto* self = static_cast<EndOfBookOptions*>(user);
   if (event.value < 0 || event.value > static_cast<int16_t>(self->names.size())) return;
-  self->selector = event.value;
+  self->selector.store(event.value, std::memory_order_relaxed);
   // The tapped row leaves this screen (open book or home); a lingering flash
   // would gray an unrelated element on the next render.
   self->app.clearTapFlash();
@@ -112,10 +112,11 @@ EndOfBookOptions::Action EndOfBookOptions::handleMenuInput(const MappedInputMana
     return Action::Redraw;
   }
 
+  const int selectedIndex = selector.load(std::memory_order_relaxed);
   if (input.wasReleased(MappedInputManager::Button::Confirm)) {
-    if (selector < static_cast<int>(names.size())) {
+    if (selectedIndex < static_cast<int>(names.size())) {
       if (openPath) {
-        *openPath = fullPath(selector);
+        *openPath = fullPath(selectedIndex);
       }
       return Action::OpenBook;
     }
@@ -140,11 +141,11 @@ EndOfBookOptions::Action EndOfBookOptions::handleMenuInput(const MappedInputMana
   };
   const int itemCount = static_cast<int>(names.size()) + 1;  // + "Home" entry
   if (triggered(MappedInputManager::Button::NavPrevious)) {
-    selector = ButtonNavigator::previousIndex(selector, itemCount);  // wraps to the bottom
+    selector.store(ButtonNavigator::previousIndex(selectedIndex, itemCount), std::memory_order_relaxed);
     return Action::Redraw;
   }
   if (triggered(MappedInputManager::Button::NavNext)) {
-    selector = ButtonNavigator::nextIndex(selector, itemCount);  // wraps to the top
+    selector.store(ButtonNavigator::nextIndex(selectedIndex, itemCount), std::memory_order_relaxed);
     return Action::Redraw;
   }
   return Action::None;
@@ -172,7 +173,7 @@ void EndOfBookOptions::buildListScreen(UiScreen& screen) {
   fui::ListProps props;
   props.items = rowItems;
   props.count = static_cast<uint16_t>(rowCount);
-  props.selectedIndex = static_cast<int16_t>(selector);
+  props.selectedIndex = static_cast<int16_t>(selector.load(std::memory_order_relaxed));
   props.action = ACTION_ROW;
   props.inputMask = fui::InputTouch;  // physical buttons stay in handleMenuInput()
   if (!gpio.hasTouch()) {

--- a/src/activities/reader/EndOfBookOptions.h
+++ b/src/activities/reader/EndOfBookOptions.h
@@ -53,7 +53,8 @@ class EndOfBookOptions : private UiAppHost {
   // Written by the render task in loadOnce(), immutable afterwards; the main task only
   // reads it after isLoaded is observed true (acquire), so no further locking is needed.
   std::vector<std::string> names;
-  int selector = 0;
+  // Main-task selection updates may overlap a repaint on the render task.
+  std::atomic<int> selector{0};
   std::atomic<bool> isLoaded{false};
 
   // Row storage, built once in loadOnce() (same acquire/release publication


### PR DESCRIPTION
## Summary

The input task updates the end-of-book selection while the render task reads it for list painting. The existing `isLoaded` release/acquire pair publishes the initial list but does not synchronize later writes to the plain `int selector`.

Use an atomic selector with relaxed loads/stores. Input handling takes one snapshot after touch routing; rendering reads the selection atomically. The immutable list retains its existing publication mechanism. Only the two reader-menu files change.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This is not a new built-in theme.
- [x] This is not a new external network connector.
- [x] This is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] This improves the existing reader. It extracts a generic correction developed in my fork; upstream currently has the unsynchronized selector.
- HAL / SDK / bootloader / OTA / recovery coordination: not applicable.

## Validation and additional context

- Built `pio run -e default -e x4pro` from `develop` at `7db14a01` plus only this patch; both passed with the pinned SDK.
- Complete `bin/clang-format-fix` wrapper and `git diff --check` passed.
- Reviewed the single-writer flow, touch selection, Confirm and wrapping navigation. Relaxed ordering suffices because the atomic does not publish other data.
- Static RAM unchanged: 56,360 bytes (C3) / 100,040 bytes (X4 Pro). Application flash delta: +72 / +56 bytes respectively.
- No hardware stress test or ThreadSanitizer reproduction was run. Device verification: navigate/tap recommendations during repeated repaints, then verify Confirm, Home and wrapping navigation.

### AI Usage

Did you use AI tools to help write this code? **YES** — implementation, review and build verification were AI-assisted.
