### PR TITLE
fix: prefer exact dictionary headword matches

### DIFF
--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -389,8 +389,9 @@ DictLocation Dictionary::locate(LookupSession& session, const char* target, std:
   // Bisect the sampled offsets to the last sample whose headword <= target.
   const uint32_t startByte = bisectSamples(session.qidx, session.idx, session.sampleCount, target);
 
-  // Linear scan of at most SAMPLE_INTERVAL entries: headword NUL, BE32 offset,
-  // BE32 size. The index is sorted, so stop at the first headword > target.
+  // Linear scan from the sampled entry: headword NUL, BE32 offset, BE32 size.
+  // Keep the first case-insensitive match as a fallback, but prefer an exact
+  // spelling within the adjacent equal run (for example "husk" over "Husk").
   if (!session.idx.seekSet(startByte)) {
     LOG_ERR("DICT", "Index seek to %lu failed", static_cast<unsigned long>(startByte));
     result.readError = true;
@@ -407,11 +408,15 @@ DictLocation Dictionary::locate(LookupSession& session, const char* target, std:
 
     const int cmp = StringUtils::asciiCaseCmp(wordBuf, target);
     if (cmp == 0) {
-      result.offset = readBe32(suffix);
-      result.size = readBe32(suffix + 4);
-      result.found = true;
-      if (matchedHeadwordOut) *matchedHeadwordOut = wordBuf;
-      return result;
+      const bool exact = strcmp(wordBuf, target) == 0;
+      if (!result.found || exact) {
+        result.offset = readBe32(suffix);
+        result.size = readBe32(suffix + 4);
+        result.found = true;
+        if (matchedHeadwordOut) *matchedHeadwordOut = wordBuf;
+      }
+      if (exact) return result;
+      continue;
     }
     if (cmp > 0) break;
   }

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -371,7 +371,9 @@ uint32_t Dictionary::bisectSamples(HalFile& sidecar, HalFile& source, uint32_t s
       lo = 0;  // unreadable sample: abandon the descent and scan from the start
       break;
     }
-    if (StringUtils::asciiCaseCmp(wordBuf, target) <= 0) {
+    // Equal headwords may begin before this sample boundary. Keep the search
+    // strictly below the target so locate() can inspect the full equal run.
+    if (StringUtils::asciiCaseCmp(wordBuf, target) < 0) {
       lo = mid;
     } else {
       hi = mid - 1;
@@ -386,7 +388,8 @@ uint32_t Dictionary::bisectSamples(HalFile& sidecar, HalFile& source, uint32_t s
 DictLocation Dictionary::locate(LookupSession& session, const char* target, std::string* matchedHeadwordOut) {
   DictLocation result;
 
-  // Bisect the sampled offsets to the last sample whose headword <= target.
+  // Bisect to the last sample strictly before the target so a case-insensitive
+  // equal run crossing a sample boundary is scanned from its beginning.
   const uint32_t startByte = bisectSamples(session.qidx, session.idx, session.sampleCount, target);
 
   // Linear scan from the sampled entry: headword NUL, BE32 offset, BE32 size.

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -23,7 +23,8 @@ struct DictLocation {
 // <stem>.dict.dz, and an optional <stem>.syn synonym index. Lookups
 // binary-search a lazily built sampled-offset sidecar (<stem>.qidx, byte offset
 // of every SAMPLE_INTERVAL-th .idx entry), then linear-scan from the preceding
-// sample. A present .syn gets a parallel <stem>.sidx sidecar;
+// sample, or sample 0 when the target is at or before the first sample. A
+// present .syn gets a parallel <stem>.sidx sidecar;
 // its entries carry an ordinal (the N-th .idx entry) resolved back to a byte
 // offset via the same fixed-interval .qidx samples. Everything streams from SD;
 // no index is held in RAM.
@@ -146,8 +147,9 @@ class Dictionary {
 
   // Bisect a sampled-offset sidecar (.qidx over .idx, .sidx over .syn) to the
   // byte offset of the last sampled entry whose word is strictly before target,
-  // so an equal run crossing a sample boundary is scanned from its start. Returns
-  // 0 — scan source from the start — when sampleCount is 0 or a sample is
+  // so an equal run crossing a sample boundary is scanned from its start. Uses
+  // sample 0 when the target is at or before the first sampled word. Returns 0
+  // — scan source from the start — when sampleCount is 0 or a sample is
   // unreadable. Clobbers wordBuf.
   uint32_t bisectSamples(HalFile& sidecar, HalFile& source, uint32_t sampleCount, const char* target);
 

--- a/src/util/Dictionary.h
+++ b/src/util/Dictionary.h
@@ -22,8 +22,8 @@ struct DictLocation {
 // Expects /dictionaries/<folder>/<stem>.idx (uncompressed) plus <stem>.dict or
 // <stem>.dict.dz, and an optional <stem>.syn synonym index. Lookups
 // binary-search a lazily built sampled-offset sidecar (<stem>.qidx, byte offset
-// of every SAMPLE_INTERVAL-th .idx entry), then linear-scan at most
-// SAMPLE_INTERVAL entries. A present .syn gets a parallel <stem>.sidx sidecar;
+// of every SAMPLE_INTERVAL-th .idx entry), then linear-scan from the preceding
+// sample. A present .syn gets a parallel <stem>.sidx sidecar;
 // its entries carry an ordinal (the N-th .idx entry) resolved back to a byte
 // offset via the same fixed-interval .qidx samples. Everything streams from SD;
 // no index is held in RAM.
@@ -145,8 +145,8 @@ class Dictionary {
   bool openSynonyms(LookupSession& session);
 
   // Bisect a sampled-offset sidecar (.qidx over .idx, .sidx over .syn) to the
-  // byte offset of the last sampled entry whose word is <= target, so the caller
-  // only has to linear-scan at most SAMPLE_INTERVAL entries from there. Returns
+  // byte offset of the last sampled entry whose word is strictly before target,
+  // so an equal run crossing a sample boundary is scanned from its start. Returns
   // 0 — scan source from the start — when sampleCount is 0 or a sample is
   // unreadable. Clobbers wordBuf.
   uint32_t bisectSamples(HalFile& sidecar, HalFile& source, uint32_t sampleCount, const char* target);


### PR DESCRIPTION
The StarDict index can contain adjacent case variants for the same headword. Lookup normalizes the selected word to lowercase and compares case-insensitively, so it previously returned the first variant even when a later entry exactly matched the normalized word.

Keep the first case-insensitive match as the existing fallback, then scan the adjacent equal run for an exact spelling. In the dictionary linked from #2913, this changes `husk` from the 53-byte `Husk` surname entry to the 671-byte lowercase noun/verb entry. The scan adds no allocation or UI state.

Validation:

- Parsed the current linked `dict-en-en-noetym` index: `Husk` and `husk` are adjacent with distinct definition offsets.
- Confirmed the exact lowercase entry contains the expected common-word definition.
- Checked the full 843,935-entry index: 20,627 case-insensitive duplicate groups, no repeated exact spellings, and at most five variants per group.
- `git diff --check` passes.

Fixes #2913.

AI assistance disclosure: the investigation and patch were prepared with OpenAI Codex under the contributor's direction, and the fixture behavior was independently reproduced against the current public dictionary.
