### PR TITLE
fix: cap serial read timeout so a stray byte can't stall the loop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,6 +354,12 @@ void setup() {
 #if LOG_SERIAL_HAS_TX_TIMEOUT
   logSerial.setTxTimeoutMs(1);  // This is a load-bearing 1. Do not modify.
 #endif
+  // loop()'s serial CMD handler reads with readStringUntil('\n'), whose default
+  // 1000ms Stream timeout would stall the entire loop for a full second on any
+  // stray RX byte that isn't followed by a newline (a serial monitor attaching
+  // and toggling DTR/RTS is enough). A real "CMD:...\n" line is already in
+  // flight when available() fires, so a short timeout serves it fine.
+  logSerial.setTimeout(20);
 #endif
 
   HalSystem::begin();


### PR DESCRIPTION
`loop()`'s serial CMD handler reads with `readStringUntil('\n')`, which inherits Arduino `Stream`'s default 1000ms timeout. Any RX byte that arrives without a trailing newline — a serial monitor attaching or reopening the port and toggling DTR/RTS is enough to inject one — makes `available()` fire and then blocks the entire main loop for a full second waiting for a `'\n'` that never comes. During that second nothing runs: no input polling, no rendering.

It also pollutes profiling: the stall surfaces as a phantom `[LOOP] New max loop duration: 1001 ms (activity: 0 ms)` that's easy to misread as a firmware regression when measuring boot/wake timing over serial.

**Fix:** set `logSerial.setTimeout(20)` once in `setup()` (inside `ENABLE_SERIAL_LOG`). A real `CMD:...` line is already fully in flight when `available()` fires, so a short timeout serves legitimate commands fine — it only bounds how long a malformed/stray byte can hold the loop.

**Measured on an Xteink X4 Pro** (timing probe around the `readStringUntil` call, stray byte injected by a pyserial open/close):
- pre-fix: `readStringUntil took 1000 ms` + the phantom `1001 ms (activity: 0 ms)` max-loop line
- with fix: `readStringUntil took 20 ms`, no max-loop event

One-line behavior change, no effect on the CMD protocol itself.