### PR TITLE
fix: bound readString() length to stop OOM-aborts on corrupt cache data

### DIFF
--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -42,22 +42,17 @@ uint32_t writeTocEntryTo(F& file, const BookMetadataCache::TocEntry& entry) {
   return pos;
 }
 
-// readString()'s bool return (a corrupt length -- see Serialization.h) isn't
-// propagated here: SpineEntry/TocEntry are returned by value through
-// getSpineEntry()/getTocEntry(), a public API called from many places across
-// the reader, so turning this into e.g. std::optional<SpineEntry> would ripple
-// out to every caller for a narrower gain than it looks -- BookMetadataCache::
-// load() (which runs once per book open, not per entry) already rejects the
-// whole cache on a corrupt metadata string, which is the common-cause case
-// (a truncated/corrupted book.bin almost always fails there first). A corrupt
-// length reaching all the way down to one individual entry read, with the
-// aggregate metadata intact, is a narrower residual risk: at worst a wrong
-// title/href for that one spine/TOC entry, not a crash (readString() itself
-// still refuses to grow the string past MAX_SERIALIZED_STRING_LEN).
+// Does not check readString()'s bool return: SpineEntry/TocEntry are returned
+// by value through the public getSpineEntry()/getTocEntry() API, so signaling
+// failure here would mean changing that return type for every caller across
+// the reader. A corrupt length still can't crash (readString() itself refuses
+// to grow past MAX_SERIALIZED_STRING_LEN), but sequential callers of this
+// template during buildBookBin (no reseek between iterations) will desync for
+// the rest of that pass, not just this one entry.
 template <typename F>
 BookMetadataCache::SpineEntry readSpineEntryFrom(F& file) {
   BookMetadataCache::SpineEntry entry;
-  serialization::readString(file, entry.href);
+  (void)serialization::readString(file, entry.href);  // see comment above
   serialization::readPod(file, entry.cumulativeSize);
   serialization::readPod(file, entry.tocIndex);
   return entry;
@@ -66,9 +61,9 @@ BookMetadataCache::SpineEntry readSpineEntryFrom(F& file) {
 template <typename F>
 BookMetadataCache::TocEntry readTocEntryFrom(F& file) {
   BookMetadataCache::TocEntry entry;
-  serialization::readString(file, entry.title);
-  serialization::readString(file, entry.href);
-  serialization::readString(file, entry.anchor);
+  (void)serialization::readString(file, entry.title);  // see comment above
+  (void)serialization::readString(file, entry.href);
+  (void)serialization::readString(file, entry.anchor);
   serialization::readPod(file, entry.level);
   serialization::readPod(file, entry.spineIndex);
   return entry;

--- a/lib/Epub/Epub/BookMetadataCache.cpp
+++ b/lib/Epub/Epub/BookMetadataCache.cpp
@@ -42,6 +42,18 @@ uint32_t writeTocEntryTo(F& file, const BookMetadataCache::TocEntry& entry) {
   return pos;
 }
 
+// readString()'s bool return (a corrupt length -- see Serialization.h) isn't
+// propagated here: SpineEntry/TocEntry are returned by value through
+// getSpineEntry()/getTocEntry(), a public API called from many places across
+// the reader, so turning this into e.g. std::optional<SpineEntry> would ripple
+// out to every caller for a narrower gain than it looks -- BookMetadataCache::
+// load() (which runs once per book open, not per entry) already rejects the
+// whole cache on a corrupt metadata string, which is the common-cause case
+// (a truncated/corrupted book.bin almost always fails there first). A corrupt
+// length reaching all the way down to one individual entry read, with the
+// aggregate metadata intact, is a narrower residual risk: at worst a wrong
+// title/href for that one spine/TOC entry, not a crash (readString() itself
+// still refuses to grow the string past MAX_SERIALIZED_STRING_LEN).
 template <typename F>
 BookMetadataCache::SpineEntry readSpineEntryFrom(F& file) {
   BookMetadataCache::SpineEntry entry;
@@ -475,11 +487,15 @@ bool BookMetadataCache::load() {
   serialization::readPod(bookFile, spineCount);
   serialization::readPod(bookFile, tocCount);
 
-  serialization::readString(bookFile, coreMetadata.title);
-  serialization::readString(bookFile, coreMetadata.author);
-  serialization::readString(bookFile, coreMetadata.language);
-  serialization::readString(bookFile, coreMetadata.coverItemHref);
-  serialization::readString(bookFile, coreMetadata.textReferenceHref);
+  if (!serialization::readString(bookFile, coreMetadata.title) ||
+      !serialization::readString(bookFile, coreMetadata.author) ||
+      !serialization::readString(bookFile, coreMetadata.language) ||
+      !serialization::readString(bookFile, coreMetadata.coverItemHref) ||
+      !serialization::readString(bookFile, coreMetadata.textReferenceHref)) {
+    LOG_ERR("BMC", "Corrupt metadata string length -- treating cache as invalid");
+    bookFile.close();
+    return false;
+  }
 
   // Cache cumulative spine sizes in RAM. The progress bar (every render) and percent
   // jumps otherwise pay 2 seeks + a heap-allocating SpineEntry read per access. Spine

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -76,6 +76,10 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
+  if (!ib) {
+    LOG_ERR("PGE", "Deserialization failed: null ImageBlock");
+    return nullptr;
+  }
   return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
 }
 

--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -80,7 +80,12 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
     LOG_ERR("PGE", "Deserialization failed: null ImageBlock");
     return nullptr;
   }
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  auto* image = new (std::nothrow) PageImage(std::move(ib), xPos, yPos);
+  if (!image) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageImage");
+    return nullptr;
+  }
+  return std::unique_ptr<PageImage>(image);
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -859,7 +859,10 @@ std::optional<uint16_t> Section::getPageForAnchor(const std::string& anchor) con
   for (uint16_t i = 0; i < count; i++) {
     std::string key;
     uint16_t page;
-    serialization::readString(f, key);
+    if (!serialization::readString(f, key)) {
+      LOG_ERR("SCT", "getPageForAnchor: corrupt anchor-map entry %u, aborting scan", i);
+      return std::nullopt;
+    }
     serialization::readPod(f, page);
     if (key == anchor) {
       return page;

--- a/lib/Epub/Epub/blocks/ImageBlock.cpp
+++ b/lib/Epub/Epub/blocks/ImageBlock.cpp
@@ -435,8 +435,10 @@ bool ImageBlock::serialize(HalFile& file) {
 std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile& file) {
   std::string path;
   std::string src;
-  serialization::readString(file, path);
-  serialization::readString(file, src);
+  if (!serialization::readString(file, path) || !serialization::readString(file, src)) {
+    LOG_ERR("IMG", "Deserialization failed: corrupt path/src length");
+    return nullptr;
+  }
   int16_t w, h;
   serialization::readPod(file, w);
   serialization::readPod(file, h);

--- a/lib/Epub/Epub/blocks/TextBlock.cpp
+++ b/lib/Epub/Epub/blocks/TextBlock.cpp
@@ -412,7 +412,10 @@ std::unique_ptr<TextBlock> TextBlock::deserialize(HalFile& file) {
   // overwrites every byte, so a moved-from value carries nothing into the next iteration.
   std::string scratch;
   for (uint16_t i = 0; i < wc; i++) {
-    serialization::readString(file, scratch);
+    if (!serialization::readString(file, scratch)) {
+      LOG_ERR("TXB", "Deserialization failed: corrupt ruby-text length for word %u", i);
+      return nullptr;
+    }
     if (scratch.empty()) continue;
     if (block->rubyTexts.empty()) {
       block->rubyTexts.resize(wc);

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -273,14 +273,20 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
                                          return a.idHash < b.idHash || (a.idHash == b.idHash && a.idLen < b.idLen);
                                        });
 
-            // Check for match (may need to check a few due to hash collisions)
+            // Check for match (may need to check a few due to hash collisions).
+            // A readString() failure (corrupt length -- see Serialization.h)
+            // desyncs tempItemStore from this entry's boundary; stop rather
+            // than keep matching against garbage. tempItemStore is this
+            // parser's own temp file, written moments earlier in this same
+            // pass, so this is a defensive stop, not an expected case.
             while (it != self->itemIndex.end() && it->idHash == targetHash) {
               self->tempItemStore.seek(it->fileOffset);
               std::string itemId;
-              serialization::readString(self->tempItemStore, itemId);
+              if (!serialization::readString(self->tempItemStore, itemId)) break;
               if (itemId == idref) {
-                serialization::readString(self->tempItemStore, href);
-                found = true;
+                if (serialization::readString(self->tempItemStore, href)) {
+                  found = true;
+                }
                 break;
               }
               ++it;
@@ -291,8 +297,10 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             self->tempItemStore.seek(0);
             std::string itemId;
             while (self->tempItemStore.available()) {
-              serialization::readString(self->tempItemStore, itemId);
-              serialization::readString(self->tempItemStore, href);
+              if (!serialization::readString(self->tempItemStore, itemId) ||
+                  !serialization::readString(self->tempItemStore, href)) {
+                break;
+              }
               if (itemId == idref) {
                 found = true;
                 break;

--- a/lib/Epub/Epub/parsers/ContentOpfParser.cpp
+++ b/lib/Epub/Epub/parsers/ContentOpfParser.cpp
@@ -274,16 +274,15 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
                                        });
 
             // Check for match (may need to check a few due to hash collisions).
-            // A readString() failure (corrupt length -- see Serialization.h)
-            // desyncs tempItemStore from this entry's boundary; stop rather
-            // than keep matching against garbage. tempItemStore is this
-            // parser's own temp file, written moments earlier in this same
-            // pass, so this is a defensive stop, not an expected case.
+            // Each candidate re-seeks to its own it->fileOffset, so a
+            // readString() failure (corrupt length -- see Serialization.h)
+            // only desyncs this one candidate's read, not the rest of the
+            // chain -- treat it as a non-match and keep checking, same as
+            // the pre-existing "itemId != idref" case.
             while (it != self->itemIndex.end() && it->idHash == targetHash) {
               self->tempItemStore.seek(it->fileOffset);
               std::string itemId;
-              if (!serialization::readString(self->tempItemStore, itemId)) break;
-              if (itemId == idref) {
+              if (serialization::readString(self->tempItemStore, itemId) && itemId == idref) {
                 if (serialization::readString(self->tempItemStore, href)) {
                   found = true;
                 }
@@ -299,6 +298,7 @@ void XMLCALL ContentOpfParser::startElement(void* userData, const XML_Char* name
             while (self->tempItemStore.available()) {
               if (!serialization::readString(self->tempItemStore, itemId) ||
                   !serialization::readString(self->tempItemStore, href)) {
+                LOG_ERR("OPF", "Corrupt tempItemStore entry, aborting manifest scan");
                 break;
               }
               if (itemId == idref) {

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -1,10 +1,13 @@
 #pragma once
 #include <HalStorage.h>
+#include <Logging.h>
 #include <Memory.h>
 
 #include <algorithm>
 #include <cstring>
 #include <string>
+
+#include "Serialization.h"
 
 namespace serialization {
 
@@ -152,6 +155,12 @@ inline void writeString(BufferedFileWriter& out, const std::string& s) {
 inline void readString(BufferedFileReader& in, std::string& s) {
   uint32_t len;
   readPod(in, len);
+  // See Serialization.h's MAX_SERIALIZED_STRING_LEN for why this is capped.
+  if (len > MAX_SERIALIZED_STRING_LEN) {
+    LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
+    s.clear();
+    return;
+  }
   s.resize(len);
   if (len > 0) {
     in.read(&s[0], len);

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -155,7 +155,7 @@ inline void writeString(BufferedFileWriter& out, const std::string& s) {
 // See Serialization.h's readString() overloads for why this returns bool: a
 // rejected length leaves the stream desynced, so the caller must abort the
 // whole record rather than continue parsing.
-inline bool readString(BufferedFileReader& in, std::string& s) {
+[[nodiscard]] inline bool readString(BufferedFileReader& in, std::string& s) {
   uint32_t len;
   readPod(in, len);
   // See Serialization.h's MAX_SERIALIZED_STRING_LEN for why this is capped.

--- a/lib/Serialization/BufferedFile.h
+++ b/lib/Serialization/BufferedFile.h
@@ -152,19 +152,23 @@ inline void writeString(BufferedFileWriter& out, const std::string& s) {
   out.write(s.data(), len);
 }
 
-inline void readString(BufferedFileReader& in, std::string& s) {
+// See Serialization.h's readString() overloads for why this returns bool: a
+// rejected length leaves the stream desynced, so the caller must abort the
+// whole record rather than continue parsing.
+inline bool readString(BufferedFileReader& in, std::string& s) {
   uint32_t len;
   readPod(in, len);
   // See Serialization.h's MAX_SERIALIZED_STRING_LEN for why this is capped.
   if (len > MAX_SERIALIZED_STRING_LEN) {
     LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
     s.clear();
-    return;
+    return false;
   }
   s.resize(len);
   if (len > 0) {
     in.read(&s[0], len);
   }
+  return true;
 }
 
 }  // namespace serialization

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -57,7 +57,7 @@ constexpr uint32_t MAX_SERIALIZED_STRING_LEN = 65535;
 // must abort the whole record (matching how e.g. TextBlock::deserialize()
 // already returns nullptr on its own corruption checks) rather than pressing
 // on.
-inline bool readString(std::istream& is, std::string& s) {
+[[nodiscard]] inline bool readString(std::istream& is, std::string& s) {
   uint32_t len;
   readPod(is, len);
   if (len > MAX_SERIALIZED_STRING_LEN) {
@@ -70,7 +70,7 @@ inline bool readString(std::istream& is, std::string& s) {
   return true;
 }
 
-inline bool readString(HalFile& file, std::string& s) {
+[[nodiscard]] inline bool readString(HalFile& file, std::string& s) {
   uint32_t len;
   readPod(file, len);
   if (len > MAX_SERIALIZED_STRING_LEN) {

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <HalStorage.h>
+#include <Logging.h>
 
 #include <iostream>
 
@@ -36,9 +37,25 @@ inline void writeString(HalFile& file, const std::string& s) {
   file.write(reinterpret_cast<const uint8_t*>(s.data()), len);
 }
 
+// Every real writeString() call in this codebase serializes a short field
+// (a file path, a title, a ruby-text annotation, ...) -- never raw chapter
+// content, which flows through a separate path. A length this large can only
+// come from a corrupt/truncated cache file, not a legitimate string; resizing
+// to it blindly risks a multi-hundred-KB allocation that fails and, since
+// this build has -fno-exceptions, aborts the whole device instead of
+// throwing (see CLAUDE.md's "new is not nothrow on ESP32" -- the same
+// failure mode applies transitively through std::string/std::vector's
+// default allocator, not just a bare `new`).
+constexpr uint32_t MAX_SERIALIZED_STRING_LEN = 65535;
+
 inline void readString(std::istream& is, std::string& s) {
   uint32_t len;
   readPod(is, len);
+  if (len > MAX_SERIALIZED_STRING_LEN) {
+    LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
+    s.clear();
+    return;
+  }
   s.resize(len);
   is.read(&s[0], len);
 }
@@ -46,6 +63,11 @@ inline void readString(std::istream& is, std::string& s) {
 inline void readString(HalFile& file, std::string& s) {
   uint32_t len;
   readPod(file, len);
+  if (len > MAX_SERIALIZED_STRING_LEN) {
+    LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
+    s.clear();
+    return;
+  }
   s.resize(len);
   file.read(&s[0], len);
 }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -48,27 +48,38 @@ inline void writeString(HalFile& file, const std::string& s) {
 // default allocator, not just a bare `new`).
 constexpr uint32_t MAX_SERIALIZED_STRING_LEN = 65535;
 
-inline void readString(std::istream& is, std::string& s) {
+// Returns false if len was rejected as corrupt. Callers must treat this as a
+// hard stop, not just a bad value for this one field: the length prefix has
+// already been consumed but the (untrustworthy) payload bytes have not, so
+// the stream is no longer positioned at a field boundary. Any further read
+// from this stream/file would parse payload bytes -- or bytes belonging to
+// the next field -- as if they were the next field's own data. The caller
+// must abort the whole record (matching how e.g. TextBlock::deserialize()
+// already returns nullptr on its own corruption checks) rather than pressing
+// on.
+inline bool readString(std::istream& is, std::string& s) {
   uint32_t len;
   readPod(is, len);
   if (len > MAX_SERIALIZED_STRING_LEN) {
     LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
     s.clear();
-    return;
+    return false;
   }
   s.resize(len);
   is.read(&s[0], len);
+  return true;
 }
 
-inline void readString(HalFile& file, std::string& s) {
+inline bool readString(HalFile& file, std::string& s) {
   uint32_t len;
   readPod(file, len);
   if (len > MAX_SERIALIZED_STRING_LEN) {
     LOG_ERR("SER", "readString: length %u exceeds max, treating as corrupt", len);
     s.clear();
-    return;
+    return false;
   }
   s.resize(len);
   file.read(&s[0], len);
+  return true;
 }
 }  // namespace serialization


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a real device crash: `serialization::readString()` trusted the serialized length prefix unconditionally, so a corrupt/truncated cache file could make `std::string::resize()` demand a multi-hundred-KB allocation. That failure runs through `std::string`'s default (throwing) allocator, and with `-fno-exceptions` there's nothing to catch the throw — libstdc++ routes it to `std::terminate()` → `abort()`, crashing the whole device instead of failing just that one read.
* **What changes are included?**
  - `readString()` (both overloads in `lib/Serialization/Serialization.h`, plus the `BufferedFileReader` variant in `lib/Serialization/BufferedFile.h`) now rejects a length above `MAX_SERIALIZED_STRING_LEN` (65535 bytes) instead of blindly resizing to it. Every real `writeString()` call in this codebase serializes a short field (a file path, a title, a ruby-text annotation, an item ID) — never raw chapter content, which flows through a separate path — so this cap can't reject a legitimate string, only a corrupt length.
  - On rejection: `LOG_ERR` + clear the string and return, so the caller sees an empty string rather than the device aborting. This matches the existing "corrupt cache → fail this operation, don't crash" pattern already used elsewhere in the same file (`TextBlock::deserialize()`'s own sanity checks a few lines above the vulnerable call).
  - **Update**: `readString()` now returns `bool` (`[[nodiscard]]`) instead of `void`. A rejected length still consumes the length prefix but not the (untrustworthy) payload bytes, leaving the stream desynced from the next field's boundary — returning `void` meant callers had no way to know and kept parsing subsequent fields at the wrong offset. Every hot/persisted-cache read path now checks the return and aborts the whole record instead: `TextBlock::deserialize()` (the actual crash site), `ImageBlock::deserialize()`, `PageImage::deserialize()` (was missing a null-check on `ImageBlock::deserialize()`'s result, found while fixing this), `Section::getPageForAnchor()`, `BookMetadataCache::load()`, and `ContentOpfParser`'s manifest lookup (its hash-collision chain skips just the corrupt candidate and keeps searching, since each candidate re-seeks independently; its linear-scan fallback aborts the whole scan, since that one is genuinely sequential). `BookMetadataCache`'s per-entry `readSpineEntryFrom()`/`readTocEntryFrom()` helpers are the one place left not propagating — documented in a comment there (they return by value through the public `getSpineEntry()`/`getTocEntry()` API used across the reader, so changing that return type is out of this PR's scope).

## Root cause (from a real panic)

Reproduced from an actual device panic while opening a cached chapter page. Symbolicated the panic PC and scanned the stack for return addresses against the build's own `.elf` (`addr2line`):

```
vPortTaskWrapper → ActivityManager::renderTaskLoop()
  → EpubReaderActivity::renderBook() → Section::loadPage()
    → PageLine::deserialize() → TextBlock::deserialize()
      → serialization::readString(file, scratch)   (ruby-text annotation for a word)
        → std::string::resize(garbage_len)
          → operator new (throwing) fails → std::bad_alloc::bad_alloc()
            → __cxa_allocate_exception → __cxxabiv1::__terminate() → abort()
```

`TextBlock::deserialize()` already guards its own direct allocations with `new (std::nothrow)` + null checks (word count capped at 10000, arena allocated via `makeUniqueNoThrow`), but the `readString()` call for each word's ruby-text annotation had no such guard — the vulnerability was in the shared serialization helper, not in `TextBlock` itself.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Risk**: very low. The change only adds a bounds check before an existing `resize()`/`read()` pair; the success path (a legitimate, short serialized string) is byte-for-byte unchanged. The only behavior change is on already-corrupt input: previously a hard device crash, now a logged error and an empty string.

**Testing**:
- `pio run -e simulator` and `pio run -e default`: build successfully after every commit, flash/RAM unaffected (no new allocations, no new fields).
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` (scoped to every file this PR touches): no defects beyond the pre-existing baseline (diffed cppcheck output before/after against `develop` to confirm nothing new).
- Verified against the real panic report that motivated this (see stack trace above) — the crashing call site (`TextBlock::deserialize()`'s `readString(file, scratch)` for ruby text) is exactly the code path this PR bounds-checks.
- Ran a local review pass after the propagation-fix commit, which caught and fixed: a missing null-check in `PageImage::deserialize()` that this PR's own change made reachable; an over-aggressive `break` in `ContentOpfParser`'s hash-collision search that could have skipped a real match; a missing `LOG_ERR` on one corruption path; and an inaccurate/oversized code comment. See the review thread for details.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEwN3eYanQe5rBL4TdKH7j