### PR TITLE
fix: hash bookmark file paths to stop collisions between books

### DIFF
--- a/src/util/BookmarkFile.cpp
+++ b/src/util/BookmarkFile.cpp
@@ -14,8 +14,17 @@ bool BookmarkFile::load(const std::string& bookPath, std::vector<BookmarkEntry>&
   // serializer stay instantiated once, in PersistableStore.cpp.
   const std::string path = BookmarkUtil::getBookmarkPath(bookPath);
   JsonDocument doc;
+  bool migrating = false;
   if (!PersistableStoreBase::readDocFromFile(path.c_str(), doc)) {
-    return false;
+    // One-time fallback: this book's bookmarks may still live under the old,
+    // collision-prone sanitized-path scheme (see getLegacyBookmarkPath()).
+    // Load from there if so, then re-save below under the new path so this
+    // fallback is only paid once per book.
+    const std::string legacyPath = BookmarkUtil::getLegacyBookmarkPath(bookPath);
+    if (!PersistableStoreBase::readDocFromFile(legacyPath.c_str(), doc)) {
+      return false;
+    }
+    migrating = true;
   }
 
   JsonArray arr = doc["bookmarks"].as<JsonArray>();
@@ -36,6 +45,16 @@ bool BookmarkFile::load(const std::string& bookPath, std::vector<BookmarkEntry>&
   }
 
   LOG_DBG("BKM", "Loaded %zu bookmarks from file", bookmarks.size());
+
+  if (migrating) {
+    LOG_INF("BKM", "Migrating legacy bookmark file to hash-based path");
+    if (save(bookPath, bookmarks)) {
+      Storage.remove(BookmarkUtil::getLegacyBookmarkPath(bookPath).c_str());
+    } else {
+      LOG_ERR("BKM", "Failed to save migrated bookmarks -- leaving legacy file in place");
+    }
+  }
+
   return true;
 }
 

--- a/src/util/BookmarkFile.cpp
+++ b/src/util/BookmarkFile.cpp
@@ -15,7 +15,15 @@ bool BookmarkFile::load(const std::string& bookPath, std::vector<BookmarkEntry>&
   const std::string path = BookmarkUtil::getBookmarkPath(bookPath);
   JsonDocument doc;
   bool migrating = false;
-  if (!PersistableStoreBase::readDocFromFile(path.c_str(), doc)) {
+  if (Storage.exists(path.c_str())) {
+    // Exists but failed to read/parse -- a real corruption, not a missing
+    // file. Don't guess by falling back to the legacy path: that could load
+    // an unrelated book's bookmarks (see the migration note below) and
+    // silently overwrite this file with the wrong data.
+    if (!PersistableStoreBase::readDocFromFile(path.c_str(), doc)) {
+      return false;
+    }
+  } else {
     // One-time fallback: this book's bookmarks may still live under the old,
     // collision-prone sanitized-path scheme (see getLegacyBookmarkPath()).
     // Load from there if so, then re-save below under the new path so this
@@ -48,10 +56,13 @@ bool BookmarkFile::load(const std::string& bookPath, std::vector<BookmarkEntry>&
 
   if (migrating) {
     LOG_INF("BKM", "Migrating legacy bookmark file to hash-based path");
-    if (save(bookPath, bookmarks)) {
-      Storage.remove(BookmarkUtil::getLegacyBookmarkPath(bookPath).c_str());
-    } else {
-      LOG_ERR("BKM", "Failed to save migrated bookmarks -- leaving legacy file in place");
+    // Deliberately does not remove the legacy file: it may be shared with
+    // another book that collided under the old scheme (see
+    // getLegacyBookmarkPath()) and hasn't migrated yet. Leaving it in place
+    // costs a small orphaned file but keeps that book's migration possible;
+    // deleting it here would strand it after only the first book to load.
+    if (!save(bookPath, bookmarks)) {
+      LOG_ERR("BKM", "Failed to save migrated bookmarks");
     }
   }
 

--- a/src/util/BookmarkUtil.cpp
+++ b/src/util/BookmarkUtil.cpp
@@ -1,11 +1,16 @@
 #include "BookmarkUtil.h"
 
 #include <algorithm>
+#include <functional>
 #include <string>
 
 std::string BookmarkUtil::getBookmarksDir() { return "/.crosspoint/bookmarks/"; }
 
 std::string BookmarkUtil::getBookmarkPath(const std::string& bookPath) {
+  return getBookmarksDir() + std::to_string(std::hash<std::string>{}(bookPath)) + ".json";
+}
+
+std::string BookmarkUtil::getLegacyBookmarkPath(const std::string& bookPath) {
   // remove leading slash and replace internal slashes to create a flat filename
   std::string bookName = std::string(bookPath).erase(0, 1);
   std::replace(bookName.begin(), bookName.end(), '/', '_');

--- a/src/util/BookmarkUtil.h
+++ b/src/util/BookmarkUtil.h
@@ -4,6 +4,16 @@
 class BookmarkUtil {
  public:
   static std::string getBookmarksDir();
+  // Hash-based, not the book's (sanitized) path: two different bookPaths
+  // whose only difference is a '/' vs. a literal '_' flatten to the same
+  // string under substitution (e.g. "/books/a/b.epub" and "/books/a_b.epub"
+  // both become "books_a_b.json"), silently sharing -- and overwriting --
+  // one bookmark file between two unrelated books. See getLegacyBookmarkPath().
   static std::string getBookmarkPath(const std::string& bookPath);
+  // The old sanitized-path scheme getBookmarkPath() used before the
+  // collision above was found. Kept only so BookmarkFile::load() can do a
+  // one-time migration for files that still exist under it -- never write
+  // here.
+  static std::string getLegacyBookmarkPath(const std::string& bookPath);
   static std::string sanitizeBookmarkSummary(std::string summary);
 };


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a silent data-loss bug: `BookmarkUtil::getBookmarkPath()` flattened a book's path into a filename by replacing `/` with `_`, which isn't an injective transform -- two different book paths can collide on the same flattened string (e.g. `/books/a/b.epub` and `/books/a_b.epub` both become `books_a_b.json`). Two unrelated books would then silently share one bookmark file, one overwriting the other's bookmarks with no error surfaced anywhere.
* **What changes are included?**
  - `BookmarkUtil::getBookmarkPath()` now hashes the full book path (`std::hash<std::string>{}(bookPath)`) instead of sanitizing it into a filename, matching the scheme every other on-disk cache in this codebase already uses (`Epub.h`, `Xtc.h`, `Txt.cpp`).
  - The old scheme is kept as `BookmarkUtil::getLegacyBookmarkPath()`, used only as a one-time fallback in `BookmarkFile::load()`: if a book's bookmarks aren't found under the new hash path, it checks the legacy path, and if found, loads from there and re-saves under the new path -- so existing users' bookmarks survive the upgrade instead of silently becoming unreachable.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does.
- [x] This PR does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

**Risk**: low. `getBookmarkPath()` computing a different path is fully compensated by the legacy-path fallback in `load()`, so no existing bookmark becomes unreachable. `BookmarkFile::save()`/new bookmarks always use the new hash-based path going forward.

**Testing**:
- `pio run -e simulator`: builds successfully.
- `pio check --fail-on-defect low --fail-on-defect medium --fail-on-defect high` (scoped to `src/util/BookmarkFile.cpp` and `src/util/BookmarkUtil.cpp`): no defects.
- `pio run -e default`: builds successfully.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEwN3eYanQe5rBL4TdKH7j
