### PR TITLE
fix(input): wake the idle poll on raw button contact so short presses register

### DIFF
--- a/lib/hal/HalGPIO.cpp
+++ b/lib/hal/HalGPIO.cpp
@@ -158,6 +158,15 @@ bool HalGPIO::wasReleased(uint8_t buttonIndex) const { return inputMgr.wasReleas
 
 bool HalGPIO::wasAnyReleased() const { return inputMgr.wasAnyReleased(); }
 
+bool HalGPIO::rawInputActive() {
+  if (inputMgr.isPowerButtonPhysicallyPressed()) return true;
+  InputManager::ButtonAdcSample g1{}, g2{};
+  inputMgr.readButtonAdc(g1, g2);
+  // The Xteink ladder idles at the ADC full-scale rail (~4095); every button band sits below 3900.
+  constexpr int kIdleRailMin = 4000;
+  return (g1.raw >= 0 && g1.raw < kIdleRailMin) || (g2.raw >= 0 && g2.raw < kIdleRailMin);
+}
+
 unsigned long HalGPIO::getHeldTime() const { return inputMgr.getHeldTime(); }
 
 unsigned long HalGPIO::getPowerButtonHeldTime() const { return inputMgr.getPowerButtonHeldTime(); }

--- a/lib/hal/HalGPIO.h
+++ b/lib/hal/HalGPIO.h
@@ -78,6 +78,10 @@ class HalGPIO {
   bool wasAnyReleased() const;
   unsigned long getHeldTime() const;
   unsigned long getPowerButtonHeldTime() const;
+  // True when any button contact is closed right now, read straight from the
+  // hardware (ADC ladder off its idle rail, or the power GPIO asserted), without
+  // going through the debounced state. Cheap enough to call every few ms.
+  bool rawInputActive();
   bool hasTouch() const;
   // Capacitive Home key reported by the touch controller (X4 Pro). The tap
   // event fires on release and excludes a long hold.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -771,7 +771,14 @@ void loop() {
     if (millis() - lastActivityTime >= HalPowerManager::IDLE_POWER_SAVING_MS) {
       // If we've been inactive for a while, increase the delay to save power
       powerManager.setPowerSaving(true);  // Lower CPU frequency after extended inactivity
-      delay(50);
+      // Sleep in short slices and wake the poll as soon as a button contact closes.
+      // InputManager commits a press only when two consecutive polls agree, so a
+      // press shorter than one 50 ms sleep could land in a single sample and be lost.
+      const unsigned long idleStart = millis();
+      while (millis() - idleStart < 50) {
+        delay(10);
+        if (gpio.rawInputActive()) break;
+      }
     } else {
       // Short delay to prevent tight loop while still being responsive
       delay(10);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop losing short page-turn presses on button boards while the reader is idle. After 3 s without input the main loop sleeps 50 ms between input polls, and `InputManager` commits a press only when two consecutive polls agree, so a press shorter than one poll gap (~65 ms measured on an X3 at 10 MHz) is sampled once or not at all and silently dropped. Users see "I pressed Next and nothing happened."
* **What changes are included?**
  - `src/main.cpp`: the idle sleep is taken in 10 ms slices and exits as soon as a button contact closes, so the next `InputManager::update()` samples the press within ~10 ms and the confirming sample follows on the next pass. Active-mode polling (10 ms) is unchanged.
  - `lib/hal/HalGPIO`: `rawInputActive()`, a read-only check of the button ladder ADC (off its idle rail) and the power GPIO, without touching the debounced state. Uses the SDK's existing `InputManager::readButtonAdc()` diagnostics readback.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, and no other popular CrossPoint fork already does (the idle-sleep loop is CrossPoint's own).
- [ ] Touches `lib/hal/HalGPIO` (one new read-only accessor, no SDK change). Not coordinated in advance; flagging for the HAL maintainer here.

## Additional Context

**Mechanism.** `InputManager::update()` (`freeink-sdk/.../InputManager.cpp:500-540`) requires the same raw state on two polls more than 5 ms apart; the header documents that slow pollers drop presses shorter than the poll period and should re-poll while `isDebouncePending()`. The main loop's idle branch (`src/main.cpp`, end of `loop()`) polls once per `delay(50)` pass at 10 MHz; on an X3 each pass also carries the BQ27220 I2C read for USB detection, so consecutive polls are ~65 ms apart. Loss probability for a press of length d: 100% below 65 ms, ~60% at 90 ms, ~15% at 120 ms, 0% from 130 ms.

**Measured on an Xteink X3 (UC8253), 2026-09-08**, with a compile-time input trace that records every poll seeing a non-idle sample:

| | before | after |
|---|---|---|
| user press lengths (89 presses) | median 145 ms, p10 120 ms, min 31 ms | same user |
| presses in the idle regime | 10 registered, 1 vanished with no ADC sample in a 4.6 s window | 10 of 10 registered |
| direct A/B, 11 quick taps after 4 s pauses | tap 8 sampled once at a 66 ms poll, gone at the next, discarded; user saw no page turn | 8 of 8 comparable taps registered, including ones ~65-75 ms long |
| first contact to committed press | 66-132 ms | 27-29 ms |
| idle battery current (BQ27220, 1 mA resolution, 10+ min untouched in a book) | -10 mA, 66 of 66 samples | -10 mA, 68 of 68 samples |

Presses while actively turning pages (10 ms polls) were never affected: 130+ of 130+ registered.

**Cost.** Two `analogRead()`s per 10 ms slice while idle, no I2C. Added idle draw is below the gauge's 1 mA resolution (estimate: a few tenths of a mA at 10 MHz). Flash +290 bytes (`gh_release`, 5,439,417 -> 5,439,707), static RAM unchanged (56,344 bytes).

**Other boards.** X4 shares the ADC ladder and pinout, so it gets the same behavior. Boards without the ladder report `raw = -1` from `readButtonAdc()`, so `rawInputActive()` only reflects the power GPIO and the idle sleep behaves as before apart from being sliced. Not tested on X4 / X4 Pro / Sticky / Paper Mono.

**Verification.** `pio run -e default -e gh_release` on `develop` plus this commit; `./bin/clang-format-fix -g` (no changes); `pio check -e default --fail-on-defect low --fail-on-defect medium --fail-on-defect high` passed. Hardware: X3, ~90 minutes of reading and the tests above. To reproduce the bug on `develop`: open a book, wait 5 s, tap Next as briefly as you can; about one tap in ten does nothing.

Independent of Free-Ink/freeink-sdk#87 (X3 full-refresh pre-flash latency); the two fixes address different symptoms and neither depends on the other.

---

### AI Usage

Did you use AI tools to help write this code? **YES** — investigation, the instrumentation used to measure it, the patch, and this description were done with Claude Code; measurements and visual checks were on hardware.

https://claude.ai/code/session_01VVasxz6wBFvSHxcRukAis3
