### PR TITLE
fix: display grayscale BMPs in the viewer

### DIFF
--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -153,15 +153,48 @@ void BmpViewerActivity::onEnter() {
       GUI.fillPopupProgress(renderer, popupRect, 50);
 
       renderer.clearScreen();
-      // Assuming drawBitmap defaults to 0,0 crop if omitted, or pass explicitly: drawBitmap(bitmap, x, y, pageWidth,
-      // pageHeight, 0, 0)
       renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
 
       // Draw UI hints on the base layer
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-      // Single pass for non-grayscale images
+      if (bitmap.hasGreyscale()) {
+        renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
 
-      renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+        bool planesReady = true;
+        for (const auto mode : {GfxRenderer::GRAYSCALE_LSB, GfxRenderer::GRAYSCALE_MSB}) {
+          if (bitmap.rewindToData() != BmpReaderError::Ok) {
+            LOG_ERR("BMP", "Failed to rewind bitmap for grayscale rendering");
+            planesReady = false;
+            break;
+          }
+          renderer.clearScreen(0x00);
+          renderer.setRenderMode(mode);
+          renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
+          GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+          if (mode == GfxRenderer::GRAYSCALE_LSB) {
+            renderer.copyGrayscaleLsbBuffers();
+          } else {
+            renderer.copyGrayscaleMsbBuffers();
+          }
+        }
+        if (planesReady) renderer.displayGrayBuffer();
+
+        // Rebuild the BW framebuffer for popups and subsequent differential updates.
+        renderer.setRenderMode(GfxRenderer::BW);
+        renderer.clearScreen();
+        if (bitmap.rewindToData() == BmpReaderError::Ok) {
+          renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
+        } else {
+          LOG_ERR("BMP", "Failed to rewind bitmap to restore the BW framebuffer");
+          renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2, tr(STR_FILE_OPEN_FAILED));
+          planesReady = false;
+        }
+        GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+        renderer.cleanupGrayscaleWithFrameBuffer();
+        if (!planesReady) renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+      } else {
+        renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+      }
 
     } else {
       // Handle file parsing error

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -186,12 +186,15 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {38, 154, 268, 384};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
 
   for (int i = 0; i < 4; i++) {
     // Only draw if the label is non-empty
     if (labels[i] != nullptr && labels[i][0] != '\0') {
       const int x = buttonPositions[i];
-      renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, false);
+      // Zero gray-plane bits leave the monochrome hint from the base pass intact.
+      renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, grayscale);
+      if (grayscale) continue;
       renderer.drawRect(x, pageHeight - buttonY, buttonWidth, buttonHeight);
       drawHintLabel(renderer, UI_10_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight,
                     textYOffset);

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -123,12 +123,15 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {65, 157, 291, 383};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
 
   for (int i = 0; i < 4; i++) {
     const int x = buttonPositions[i];
     if (labels[i] != nullptr && labels[i][0] != '\0') {
       // Draw the filled background and border for a FULL-sized button
-      renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius, Color::White);
+      renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius,
+                               grayscale ? Color::Black : Color::White);
+      if (grayscale) continue;
       renderer.drawRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, 1, cornerRadius, true, true, false,
                                false, true);
       drawHintLabel(renderer, SMALL_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight,
@@ -136,7 +139,8 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
     } else {
       // Draw the filled background and border for a SMALL-sized button
       renderer.fillRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, cornerRadius,
-                               Color::White);
+                               grayscale ? Color::Black : Color::White);
+      if (grayscale) continue;
       renderer.drawRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, 1, cornerRadius, true,
                                true, false, false, true);
     }

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -214,6 +214,13 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int hintY = pageHeight - hintHeight - bottomMargin;
   const int textY = hintY + (hintHeight - renderer.getLineHeight(kGuideFontId)) / 2;
 
+  if (renderer.getRenderMode() != GfxRenderer::BW) {
+    renderer.fillRect(sidePadding, hintY, groupWidth, hintHeight, true);
+    renderer.fillRect(sidePadding + groupWidth + groupGap, hintY, groupWidth, hintHeight, true);
+    renderer.setOrientation(origOrientation);
+    return;
+  }
+
   const bool backDisabled = (btn1 == nullptr || btn1[0] == '\0');
   const int leftGroupX = sidePadding;
   const int rightGroupX = leftGroupX + groupWidth + groupGap;


### PR DESCRIPTION
## Summary

Opening a native grayscale BMP in the image viewer leaves its gray pixels black, even though the same file displays correctly as a sleep image. The viewer renders the black/white base but never submits the grayscale planes.

This follows the sleep-screen sequence for BMPs with more than one bit per pixel: display the grayscale base, rewind and render each gray plane, then perform the grayscale refresh. One-bit BMPs keep their existing fast refresh. Each theme clears its button-hint footprint from the gray planes so the image cannot tint the monochrome controls.

After the gray refresh, the viewer re-renders the BW framebuffer and restores the controller baseline for popups and subsequent navigation. Failed rewinds fall back to a BW refresh, with the renderer returned to BW mode.

Fixes #3464.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not a new interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [ ] Stock firmware / popular-fork comparison: not surveyed. This fixes a bug within CrossPoint's existing viewer, using rendering behavior already present in its sleep screen.
- SDK / HAL / bootloader / OTA / recovery coordination: not applicable; none of these are changed.

## Validation

- `pio run -e default`: passed (the shared X3/X4 ESP32-C3 firmware).
- `pio check -e default` scoped to all four changed C++ files, failing on low/medium/high defects: passed.
- `./bin/clang-format-fix -g` with clang-format 21: passed.
- GitHub CI: all four firmware builds (`default`, `sticky`, `x4pro`, and `papermono`), unit tests, clang-format, and cppcheck passed.
- Hardware: installed CI firmware `1.6.0-dev-detached-d42869e` on an Xteink X3. I confirmed that this fixes the original grayscale BMP image-viewer bug.

Broader hardware coverage of BMP bit depths, scaling, orientations, themes, navigation, and error paths has not yet been verified.

## Additional Context

The viewer reuses the existing framebuffer and bitmap row-buffer path. It adds two gray renders and one BW reconstruction for multibit BMPs, without an additional full-screen snapshot allocation. Runtime heap usage has not been measured.

### AI Usage

YES
