### PR TITLE
fix: vertical banding on X3 grayscale images

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -1433,12 +1433,22 @@ void GfxRenderer::drawBitmap(const Bitmap& bitmap, const int x, const int y, con
 
       const uint8_t val = outputRow[bmpX / 4] >> (6 - ((bmpX * 2) % 8)) & 0x3;
 
+      // Differential masks set only the pixels to nudge. Absolute planes are a
+      // full image: LSB holds white|dark, MSB white|light, every pixel written.
       if (renderMode == BW && val < 3) {
         drawPixel(screenX, screenY);
-      } else if (renderMode == GRAYSCALE_MSB && (val == 1 || val == 2)) {
-        drawPixel(screenX, screenY, false);
-      } else if (renderMode == GRAYSCALE_LSB && val == 1) {
-        drawPixel(screenX, screenY, false);
+      } else if (renderMode == GRAYSCALE_MSB) {
+        if (absoluteGrayPlanes) {
+          drawPixel(screenX, screenY, !(val == 3 || val == 2));
+        } else if (val == 1 || val == 2) {
+          drawPixel(screenX, screenY, false);
+        }
+      } else if (renderMode == GRAYSCALE_LSB) {
+        if (absoluteGrayPlanes) {
+          drawPixel(screenX, screenY, !(val == 3 || val == 1));
+        } else if (val == 1) {
+          drawPixel(screenX, screenY, false);
+        }
       }
     }
   }
@@ -2228,7 +2238,9 @@ void GfxRenderer::copyGrayscaleLsbBuffers() const { display.copyGrayscaleLsbBuff
 
 void GfxRenderer::copyGrayscaleMsbBuffers() const { display.copyGrayscaleMsbBuffers(frameBuffer); }
 
-void GfxRenderer::displayGrayBuffer() const { display.displayGrayBuffer(fadingFix); }
+void GfxRenderer::displayGrayBuffer(const bool absolute) const { display.displayGrayBuffer(fadingFix, absolute); }
+
+bool GfxRenderer::supportsAbsoluteGrayPlanes() const { return display.supportsAbsoluteGrayPlanes(); }
 
 void GfxRenderer::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* scratch, int yStart, int numRows) const {
   // Guard the uint16_t casts below: a negative would wrap to a huge length.

--- a/lib/GfxRenderer/GfxRenderer.h
+++ b/lib/GfxRenderer/GfxRenderer.h
@@ -43,6 +43,7 @@ class GfxRenderer {
 
   HalDisplay& display;
   RenderMode renderMode;
+  bool absoluteGrayPlanes = false;
   Orientation orientation;
   bool fadingFix;
   uint8_t* frameBuffer = nullptr;
@@ -328,7 +329,18 @@ class GfxRenderer {
   void displayGrayscaleBase(HalDisplay::RefreshMode fallback = HalDisplay::HALF_REFRESH) const;
   void copyGrayscaleLsbBuffers() const;
   void copyGrayscaleMsbBuffers() const;
-  void displayGrayBuffer() const;
+  // absolute = true runs the driver's factoryMode four-tone waveform on
+  // absolute planes (see setAbsoluteGrayPlanes).
+  void displayGrayBuffer(bool absolute = false) const;
+  // True when the display can render images through an absolute four-tone
+  // pass: the GRAYSCALE_LSB plane then holds white|dark gray and the
+  // GRAYSCALE_MSB plane white|light gray, instead of the differential masks.
+  bool supportsAbsoluteGrayPlanes() const;
+  // Switch the plane content drawBitmap() produces in GRAYSCALE_LSB/MSB modes
+  // between differential masks (default) and absolute planes. Absolute planes
+  // are cleared to white (0xFF) and B/W overlays are drawn normally into them.
+  void setAbsoluteGrayPlanes(const bool absolute) { this->absoluteGrayPlanes = absolute; }
+  bool grayPlanesAreAbsolute() const { return absoluteGrayPlanes; }
 
   // Tiled grayscale (X4): stream one band of a plane straight to controller RAM
   // from `scratch` (panelWidthBytes * numRows, physical rows [yStart, yStart+

--- a/lib/hal/HalDisplay.cpp
+++ b/lib/hal/HalDisplay.cpp
@@ -130,7 +130,9 @@ void HalDisplay::copyGrayscaleMsbBuffers(const uint8_t* msbBuffer) { einkDisplay
 
 void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* bwBuffer) { einkDisplay.cleanupGrayscaleBuffers(bwBuffer); }
 
-void HalDisplay::displayGrayBuffer(bool turnOffScreen) { einkDisplay.displayGrayBuffer(turnOffScreen); }
+void HalDisplay::displayGrayBuffer(bool turnOffScreen, bool factoryMode) {
+  einkDisplay.displayGrayBuffer(turnOffScreen, nullptr, factoryMode);
+}
 
 void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows) {
   einkDisplay.writeGrayscalePlaneStrip(lsbPlane ? EInkDisplay::GRAY_PLANE_LSB : EInkDisplay::GRAY_PLANE_MSB, rows,
@@ -138,6 +140,8 @@ void HalDisplay::writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, ui
 }
 
 bool HalDisplay::supportsStripGrayscale() const { return einkDisplay.supportsStripGrayscale(); }
+
+bool HalDisplay::supportsAbsoluteGrayPlanes() const { return einkDisplay.supportsAbsoluteGrayPlanes(); }
 
 bool HalDisplay::combinesGrayscaleBase() const { return einkDisplay.combinesGrayscaleBase(); }
 

--- a/lib/hal/HalDisplay.h
+++ b/lib/hal/HalDisplay.h
@@ -90,13 +90,18 @@ class HalDisplay {
   void copyGrayscaleMsbBuffers(const uint8_t* msbBuffer);
   void cleanupGrayscaleBuffers(const uint8_t* bwBuffer);
 
-  void displayGrayBuffer(bool turnOffScreen = false);
+  // factoryMode selects the driver's absolute four-tone image waveform; the
+  // planes must then be absolute (see supportsAbsoluteGrayPlanes).
+  void displayGrayBuffer(bool turnOffScreen = false, bool factoryMode = false);
 
   // Tiled grayscale: stream one band of a plane (lsbPlane selects LSB/MSB RAM)
   // straight to the controller; supportsStripGrayscale() gates the path. See
   // EInkDisplay::writeGrayscalePlaneStrip.
   void writeGrayscalePlaneStrip(bool lsbPlane, const uint8_t* rows, uint16_t yStart, uint16_t numRows);
   bool supportsStripGrayscale() const;
+  // True when the driver's factoryMode grayscale consumes absolute planes:
+  // LSB plane bit = white or dark gray, MSB plane bit = white or light gray.
+  bool supportsAbsoluteGrayPlanes() const;
 
   // True when displayGrayscaleBase() defers the base activation so the gray
   // planes join it in a single waveform (Paper Mono). Callers should then route

--- a/src/activities/boot_sleep/SleepActivity.cpp
+++ b/src/activities/boot_sleep/SleepActivity.cpp
@@ -644,19 +644,27 @@ void SleepActivity::renderBitmapSleepScreen(const Bitmap& bitmap, const bool pre
   }
 
   if (hasGreyscale) {
+    // Absolute four-tone planes where the panel supports them (cleared to
+    // white), differential masks otherwise (cleared to black). A preserved
+    // background is not part of the planes, so it keeps the differential path.
+    const bool absolute = renderer.supportsAbsoluteGrayPlanes() && !preserveBackground;
+    renderer.setAbsoluteGrayPlanes(absolute);
+    const uint8_t clearColor = absolute ? 0xFF : 0x00;
+
     bitmap.rewindToData();
-    renderer.clearScreen(0x00);
+    renderer.clearScreen(clearColor);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_LSB);
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
     renderer.copyGrayscaleLsbBuffers();
 
     bitmap.rewindToData();
-    renderer.clearScreen(0x00);
+    renderer.clearScreen(clearColor);
     renderer.setRenderMode(GfxRenderer::GRAYSCALE_MSB);
     renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, cropX, cropY);
     renderer.copyGrayscaleMsbBuffers();
 
-    renderer.displayGrayBuffer();
+    renderer.displayGrayBuffer(absolute);
+    renderer.setAbsoluteGrayPlanes(false);
     renderer.setRenderMode(GfxRenderer::BW);
   }
 }

--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -153,15 +153,48 @@ void BmpViewerActivity::onEnter() {
       GUI.fillPopupProgress(renderer, popupRect, 50);
 
       renderer.clearScreen();
-      // Assuming drawBitmap defaults to 0,0 crop if omitted, or pass explicitly: drawBitmap(bitmap, x, y, pageWidth,
-      // pageHeight, 0, 0)
       renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
 
       // Draw UI hints on the base layer
       GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
-      // Single pass for non-grayscale images
+      if (bitmap.hasGreyscale()) {
+        renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
 
-      renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+        bool planesReady = true;
+        for (const auto mode : {GfxRenderer::GRAYSCALE_LSB, GfxRenderer::GRAYSCALE_MSB}) {
+          if (bitmap.rewindToData() != BmpReaderError::Ok) {
+            LOG_ERR("BMP", "Failed to rewind bitmap for grayscale rendering");
+            planesReady = false;
+            break;
+          }
+          renderer.clearScreen(0x00);
+          renderer.setRenderMode(mode);
+          renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
+          GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+          if (mode == GfxRenderer::GRAYSCALE_LSB) {
+            renderer.copyGrayscaleLsbBuffers();
+          } else {
+            renderer.copyGrayscaleMsbBuffers();
+          }
+        }
+        if (planesReady) renderer.displayGrayBuffer();
+
+        // Rebuild the BW framebuffer for popups and subsequent differential updates.
+        renderer.setRenderMode(GfxRenderer::BW);
+        renderer.clearScreen();
+        if (bitmap.rewindToData() == BmpReaderError::Ok) {
+          renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
+        } else {
+          LOG_ERR("BMP", "Failed to rewind bitmap to restore the BW framebuffer");
+          renderer.drawCenteredText(UI_10_FONT_ID, pageHeight / 2, tr(STR_FILE_OPEN_FAILED));
+          planesReady = false;
+        }
+        GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
+        renderer.cleanupGrayscaleWithFrameBuffer();
+        if (!planesReady) renderer.displayBuffer(HalDisplay::HALF_REFRESH);
+      } else {
+        renderer.displayBuffer(HalDisplay::FAST_REFRESH);
+      }
 
     } else {
       // Handle file parsing error

--- a/src/activities/util/BmpViewerActivity.cpp
+++ b/src/activities/util/BmpViewerActivity.cpp
@@ -160,6 +160,11 @@ void BmpViewerActivity::onEnter() {
       if (bitmap.hasGreyscale()) {
         renderer.displayGrayscaleBase(HalDisplay::HALF_REFRESH);
 
+        // Panels with an absolute four-tone image waveform take absolute planes
+        // (white|dark, white|light) cleared to white; the others take the
+        // differential masks cleared to black.
+        const bool absolute = renderer.supportsAbsoluteGrayPlanes();
+        renderer.setAbsoluteGrayPlanes(absolute);
         bool planesReady = true;
         for (const auto mode : {GfxRenderer::GRAYSCALE_LSB, GfxRenderer::GRAYSCALE_MSB}) {
           if (bitmap.rewindToData() != BmpReaderError::Ok) {
@@ -167,7 +172,7 @@ void BmpViewerActivity::onEnter() {
             planesReady = false;
             break;
           }
-          renderer.clearScreen(0x00);
+          renderer.clearScreen(absolute ? 0xFF : 0x00);
           renderer.setRenderMode(mode);
           renderer.drawBitmap(bitmap, x, y, pageWidth, pageHeight, 0, 0);
           GUI.drawButtonHints(renderer, labels.btn1, labels.btn2, labels.btn3, labels.btn4);
@@ -177,7 +182,8 @@ void BmpViewerActivity::onEnter() {
             renderer.copyGrayscaleMsbBuffers();
           }
         }
-        if (planesReady) renderer.displayGrayBuffer();
+        if (planesReady) renderer.displayGrayBuffer(absolute);
+        renderer.setAbsoluteGrayPlanes(false);
 
         // Rebuild the BW framebuffer for popups and subsequent differential updates.
         renderer.setRenderMode(GfxRenderer::BW);

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -186,7 +186,7 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {38, 154, 268, 384};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
-  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW && !renderer.grayPlanesAreAbsolute();
 
   for (int i = 0; i < 4; i++) {
     // Only draw if the label is non-empty

--- a/src/components/themes/BaseTheme.cpp
+++ b/src/components/themes/BaseTheme.cpp
@@ -186,12 +186,15 @@ void BaseTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {38, 154, 268, 384};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
 
   for (int i = 0; i < 4; i++) {
     // Only draw if the label is non-empty
     if (labels[i] != nullptr && labels[i][0] != '\0') {
       const int x = buttonPositions[i];
-      renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, false);
+      // Zero gray-plane bits leave the monochrome hint from the base pass intact.
+      renderer.fillRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, grayscale);
+      if (grayscale) continue;
       renderer.drawRect(x, pageHeight - buttonY, buttonWidth, buttonHeight);
       drawHintLabel(renderer, UI_10_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight,
                     textYOffset);

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -123,12 +123,15 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {65, 157, 291, 383};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
 
   for (int i = 0; i < 4; i++) {
     const int x = buttonPositions[i];
     if (labels[i] != nullptr && labels[i][0] != '\0') {
       // Draw the filled background and border for a FULL-sized button
-      renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius, Color::White);
+      renderer.fillRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, cornerRadius,
+                               grayscale ? Color::Black : Color::White);
+      if (grayscale) continue;
       renderer.drawRoundedRect(x, pageHeight - buttonY, buttonWidth, buttonHeight, 1, cornerRadius, true, true, false,
                                false, true);
       drawHintLabel(renderer, SMALL_FONT_ID, labels[i], x, buttonWidth, pageHeight - buttonY, buttonHeight,
@@ -136,7 +139,8 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
     } else {
       // Draw the filled background and border for a SMALL-sized button
       renderer.fillRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, cornerRadius,
-                               Color::White);
+                               grayscale ? Color::Black : Color::White);
+      if (grayscale) continue;
       renderer.drawRoundedRect(x, pageHeight - smallButtonHeight, buttonWidth, smallButtonHeight, 1, cornerRadius, true,
                                true, false, false, true);
     }

--- a/src/components/themes/lyra/LyraTheme.cpp
+++ b/src/components/themes/lyra/LyraTheme.cpp
@@ -123,7 +123,7 @@ void LyraTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, const c
   constexpr int wideButtonPositions[] = {65, 157, 291, 383};
   const int* buttonPositions = renderer.getScreenWidth() >= 528 ? wideButtonPositions : narrowButtonPositions;
   const char* labels[] = {btn1, btn2, btn3, btn4};
-  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW;
+  const bool grayscale = renderer.getRenderMode() != GfxRenderer::BW && !renderer.grayPlanesAreAbsolute();
 
   for (int i = 0; i < 4; i++) {
     const int x = buttonPositions[i];

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -214,7 +214,7 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int hintY = pageHeight - hintHeight - bottomMargin;
   const int textY = hintY + (hintHeight - renderer.getLineHeight(kGuideFontId)) / 2;
 
-  if (renderer.getRenderMode() != GfxRenderer::BW) {
+  if (renderer.getRenderMode() != GfxRenderer::BW && !renderer.grayPlanesAreAbsolute()) {
     renderer.fillRect(sidePadding, hintY, groupWidth, hintHeight, true);
     renderer.fillRect(sidePadding + groupWidth + groupGap, hintY, groupWidth, hintHeight, true);
     renderer.setOrientation(origOrientation);

--- a/src/components/themes/roundedraff/RoundedRaffTheme.cpp
+++ b/src/components/themes/roundedraff/RoundedRaffTheme.cpp
@@ -214,6 +214,13 @@ void RoundedRaffTheme::drawButtonHints(GfxRenderer& renderer, const char* btn1, 
   const int hintY = pageHeight - hintHeight - bottomMargin;
   const int textY = hintY + (hintHeight - renderer.getLineHeight(kGuideFontId)) / 2;
 
+  if (renderer.getRenderMode() != GfxRenderer::BW) {
+    renderer.fillRect(sidePadding, hintY, groupWidth, hintHeight, true);
+    renderer.fillRect(sidePadding + groupWidth + groupGap, hintY, groupWidth, hintHeight, true);
+    renderer.setOrientation(origOrientation);
+    return;
+  }
+
   const bool backDisabled = (btn1 == nullptr || btn1[0] == '\0');
   const int leftGroupX = sidePadding;
   const int rightGroupX = leftGroupX + groupWidth + groupGap;


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  * Use the SDK's new absolute four-tone grayscale pass for images on the UC8279 Xteink X3, which removes the vertical striping visible on dithered gray images there and renders all four gray levels. Depends on Free-Ink/freeink-sdk#95 (stacked on Free-Ink/freeink-sdk#94).

* **What changes are included?**
  * `HalDisplay` / `GfxRenderer`: expose `supportsAbsoluteGrayPlanes()` and pass `factoryMode` through `displayGrayBuffer(absolute)`.
  * `GfxRenderer::drawBitmap`: when absolute planes are selected, the GRAYSCALE_LSB pass writes white|dark gray and the GRAYSCALE_MSB pass white|light gray for every pixel, instead of setting differential mask bits.
  * BMP viewer and BMP sleep screen: on panels that support it, clear the planes to white, draw the image as absolute planes, and run the factory-mode refresh. Other panels, preserved-background sleep screens and the transparent PNG overlay keep the differential path unchanged.
  * Themes: button hints are drawn normally into absolute planes (both planes hold the B/W rendering), since zero plane bits are not "leave as is" in an absolute pass.

## Additional Context

* Behaviour is unchanged on every panel whose driver does not report the capability. The submodule pointer is not bumped here; it will be once the SDK change is merged.
* Measured on an X3 (UC8279): checkerboard column banding drops from 3.5–4.7% to 0.9% of the black-to-white range and the 8-gate-line period disappears; the four flat levels render at 0, 0.17, 0.67, 1.0 of the range. The image refresh takes about a second instead of a tenth.
* Text anti-aliasing and EPUB/XTC pages are untouched; they keep the short nudge.
* Stacked on #3465 (the viewer's grayscale passes); its commit appears here until it merges. Draft until Free-Ink/freeink-sdk#95 lands and the submodule can be bumped.
