### PR TITLE
fix: dictionary lookup prefers exact case match

### DIFF
--- a/docs/dictionary.md
+++ b/docs/dictionary.md
@@ -40,7 +40,7 @@ On the very first lookup with a dictionary (and again whenever the `.idx` or `.s
 
 ### How Lookup Works
 
-1. **Direct match** — the word is found as-is (case-insensitive) in the dictionary index. Surrounding punctuation is ignored.
+1. **Direct match** — the word is found as-is (case-insensitive) in the dictionary index. Surrounding punctuation is ignored. Where a dictionary holds both a common noun and a proper noun spelled alike (`matter` and `Matter`), the lowercase entry wins; a word that only exists capitalized (`Paris`) is still found.
 2. **Synonyms** — on a miss, if the dictionary ships a `.syn` file, alternate spellings and irregular forms recorded there are resolved to their headword (e.g. `oxen` → `ox`, `colour` → `color`). This step is skipped if the `.sidx` sidecar could not be built (e.g. transient low memory during indexing); the dictionary otherwise stays usable, and the build is retried the next time it is opened.
 3. **Stemming** — still no match: common English word forms are retried automatically: possessives and plurals (`dogs` → `dog`, `stories` → `story`) and verb endings (`walked` → `walk`, `running` → `run`, `making` → `make`).
 4. **Not found** — a short popup appears and you return to word selection.

--- a/src/util/Dictionary.cpp
+++ b/src/util/Dictionary.cpp
@@ -391,6 +391,14 @@ DictLocation Dictionary::locate(LookupSession& session, const char* target, std:
 
   // Linear scan of at most SAMPLE_INTERVAL entries: headword NUL, BE32 offset,
   // BE32 size. The index is sorted, so stop at the first headword > target.
+  //
+  // Headwords equal under asciiCaseCmp sit in a contiguous run, ordered among
+  // themselves by StarDict's strcmp tiebreak — which puts "Pate" ahead of
+  // "pate", since uppercase sorts first in ASCII. Taking the first of the run
+  // would answer a lookup of "pate" with the proper noun, so walk the run and
+  // prefer the entry matching target byte for byte, keeping the first
+  // case-insensitive hit as the fallback for a run with no exact-case member
+  // (a query for "paris" against a dictionary holding only "Paris").
   if (!session.idx.seekSet(startByte)) {
     LOG_ERR("DICT", "Index seek to %lu failed", static_cast<unsigned long>(startByte));
     result.readError = true;
@@ -407,11 +415,15 @@ DictLocation Dictionary::locate(LookupSession& session, const char* target, std:
 
     const int cmp = StringUtils::asciiCaseCmp(wordBuf, target);
     if (cmp == 0) {
-      result.offset = readBe32(suffix);
-      result.size = readBe32(suffix + 4);
-      result.found = true;
-      if (matchedHeadwordOut) *matchedHeadwordOut = wordBuf;
-      return result;
+      const bool exactCase = strcmp(wordBuf, target) == 0;
+      if (exactCase || !result.found) {
+        result.offset = readBe32(suffix);
+        result.size = readBe32(suffix + 4);
+        result.found = true;
+        if (matchedHeadwordOut) *matchedHeadwordOut = wordBuf;
+      }
+      if (exactCase) return result;
+      continue;  // keep scanning the run for an exact-case entry
     }
     if (cmp > 0) break;
   }


### PR DESCRIPTION
## Summary

This changes the dictionary lookup to prefer case exact matches. This is needed because the stardict index stores words with capitals first (ascii value is lower, sorted first) so a word with a proper noun variant is picked over the noun, even though the noun is used in the book.

i.e. `Matter` (surname) vs `matter`.

This is particularly important in the `reader.dict` dictionaries from Wiktionary that have surnames.

This change also updates the docs to reference this behavior.

## Scope Check

Bugfix for #3409 

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**< YES >**_
