### PR TITLE
fix: unaligned ZIP EOCD scan crashes on RISC-V

### DIFF
--- a/lib/ZipFile/ZipFile.cpp
+++ b/lib/ZipFile/ZipFile.cpp
@@ -5,6 +5,7 @@
 #include <Logging.h>
 
 #include <algorithm>
+#include <cstring>
 
 struct ZipInflateCtx {
   HalFile* file = nullptr;
@@ -246,11 +247,15 @@ bool ZipFile::loadZipDetails() {
   file.seek(fileSize - scanRange);
   file.read(buffer, scanRange);
 
-  // Scan backwards for the signature
+  // Scan backwards for the signature. Buffer offsets aren't 4-byte aligned,
+  // so reads must go through memcpy -- a direct pointer-cast dereference
+  // faults on RISC-V (ESP32-C3).
   int foundOffset = -1;
   for (int i = scanRange - 22; i >= 0; i--) {
     constexpr uint32_t signature = 0x06054b50;
-    if (*reinterpret_cast<uint32_t*>(&buffer[i]) == signature) {
+    uint32_t candidate;
+    memcpy(&candidate, &buffer[i], sizeof(candidate));
+    if (candidate == signature) {
       foundOffset = i;
       break;
     }
@@ -266,8 +271,8 @@ bool ZipFile::loadZipDetails() {
   // Relative positions within EOCD:
   // Offset 10: Total number of entries (2 bytes)
   // Offset 16: Offset of start of central directory with respect to the starting disk number (4 bytes)
-  zipDetails.totalEntries = *reinterpret_cast<uint16_t*>(&buffer[foundOffset + 10]);
-  zipDetails.centralDirOffset = *reinterpret_cast<uint32_t*>(&buffer[foundOffset + 16]);
+  memcpy(&zipDetails.totalEntries, &buffer[foundOffset + 10], sizeof(zipDetails.totalEntries));
+  memcpy(&zipDetails.centralDirOffset, &buffer[foundOffset + 16], sizeof(zipDetails.centralDirOffset));
   zipDetails.isSet = true;
 
   free(buffer);


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Fix a real crash risk: `ZipFile::loadZipDetails()`
  scans backward through a buffer for the ZIP End-Of-Central-Directory signature and
  dereferences each byte offset as a `uint32_t*`/`uint16_t*`. Most of those offsets
  aren't 4-byte aligned, and ESP32-C3 (RISC-V) faults on unaligned multi-byte loads.
* **What changes are included?** Replace the three pointer-cast dereferences with
  `memcpy` into aligned locals. No behavior change — only how the bytes are read,
  not what's read.

## Scope Check

CrossPoint is intentionally narrow. See SCOPE.md and ROADMAP.md.

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] Not a new built-in theme.
- [x] Not a new external network connector.
- [x] Not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] Pure correctness fix, not new functionality.
- [x] Does not touch `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code.

## Additional Context

* No flash/memory impact — same allocation, same data, just alignment-safe reads.
* Verified: `pio run -e simulator` builds clean, `pio check` (cppcheck) has no new
  findings, `clang-format-fix` clean, and manually confirmed in the simulator that
  opening/resuming a book (which exercises this exact code path) still works.
* **Not yet verified on real hardware** — happy to have this tested on-device before
  merge.

---

### AI Usage

Did you use AI tools to help write this code? **YES**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Qa2K1VtexcEFWqPx1CVRQ