### PR TITLE
fix: add non-CJK GUI fallback font support

### DIFF
--- a/lib/GfxRenderer/GfxRenderer.cpp
+++ b/lib/GfxRenderer/GfxRenderer.cpp
@@ -199,11 +199,13 @@ int GfxRenderer::resolveTextFontId(const int fontId, const char* text, const Epd
   const char* cursor = text;
   uint32_t cp;
   while ((cp = utf8NextCodepoint(reinterpret_cast<const uint8_t**>(&cursor)))) {
-    // Only redirect for CJK the primary font cannot draw but the fallback can.
-    // Latin/symbol strings the built-in UI fonts already cover are left
-    // untouched, and a partial-coverage fallback (e.g. kana-only) is not worth
-    // dragging the whole string into for glyphs it would also miss.
-    if (utf8IsCjkCodepoint(cp) && !primary.hasCodepoint(cp, style) && fallback.hasCodepoint(cp, style)) {
+    // Redirect for any non-ASCII codepoint the primary font cannot draw but
+    // the fallback can, covering CJK, Armenian, Greek, Cyrillic, or any other
+    // script the installed SD-card font supports. ASCII is excluded: the
+    // built-in flash fonts are guaranteed to cover it, and a partial-coverage
+    // fallback (e.g. kana-only) is not worth dragging an otherwise-Latin
+    // string into for glyphs it would also miss.
+    if (cp > 0x7F && !primary.hasCodepoint(cp, style) && fallback.hasCodepoint(cp, style)) {
       return fallbackFontId;
     }
   }
@@ -216,7 +218,7 @@ void GfxRenderer::prewarmFallbackText(const int fontId, const TextGetter getter,
     return;
   }
   // Resolve the fallback id from the first string that actually redirects; a
-  // screen with no CJK strings resolves nothing and this is a no-op.
+  // screen with no non-Latin strings resolves nothing and this is a no-op.
   int fallbackFontId = fontId;
   for (uint32_t i = 0; i < textCount && fallbackFontId == fontId; i++) {
     const char* text = getter(ctx, i);
@@ -266,9 +268,10 @@ void GfxRenderer::ensureSdGlyphsResident(const int fontId, const char* text, con
   }
   // SUP/SUB bits don't select a distinct .cpfont style bitstream — mask to the
   // base style. resolveStyleMask() inside prewarm folds absent styles.
-  // loadKernLig=false: redirected fallback strings (CJK titles, filenames)
-  // have no useful kern pairs, and the ~3KB class-table load plus per-rebuild
-  // mini-matrix build cost heap and SD time exactly where these strings live
+  // loadKernLig=false: redirected fallback strings (non-Latin titles,
+  // filenames) have no useful kern pairs, and the ~3KB class-table load plus
+  // per-rebuild mini-matrix build cost heap and SD time exactly where these
+  // strings live
   // (heap-tight UI screens). The reader's PrewarmScope path keeps kern; a
   // kern-wanting request that subset-hits a kern-free mini tops the matrix up
   // in prewarmStyle without re-reading glyphs.
@@ -597,7 +600,7 @@ int GfxRenderer::getTextWidth(const int fontId, const char* text, const EpdFontF
   }
 
   // Measure with the same font drawText would render with (see resolveTextFontId)
-  // so wrapping, truncation and centering of CJK strings stay consistent.
+  // so wrapping, truncation and centering of non-Latin strings stay consistent.
   const int resolvedFontId = resolveTextFontId(fontId, text, style);
   const auto fontIt = fontMap.find(resolvedFontId);
   if (fontIt == fontMap.end()) {
@@ -633,7 +636,7 @@ void GfxRenderer::drawText(const int fontId, const int x, const int y, const cha
     return;
   }
 
-  // Route CJK-bearing strings to the fallback font when the requested font
+  // Route non-Latin strings to the fallback font when the requested font
   // lacks the glyphs (e.g. Chinese book titles drawn with a Latin UI font).
   const int resolvedFontId = resolveTextFontId(fontId, text, style);
 
@@ -2009,7 +2012,7 @@ int GfxRenderer::getKerning(const int fontId, const uint32_t leftCp, const uint3
 }
 
 int GfxRenderer::getTextAdvanceX(const int fontId, const char* text, EpdFontFamily::Style style) const {
-  // Match the font drawText would use for CJK-bearing strings (see resolveTextFontId).
+  // Match the font drawText would use for non-Latin strings (see resolveTextFontId).
   const int resolvedFontId = resolveTextFontId(fontId, text, style);
   // Measure the exact codepoint stream drawText renders: bidi-reordered and
   // Arabic-shaped (contextual presentation forms, Lam-Alef collapse).
@@ -2128,7 +2131,7 @@ void GfxRenderer::drawTextRotated90CW(const int fontId, const int x, const int y
     return;
   }
 
-  // Route CJK-bearing strings to the fallback font (see resolveTextFontId).
+  // Route non-Latin strings to the fallback font (see resolveTextFontId).
   const int resolvedFontId = resolveTextFontId(fontId, text, style);
   // Redirected to the SD fallback: batch-load the string's glyphs so the draw
   // loop below doesn't fault them in one SD read at a time (#2725).

--- a/lib/Utf8/Utf8.h
+++ b/lib/Utf8/Utf8.h
@@ -44,29 +44,6 @@ inline bool utf8IsCjkBreakable(const uint32_t cp) {
          || (cp >= 0x2A700 && cp <= 0x2B73F);  // CJK Extension C
 }
 
-// Returns true for any codepoint in a CJK script block (Han, Kana, Hangul, Bopomofo,
-// radicals, and CJK punctuation/compatibility/enclosed forms). Used for fallback font
-// selection — deliberately broader than utf8IsCjkBreakable, whose ranges are tuned to
-// implicit line-break opportunities and must not grow without rethinking layout.
-inline bool utf8IsCjkCodepoint(const uint32_t cp) {
-  return (cp >= 0x1100 && cp <= 0x11FF)        // Hangul Jamo
-         || (cp >= 0x2E80 && cp <= 0x2FDF)     // CJK Radicals Supplement, Kangxi Radicals
-         || (cp >= 0x3000 && cp <= 0x33FF)     // CJK punctuation, Kana, Bopomofo, Hangul Compat
-                                               // Jamo, Kanbun, strokes, enclosed + compat forms
-         || (cp >= 0x3400 && cp <= 0x4DBF)     // CJK Extension A
-         || (cp >= 0x4E00 && cp <= 0x9FFF)     // CJK Unified Ideographs
-         || (cp >= 0xA960 && cp <= 0xA97F)     // Hangul Jamo Extended-A
-         || (cp >= 0xAC00 && cp <= 0xD7FF)     // Hangul Syllables, Hangul Jamo Extended-B
-         || (cp >= 0xF900 && cp <= 0xFAFF)     // CJK Compatibility Ideographs
-         || (cp >= 0xFE10 && cp <= 0xFE1F)     // Vertical Forms
-         || (cp >= 0xFE30 && cp <= 0xFE4F)     // CJK Compatibility Forms
-         || (cp >= 0xFF01 && cp <= 0xFF60)     // Fullwidth Latin / Punctuation
-         || (cp >= 0xFF65 && cp <= 0xFFEF)     // Halfwidth Katakana / Hangul
-         || (cp >= 0x20000 && cp <= 0x2EBEF)   // CJK Extensions B-F
-         || (cp >= 0x2F800 && cp <= 0x2FA1F)   // CJK Compatibility Ideographs Supplement
-         || (cp >= 0x30000 && cp <= 0x323AF);  // CJK Extensions G-H
-}
-
 // Returns true for Unicode combining diacritical marks that should not advance the cursor.
 inline bool utf8IsCombiningMark(const uint32_t cp) {
   return (cp >= 0x0300 && cp <= 0x036F)      // Combining Diacritical Marks

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -144,15 +144,15 @@ void SdCardFontSystem::setupUiFallbacks(GfxRenderer& renderer) {
   // Probe the already-loaded reader-size font before paying for the UI sizes:
   // resolveTextFontId redirects on any codepoint the built-in UI fonts lack,
   // so a family with no non-Latin coverage at all can never act as a fallback
-  // and its UI sizes would be dead weight in RAM. There's no cheap way to ask
-  // a font "do you cover anything the built-in fonts don't" without an
-  // exhaustive scan, so this probes one representative codepoint per non-Latin
-  // script instead: every named interval preset the SD-font converter ships
-  // (docs/sd-card-fonts.md) other than the Latin ones (latin1/latin-ext --
-  // the built-in UI fonts already ship broad European Latin coverage, so a
-  // Latin-only family redirects nothing in resolveTextFontId and correctly
-  // stays excluded), plus Devanagari and Bengali, which don't have a named
-  // preset yet but are already supported by a custom --intervals range.
+  // and its UI sizes would be dead weight in RAM. Probes specific codepoints
+  // rather than scanning the font's own interval table: SD-card fonts only
+  // keep a RAM-resident subset of their coverage after load, so hasCodepoint()
+  // is the only full-coverage query available. Every named interval preset
+  // the SD-font converter ships (docs/sd-card-fonts.md) is probed here except
+  // the Latin ones (latin1/latin-ext -- the built-in UI fonts already ship
+  // broad European Latin coverage, so a Latin-only family correctly redirects
+  // nothing in resolveTextFontId), plus Devanagari and Bengali, which don't
+  // have a named preset yet but already work via a custom --intervals range.
   const auto readerIt = renderer.getFontMap().find(manager_.getFontId(familyName));
   if (readerIt == renderer.getFontMap().end()) return;
   static constexpr uint32_t kNonLatinProbes[] = {

--- a/src/SdCardFontSystem.cpp
+++ b/src/SdCardFontSystem.cpp
@@ -22,8 +22,8 @@ void snapFontPointSizeTo(const uint8_t availablePointSize) {
 }
 
 // Built-in UI fonts and their physical point sizes (at 150 DPI, matching the
-// SD-font converter). Each is paired with a same-size SD fallback so CJK UI
-// text matches the surrounding Latin. See SdCardFontSystem::setupUiFallbacks.
+// SD-font converter). Each is paired with a same-size SD fallback so non-Latin
+// UI text matches the surrounding Latin. See SdCardFontSystem::setupUiFallbacks.
 struct UiFontSize {
   int fontId;
   uint8_t pointSize;
@@ -142,21 +142,47 @@ void SdCardFontSystem::setupUiFallbacks(GfxRenderer& renderer) {
   if (!family) return;
 
   // Probe the already-loaded reader-size font before paying for the UI sizes:
-  // resolveTextFontId only redirects on CJK codepoints, so a Latin-only family
-  // can never act as a fallback and its UI sizes would be dead weight in RAM.
+  // resolveTextFontId redirects on any codepoint the built-in UI fonts lack,
+  // so a family with no non-Latin coverage at all can never act as a fallback
+  // and its UI sizes would be dead weight in RAM. There's no cheap way to ask
+  // a font "do you cover anything the built-in fonts don't" without an
+  // exhaustive scan, so this probes one representative codepoint per non-Latin
+  // script instead: every named interval preset the SD-font converter ships
+  // (docs/sd-card-fonts.md) other than the Latin ones (latin1/latin-ext --
+  // the built-in UI fonts already ship broad European Latin coverage, so a
+  // Latin-only family redirects nothing in resolveTextFontId and correctly
+  // stays excluded), plus Devanagari and Bengali, which don't have a named
+  // preset yet but are already supported by a custom --intervals range.
   const auto readerIt = renderer.getFontMap().find(manager_.getFontId(familyName));
   if (readerIt == renderer.getFontMap().end()) return;
-  // One representative codepoint per script: Han, Hiragana, Katakana, Hangul.
-  static constexpr uint32_t kCjkProbes[] = {0x4E00, 0x3042, 0x30A2, 0xAC00};
-  bool hasCjk = false;
-  for (const uint32_t cp : kCjkProbes) {
+  static constexpr uint32_t kNonLatinProbes[] = {
+      0x4E00,  // CJK Unified Ideographs (Han)
+      0x3042,  // Hiragana
+      0x30A2,  // Katakana
+      0xAC00,  // Hangul Syllables
+      0x0391,  // Greek
+      0x0410,  // Cyrillic
+      0x0531,  // Armenian
+      0x10D0,  // Georgian
+      0x05D0,  // Hebrew
+      0x0627,  // Arabic
+      0x1200,  // Ethiopic
+      0x13A0,  // Cherokee
+      0x2D30,  // Tifinagh
+      0x01A1,  // Vietnamese-specific Latin Extended-B (ơ)
+      0x0259,  // IPA Extensions (ə)
+      0x0905,  // Devanagari
+      0x0985,  // Bengali
+  };
+  bool hasNonLatinCoverage = false;
+  for (const uint32_t cp : kNonLatinProbes) {
     if (readerIt->second.hasCodepoint(cp)) {
-      hasCjk = true;
+      hasNonLatinCoverage = true;
       break;
     }
   }
-  if (!hasCjk) {
-    LOG_DBG("SDFS", "%s has no CJK coverage - skipping UI fallback sizes", familyName.c_str());
+  if (!hasNonLatinCoverage) {
+    LOG_DBG("SDFS", "%s has no non-Latin coverage - skipping UI fallback sizes", familyName.c_str());
     return;
   }
 


### PR DESCRIPTION
## Summary

Fixes #3109, fixes #2948. The GUI's SD-card fallback font only triggered for CJK
codepoints, so non-Latin scripts like Armenian stayed unrendered in the
file browser, home screen, and chapter lists — even with a compatible SD
font installed.

Two changes:
- `GfxRenderer::resolveTextFontId()`: redirect condition is now "any
  codepoint above ASCII the primary font can't draw but the fallback can,"
  instead of a CJK-only check. Glyph-driven, no script list to maintain.
- `SdCardFontSystem::setupUiFallbacks()`: there was a second, separate
  CJK-only gate here that skips loading UI fallback sizes at all (to avoid
  wasting RAM on families that'll never be used as fallback). Fixing just
  the first spot wasn't enough — a non-CJK family would still get skipped
  here. Broadened the probe list to cover the other scripts #3109 asks for
  (Greek, Cyrillic, Armenian, Georgian, Hebrew, Arabic, Devanagari,
  Bengali), plus the other non-Latin presets the SD-font converter already
  ships (Ethiopic, Cherokee, Tifinagh, Vietnamese, IPA).

## Scope Check

- [x] Read SCOPE.md / ROADMAP.md
- [x] Not a new theme
- [x] Not a new network connector
- [x] Not an interactive app / writing tool / RSS / media / PDF feature
- [x] Correctness fix extending an existing mechanism, not new functionality
- [x] Doesn't touch freeink-sdk/, lib/hal/, bootloader, OTA, recovery

## Additional Context

Tested by converting Noto Sans Armenian (OFL) into a `.cpfont` with the
repo's own converter, building a small Armenian test EPUB, and checking
the simulator before/after: filename and chapter title rendered blank
before, real Armenian glyphs after. `pio run -e simulator` + `pio check`
both clean, no new cppcheck findings vs. develop.

| Before | After |
|:---:|:---:|
| <img width="360" alt="before_crop" src="https://github.com/user-attachments/assets/ef635ab8-0895-48b2-9f5e-cd42b94fb24a" /> | <img width="360" alt="final_check" src="https://github.com/user-attachments/assets/c3c48639-b683-4138-af5c-d25b61887c3d" /> |

*(The other rows are Chinese-titled test books, blank in both shots — the test used an Armenian-only SD font with no CJK coverage, so that's expected, not a regression.)*

---

### AI Usage

Did you use AI tools to help write this code? **YES**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173bFjcgtBKRwEc8f6qBit5

