### PR TITLE
fix: reclaim S3 RAM by trimming unused TinyUSB drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
       - name: Configure
         run: cmake -S test -B build/test -G Ninja -DCMAKE_BUILD_TYPE=Release
 
+      - name: TinyUSB build tests
+        run: python3 -m unittest discover -s test/tinyusb -v
+
       - name: Build
         run: cmake --build build/test
 

--- a/docs/tinyusb-build.md
+++ b/docs/tinyusb-build.md
@@ -1,0 +1,53 @@
+# TinyUSB device build
+
+The `usb_msc` PlatformIO profile keeps the prebuilt ESP32-S3 SDK, including
+its PSRAM configuration, and replaces only `libarduino_tinyusb.a` with a
+project-local build. X4 Pro, X4 Classic, and Paper Mono inherit this profile.
+C3 and Sticky use their existing SDK builds.
+
+The SDK's default USB driver tables retain host drivers and unused device
+classes even when USB Drive is inactive. With Arduino 3.3.11, the original
+TinyUSB component occupies 30,927 bytes of static DRAM. The device build
+occupies 5,735 bytes: 25,192 fewer bytes of permanent internal-RAM storage.
+These are linker-map measurements, not on-device free-heap measurements.
+
+`scripts/tinyusb/crosspoint_tusb_config.h` includes the SDK configuration
+and disables USB host support and unused device classes. MSC, CDC, endpoint
+sizes, alignment, and FreeRTOS settings come from the SDK. The same header
+is selected through `CFG_TUSB_CONFIG_FILE` when compiling the Arduino core
+and the replacement TinyUSB archive. Normal serial uses the separate USB
+Serial/JTAG peripheral.
+
+PlatformIO installs TinyUSB at the full commit pinned in `platformio.ini`.
+`lib_ignore` prevents automatic library compilation; `scripts/build_tinyusb.py`
+builds only the required sources and replaces every packaged TinyUSB link
+entry. Objects and the archive live under `.pio/build/<environment>/`.
+SCons tracks their source, header, and compiler-command dependencies using
+the existing build cache. A pre-build hook adds the overlay's content hash
+to compiler flags because SCons does not follow macro-based includes; editing
+the overlay invalidates both the core and component objects. These hooks do
+not modify shared SDK files.
+
+The hook checks the SDK's `versions.txt` and stops on an unsupported SDK
+revision. When upgrading Arduino, inspect the new SDK's TinyUSB and
+lib-builder revisions, update the source pin and guard together, and compare
+the upstream configuration and build recipe. Do not bypass the guard or
+link an older TinyUSB archive against newer headers.
+
+Every affected firmware link checks for MSC/CDC symbols and rejects unused
+USB class and host symbols. Host tests run in CI:
+
+```sh
+python3 -m unittest discover -s test/tinyusb -v
+pio run -e x4pro-gh_release
+pio run -e papermono -e x4c -e default
+```
+
+Before release, test on an S3 device:
+
+1. Record total/free internal heap and PSRAM after a fresh boot at Home.
+2. Enter USB Drive; confirm enumeration and read/write a file, checking its hash.
+3. Eject, exit USB Drive, and confirm the reader reboots into normal serial mode.
+4. Confirm SD access and serial screenshots still work after reconnecting.
+
+The fix does not reduce IPC task stacks or alter the SDK's IRAM placement.

--- a/platformio.ini
+++ b/platformio.ini
@@ -125,8 +125,7 @@ lib_ignore =
 
 ; The standard firmware profiles reclaim heap by rebuilding the Arduino core.
 ; USB-OTG (FREEINK_CAP_USB_MSC) profiles like the X4 Pro and Paper Mono
-; intentionally do not inherit this section: they need PioArduino's complete
-; prebuilt TinyUSB component graph, which the custom core rebuild omits.
+; use the prebuilt SDK with a separately rebuilt TinyUSB device component.
 [firmware_tuned]
 ; MEMFIX-PORT: custom_sdkconfig heap reclamation (~32-37 KB). Rebuilds the
 ; Arduino core libs on first build (slower once, cached after; needs the CMake
@@ -235,6 +234,25 @@ build_flags =
   ; serial output is disabled in slim builds to save space
   -UENABLE_SERIAL_LOG
 
+; USB-OTG profiles keep the prebuilt S3 SDK and rebuild only TinyUSB.
+[usb_msc]
+extends = base
+lib_deps =
+  ${base.lib_deps}
+  TinyUSB=https://github.com/hathach/tinyusb.git#53f8c53c2cbd73a91a172f1ae35e9abc00eb5075
+lib_ignore =
+  ${base.lib_ignore}
+  TinyUSB
+extra_scripts =
+  ${base.extra_scripts}
+  pre:scripts/configure_tinyusb.py
+  post:scripts/build_tinyusb.py
+build_flags =
+  ${base.build_flags}
+  -I scripts/tinyusb
+  -DCFG_TUSB_MCU=OPT_MCU_ESP32S3
+  -DCFG_TUSB_CONFIG_FILE=\"crosspoint_tusb_config.h\"
+
 ; --- Seeed Sticky — ESP32-S3R8, 3.97" 800x480 SSD1677 + GT911 touch -----------
 ; Different MCU family than the C3 envs (one binary per family). The SDK
 ; auto-enables CAP_TOUCH (GT911) and the BQ27220 gauge for this device; PSRAM is
@@ -280,15 +298,13 @@ build_flags =
 ; that File Transfer activity, then reboots back to this default on exit.
 ;   pio run -e x4pro -t upload
 [env:x4pro]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
-; Use the prebuilt dio_opi Arduino variant: its TinyUSB component is enabled
-; for CDC and MSC. This profile deliberately extends base rather than
-; firmware_tuned, whose custom SDK rebuild omits that component.
+; Keep the prebuilt dio_opi SDK for PSRAM; usb_msc supplies the device-only TinyUSB component.
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -309,12 +325,12 @@ build_flags =
 ; frontlight flag. See freeink-sdk/docs/xteink-x4c-support.md.
 ;   pio run -e x4c -t upload
 [env:x4c]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_X4CLASSIC=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -328,12 +344,12 @@ build_flags =
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:x4c-gh_release]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_X4CLASSIC=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -345,12 +361,12 @@ build_flags =
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:x4pro-gh_release]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -362,12 +378,12 @@ build_flags =
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:x4pro-gh_release_rc]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_X4PRO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -382,16 +398,15 @@ build_flags =
 ; Power/reset plumbing runs through the M5PM1 PMIC and M5IOE1 expander; the SDK
 ; sequences them itself. Touch, frontlight, RTC, and other capabilities are
 ; selected by the Paper Mono BoardConfig profile.
-; Extends base (not firmware_tuned): USB Drive needs the prebuilt dio_opi
-; Arduino variant, whose TinyUSB component is enabled for CDC and MSC.
+; USB Drive uses the device-only TinyUSB component with the prebuilt dio_opi SDK.
 ;   pio run -e papermono -t upload
 [env:papermono]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_PAPERMONO=1
   -DFREEINK_CAP_USB_MSC=1
   ; The SSD1683 grayscale target planes are batched in PSRAM.
@@ -406,12 +421,12 @@ build_flags =
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:papermono-gh_release]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_PAPERMONO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM
@@ -423,12 +438,12 @@ build_flags =
   -DUSE_BLOCK_DEVICE_INTERFACE=1
 
 [env:papermono-gh_release_rc]
-extends = base
+extends = usb_msc
 board = esp32-s3-devkitc1-n16r8
 board_build.mcu = esp32s3
 board_build.arduino.memory_type = dio_opi
 build_flags =
-  ${base.build_flags}
+  ${usb_msc.build_flags}
   -DFREEINK_DEVICE_PAPERMONO=1
   -DFREEINK_CAP_USB_MSC=1
   -DBOARD_HAS_PSRAM

--- a/scripts/build_tinyusb.py
+++ b/scripts/build_tinyusb.py
@@ -1,0 +1,64 @@
+"""Build the pinned TinyUSB device stack without changing the shared SDK package."""
+
+import importlib.util
+from pathlib import Path
+
+Import("env")  # noqa: F821 -- PlatformIO
+
+TINYUSB_REVISION = "53f8c53c2cbd73a91a172f1ae35e9abc00eb5075"
+
+
+def configure_tinyusb(env):
+    if env.BoardConfig().get("build.mcu") != "esp32s3":
+        raise RuntimeError("The minimal TinyUSB build is only supported on ESP32-S3")
+    if env.GetProjectOption("custom_sdkconfig", "").strip():
+        raise RuntimeError("The minimal TinyUSB build requires the prebuilt S3 SDK")
+
+    sdk = Path(env.PioPlatform().get_package_dir("framework-arduinoespressif32-libs"))
+    versions = (sdk / "versions.txt").read_text(encoding="utf-8").splitlines()
+    if "tinyusb: master " + TINYUSB_REVISION[:9] not in versions or "lib-builder: master ee57070" not in versions:
+        raise RuntimeError("TinyUSB SDK revision changed; update and validate the minimal USB build")
+
+    source = Path(env.subst("$PROJECT_LIBDEPS_DIR")) / env.subst("$PIOENV") / "TinyUSB" / "src"
+    if not (source / "tusb.c").is_file():
+        raise RuntimeError(f"Pinned TinyUSB dependency missing: {source}")
+
+    tinyusb_env = env.Clone()
+    tinyusb_env.Prepend(CPPPATH=[str(source)])
+    tinyusb_env.Append(CCFLAGS=["-Wno-type-limits"])
+    sources = [
+        "tusb.c", "common/tusb_fifo.c", "device/usbd.c",
+        "class/cdc/cdc_device.c", "class/msc/msc_device.c",
+        "portable/synopsys/dwc2/dcd_dwc2.c", "portable/synopsys/dwc2/dwc2_common.c",
+    ]
+    library = tinyusb_env.BuildLibrary(
+        env.subst("$BUILD_DIR") + "/tinyusb-device", str(source),
+        src_filter=["-<*>"] + [f"+<{name}>" for name in sources],
+    )
+    libraries = list(env["LIBS"])
+    if "-larduino_tinyusb" not in libraries:
+        raise RuntimeError("SDK TinyUSB link entry changed; refusing to link mixed USB stacks")
+    env.Replace(LIBS=[library if lib == "-larduino_tinyusb" else lib for lib in libraries])
+
+    checker_path = Path(env.subst("$PROJECT_DIR")) / "scripts" / "check_tinyusb.py"
+    spec = importlib.util.spec_from_file_location("crosspoint_check_tinyusb", checker_path)
+    checker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(checker)
+    compiler = Path(env.WhereIs(env.subst("$CC")))
+    nm = compiler.with_name(compiler.name.replace("gcc", "nm"))
+    if not nm.is_file():
+        raise RuntimeError(f"Missing toolchain symbol reader: {nm}")
+
+    def check_link(source, target, env):
+        checker.check_firmware(nm, target[0].get_abspath())
+        print("TinyUSB link check passed (MSC/CDC only).")
+
+    env.Depends("$BUILD_DIR/${PROGNAME}.elf", str(checker_path))
+    env.AddPostAction(
+        "$BUILD_DIR/${PROGNAME}.elf",
+        env.VerboseAction(check_link, "Checking TinyUSB device-only linkage"),
+    )
+    print("Building pinned TinyUSB with device MSC/CDC only")
+
+
+configure_tinyusb(env)  # noqa: F821

--- a/scripts/check_tinyusb.py
+++ b/scripts/check_tinyusb.py
@@ -1,0 +1,33 @@
+"""Check that a firmware retains USB MSC/CDC without unused TinyUSB RAM."""
+
+import argparse
+import subprocess
+
+
+def check_symbols(symbols):
+    names = {line.split()[-1] for line in symbols.splitlines() if line.split()}
+    required = {"tud_msc_set_sense", "cdcd_init", "_mscd_itf"}
+    forbidden = {
+        "_audiod_fct", "ep_in_sw_buf", "ep_out_sw_buf", "_hidh_itf",
+        "_midi_host", "_usbh_devices", "_dfu_ctx", "_netd_itf",
+        "audiod_init", "hidh_init", "midih_init", "tuh_init", "tuh_rhport_init",
+        "dfu_moded_init", "netd_init", "vendord_init", "videod_init", "hidd_init", "midid_init",
+    }
+    missing = required - names
+    retained = forbidden & names
+    if missing or retained:
+        raise ValueError(f"TinyUSB link check: missing {sorted(missing)}, unwanted {sorted(retained)}")
+
+
+def check_firmware(nm, firmware):
+    result = subprocess.run([str(nm), "--defined-only", str(firmware)], check=True, capture_output=True, text=True)
+    check_symbols(result.stdout)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("firmware")
+    parser.add_argument("--nm", required=True)
+    args = parser.parse_args()
+    check_firmware(args.nm, args.firmware)
+    print("TinyUSB link check passed (MSC/CDC only).")

--- a/scripts/configure_tinyusb.py
+++ b/scripts/configure_tinyusb.py
@@ -1,0 +1,12 @@
+"""Include the USB overlay contents in every affected compiler command's cache key."""
+
+import hashlib
+from pathlib import Path
+
+Import("env")  # noqa: F821 -- PlatformIO
+
+config = Path(env.subst("$PROJECT_DIR")) / "scripts/tinyusb/crosspoint_tusb_config.h"
+# SCons' C scanner does not follow the CFG_TUSB_CONFIG_FILE macro include.
+# Compiler flags reach both the Arduino core and the separately built component.
+digest = hashlib.sha256(config.read_bytes()).hexdigest()
+env.Append(CPPDEFINES=[("CROSSPOINT_TINYUSB_CONFIG_HASH", '"' + digest + '"')])

--- a/scripts/tinyusb/crosspoint_tusb_config.h
+++ b/scripts/tinyusb/crosspoint_tusb_config.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Keep the SDK's OS, endpoint sizes, alignment, MSC and CDC configuration.
+#include <tusb_config.h>
+
+// USB Drive uses device mode; serial normally uses the separate USB Serial/JTAG peripheral.
+#undef CFG_TUH_ENABLED
+#define CFG_TUH_ENABLED 0
+#undef CFG_TUSB_RHPORT1_MODE
+#define CFG_TUSB_RHPORT1_MODE 0
+#undef CFG_TUH_HUB
+#define CFG_TUH_HUB 0
+#undef CFG_TUH_CDC
+#define CFG_TUH_CDC 0
+#undef CFG_TUH_HID
+#define CFG_TUH_HID 0
+#undef CFG_TUH_MSC
+#define CFG_TUH_MSC 0
+#undef CFG_TUH_MIDI
+#define CFG_TUH_MIDI 0
+
+#undef CFG_TUD_HID
+#define CFG_TUD_HID 0
+#undef CFG_TUD_MIDI
+#define CFG_TUD_MIDI 0
+#undef CFG_TUD_AUDIO
+#define CFG_TUD_AUDIO 0
+#undef CFG_TUD_VIDEO
+#define CFG_TUD_VIDEO 0
+#undef CFG_TUD_DFU_RUNTIME
+#define CFG_TUD_DFU_RUNTIME 0
+#undef CFG_TUD_DFU
+#define CFG_TUD_DFU 0
+#undef CFG_TUD_VENDOR
+#define CFG_TUD_VENDOR 0
+#undef CFG_TUD_NCM
+#define CFG_TUD_NCM 0
+#undef CFG_TUD_CUSTOM_CLASS
+#define CFG_TUD_CUSTOM_CLASS 0
+
+#if !CFG_TUD_ENABLED || !CFG_TUD_MSC || !CFG_TUD_CDC
+#error "CrossPoint USB Drive requires TinyUSB device MSC and CDC support"
+#endif

--- a/test/tinyusb/test_tinyusb.py
+++ b/test/tinyusb/test_tinyusb.py
@@ -1,0 +1,81 @@
+"""Host checks for the USB configuration overlay and firmware link guard."""
+
+import importlib.util
+from pathlib import Path
+import runpy
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location("check_tinyusb", ROOT / "scripts/check_tinyusb.py")
+checker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(checker)
+
+
+class TinyUsbTests(unittest.TestCase):
+    def test_overlay_edits_change_the_compiler_cache_key(self):
+        class BuildEnvironment(dict):
+            def subst(self, value):
+                return self["PROJECT_DIR"]
+
+            def Append(self, **values):
+                for key, value in values.items():
+                    self.setdefault(key, []).extend(value)
+
+        with tempfile.TemporaryDirectory() as folder:
+            header = Path(folder) / "scripts/tinyusb/crosspoint_tusb_config.h"
+            header.parent.mkdir(parents=True)
+
+            def compiler_defines(content):
+                header.write_text(content)
+                env = BuildEnvironment(PROJECT_DIR=folder)
+                runpy.run_path(
+                    str(ROOT / "scripts/configure_tinyusb.py"),
+                    init_globals={"env": env, "Import": lambda name: None},
+                )
+                return env["CPPDEFINES"]
+
+            original = compiler_defines("#define CFG_TUH_ENABLED 0\n")
+            self.assertEqual(original, compiler_defines("#define CFG_TUH_ENABLED 0\n"))
+            self.assertNotEqual(original, compiler_defines("#define CFG_TUH_ENABLED 1\n"))
+
+    def test_overlay_keeps_device_sizes_and_removes_other_drivers(self):
+        # Model the SDK's permissive defaults; compile the actual overlay.
+        enabled = (
+            "TUD_ENABLED TUD_MSC TUD_CDC TUH_ENABLED TUSB_RHPORT1_MODE "
+            "TUH_HUB TUH_CDC TUH_HID TUH_MSC TUH_MIDI "
+            "TUD_HID TUD_MIDI TUD_AUDIO TUD_VIDEO TUD_DFU_RUNTIME TUD_DFU "
+            "TUD_VENDOR TUD_NCM TUD_CUSTOM_CLASS"
+        ).split()
+        with tempfile.TemporaryDirectory() as folder:
+            directory = Path(folder)
+            (directory / "tusb_config.h").write_text(
+                "\n".join(f"#define CFG_{name} 1" for name in enabled)
+                + "\n#define CFG_TUD_MSC_BUFSIZE 4096\n#define CFG_TUD_CDC_RX_BUFSIZE 64\n"
+            )
+            source = '#include "crosspoint_tusb_config.h"\n'
+            for name in enabled:
+                expected = 1 if name in {"TUD_ENABLED", "TUD_MSC", "TUD_CDC"} else 0
+                source += f'#if CFG_{name} != {expected}\n#error unexpected {name}\n#endif\n'
+            source += '#if CFG_TUD_MSC_BUFSIZE != 4096 || CFG_TUD_CDC_RX_BUFSIZE != 64\n#error endpoint sizes changed\n#endif\n'
+            result = subprocess.run(
+                ["cc", "-E", "-x", "c", "-I", str(ROOT / "scripts/tinyusb"), "-I", folder, "-"],
+                input=source, capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_link_guard_accepts_msc_cdc(self):
+        checker.check_symbols("4000 T tud_msc_set_sense\n4010 T cdcd_init\n3fc0 b _mscd_itf\n")
+
+    def test_link_guard_rejects_unused_ram(self):
+        with self.assertRaisesRegex(ValueError, "_audiod_fct"):
+            checker.check_symbols("4000 T tud_msc_set_sense\n4010 T cdcd_init\n3fc0 b _mscd_itf\n3fd0 b _audiod_fct\n")
+
+    def test_link_guard_rejects_missing_mass_storage(self):
+        with self.assertRaisesRegex(ValueError, "tud_msc_set_sense"):
+            checker.check_symbols("4010 T cdcd_init\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The Arduino upgrade in #3397 reduced X4 Pro's total internal heap by 12,248 bytes. Most of that change comes from TinyUSB's prebuilt audio and USB host buffers, which remain linked even when USB Drive is inactive. This PR rebuilds only TinyUSB with MSC and CDC device support, removing the unused classes and host stack while keeping Arduino 3.3.11 and the prebuilt S3 SDK.

Related: the [remaining memory regression reported in #3428](https://github.com/crosspoint-reader/crosspoint-reader/issues/3428#issuecomment-5573465523). This addresses the smaller SDK-upgrade regression discussed there; the earlier release-asset PSRAM problem was a separate issue.

**Hardware testing is needed before this is ready to merge. I do not have an X4 Pro, so I cannot validate USB behavior or the resulting free heap on that device.**

## Memory impact

X4 Pro linker-map measurements for the TinyUSB component:

| Configuration | Static DRAM |
|---|---:|
| Standard Arduino 3.3.11 TinyUSB | 30,927 bytes |
| MSC/CDC device build | 5,735 bytes |
| Reduction | **25,192 bytes** |

The reduction comes from removing permanent buffers for audio, HID, MIDI, video, DFU, vendor/network classes, and USB host support. These are static RAM measurements, not measured on-device free-heap gains. IPC task stacks and SDK IRAM placement are unchanged.

## Implementation

- Pin TinyUSB to the exact source revision recorded in the installed SDK. Stop the build if the SDK's TinyUSB or lib-builder revision changes without revalidation.
- Build the replacement archive under the project's build directory and use the same configuration overlay for the Arduino core and TinyUSB. The new hooks do not modify shared SDK files.
- Include the overlay's content hash in compiler flags so cached core and TinyUSB objects are invalidated when it changes.
- Apply the shared profile to X4 Pro, X4 Classic, and Paper Mono, including their release variants. C3 and Sticky retain their existing build paths.
- Check each affected firmware link for required MSC/CDC symbols and unwanted USB classes. Add five Python `unittest` tests for the overlay, cache fingerprint, and link guard, and run them in CI.

## Validation

Local validation passed:

- Firmware builds: `x4pro-gh_release`, `x4c`, `papermono`, and C3 `default`.
- Post-link USB checks for the affected S3 builds.
- All five Python tests and `git diff --check`.
- Compile-command inspection confirms that both the Arduino USB core and TinyUSB receive the same overlay and content hash.
- The X4 Pro ELF retains PSRAM initialization and normal hardware USB serial support.

An X4 Pro owner is needed to check:

- [ ] Total/free internal heap and PSRAM after a fresh boot at Home.
- [ ] USB Drive enumeration and file read/write, with a hash check.
- [ ] Ejecting and exiting USB Drive, reboot, and normal serial reconnect.
- [ ] SD access and serial screenshots after reconnecting.

Build maintenance and testing details are in `docs/tinyusb-build.md`.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is not a new built-in theme.
- [x] This PR is not a new external network connector.
- [x] This PR is not an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.

Stock/fork feature comparison is not applicable: this reduces the RAM cost of CrossPoint's existing USB Drive support. No source changes to `freeink-sdk/`, `lib/hal/`, bootloader, OTA, or recovery code.

### AI Usage

**YES** — AI tools assisted with investigation, implementation, review, and local build validation. Hardware validation remains outstanding.
