### PR TITLE
fix: update OTA to recognize the new format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Artifact names match the release asset names OtaUpdater requests:
-        # plain firmware.bin for the C3 X4/X3 binary, firmware-<board>.bin for
-        # the S3 boards.
+        # Short board-specific names keep pull-request artifacts easy to identify.
+        # The release workflow applies the published crosspoint-<version>-<device>.bin names.
         include:
           - env: default
             asset: firmware.bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,11 @@
 name: Compile Release
 
-# Builds every board's release firmware on tag push, with the .bin named
-# exactly as OtaUpdater requests it from the GitHub release: plain
-# firmware.bin for the C3 X4/X3 binary, firmware-<board>.bin for every other
-# board. Attach the artifacts' .bin files to the release as-is.
+# Build and attach firmware only after a release is published. The release tag
+# supplies both the source revision and the version in each asset name.
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 permissions:
   contents: read
@@ -21,17 +18,26 @@ jobs:
       matrix:
         include:
           - pio_env: gh_release
-            asset: firmware.bin
+            device: x3-x4
           - pio_env: sticky-gh_release
-            asset: firmware-sticky.bin
+            device: sticky
           - pio_env: x4pro-gh_release
-            asset: firmware-x4pro.bin
+            device: x4pro
           - pio_env: papermono-gh_release
-            asset: firmware-papermono.bin
+            device: papermono
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.release.tag_name }}
           submodules: recursive
+
+      - name: Validate release version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          configured_version="$(sed -n 's/^version = //p' platformio.ini | head -n1)"
+          test "$version" = "$configured_version"
 
       - uses: actions/setup-python@v6
         with:
@@ -54,30 +60,50 @@ jobs:
             "cryptography>=45.0.3" "certifi>=2025.8.3" "ecdsa>=0.19.1" "bitstring>=4.3.1" \
             "reedsolo>=1.5.3,<1.8" "esp-idf-size>=2.0.0" "esp-coredump>=1.14.0"
 
-      - name: Cache PlatformIO packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.platformio
-          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
-          restore-keys: pio-${{ runner.os }}-
-
       - name: Build CrossPoint
         run: pio run -e ${{ matrix.pio_env }} -j1
 
-      - name: Name release asset
+      - name: Prepare firmware asset
+        id: asset
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          if [ "${{ matrix.asset }}" != "firmware.bin" ]; then
-            cp ".pio/build/${{ matrix.pio_env }}/firmware.bin" \
-              ".pio/build/${{ matrix.pio_env }}/${{ matrix.asset }}"
-          fi
+          version="${RELEASE_TAG#v}"
+          asset="crosspoint-${version}-${{ matrix.device }}.bin"
+          cp ".pio/build/${{ matrix.pio_env }}/firmware.bin" "$asset"
+          echo "name=$asset" >> "$GITHUB_OUTPUT"
 
-      - name: Upload Artifacts
+      - name: Stage firmware asset
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.asset }}
-          path: |
-            .pio/build/${{ matrix.pio_env }}/bootloader.bin
-            .pio/build/${{ matrix.pio_env }}/${{ matrix.asset }}
-            .pio/build/${{ matrix.pio_env }}/firmware.elf
-            .pio/build/${{ matrix.pio_env }}/firmware.map
-            .pio/build/${{ matrix.pio_env }}/partitions.bin
+          name: ${{ steps.asset.outputs.name }}
+          path: ${{ steps.asset.outputs.name }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish-release:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware assets
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: crosspoint-*.bin
+          merge-multiple: true
+
+      - name: Attach firmware assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${RELEASE_TAG#v}"
+          for device in x3-x4 sticky x4pro papermono; do
+            test -f "dist/crosspoint-${version}-${device}.bin"
+          done
+          test "$(find dist -maxdepth 1 -type f -name 'crosspoint-*.bin' | wc -l)" -eq 4
+          gh release upload "$RELEASE_TAG" dist/crosspoint-*.bin \
+            --repo "$GITHUB_REPOSITORY" --clobber

--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -15,20 +15,13 @@ void safeCopy(char* dst, size_t dstSize, const char* src, size_t srcLen) {
 
 ReleaseJsonParser::ReleaseJsonParser()
     : parser(JsonCallbacks{this, sOnKey, sOnString, sOnNumber, sOnBool, sOnNull, sOnObjectStart, sOnObjectEnd,
-                           sOnArrayStart, sOnArrayEnd}),
-      firmwareAssetSuffixMatch(false) {
+                           sOnArrayStart, sOnArrayEnd}) {
   safeCopy(firmwareAssetName, sizeof(firmwareAssetName), "firmware.bin", sizeof("firmware.bin") - 1);
   reset();
 }
 
 void ReleaseJsonParser::setFirmwareAssetName(const char* name) {
   safeCopy(firmwareAssetName, sizeof(firmwareAssetName), name, strlen(name));
-  firmwareAssetSuffixMatch = false;
-}
-
-void ReleaseJsonParser::setFirmwareAssetSuffix(const char* suffix) {
-  safeCopy(firmwareAssetName, sizeof(firmwareAssetName), suffix, strlen(suffix));
-  firmwareAssetSuffixMatch = true;
 }
 
 void ReleaseJsonParser::reset() {
@@ -56,14 +49,7 @@ const char* ReleaseJsonParser::getFirmwareUrl() const { return firmwareUrl; }
 size_t ReleaseJsonParser::getFirmwareSize() const { return firmwareSize; }
 
 void ReleaseJsonParser::commitAsset() {
-  static constexpr char VERSIONED_PREFIX[] = "crosspoint-";
-  const size_t nameLen = strlen(currentAssetName);
-  const size_t matchLen = strlen(firmwareAssetName);
-  const bool exactMatch = !firmwareAssetSuffixMatch && strcmp(currentAssetName, firmwareAssetName) == 0;
-  const bool suffixMatch = firmwareAssetSuffixMatch && nameLen > sizeof(VERSIONED_PREFIX) - 1 + matchLen &&
-                           memcmp(currentAssetName, VERSIONED_PREFIX, sizeof(VERSIONED_PREFIX) - 1) == 0 &&
-                           memcmp(currentAssetName + nameLen - matchLen, firmwareAssetName, matchLen) == 0;
-  if (exactMatch || suffixMatch) {
+  if (strcmp(currentAssetName, firmwareAssetName) == 0) {
     memcpy(firmwareUrl, currentAssetUrl, sizeof(firmwareUrl));
     firmwareSize = currentAssetSize;
     firmwareFound = true;

--- a/lib/JsonParser/ReleaseJsonParser.cpp
+++ b/lib/JsonParser/ReleaseJsonParser.cpp
@@ -15,13 +15,20 @@ void safeCopy(char* dst, size_t dstSize, const char* src, size_t srcLen) {
 
 ReleaseJsonParser::ReleaseJsonParser()
     : parser(JsonCallbacks{this, sOnKey, sOnString, sOnNumber, sOnBool, sOnNull, sOnObjectStart, sOnObjectEnd,
-                           sOnArrayStart, sOnArrayEnd}) {
+                           sOnArrayStart, sOnArrayEnd}),
+      firmwareAssetSuffixMatch(false) {
   safeCopy(firmwareAssetName, sizeof(firmwareAssetName), "firmware.bin", sizeof("firmware.bin") - 1);
   reset();
 }
 
 void ReleaseJsonParser::setFirmwareAssetName(const char* name) {
   safeCopy(firmwareAssetName, sizeof(firmwareAssetName), name, strlen(name));
+  firmwareAssetSuffixMatch = false;
+}
+
+void ReleaseJsonParser::setFirmwareAssetSuffix(const char* suffix) {
+  safeCopy(firmwareAssetName, sizeof(firmwareAssetName), suffix, strlen(suffix));
+  firmwareAssetSuffixMatch = true;
 }
 
 void ReleaseJsonParser::reset() {
@@ -49,7 +56,14 @@ const char* ReleaseJsonParser::getFirmwareUrl() const { return firmwareUrl; }
 size_t ReleaseJsonParser::getFirmwareSize() const { return firmwareSize; }
 
 void ReleaseJsonParser::commitAsset() {
-  if (strcmp(currentAssetName, firmwareAssetName) == 0) {
+  static constexpr char VERSIONED_PREFIX[] = "crosspoint-";
+  const size_t nameLen = strlen(currentAssetName);
+  const size_t matchLen = strlen(firmwareAssetName);
+  const bool exactMatch = !firmwareAssetSuffixMatch && strcmp(currentAssetName, firmwareAssetName) == 0;
+  const bool suffixMatch = firmwareAssetSuffixMatch && nameLen > sizeof(VERSIONED_PREFIX) - 1 + matchLen &&
+                           memcmp(currentAssetName, VERSIONED_PREFIX, sizeof(VERSIONED_PREFIX) - 1) == 0 &&
+                           memcmp(currentAssetName + nameLen - matchLen, firmwareAssetName, matchLen) == 0;
+  if (exactMatch || suffixMatch) {
     memcpy(firmwareUrl, currentAssetUrl, sizeof(firmwareUrl));
     firmwareSize = currentAssetSize;
     firmwareFound = true;

--- a/lib/JsonParser/ReleaseJsonParser.h
+++ b/lib/JsonParser/ReleaseJsonParser.h
@@ -15,10 +15,10 @@ class ReleaseJsonParser {
   void reset();
   void feed(const char* data, size_t len);
 
-  // Release-asset filename to match (default "firmware.bin"). Boards with
-  // their own release binaries pass e.g. "firmware-papermono.bin". Survives
-  // reset(); truncated silently if longer than the internal buffer.
+  // Exact release-asset filename to match (default "firmware.bin").
   void setFirmwareAssetName(const char* name);
+  // Match crosspoint-<version><suffix>, for example "-x4pro.bin".
+  void setFirmwareAssetSuffix(const char* suffix);
 
   bool foundTag() const;
   bool foundFirmware() const;
@@ -67,9 +67,10 @@ class ReleaseJsonParser {
   bool tagFound;
   bool firmwareFound;
 
-  char currentAssetName[32];
+  char currentAssetName[48];
   char currentAssetUrl[512];
   size_t currentAssetSize;
 
   char firmwareAssetName[32];
+  bool firmwareAssetSuffixMatch;
 };

--- a/lib/JsonParser/ReleaseJsonParser.h
+++ b/lib/JsonParser/ReleaseJsonParser.h
@@ -15,10 +15,8 @@ class ReleaseJsonParser {
   void reset();
   void feed(const char* data, size_t len);
 
-  // Exact release-asset filename to match (default "firmware.bin").
+  // Release-asset filename to match (default "firmware.bin").
   void setFirmwareAssetName(const char* name);
-  // Match crosspoint-<version><suffix>, for example "-x4pro.bin".
-  void setFirmwareAssetSuffix(const char* suffix);
 
   bool foundTag() const;
   bool foundFirmware() const;
@@ -71,6 +69,5 @@ class ReleaseJsonParser {
   char currentAssetUrl[512];
   size_t currentAssetSize;
 
-  char firmwareAssetName[32];
-  bool firmwareAssetSuffixMatch;
+  char firmwareAssetName[48];
 };

--- a/src/network/FirmwareBoardTag.cpp
+++ b/src/network/FirmwareBoardTag.cpp
@@ -6,8 +6,7 @@
 
 // The board name derives from the FREEINK_DEVICE_* build flags so every env
 // (and any fork built from this source) is tagged automatically. The combined
-// X3/X4 ESP32-C3 binary is one compatibility class, tagged "x4". Names match
-// the release asset suffixes (firmware-<name>.bin; plain firmware.bin for x4).
+// X3/X4 ESP32-C3 binary is one compatibility class, tagged "x4".
 #if FREEINK_DEVICE_X4PRO
 #define CROSSPOINT_BOARD_NAME "x4pro"
 #elif FREEINK_DEVICE_X4CLASSIC

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -31,15 +31,15 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   // OOM there aborts. fetchUrl handles the verified-https GET, redirects, and
   // User-Agent (see HttpDownloader).
   ReleaseJsonParser releaseParser;
-  // Each board updates from its own release asset: plain firmware.bin for the
-  // C3 X4/X3 binary (pre-existing releases), firmware-<board>.bin otherwise.
+  // Each board updates from crosspoint-<version>-<device>.bin. The combined
+  // C3 image uses x3-x4; other asset suffixes match their firmware board tag.
   const bool isX4 = board_tag::boardNameLen() == 2 && memcmp(board_tag::boardName(), "x4", 2) == 0;
-  char assetName[48] = "firmware.bin";
+  char assetSuffix[24] = "-x3-x4.bin";
   if (!isX4) {
-    snprintf(assetName, sizeof(assetName), "firmware-%.*s.bin", static_cast<int>(board_tag::boardNameLen()),
+    snprintf(assetSuffix, sizeof(assetSuffix), "-%.*s.bin", static_cast<int>(board_tag::boardNameLen()),
              board_tag::boardName());
   }
-  releaseParser.setFirmwareAssetName(assetName);
+  releaseParser.setFirmwareAssetSuffix(assetSuffix);
   const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&releaseParser](const uint8_t* data, size_t len) {
     releaseParser.feed(reinterpret_cast<const char*>(data), len);
     return true;
@@ -58,7 +58,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   }
 
   if (!releaseParser.foundFirmware()) {
-    LOG_INF("OTA", "No %s asset in latest release", assetName);
+    LOG_INF("OTA", "No crosspoint-<version>%s asset in latest release", assetSuffix);
     return NO_UPDATE;
   }
 

--- a/src/network/OtaUpdater.cpp
+++ b/src/network/OtaUpdater.cpp
@@ -31,17 +31,29 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   // OOM there aborts. fetchUrl handles the verified-https GET, redirects, and
   // User-Agent (see HttpDownloader).
   ReleaseJsonParser releaseParser;
+  releaseParser.setFirmwareAssetName("");
   // Each board updates from crosspoint-<version>-<device>.bin. The combined
   // C3 image uses x3-x4; other asset suffixes match their firmware board tag.
   const bool isX4 = board_tag::boardNameLen() == 2 && memcmp(board_tag::boardName(), "x4", 2) == 0;
-  char assetSuffix[24] = "-x3-x4.bin";
+  char assetSuffix[20] = "-x3-x4";
   if (!isX4) {
-    snprintf(assetSuffix, sizeof(assetSuffix), "-%.*s.bin", static_cast<int>(board_tag::boardNameLen()),
+    snprintf(assetSuffix, sizeof(assetSuffix), "-%.*s", static_cast<int>(board_tag::boardNameLen()),
              board_tag::boardName());
   }
-  releaseParser.setFirmwareAssetSuffix(assetSuffix);
-  const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&releaseParser](const uint8_t* data, size_t len) {
-    releaseParser.feed(reinterpret_cast<const char*>(data), len);
+  char assetName[48] = {};
+  bool assetNameSet = false;
+  const bool ok = HttpDownloader::fetchUrl(latestReleaseUrl, [&](const uint8_t* data, size_t len) {
+    size_t offset = 0;
+    while (!assetNameSet && offset < len) {
+      releaseParser.feed(reinterpret_cast<const char*>(data + offset), 1);
+      offset++;
+      if (releaseParser.foundTag()) {
+        snprintf(assetName, sizeof(assetName), "crosspoint-%s%s.bin", releaseParser.getTagName(), assetSuffix);
+        releaseParser.setFirmwareAssetName(assetName);
+        assetNameSet = true;
+      }
+    }
+    if (offset < len) releaseParser.feed(reinterpret_cast<const char*>(data + offset), len - offset);
     return true;
   });
   if (!ok) {
@@ -58,7 +70,7 @@ OtaUpdater::OtaUpdaterError OtaUpdater::checkForUpdate() {
   }
 
   if (!releaseParser.foundFirmware()) {
-    LOG_INF("OTA", "No crosspoint-<version>%s asset in latest release", assetSuffix);
+    LOG_INF("OTA", "No %s asset in latest release", assetName);
     return NO_UPDATE;
   }
 

--- a/test/release_json_parser/ReleaseJsonParserTest.cpp
+++ b/test/release_json_parser/ReleaseJsonParserTest.cpp
@@ -545,6 +545,36 @@ TEST(ReleaseJsonParser, FirmwareBinExactMatch) {
   EXPECT_EQ(p.getFirmwareSize(), 200u);
 }
 
+TEST(ReleaseJsonParser, VersionedFirmwareSuffixMatch) {
+  const char* json = R"({
+      "tag_name": "1.6.1",
+      "assets": [
+        {"name": "firmware-x4pro.bin", "browser_download_url": "https://legacy", "size": 100},
+        {"name": "crosspoint-1.6.1-sticky.bin", "browser_download_url": "https://sticky", "size": 200},
+        {"name": "crosspoint-1.6.1-x4pro.bin", "browser_download_url": "https://x4pro", "size": 300}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.setFirmwareAssetSuffix("-x4pro.bin");
+  p.feed(json, strlen(json));
+
+  EXPECT_TRUE(p.foundFirmware());
+  EXPECT_STREQ(p.getFirmwareUrl(), "https://x4pro");
+  EXPECT_EQ(p.getFirmwareSize(), 300u);
+}
+
+TEST(ReleaseJsonParser, VersionedFirmwareRejectsLegacyName) {
+  const char* json =
+      R"({"tag_name":"1.6.1","assets":[{"name":"firmware-x4pro.bin","browser_download_url":"https://legacy","size":100}]})";
+
+  ReleaseJsonParser p;
+  p.setFirmwareAssetSuffix("-x4pro.bin");
+  p.feed(json, strlen(json));
+
+  EXPECT_FALSE(p.foundFirmware());
+}
+
 TEST(ReleaseJsonParser, LargeSize) {
   // 16MB firmware (maximum flash size)
   const char* json =

--- a/test/release_json_parser/ReleaseJsonParserTest.cpp
+++ b/test/release_json_parser/ReleaseJsonParserTest.cpp
@@ -545,7 +545,7 @@ TEST(ReleaseJsonParser, FirmwareBinExactMatch) {
   EXPECT_EQ(p.getFirmwareSize(), 200u);
 }
 
-TEST(ReleaseJsonParser, VersionedFirmwareSuffixMatch) {
+TEST(ReleaseJsonParser, ConfiguredFirmwareNameMatch) {
   const char* json = R"({
       "tag_name": "1.6.1",
       "assets": [
@@ -556,7 +556,7 @@ TEST(ReleaseJsonParser, VersionedFirmwareSuffixMatch) {
     })";
 
   ReleaseJsonParser p;
-  p.setFirmwareAssetSuffix("-x4pro.bin");
+  p.setFirmwareAssetName("crosspoint-1.6.1-x4pro.bin");
   p.feed(json, strlen(json));
 
   EXPECT_TRUE(p.foundFirmware());
@@ -564,12 +564,34 @@ TEST(ReleaseJsonParser, VersionedFirmwareSuffixMatch) {
   EXPECT_EQ(p.getFirmwareSize(), 300u);
 }
 
-TEST(ReleaseJsonParser, VersionedFirmwareRejectsLegacyName) {
-  const char* json =
-      R"({"tag_name":"1.6.1","assets":[{"name":"firmware-x4pro.bin","browser_download_url":"https://legacy","size":100}]})";
+TEST(ReleaseJsonParser, ConfiguredFirmwareNameIsNotOverwrittenBySameSuffix) {
+  const char* json = R"({
+      "tag_name": "1.6.1",
+      "assets": [
+        {"name": "crosspoint-1.6.1-x4pro.bin", "browser_download_url": "https://correct", "size": 100},
+        {"name": "crosspoint-1.6.0-x4pro.bin", "browser_download_url": "https://stale", "size": 200}
+      ]
+    })";
 
   ReleaseJsonParser p;
-  p.setFirmwareAssetSuffix("-x4pro.bin");
+  p.setFirmwareAssetName("crosspoint-1.6.1-x4pro.bin");
+  p.feed(json, strlen(json));
+
+  EXPECT_TRUE(p.foundFirmware());
+  EXPECT_STREQ(p.getFirmwareUrl(), "https://correct");
+  EXPECT_EQ(p.getFirmwareSize(), 100u);
+}
+
+TEST(ReleaseJsonParser, ConfiguredFirmwareNameRejectsDifferentVersion) {
+  const char* json = R"({
+      "tag_name": "1.6.1",
+      "assets": [
+        {"name": "crosspoint-1.6.0-x4pro.bin", "browser_download_url": "https://stale", "size": 200}
+      ]
+    })";
+
+  ReleaseJsonParser p;
+  p.setFirmwareAssetName("crosspoint-1.6.1-x4pro.bin");
   p.feed(json, strlen(json));
 
   EXPECT_FALSE(p.foundFirmware());


### PR DESCRIPTION
# Summary

Two things bundled together:
- Update firmware OTA to recognize the new assets naming `crosspoint-tag-device`.
- Attach binaries when new release is out automatically. Example: https://github.com/Uri-Tauber/crosspoint-reader-fork/releases/tag/1.6.0 