### PR TITLE
fix(reader): preserve reading progress after in-book link jumps

### DIFF
--- a/src/activities/reader/EpubReaderActivity.cpp
+++ b/src/activities/reader/EpubReaderActivity.cpp
@@ -155,8 +155,18 @@ EpubReaderActivity::~EpubReaderActivity() {
   discardOverlayPage();  // free the overlay's page snapshot if one is held
 
   if (footnoteDepth > 0 && epub) {
-    const SavedPosition& origin = savedPositions[0];
-    saveProgress(origin.spineIndex, origin.pageNumber, 0);
+    // Exiting mid-footnote must not leave progress on the footnote text:
+    // resume at the origin of the footnote excursion, its lowest stack entry.
+    // Link jumps are reading navigation, not excursions — per-render saves
+    // already hold the current page, so restoring a pre-link origin would
+    // silently discard everything read since the jump.
+    for (int i = 0; i < footnoteDepth; i++) {
+      if (savedPositions[i].isFootnote) {
+        const SavedPosition& origin = savedPositions[i];
+        saveProgress(origin.spineIndex, origin.pageNumber, 0);
+        break;
+      }
+    }
   }
 
   section.reset();
@@ -555,7 +565,7 @@ void EpubReaderActivity::loop() {
       const auto* link = EpubReaderUtils::linkAtPoint(currentPageLinks, touchX, touchY, currentPageLinkMarginLeft,
                                                       currentPageLinkMarginTop);
       if (link) {
-        navigateToHref(link->href, true);
+        navigateToHref(link->href, true, false);
         return;
       }
     }
@@ -2455,11 +2465,12 @@ void EpubReaderActivity::activateMoreRow(int row) {
   if (action != MA::GO_HOME && action != MA::DELETE_CACHE) requestUpdate();
 }
 
-void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool savePosition) {
+void EpubReaderActivity::navigateToHref(const std::string& hrefStr, const bool savePosition,
+                                        const bool isFootnoteJump) {
   if (!epub) return;
 
   if (savePosition && section && footnoteDepth < MAX_FOOTNOTE_DEPTH) {
-    savedPositions[footnoteDepth] = {currentSpineIndex, section->currentPage};
+    savedPositions[footnoteDepth] = {currentSpineIndex, section->currentPage, isFootnoteJump};
     footnoteDepth++;
     LOG_DBG("ERS", "Saved position [%d]: spine %d, page %d", footnoteDepth, currentSpineIndex, section->currentPage);
   }

--- a/src/activities/reader/EpubReaderActivity.h
+++ b/src/activities/reader/EpubReaderActivity.h
@@ -93,6 +93,9 @@ class EpubReaderActivity final : public ReaderActivity {
   struct SavedPosition {
     int spineIndex;
     int pageNumber;
+    // Footnote entries mark an excursion whose origin is the reading position
+    // to restore on exit; link entries only record a Back target.
+    bool isFootnote = false;
   };
   static constexpr int MAX_FOOTNOTE_DEPTH = 3;
   SavedPosition savedPositions[MAX_FOOTNOTE_DEPTH] = {};
@@ -162,7 +165,10 @@ class EpubReaderActivity final : public ReaderActivity {
   void addBookmark();
   void updateBookmarkFlag();
 
-  void navigateToHref(const std::string& href, bool savePosition = false);
+  // Footnote jumps restore their saved origin when the reader exits; link jumps
+  // are reading navigation and exit on the per-render saved progress. Defaults
+  // to footnote semantics for callers that don't specify.
+  void navigateToHref(const std::string& href, bool savePosition = false, bool isFootnoteJump = true);
   void restoreSavedPosition();
 
   void renderContents(std::unique_ptr<Page> page, int orientedMarginTop, int orientedMarginRight,


### PR DESCRIPTION
## Summary

**Problem.** Reading progress is silently destroyed when the reader is exited after navigating with an in-book link. Reproduced repeatedly on an X4 Pro running v1.6.0: tap a "Begin Reading" or mini-TOC link, read several chapters, exit via menu → Home (or long-press Back) — the book reopens at the pre-jump front matter. Forensic evidence from the on-device cache: `progress.bin` held spine 3 (the pre-jump mini-TOC page) while the section caches showed chapters read well past it.

**Root cause.** Three anchors in `src/activities/reader/EpubReaderActivity.cpp`:

1. `navigateToHref(href, savePosition)` pushes `{spineIndex, page}` onto `savedPositions` for every position-saving jump — footnotes and in-book links share one stack, with no distinction between them.
2. Progress is saved after every rendered page (the per-render autosave in the reader's update path), so `progress.bin` always reflects the page currently on screen.
3. `~EpubReaderActivity()` unconditionally runs `saveProgress(savedPositions[0], ...)` whenever `footnoteDepth > 0`, overwriting that autosave with the page recorded *before the first jump*.

The destructor restore is intentional design for footnote chains: the footnote text is not the reading position, and while a footnote page is on screen the autosave points at footnote pages — so the excursion's origin must be written back over it. Link navigation breaks that invariant from the other side: a link target *is* a reading position. After a TOC/"Begin Reading" jump the autosave already holds the truth, so the origin-restore becomes a destructive overwrite of everything read since the jump.

**Fix.** `SavedPosition` now records `isFootnote`, threaded through `navigateToHref` as an `isFootnoteJump` parameter (default `true`, so unspecified callers keep footnote semantics). The tap-link call site passes `false`; the three footnote call sites (short-power footnote toggle and the footnote picker) keep the default. On exit, the destructor restores only the origin of a footnote excursion — the lowest footnote entry remaining on the stack. If the stack holds only link entries, the destructor does not touch progress at all.

**Behavior after fix**

| Exit state | Stack (bottom→top) | Before | After |
| --- | --- | --- | --- |
| While reading a footnote | `[F]`, `[F, F]` | restore `savedPositions[0]` | unchanged — restore the excursion origin (lowest `F`) |
| After link jump(s) | `[L]`, `[L, L]` | progress rewritten to pre-link page (the bug) | **no** destructor save; per-render autosave stands |
| Footnote opened from a link target | `[L, F]` | progress rewritten to the *pre-link* page (same bug via mixed stack) | restore the `F` origin = the link-target page where the footnote was opened |
| Link followed from inside a footnote | `[F, L]`, `[F, L, F]` | restore `savedPositions[0]` | unchanged — still inside one excursion from `F`'s origin |
| Short Back-press with depth > 0 | any | `restoreSavedPosition()` pops one entry and returns to its origin | unchanged for both jump kinds |
| Stack already at `MAX_FOOTNOTE_DEPTH` | `[F, F, F]` | `navigateToHref` navigates without pushing | unchanged; the exit scan only consults entries actually pushed |
| `navigateToHref` fails to resolve the href | push then rollback | `footnoteDepth--` rolls the push back | unchanged |
| Exit with empty stack | `[]` | no restore, autosave stands | unchanged |

**Testing.** The bug was root-caused and reproduced on-device (X4 Pro, v1.6.0) before this change, including reading the stale `progress.bin` and the section caches directly from the SD card. The fix itself is compile-reviewed only — no PlatformIO toolchain or hardware was available to build and test it. There is no host-side harness for `EpubReaderActivity` (`test/` covers parsers and layout primitives; the activity's input/render loop is not host-testable as-is), so the behavior matrix above is desk-checked. CI's build check is the compile gate.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/develop/SCOPE.md) and [ROADMAP.md](../blob/develop/ROADMAP.md).

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below). This is a progress-persistence bug in the
      stock reader itself.
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer. (Not applicable — reader activity only.)

## Additional Context

* Memory/flash impact: `SavedPosition` grows from 8 to 12 bytes (padding), i.e. +12 bytes in the heap-allocated
  `EpubReaderActivity` object (`savedPositions[MAX_FOOTNOTE_DEPTH]`). No dynamic allocation, no flash growth.
* On-device verification steps for a reviewer with hardware: open a book with a "Begin Reading"/TOC link, follow it,
  read past several chapters, exit to Home, reopen — progress should now resume at the last page read (it previously
  reopened at the pre-link page). Exit while a footnote page is on screen — progress should still resume at the page
  the footnote was opened from.

### AI Usage

Did you use AI tools to help write this code? **YES** (on-device debugging and root-cause analysis were done by hand;
the patch, PR description, and behavior-matrix enumeration were AI-assisted.)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
