### PR TITLE
fix: hide status bar clock when RTC time is invalid

### DIFF
--- a/lib/hal/HalClock.cpp
+++ b/lib/hal/HalClock.cpp
@@ -16,7 +16,7 @@ bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
   if (!_available) return false;
 
   const unsigned long now = millis();
-  const bool firstPoll = _lastPollMs == 0;
+  const bool firstPoll = !_hasPolled;
   if (firstPoll || (now - _lastPollMs) >= CLOCK_POLL_MS) {
     Rtc::DateTime dt;
     const bool valid = _sdkRtc.now(dt) && dt.year >= MIN_VALID_YEAR;
@@ -29,6 +29,7 @@ bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
     }
     _cachedTimeValid = valid;
     _lastPollMs = now;
+    _hasPolled = true;
   }
 
   if (!_cachedTimeValid) return false;
@@ -92,7 +93,7 @@ bool HalClock::syncFromNTP() {
       dt.second = static_cast<uint8_t>(timeinfo.tm_sec);
       dt.weekday = static_cast<uint8_t>(timeinfo.tm_wday);
       if (_sdkRtc.set(dt)) {
-        _lastPollMs = 0;
+        _hasPolled = false;
         _cachedHour = dt.hour;
         _cachedMinute = dt.minute;
         _cachedTimeValid = true;

--- a/lib/hal/HalClock.cpp
+++ b/lib/hal/HalClock.cpp
@@ -16,24 +16,22 @@ bool HalClock::getTime(uint8_t& hour, uint8_t& minute) const {
   if (!_available) return false;
 
   const unsigned long now = millis();
-  if (_lastPollMs != 0 && (now - _lastPollMs) < CLOCK_POLL_MS) {
-    hour = _cachedHour;
-    minute = _cachedMinute;
-    return true;
+  const bool firstPoll = _lastPollMs == 0;
+  if (firstPoll || (now - _lastPollMs) >= CLOCK_POLL_MS) {
+    Rtc::DateTime dt;
+    const bool valid = _sdkRtc.now(dt) && dt.year >= MIN_VALID_YEAR;
+    if (!valid && (firstPoll || _cachedTimeValid)) {
+      LOG_ERR("CLK", "RTC time unreadable or not set, hiding clock");
+    }
+    if (valid) {
+      _cachedHour = dt.hour;
+      _cachedMinute = dt.minute;
+    }
+    _cachedTimeValid = valid;
+    _lastPollMs = now;
   }
 
-  Rtc::DateTime dt;
-  if (!_sdkRtc.now(dt)) {
-    if (!_hasCachedTime) return false;
-    _lastPollMs = now;
-    hour = _cachedHour;
-    minute = _cachedMinute;
-    return true;
-  }
-  _cachedHour = dt.hour;
-  _cachedMinute = dt.minute;
-  _lastPollMs = now;
-  _hasCachedTime = true;
+  if (!_cachedTimeValid) return false;
   hour = _cachedHour;
   minute = _cachedMinute;
   return true;
@@ -97,7 +95,7 @@ bool HalClock::syncFromNTP() {
         _lastPollMs = 0;
         _cachedHour = dt.hour;
         _cachedMinute = dt.minute;
-        _hasCachedTime = true;
+        _cachedTimeValid = true;
         LOG_INF("CLK", "RTC set to %04u-%02u-%02u %02u:%02u:%02u UTC", dt.year, dt.month, dt.day, dt.hour, dt.minute,
                 dt.second);
         return true;

--- a/lib/hal/HalClock.h
+++ b/lib/hal/HalClock.h
@@ -11,10 +11,12 @@ class HalClock {
   mutable Rtc _sdkRtc;
   mutable uint8_t _cachedHour = 0;
   mutable uint8_t _cachedMinute = 0;
-  mutable bool _hasCachedTime = false;
+  mutable bool _cachedTimeValid = false;
   mutable unsigned long _lastPollMs = 0;
 
   static constexpr unsigned long CLOCK_POLL_MS = 10000;  // 10 seconds
+  // Zeroed time registers decode as year 2000 (or 1900); any time set from NTP is later than this.
+  static constexpr uint16_t MIN_VALID_YEAR = 2024;
 
  public:
   // Call after BoardConfig has selected the active device.
@@ -24,14 +26,14 @@ class HalClock {
   bool isAvailable() const { return _available; }
 
   // Get current hour (0-23) and minute (0-59).
-  // Returns false if RTC is not available.
+  // Returns false if RTC is not available, or its time is unreadable or was never set.
   bool getTime(uint8_t& hour, uint8_t& minute) const;
 
   // Format time into a caller-provided buffer.
   // 24h mode produces "HH:MM" (needs >=6 bytes); 12h mode produces "H:MM AM"/"HH:MM PM" (needs >=9 bytes).
   // utcOffsetQuarterHoursBiased: biased quarter-hour offset (48 = UTC+0, 0 = UTC-12, 104 = UTC+14).
   // use12Hour: when true, format as 12-hour clock with AM/PM suffix.
-  // Returns false if RTC is not available.
+  // Returns false if RTC is not available, or its time is unreadable or was never set.
   bool formatTime(char* buf, size_t bufSize, uint8_t utcOffsetQuarterHoursBiased = 48, bool use12Hour = false) const;
 
   // Sync the RTC from an NTP server. Requires WiFi to be connected.

--- a/lib/hal/HalClock.h
+++ b/lib/hal/HalClock.h
@@ -12,6 +12,7 @@ class HalClock {
   mutable uint8_t _cachedHour = 0;
   mutable uint8_t _cachedMinute = 0;
   mutable bool _cachedTimeValid = false;
+  mutable bool _hasPolled = false;
   mutable unsigned long _lastPollMs = 0;
 
   static constexpr unsigned long CLOCK_POLL_MS = 10000;  // 10 seconds

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,5 +60,6 @@ add_subdirectory(chapter_position)
 
 add_subdirectory(inflate_stream)
 add_subdirectory(fs_helpers)
+add_subdirectory(hal_clock)
 
 add_subdirectory(absolute_grayscale)

--- a/test/hal_clock/CMakeLists.txt
+++ b/test/hal_clock/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(HalClockTest
+  HalClockTest.cpp
+  ${REPO_ROOT}/lib/hal/HalClock.cpp
+)
+target_include_directories(HalClockTest PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+  ${REPO_ROOT}/lib/hal
+)
+target_link_libraries(HalClockTest PRIVATE crosspoint_test_common GTest::gtest_main)
+gtest_discover_tests(HalClockTest)

--- a/test/hal_clock/HalClockTest.cpp
+++ b/test/hal_clock/HalClockTest.cpp
@@ -1,0 +1,90 @@
+#include <HalClock.h>
+#include <gtest/gtest.h>
+
+namespace {
+
+constexpr unsigned long POLL_INTERVAL_MS = 10000;
+
+Rtc::DateTime timeOfDay(uint8_t hour, uint8_t minute) {
+  Rtc::DateTime dt;
+  dt.year = 2026;
+  dt.month = 9;
+  dt.day = 11;
+  dt.hour = hour;
+  dt.minute = minute;
+  return dt;
+}
+
+class HalClockTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    fakeRtc = FakeRtc{};
+    fakeMillis = 1000;
+    testClock.begin();
+  }
+
+  void advance(unsigned long ms) { fakeMillis += ms; }
+
+  HalClock testClock;
+  uint8_t hour = 0;
+  uint8_t minute = 0;
+};
+
+}  // namespace
+
+TEST_F(HalClockTest, ReturnsTimeReadFromRtc) {
+  fakeRtc.time = timeOfDay(14, 5);
+
+  ASSERT_TRUE(testClock.getTime(hour, minute));
+  EXPECT_EQ(hour, 14);
+  EXPECT_EQ(minute, 5);
+}
+
+TEST_F(HalClockTest, HidesTimeWhenRtcBecomesUnreadable) {
+  fakeRtc.time = timeOfDay(14, 5);
+  ASSERT_TRUE(testClock.getTime(hour, minute));
+
+  fakeRtc.readSucceeds = false;
+  advance(POLL_INTERVAL_MS);
+
+  EXPECT_FALSE(testClock.getTime(hour, minute));
+}
+
+TEST_F(HalClockTest, HidesTimeWhenRtcRegistersAreZeroed) {
+  fakeRtc.time = Rtc::DateTime{};
+
+  EXPECT_FALSE(testClock.getTime(hour, minute));
+}
+
+TEST_F(HalClockTest, ShowsTimeAgainOnceRtcIsReadable) {
+  fakeRtc.readSucceeds = false;
+  ASSERT_FALSE(testClock.getTime(hour, minute));
+
+  fakeRtc.readSucceeds = true;
+  fakeRtc.time = timeOfDay(9, 30);
+  advance(POLL_INTERVAL_MS);
+
+  ASSERT_TRUE(testClock.getTime(hour, minute));
+  EXPECT_EQ(hour, 9);
+  EXPECT_EQ(minute, 30);
+}
+
+TEST_F(HalClockTest, ReadsRtcAtMostOncePerPollInterval) {
+  fakeRtc.time = timeOfDay(14, 5);
+  testClock.getTime(hour, minute);
+
+  advance(POLL_INTERVAL_MS - 1);
+  testClock.getTime(hour, minute);
+  EXPECT_EQ(fakeRtc.readCount, 1);
+
+  advance(1);
+  testClock.getTime(hour, minute);
+  EXPECT_EQ(fakeRtc.readCount, 2);
+}
+
+TEST_F(HalClockTest, FormatTimeFailsWhenRtcTimeIsInvalid) {
+  fakeRtc.readSucceeds = false;
+  char buf[9];
+
+  EXPECT_FALSE(testClock.formatTime(buf, sizeof(buf)));
+}

--- a/test/hal_clock/HalClockTest.cpp
+++ b/test/hal_clock/HalClockTest.cpp
@@ -82,6 +82,16 @@ TEST_F(HalClockTest, ReadsRtcAtMostOncePerPollInterval) {
   EXPECT_EQ(fakeRtc.readCount, 2);
 }
 
+TEST_F(HalClockTest, ThrottlesRtcReadsWhenFirstPollIsAtMillisZero) {
+  fakeRtc.time = timeOfDay(14, 5);
+  fakeMillis = 0;
+
+  testClock.getTime(hour, minute);
+  testClock.getTime(hour, minute);
+
+  EXPECT_EQ(fakeRtc.readCount, 1);
+}
+
 TEST_F(HalClockTest, FormatTimeFailsWhenRtcTimeIsInvalid) {
   fakeRtc.readSucceeds = false;
   char buf[9];

--- a/test/hal_clock/stubs/Arduino.h
+++ b/test/hal_clock/stubs/Arduino.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+
+inline unsigned long fakeMillis = 0;
+inline unsigned long millis() { return fakeMillis; }
+inline void delay(unsigned long) {}
+inline void configTzTime(const char*, const char*, const char*) {}

--- a/test/hal_clock/stubs/Logging.h
+++ b/test/hal_clock/stubs/Logging.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace logging_stub {
+inline void sink(const char*, ...) {}
+}  // namespace logging_stub
+
+#define LOG_ERR(origin, format, ...) logging_stub::sink(origin, format __VA_OPT__(, ) __VA_ARGS__)
+#define LOG_INF(origin, format, ...) logging_stub::sink(origin, format __VA_OPT__(, ) __VA_ARGS__)

--- a/test/hal_clock/stubs/Rtc.h
+++ b/test/hal_clock/stubs/Rtc.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+class Rtc {
+ public:
+  struct DateTime {
+    uint16_t year = 2000;
+    uint8_t month = 1;
+    uint8_t day = 1;
+    uint8_t hour = 0;
+    uint8_t minute = 0;
+    uint8_t second = 0;
+    uint8_t weekday = 0;
+  };
+
+  bool begin() { return true; }
+  bool now(DateTime& out);
+  bool set(const DateTime& dt);
+};
+
+struct FakeRtc {
+  bool readSucceeds = true;
+  Rtc::DateTime time;
+  int readCount = 0;
+};
+
+inline FakeRtc fakeRtc;
+
+inline bool Rtc::now(DateTime& out) {
+  ++fakeRtc.readCount;
+  if (!fakeRtc.readSucceeds) return false;
+  out = fakeRtc.time;
+  return true;
+}
+
+inline bool Rtc::set(const DateTime& dt) {
+  fakeRtc.time = dt;
+  return true;
+}

--- a/test/hal_clock/stubs/WiFi.h
+++ b/test/hal_clock/stubs/WiFi.h
@@ -1,0 +1,9 @@
+#pragma once
+
+constexpr int WL_CONNECTED = 3;
+
+struct WiFiHostStub {
+  int status() const { return 0; }
+};
+
+inline WiFiHostStub WiFi;

--- a/test/hal_clock/stubs/esp_sntp.h
+++ b/test/hal_clock/stubs/esp_sntp.h
@@ -1,0 +1,4 @@
+#pragma once
+
+constexpr int SNTP_SYNC_STATUS_COMPLETED = 1;
+inline int sntp_get_sync_status() { return 0; }


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?** Stop the status bar from showing a frozen time when the RTC can't provide a valid one. Refs #3201.
* **What changes are included?**
  * `HalClock::getTime()` no longer falls back to the last cached time when the RTC read fails. It returns `false`, and the status bar omits the clock (all `formatTime()` callers already handle `false`).
  * A read with a year before 2024 is treated as invalid. Zeroed RTC registers decode as 2000-01-01 00:00, which at UTC−7 renders as the 5:00 PM in the report.
  * One `LOG_ERR` on the first poll and when the time goes from valid to invalid, so a boot log shows the condition.
  * Host unit tests for `HalClock` in `test/hal_clock`, with stubs for the RTC and `millis()`. `HidesTimeWhenRtcBecomesUnreadable` and `HidesTimeWhenRtcRegistersAreZeroed` fail on current `develop`.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

## Additional Context

* No new allocations; memory impact is one `constexpr` and a renamed `bool` member.
* Local checks: `pio run -e default`, `pio check`, and host tests (`ctest`, 225/225) pass.
* Not tested on hardware: I don't have a device with an RTC. Anyone with an X3 (or another board with an RTC) can use the firmware from the CI links on this PR:
  1. After a clock sync, the status bar clock advances across page turns.
  2. If the RTC loses its time, after a reboot the clock is hidden and `RTC time unreadable or not set, hiding clock` appears on serial.
  3. "Sync clock now" brings the clock back.

---

### AI Usage

Did you use AI tools to help write this code? _**YES**_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEFsndGuSjvuyFMFP59SZF
