### PR TITLE
fix: number ordered lists and fix list container indents

### DIFF
--- a/docs/file-formats.md
+++ b/docs/file-formats.md
@@ -90,6 +90,14 @@ if (parsedSize != fileSize) {
 
 ## `section.bin`
 
+### Version 46
+
+Version 46 keeps the version 45 serialized layout unchanged. It was bumped
+because ordered lists now number their items, `list-style-type: none`
+suppresses list markers, and `<ul>`/`<ol>` containers contribute their own
+margins and padding to child block insets, changing cached word contents and
+page layout.
+
 ### Version 45
 
 Version 45 keeps the version 44 serialized layout unchanged. It was bumped

--- a/lib/Epub/Epub/Section.cpp
+++ b/lib/Epub/Epub/Section.cpp
@@ -47,7 +47,9 @@ namespace {
 // v43: Paragraph base direction excludes direction changes from inline elements.
 // v44: Persist internal-link rectangles with each page for touch navigation.
 // v45: Internal EPUB links preserve CSS superscript/subscript positioning.
-constexpr uint8_t SECTION_FILE_VERSION = 45;
+// v46: Ordered lists number their items, list-style-type: none suppresses markers,
+//      and <ul>/<ol> containers contribute their own margins/padding to child insets.
+constexpr uint8_t SECTION_FILE_VERSION = 46;
 // Written into the version field while a build is in progress; patched to
 // SECTION_FILE_VERSION only when the build is finalized. An abandoned /
 // crash-interrupted .bin therefore carries version 0, which loadSectionFile rejects

--- a/lib/Epub/Epub/css/CssParser.cpp
+++ b/lib/Epub/Epub/css/CssParser.cpp
@@ -144,8 +144,8 @@ constexpr std::array STYLE_LENGTH_FIELDS = {
 };
 constexpr size_t STYLE_LENGTH_FIELD_COUNT = STYLE_LENGTH_FIELDS.size();
 constexpr size_t STYLE_WIRE_BYTES =
-    5 + STYLE_LENGTH_FIELD_COUNT * (sizeof(decltype(CssLength::value)) + 1) + 2 + sizeof(uint32_t);
-constexpr uint32_t CSS_DEFINED_BITS_MASK = (1u << 18) - 1;
+    5 + STYLE_LENGTH_FIELD_COUNT * (sizeof(decltype(CssLength::value)) + 1) + 3 + sizeof(uint32_t);
+constexpr uint32_t CSS_DEFINED_BITS_MASK = (1u << 19) - 1;
 
 void encodeStyleWire(const CssStyle& style, uint8_t (&out)[STYLE_WIRE_BYTES]) {
   size_t offset = 0;
@@ -165,6 +165,7 @@ void encodeStyleWire(const CssStyle& style, uint8_t (&out)[STYLE_WIRE_BYTES]) {
   }
   out[offset++] = static_cast<uint8_t>(style.display);
   out[offset++] = static_cast<uint8_t>(style.verticalAlign);
+  out[offset++] = static_cast<uint8_t>(style.listStyleType);
 
   uint32_t definedBits = 0;
   if (style.defined.textAlign) definedBits |= 1 << 0;
@@ -185,6 +186,7 @@ void encodeStyleWire(const CssStyle& style, uint8_t (&out)[STYLE_WIRE_BYTES]) {
   if (style.defined.display) definedBits |= 1 << 15;
   if (style.defined.direction) definedBits |= 1 << 16;
   if (style.defined.verticalAlign) definedBits |= 1 << 17;
+  if (style.defined.listStyleType) definedBits |= 1 << 18;
   memcpy(out + offset, &definedBits, sizeof(definedBits));
 }
 
@@ -222,11 +224,14 @@ bool decodeStyleWire(const uint8_t (&in)[STYLE_WIRE_BYTES], CssStyle& style) {
 
   const uint8_t display = in[offset++];
   const uint8_t verticalAlign = in[offset++];
-  if (display > static_cast<uint8_t>(CssDisplay::None) || verticalAlign > static_cast<uint8_t>(CssVerticalAlign::Sub)) {
+  const uint8_t listStyleType = in[offset++];
+  if (display > static_cast<uint8_t>(CssDisplay::None) || verticalAlign > static_cast<uint8_t>(CssVerticalAlign::Sub) ||
+      listStyleType > static_cast<uint8_t>(CssListStyleType::None)) {
     return false;
   }
   style.display = static_cast<CssDisplay>(display);
   style.verticalAlign = static_cast<CssVerticalAlign>(verticalAlign);
+  style.listStyleType = static_cast<CssListStyleType>(listStyleType);
 
   uint32_t definedBits = 0;
   memcpy(&definedBits, in + offset, sizeof(definedBits));
@@ -249,6 +254,7 @@ bool decodeStyleWire(const uint8_t (&in)[STYLE_WIRE_BYTES], CssStyle& style) {
   style.defined.display = (definedBits & 1 << 15) != 0;
   style.defined.direction = (definedBits & 1 << 16) != 0;
   style.defined.verticalAlign = (definedBits & 1 << 17) != 0;
+  style.defined.listStyleType = (definedBits & 1 << 18) != 0;
   return true;
 }
 
@@ -628,6 +634,10 @@ void CssParser::parseDeclarationIntoStyle(std::string_view decl, CssStyle& style
       style.verticalAlign = CssVerticalAlign::Sub;
       style.defined.verticalAlign = 1;
     }
+  } else if (iequalsAscii(name, "list-style-type")) {
+    const std::string_view listStyleValue = stripTrailingImportant(value);
+    style.listStyleType = iequalsAscii(listStyleValue, "none") ? CssListStyleType::None : CssListStyleType::Disc;
+    style.defined.listStyleType = 1;
   }
 }
 

--- a/lib/Epub/Epub/css/CssStyle.h
+++ b/lib/Epub/Epub/css/CssStyle.h
@@ -72,6 +72,9 @@ enum class CssDisplay : uint8_t { Block = 0, None = 1 };
 // Vertical alignment options for inline elements (e.g. superscript/subscript)
 enum class CssVerticalAlign : uint8_t { Baseline = 0, Super = 1, Sub = 2 };
 
+// list-style-type — only None and Disc (bullet) are relevant for rendering
+enum class CssListStyleType : uint8_t { Disc = 0, None = 1 };
+
 // Bitmask for tracking which properties have been explicitly set
 struct CssPropertyFlags {
   uint16_t textAlign : 1;
@@ -92,6 +95,7 @@ struct CssPropertyFlags {
   uint16_t display : 1;
   uint16_t direction : 1;
   uint16_t verticalAlign : 1;
+  uint16_t listStyleType : 1;
 
   CssPropertyFlags()
       : textAlign(0),
@@ -111,25 +115,28 @@ struct CssPropertyFlags {
         imageWidth(0),
         display(0),
         direction(0),
-        verticalAlign(0) {}
+        verticalAlign(0),
+        listStyleType(0) {}
 
   [[nodiscard]] bool anySet() const {
     return textAlign || fontStyle || fontWeight || textDecoration || textIndent || marginTop || marginBottom ||
            marginLeft || marginRight || paddingTop || paddingBottom || paddingLeft || paddingRight || imageHeight ||
-           imageWidth || display || direction || verticalAlign;
+           imageWidth || display || direction || verticalAlign || listStyleType;
   }
 
   void clearAll() {
     textAlign = fontStyle = fontWeight = textDecoration = textIndent = 0;
     marginTop = marginBottom = marginLeft = marginRight = 0;
     paddingTop = paddingBottom = paddingLeft = paddingRight = 0;
-    imageHeight = imageWidth = display = direction = verticalAlign = 0;
+    imageHeight = imageWidth = display = direction = verticalAlign = listStyleType = 0;
   }
 };
 
-// Cache serializes defined flags as uint32_t with bit indices 0..17.
+// Cache serializes defined flags as uint32_t with bit indices 0..18.
 static_assert(sizeof(CssPropertyFlags) <= sizeof(uint32_t),
               "CssPropertyFlags exceeds 32 bits; update cache read/write in CssParser.cpp");
+static_assert(sizeof(CssPropertyFlags) * 8 >= 19,
+              "CssPropertyFlags has fewer bits than properties; update bitfield widths");
 
 // Represents a collection of CSS style properties
 // Only stores properties relevant to e-ink text rendering
@@ -154,6 +161,7 @@ struct CssStyle {
   CssLength imageWidth;     // Width for img when both or only width set
   CssDisplay display = CssDisplay::Block;                       // display property (Block or None)
   CssVerticalAlign verticalAlign = CssVerticalAlign::Baseline;  // vertical-align (super/sub positioning)
+  CssListStyleType listStyleType = CssListStyleType::Disc;      // list-style-type (Disc or None)
 
   CssPropertyFlags defined;  // Tracks which properties were explicitly set
 
@@ -232,6 +240,10 @@ struct CssStyle {
       verticalAlign = base.verticalAlign;
       defined.verticalAlign = 1;
     }
+    if (base.hasListStyleType()) {
+      listStyleType = base.listStyleType;
+      defined.listStyleType = 1;
+    }
   }
 
   [[nodiscard]] bool hasTextAlign() const { return defined.textAlign; }
@@ -252,6 +264,7 @@ struct CssStyle {
   [[nodiscard]] bool hasDisplay() const { return defined.display; }
   [[nodiscard]] bool hasDirection() const { return defined.direction; }
   [[nodiscard]] bool hasVerticalAlign() const { return defined.verticalAlign; }
+  [[nodiscard]] bool hasListStyleType() const { return defined.listStyleType; }
 
   void reset() {
     textAlign = CssTextAlign::Left;
@@ -265,6 +278,7 @@ struct CssStyle {
     imageHeight = imageWidth = CssLength{};
     display = CssDisplay::Block;
     verticalAlign = CssVerticalAlign::Baseline;
+    listStyleType = CssListStyleType::Disc;
     defined.clearAll();
   }
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -52,7 +52,7 @@ constexpr uint8_t TABLE_ROW_SEPARATOR_THICKNESS = 1;
 constexpr int16_t TABLE_MIN_CELL_WIDTH_LINE_HEIGHTS = 3;
 
 constexpr const char* HEADER_TAGS[] = {"h1", "h2", "h3", "h4", "h5", "h6"};
-constexpr const char* BLOCK_TAGS[] = {"p", "li", "div", "br", "blockquote"};
+constexpr const char* BLOCK_TAGS[] = {"p", "li", "div", "br", "blockquote", "ul", "ol"};
 constexpr const char* BOLD_TAGS[] = {"b", "strong"};
 constexpr const char* ITALIC_TAGS[] = {"i", "em"};
 constexpr const char* UNDERLINE_TAGS[] = {"u", "ins"};
@@ -1396,8 +1396,31 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
       self->updateEffectiveInlineStyle();
 
       if (strcmp(name, "li") == 0) {
-        self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR, false, false, self->visibleTextOffset);
-        self->listItemBulletOnly = true;
+        // Innermost open <ul>/<ol> (if any) decides whether this item gets a bullet,
+        // a number, or no marker at all (list-style-type: none). A malformed <li>
+        // with no enclosing list falls back to the plain bullet.
+        if (!self->listStack.empty() && self->listStack.back().styleNone) {
+          // No marker: leave the block empty so it behaves like a normal paragraph.
+        } else if (!self->listStack.empty() && self->listStack.back().ordered) {
+          self->listStack.back().counter += 1;
+          char marker[16];
+          snprintf(marker, sizeof(marker), "%d.", self->listStack.back().counter);
+          self->currentTextBlock->addWord(marker, EpdFontFamily::REGULAR, false, false, self->visibleTextOffset);
+          self->listItemBulletOnly = true;
+        } else {
+          self->currentTextBlock->addWord("\xe2\x80\xa2", EpdFontFamily::REGULAR, false, false,
+                                          self->visibleTextOffset);
+          self->listItemBulletOnly = true;
+        }
+      } else if (strcmp(name, "ul") == 0 || strcmp(name, "ol") == 0) {
+        // <ul>/<ol> container accumulation: pushing the block-style stack here includes
+        // the container's own margin/padding in the inset children combine with, so a
+        // hanging text-indent on <li><p> children keeps the first line on the page.
+        ChapterHtmlSlimParser::ListContext ctx;
+        ctx.ordered = strcmp(name, "ol") == 0;
+        ctx.styleNone = cssStyle.hasListStyleType() && cssStyle.listStyleType == CssListStyleType::None;
+        ctx.depth = self->depth;
+        self->listStack.push_back(ctx);
       }
     }
   } else if (matches(name, UNDERLINE_TAGS, std::size(UNDERLINE_TAGS))) {
@@ -1963,6 +1986,17 @@ void XMLCALL ChapterHtmlSlimParser::endElement(void* userData, const XML_Char* n
       self->listItemBulletOnly = false;
     }
   }
+
+  // </ul> or </ol> closes: pop its list context so a following sibling list at the
+  // same nesting level starts its own counter/style instead of inheriting this one's.
+  // Guarded by depth (not just tag name + non-empty stack): a display:none <ul>/<ol>
+  // returns early in startElement without ever pushing a context (see the
+  // hasDisplay()/CssDisplay::None branch above), so its closing tag must not pop
+  // the *parent* list's context out from under still-unprocessed siblings.
+  if ((strcmp(name, "ul") == 0 || strcmp(name, "ol") == 0) && !self->listStack.empty() &&
+      self->listStack.back().depth == self->depth) {
+    self->listStack.pop_back();
+  }
   if (strcmp(name, "body") == 0) {
     self->insideBody = false;
   }
@@ -1986,6 +2020,8 @@ bool ChapterHtmlSlimParser::beginParse() {
   blockStyleStack.reserve(8);
   blockStyleStack.push_back(rootBlockStyle);
 
+  listStack.clear();
+  listStack.reserve(4);
   tableDepth = 0;
   insideTableCell = false;
   tableRowStacked = false;

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -103,6 +103,20 @@ class ChapterHtmlSlimParser {
   std::vector<uint32_t> tableLineVisibleOffsets;
   bool listItemBulletOnly = false;  // true when currentTextBlock has only the <li> bullet
 
+  // Tracks the innermost open <ul>/<ol> so <li> knows whether to number itself,
+  // bullet itself, or (list-style-type: none) emit no marker at all. Pushed on
+  // <ul>/<ol> open, popped on close, so nested lists restart their own counter
+  // without disturbing the parent list's.
+  struct ListContext {
+    bool ordered = false;    // true for <ol>, false for <ul>
+    bool styleNone = false;  // true when list-style-type: none is set on this list
+    int counter = 0;         // incremented before each direct <li>; used as its number when ordered
+    int depth = 0;           // parser depth at open time; matches the depth seen in endElement
+                             // for the same tag, so a hidden nested list's close can't pop
+                             // an outer list's context
+  };
+  std::vector<ListContext> listStack;
+
   // Anchor-to-page mapping: tracks which page each HTML id attribute lands on
   int completedPageCount = 0;
   std::vector<std::pair<std::string, uint16_t>> anchorData;


### PR DESCRIPTION
Supersedes: #2676

## Summary

Two list-rendering bugs in `ChapterHtmlSlimParser`:

1. **Ordered lists showed bullets** (#291): A small nesting-aware list context stack tracks whether the innermost open list is ordered, so `<ol>` items number themselves (`1.`, `2.`, …) and nested lists restart their own counter. `list-style-type: none` suppresses the marker entirely.

2. **List containers dropped their margins**: `<ul>`/`<ol>`'s `margin-left`/`padding-left` are treated correctly now. A hanging `text-indent` pushed first-line glyphs past the left edge of the page (visible as `[GFX] !! Outside range` render errors). Containers now accumulate block styles like other block elements.

`section.bin` is bumped to **v46**.

## Comparison

Lists without this fix:
<img width="528" height="792" alt="Tenth-Anniversary;-The-Art-of-Game-Design;-A-Book-of-Lenses;-3r_ch18_p79_25pct_57647" src="https://github.com/user-attachments/assets/1fd21bf2-26af-443b-bf52-f6d04acd05d5" />



Lists with this fix:
<img width="528" height="792" alt="Tenth-Anniversary;-The-Art-of-Game-Design;-A-Book-of-Lenses;-3r_ch18_p83_25pct_369024" src="https://github.com/user-attachments/assets/84b7f774-1ecf-4a9f-b837-0e5a9562f985" />



Example from Calibre:
<img width="405" height="335" alt="image" src="https://github.com/user-attachments/assets/8869983b-de9a-41f0-8316-ab927dbfb9fd" />

ePUB:
```html
<section class="level3">
<h2 class="h3" id="sec9_6"><span class="pd_orange">Other Reading to Consider</span></h2>
<ul class="list-simple1">
<li><p class="list-item1"><b><i>Designing Virtual Worlds</i> by Richard R. Bartle</b>. An excellent book for looking at the history of virtual world development by a deep thinker who made it happen.</p></li>
<li><p class="list-item1"><b><i>Pleasures of the Brain</i> by Morten L. Kringelbach and Kent C. Berridge, editors</b>. A collection of research findings about the mechanisms of pleasure by a variety of psychologists and neuroscientists. If you are not used to scientific papers, it can be a bit daunting, but it is a treasure trove of insights for the persistent reader.</p></li>
<li><p class="list-item1"><b><i>Understanding Kids, Play, and Interactive Design: How to Create Games Children Love</i> by Mark Schlichting</b>. It can be easy for adults to forget what it was like to be a child. Mark has not forgotten, and gives us a guided tour of the wonderland that is childhood.</p></li>
<li><p class="list-item1"><b><i>Diversifying Barbie and Mortal Kombat: Intersectional Perspectives and Inclusive Goals in Gaming</i> by Yasmin B. Kafai, Gabriela T. Richard, and Brendesha M. Tynes, editors.</b> Progress on gender and sexuality issues in games has been significant and meaningful, and there are still many miles to go. This book explores inclusivity issues from multiple thoughtful perspectives.</p></li>
</ul>
</section>
```

CSS sections:
```css
.pd_orange
{
	color: #A22E0B;
}
.h3
{
	font-size: 1.3em;
	margin-top: 1.2em;
	margin-bottom: 0.4em;
	margin-left: 0em;
	text-indent: 0em;
}
.level3
{
	margin-top: 0.1em;
	margin-bottom: 0.1em;
	margin-left: 0.1em;
	margin-right: 0.1em;
	text-align: left;
}
.list-simple1
{
	margin-top: 1em;
	padding-left: 1.4em;
	margin-left: 0.1em;
	margin-bottom: 1em;
	margin-right: 0.1em;
	text-align: left;
	list-style-type: none;
}
.list-item1
{
	margin-top: 0.1em;
	margin-bottom: 0.1em;
	margin-right: 0em;
	margin-left: 0.1em;
	text-indent: -1.5em;
}
```


## Verification

Verified on Xteink X3. Parsing-time A/B against stock 1.6.0 on the same section showed no measurable difference (see numbers in #2676).

---

### AI Usage

Did you use AI tools to help write this code? **YES**