### PR TITLE
perf: batch SdFat's SPI transfers on ESP32

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -47,6 +47,13 @@ build_flags =
   -std=gnu++2a
 # Enable UTF-8 long file names in SdFat
   -DUSE_UTF8_LONG_NAMES=1
+# SdFat transfers SPI a byte at a time on ESP32: SdFatConfig.h defaults
+# USE_SPI_ARRAY_TRANSFER to 0 for every target but RP2040 and the UNO R4, and each
+# Arduino transfer(uint8_t) writes the data register, starts the transfer and spins.
+# 1 routes through transfer(buf, count) -> transferBytes() -> spiTransferBytesNL(),
+# which batches into the SPI FIFO: ~3x on SD reads, at the cost of a 512-byte stack
+# buffer on the send path. Inert on SDMMC boards, which bypass SdFat's SPI driver.
+  -DUSE_SPI_ARRAY_TRANSFER=1
 # Increase PNG scanline buffer to support up to 2048px wide images
 # Default is (320*4+1)*2=2562, we need more for larger images
   -DPNG_MAX_BUFFERED_PIXELS=16416


### PR DESCRIPTION
## Summary

* **What is the goal of this PR?**
  Storage throughput on ESP32 is limited by SdFat's per-byte SPI transfers rather
  than by the bus. This enables the SdFat build option that batches them, which
  measured ~3x on SD reads.

* **What changes are included?**
  One flag in `platformio.ini`'s `[base]` build flags — `-DUSE_SPI_ARRAY_TRANSFER=1`
  — plus a comment recording the mechanism and the cost.

`SdFatConfig.h` defaults `USE_SPI_ARRAY_TRANSFER` to `0` on every target except
RP2040 and the UNO R4. With `0`, `SdSpiArduinoDriver::receive()` is:

```cpp
for (size_t i = 0; i < count; i++) buf[i] = m_spi->transfer(0XFF);
```

On Arduino-ESP32 each `SPIClass::transfer(uint8_t)` writes the data register,
starts the transfer and spins until it completes — about 2.8 us per byte, against
0.2 us of actual bus time for a byte at 40 MHz. Reading 8 KB costs ~23 ms where
the bus alone would take ~0.2 ms.

With `1`, `receive()` memsets the caller's buffer to 0xFF and calls
`SPIClass::transfer(buf, count)`, which goes to `transferBytes()` and
`spiTransferBytesNL()` and batches into the SPI FIFO.

`2` would avoid the send-side temporary, but it calls
`m_spi->transfer(nullptr, buf, count)` and Arduino-ESP32's `SPIClass` has no
three-argument `transfer()` — only `transfer(void*, uint32_t)` and
`transferBytes(const uint8_t*, uint8_t*, uint32_t)`. So `1` is the usable value here.

## Scope Check

CrossPoint is intentionally narrow. See [SCOPE.md](../blob/master/SCOPE.md) and [ROADMAP.md](../blob/master/ROADMAP.md).
Please confirm:

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme (themes are temporarily closed pending the move to SD-loaded themes).
- [x] This PR is **not** a new external network connector (sync engine, cloud storage, remote file access, etc.).
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [x] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does
      (or, if one does, I explain why CrossPoint still needs it below).
- [x] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with
      the relevant maintainer.

On the last box: the diff does not touch `freeink-sdk/`, `lib/hal/`, the
bootloader, OTA or recovery. It does change the behaviour of the SD driver
underneath `SDCardManager`, so I am flagging that for a maintainer's attention
even though no file in those paths is modified.

## Additional Context

**Measured on an Xteink X3 (ESP32-C3, SD sharing the display SPI bus, 40 MHz)**,
same book and same cache state before and after:

| | before | after |
|---|---|---|
| 8 KB file read | 23.5 ms | **8.2 ms** |
| Extract a 1440x2048 JPEG from an EPUB zip to SD | 7,914 ms | **3,089 ms** |
| JPEGDEC's file reads during that decode (163 calls both) | 3,825 ms | **1,335 ms** |
| First view of a full-page illustration, end to end | ~16 s | **~8.1 s** |
| Per-page glyph prewarm from a `.cpfont` | 363-590 ms | **154 ms** |

Throughput went from ~340 KB/s to ~1 MB/s. **The call counts are identical before
and after**, so this is per-byte overhead and not fewer round trips. Absolute
figures will vary by card; the mechanism is a build-time default, not
device-specific.

**Risks / what to focus on**

* `SdSpiArduinoDriver::send()` under `USE_SPI_ARRAY_TRANSFER=1` uses a
  **512-byte stack buffer**. That is above the 256-byte guideline in CLAUDE.md.
  It is on the SD *write* path, and SdFat ships this same configuration as the
  default on RP2040 and the UNO R4, but it is the one thing worth a reviewer's
  judgement. Task stacks in this firmware are 2048-4096 bytes.
* `receive()` needs no extra buffer — it transfers in place.
* SDMMC boards (`x4pro`, `x4c`, de-link) mount through the block-device
  interface rather than SdFat's SPI driver, so the flag should be inert there.

**Memory / flash impact** (env `default`, ESP32-C3, measured before and after):

* Static RAM: **66,912 bytes, unchanged**
* Flash: 5,570,739 -> 5,571,667 bytes, **+928 bytes**
* Stack: +512 bytes transiently on the SD write path (see above)

**What I did not test**

I only have an X3 (ESP32-C3, SPI-attached SD). I have **not** tested the S3
(`sticky`) or the SDMMC boards. Reading, writing, glyph loading, image decoding,
section caches and cover thumbnails all behave correctly on the X3.

---

### AI Usage

While CrossPoint doesn't have restrictions on AI tools in contributing, please be transparent about their usage as it
helps set the right context for reviewers.

Did you use AI tools to help write this code? _**YES**_

The investigation (splitting the decode into phases, timing the SPI path, ruling
out an SD clock hypothesis) and this description were done with Claude Code. The
change itself is one build flag.
