### PR TITLE
refactor: reduce EPUB heap fragmentation with unique ownership

### DIFF
--- a/lib/Epub/Epub/Page.cpp
+++ b/lib/Epub/Epub/Page.cpp
@@ -2,14 +2,13 @@
 
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Serialization.h>
-
-#include <new>
 
 namespace {
 
 template <typename Predicate>
-void renderFilteredPageElements(const std::vector<std::shared_ptr<PageElement>>& elements, GfxRenderer& renderer,
+void renderFilteredPageElements(const std::vector<std::unique_ptr<PageElement>>& elements, GfxRenderer& renderer,
                                 const int fontId, const int xOffset, const int yOffset, Predicate&& predicate) {
   for (const auto& element : elements) {
     if (predicate(*element)) {
@@ -44,12 +43,12 @@ std::unique_ptr<PageLine> PageLine::deserialize(HalFile& file) {
     return nullptr;
   }
 
-  auto* line = new (std::nothrow) PageLine(std::move(tb), xPos, yPos);
+  auto line = makeUniqueNoThrow<PageLine>(std::move(tb), xPos, yPos);
   if (!line) {
     LOG_ERR("PGE", "Deserialization failed: could not allocate PageLine");
     return nullptr;
   }
-  return std::unique_ptr<PageLine>(line);
+  return line;
 }
 
 void PageImage::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -76,7 +75,16 @@ std::unique_ptr<PageImage> PageImage::deserialize(HalFile& file) {
   serialization::readPod(file, yPos);
 
   auto ib = ImageBlock::deserialize(file);
-  return std::unique_ptr<PageImage>(new PageImage(std::move(ib), xPos, yPos));
+  if (!ib) {
+    LOG_ERR("PGE", "Deserialization failed: null ImageBlock");
+    return nullptr;
+  }
+  auto image = makeUniqueNoThrow<PageImage>(std::move(ib), xPos, yPos);
+  if (!image) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate PageImage");
+    return nullptr;
+  }
+  return image;
 }
 
 void PageHorizontalRule::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) {
@@ -112,12 +120,12 @@ std::unique_ptr<PageHorizontalRule> PageHorizontalRule::deserialize(HalFile& fil
     return nullptr;
   }
 
-  auto* rule = new (std::nothrow) PageHorizontalRule(width, thickness, xPos, yPos);
+  auto rule = makeUniqueNoThrow<PageHorizontalRule>(width, thickness, xPos, yPos);
   if (!rule) {
     LOG_ERR("PGE", "Deserialization failed: could not allocate PageHorizontalRule");
     return nullptr;
   }
-  return std::unique_ptr<PageHorizontalRule>(rule);
+  return rule;
 }
 
 void Page::render(GfxRenderer& renderer, const int fontId, const int xOffset, const int yOffset) const {
@@ -183,7 +191,11 @@ bool Page::serialize(HalFile& file) const {
 }
 
 std::unique_ptr<Page> Page::deserialize(HalFile& file) {
-  auto page = std::unique_ptr<Page>(new Page());
+  auto page = makeUniqueNoThrow<Page>();
+  if (!page) {
+    LOG_ERR("PGE", "Deserialization failed: could not allocate Page");
+    return nullptr;
+  }
 
   uint16_t count;
   serialization::readPod(file, count);
@@ -191,7 +203,7 @@ std::unique_ptr<Page> Page::deserialize(HalFile& file) {
   // Reserve up front so a page load costs one allocation for the element vector
   // instead of a grow-copy-free cycle every doubling. `count` is untrusted (it
   // comes straight off the SD cache), so clamp it: a real page holds a few dozen
-  // elements, while a corrupt header could ask for 65535 * sizeof(shared_ptr) and
+  // elements, while a corrupt header could ask for 65535 * sizeof(unique_ptr) and
   // abort() on the failed allocation (vector's operator new is throwing, and this
   // firmware builds with -fno-exceptions). Under-reserving is harmless -- the
   // push_back path below still grows normally.

--- a/lib/Epub/Epub/Page.h
+++ b/lib/Epub/Epub/Page.h
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -32,12 +33,12 @@ class PageElement {
 
 // a line from a block element
 class PageLine final : public PageElement {
-  std::shared_ptr<TextBlock> block;
+  std::unique_ptr<TextBlock> block;
 
  public:
-  PageLine(std::shared_ptr<TextBlock> block, const int16_t xPos, const int16_t yPos)
+  PageLine(std::unique_ptr<TextBlock> block, const int16_t xPos, const int16_t yPos)
       : PageElement(xPos, yPos), block(std::move(block)) {}
-  const std::shared_ptr<TextBlock>& getBlock() const { return block; }
+  const TextBlock* getBlock() const { return block.get(); }
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   bool serialize(HalFile& file) override;
   PageElementTag getTag() const override { return TAG_PageLine; }
@@ -46,10 +47,10 @@ class PageLine final : public PageElement {
 
 // New PageImage class
 class PageImage final : public PageElement {
-  std::shared_ptr<ImageBlock> imageBlock;
+  std::unique_ptr<ImageBlock> imageBlock;
 
  public:
-  PageImage(std::shared_ptr<ImageBlock> block, const int16_t xPos, const int16_t yPos)
+  PageImage(std::unique_ptr<ImageBlock> block, const int16_t xPos, const int16_t yPos)
       : PageElement(xPos, yPos), imageBlock(std::move(block)) {}
   void render(GfxRenderer& renderer, int fontId, int xOffset, int yOffset) override;
   void renderPlaceholder(GfxRenderer& renderer, int xOffset, int yOffset) const;
@@ -76,7 +77,7 @@ class PageHorizontalRule final : public PageElement {
 class Page {
  public:
   // the list of block index and line numbers on this page
-  std::vector<std::shared_ptr<PageElement>> elements;
+  std::vector<std::unique_ptr<PageElement>> elements;
   std::vector<FootnoteEntry> footnotes;
   static constexpr uint16_t MAX_FOOTNOTES_PER_PAGE = 16;
   std::vector<PageLink> links;
@@ -125,11 +126,11 @@ class Page {
   // Check if page contains any images (used to force full refresh)
   bool hasImages() const {
     return std::any_of(elements.begin(), elements.end(),
-                       [](const std::shared_ptr<PageElement>& el) { return el->getTag() == TAG_PageImage; });
+                       [](const std::unique_ptr<PageElement>& el) { return el->getTag() == TAG_PageImage; });
   }
 
   bool hasImagesNeedingDecode() const {
-    return std::any_of(elements.begin(), elements.end(), [](const std::shared_ptr<PageElement>& element) {
+    return std::any_of(elements.begin(), elements.end(), [](const std::unique_ptr<PageElement>& element) {
       return element->getTag() == TAG_PageImage &&
              static_cast<const PageImage&>(*element).getImageBlock().needsDecode();
     });

--- a/lib/Epub/Epub/ParsedText.cpp
+++ b/lib/Epub/Epub/ParsedText.cpp
@@ -3,6 +3,7 @@
 #include <BidiUtils.h>
 #include <GfxRenderer.h>
 #include <Logging.h>
+#include <Memory.h>
 #include <Utf8.h>
 
 #include <algorithm>
@@ -678,7 +679,7 @@ int ParsedText::resolveFirstLineIndent(const bool isFirstLine, const GfxRenderer
 }
 // Consumes data to minimize memory usage
 void ParsedText::layoutAndExtractLines(const GfxRenderer& renderer, const int fontId, const uint16_t viewportWidth,
-                                       const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
+                                       const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                                        const bool includeLastLine) {
   if (words.empty()) {
     return;
@@ -1254,7 +1255,7 @@ bool ParsedText::hyphenateWordAtIndex(const size_t wordIndex, const int availabl
 void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const std::vector<uint16_t>& wordWidths,
                              const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                              const std::vector<size_t>& lineBreakIndices,
-                             const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
+                             const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              const GfxRenderer& renderer, const int fontId) {
   const size_t lineBreak = lineBreakIndices[breakIndex];
   const size_t lastBreakAt = breakIndex > 0 ? lineBreakIndices[breakIndex - 1] : 0;
@@ -1599,11 +1600,11 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
 
   if (!lineHasFocusSplit) {
     // TextBlock flattens the vectors into its arena; they stay owned here and die at return.
-    auto block = std::make_shared<TextBlock>(lineWords, lineXPos, lineWordStyles, std::vector<uint8_t>{},
-                                             std::vector<uint16_t>{}, blockStyle, std::move(lineRubyTexts),
-                                             std::move(lineLinks));
-    if (!block->valid()) {
-      LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
+    auto block = makeUniqueNoThrow<TextBlock>(lineWords, lineXPos, lineWordStyles, std::vector<uint8_t>{},
+                                              std::vector<uint16_t>{}, blockStyle, std::move(lineRubyTexts),
+                                              std::move(lineLinks));
+    if (!block || !block->valid()) {
+      LOG_ERR("PTX", "Dropping line: TextBlock or arena allocation failed");
       return;
     }
     processLine(std::move(block), lineVisibleOffset);
@@ -1623,10 +1624,10 @@ void ParsedText::extractLine(const size_t breakIndex, const int pageWidth, const
         boundary == 0 ? 0 : measureFocusPrefixAdvance(renderer, fontId, lineWords[i], lineWordStyles[i], boundary));
   }
 
-  auto block = std::make_shared<TextBlock>(lineWords, lineXPos, lineWordStyles, outBoundaries, outSuffixX, blockStyle,
-                                           std::move(lineRubyTexts), std::move(lineLinks));
-  if (!block->valid()) {
-    LOG_ERR("PTX", "Dropping line: TextBlock arena allocation failed");
+  auto block = makeUniqueNoThrow<TextBlock>(lineWords, lineXPos, lineWordStyles, outBoundaries, outSuffixX, blockStyle,
+                                            std::move(lineRubyTexts), std::move(lineLinks));
+  if (!block || !block->valid()) {
+    LOG_ERR("PTX", "Dropping line: TextBlock or arena allocation failed");
     return;
   }
   processLine(std::move(block), lineVisibleOffset);

--- a/lib/Epub/Epub/ParsedText.h
+++ b/lib/Epub/Epub/ParsedText.h
@@ -87,7 +87,7 @@ class ParsedText {
   void extractLine(size_t breakIndex, int pageWidth, const std::vector<uint16_t>& wordWidths,
                    const std::vector<bool>& continuesVec, const std::vector<bool>& noSpaceBeforeVec,
                    const std::vector<size_t>& lineBreakIndices,
-                   const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
+                   const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                    const GfxRenderer& renderer, int fontId);
   std::vector<uint16_t> calculateWordWidths(const GfxRenderer& renderer, int fontId);
 
@@ -118,6 +118,6 @@ class ParsedText {
   size_t size() const { return words.size(); }
   bool isEmpty() const { return words.empty(); }
   void layoutAndExtractLines(const GfxRenderer& renderer, int fontId, uint16_t viewportWidth,
-                             const std::function<void(std::shared_ptr<TextBlock>, uint32_t)>& processLine,
+                             const std::function<void(std::unique_ptr<TextBlock>, uint32_t)>& processLine,
                              bool includeLastLine = true);
 };

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
@@ -471,13 +471,12 @@ void ChapterHtmlSlimParser::emitHorizontalRule(const BlockStyle& blockStyle) {
 
   currentPageNextY += topSpacing;
 
-  auto pageRule = std::shared_ptr<PageHorizontalRule>(
-      new (std::nothrow) PageHorizontalRule(width, ruleThickness, xPos, currentPageNextY));
+  auto pageRule = makeUniqueNoThrow<PageHorizontalRule>(width, ruleThickness, xPos, currentPageNextY);
   if (!pageRule) {
     LOG_ERR("EHP", "Failed to create PageHorizontalRule");
     return;
   }
-  currentPage->elements.push_back(pageRule);
+  currentPage->elements.push_back(std::move(pageRule));
   setCurrentPageVisibleOffset(visibleTextOffset);
   currentPageNextY = static_cast<int16_t>(currentPageNextY + ruleThickness + bottomSpacing);
 
@@ -540,8 +539,8 @@ void ChapterHtmlSlimParser::addTableRowSeparator() {
     return;
   }
 
-  auto separator = std::shared_ptr<PageHorizontalRule>(
-      new (std::nothrow) PageHorizontalRule(viewportWidth, TABLE_ROW_SEPARATOR_THICKNESS, 0, currentPageNextY + 1));
+  auto separator =
+      makeUniqueNoThrow<PageHorizontalRule>(viewportWidth, TABLE_ROW_SEPARATOR_THICKNESS, 0, currentPageNextY + 1);
   if (!separator) {
     LOG_ERR("EHP", "OOM: table row separator");
     return;
@@ -597,9 +596,9 @@ void ChapterHtmlSlimParser::finishTableRow() {
       lines.reserve(MAX_GRID_TABLE_CELL_WORDS * 2);
     }
     tableRowCells[column]->layoutAndExtractLines(
-        renderer, fontId, textWidth, [this, &lines](const std::shared_ptr<TextBlock>& line, const uint32_t offset) {
+        renderer, fontId, textWidth, [this, &lines](std::unique_ptr<TextBlock> line, const uint32_t offset) {
           const size_t lineIndex = lines.size();
-          lines.push_back(line);
+          lines.push_back(std::move(line));
           if (tableLineVisibleOffsets.size() <= lineIndex) {
             tableLineVisibleOffsets.resize(lineIndex + 1, UINT32_MAX);
           }
@@ -667,7 +666,7 @@ void ChapterHtmlSlimParser::finishTableRow() {
 
       // Reset Y so every cell in this slice shares one baseline.
       currentPageNextY = rowY;
-      addLineToPage(line, lineVisibleOffset);
+      addLineToPage(std::move(line), lineVisibleOffset);
     }
     currentPageNextY = static_cast<int16_t>(rowY + rowLineHeight);
   }
@@ -1165,24 +1164,19 @@ void XMLCALL ChapterHtmlSlimParser::startElement(void* userData, const XML_Char*
                 }
                 self->currentPageNextY += imageMarginTop;
 
-                // Create ImageBlock and add to page
-                // nothrow: make_shared uses bare new, which aborts on OOM under
-                // -fno-exceptions; images arrive mid-parse when the heap is at its
-                // most loaded, so this must fail soft into the null-check below.
-                auto imageBlock = std::shared_ptr<ImageBlock>(
-                    new (std::nothrow) ImageBlock(cachedImagePath, resolvedPath, displayWidth, displayHeight));
+                auto imageBlock =
+                    makeUniqueNoThrow<ImageBlock>(cachedImagePath, resolvedPath, displayWidth, displayHeight);
                 if (!imageBlock) {
                   LOG_ERR("EHP", "Failed to create ImageBlock");
                   return;
                 }
                 int xPos = (self->viewportWidth - displayWidth) / 2;
-                auto pageImage =
-                    std::shared_ptr<PageImage>(new (std::nothrow) PageImage(imageBlock, xPos, self->currentPageNextY));
+                auto pageImage = makeUniqueNoThrow<PageImage>(std::move(imageBlock), xPos, self->currentPageNextY);
                 if (!pageImage) {
                   LOG_ERR("EHP", "Failed to create PageImage");
                   return;
                 }
-                self->currentPage->elements.push_back(pageImage);
+                self->currentPage->elements.push_back(std::move(pageImage));
                 self->setCurrentPageVisibleOffset(self->visibleTextOffset);
                 self->currentPageNextY += displayHeight + imageMarginBottom;
 
@@ -1734,8 +1728,8 @@ void XMLCALL ChapterHtmlSlimParser::characterData(void* userData, const XML_Char
                                         : self->viewportWidth;
     self->currentTextBlock->layoutAndExtractLines(
         self->renderer, self->fontId, effectiveWidth,
-        [self](const std::shared_ptr<TextBlock>& textBlock, const uint32_t offset) {
-          self->addLineToPage(textBlock, offset);
+        [self](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
+          self->addLineToPage(std::move(textBlock), offset);
         },
         false);
   }
@@ -2114,7 +2108,7 @@ bool ChapterHtmlSlimParser::parseAndBuildPages() {
   return finishParse();
 }
 
-void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const uint32_t visibleOffset) {
+void ChapterHtmlSlimParser::addLineToPage(std::unique_ptr<TextBlock> line, const uint32_t visibleOffset) {
   const int lineHeight =
       renderer.getLineHeight(fontId, lineCompression) + line->getRubyShift(renderer.getFontAscenderSize(fontId));
 
@@ -2154,7 +2148,12 @@ void ChapterHtmlSlimParser::addLineToPage(std::shared_ptr<TextBlock> line, const
       LOG_DBG("EHP", "Dropped page link: %.48s", link.href);
     }
   }
-  currentPage->elements.push_back(std::make_shared<PageLine>(line, xOffset, currentPageNextY));
+  auto pageLine = makeUniqueNoThrow<PageLine>(std::move(line), xOffset, currentPageNextY);
+  if (!pageLine) {
+    LOG_ERR("EHP", "OOM: PageLine");
+    return;
+  }
+  currentPage->elements.push_back(std::move(pageLine));
   currentPageNextY += lineHeight;
 }
 
@@ -2186,9 +2185,10 @@ void ChapterHtmlSlimParser::makePages() {
   const uint16_t effectiveWidth =
       (horizontalInset < viewportWidth) ? static_cast<uint16_t>(viewportWidth - horizontalInset) : viewportWidth;
 
-  currentTextBlock->layoutAndExtractLines(
-      renderer, fontId, effectiveWidth,
-      [this](const std::shared_ptr<TextBlock>& textBlock, const uint32_t offset) { addLineToPage(textBlock, offset); });
+  currentTextBlock->layoutAndExtractLines(renderer, fontId, effectiveWidth,
+                                          [this](std::unique_ptr<TextBlock> textBlock, const uint32_t offset) {
+                                            addLineToPage(std::move(textBlock), offset);
+                                          });
 
   // Fallback: transfer any remaining pending footnotes to current page.
   // Normally addLineToPage handles this via word-index tracking, but this catches

--- a/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
+++ b/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.h
@@ -99,7 +99,7 @@ class ChapterHtmlSlimParser {
   uint16_t tableRowsSpannedRemaining = 0;
   size_t tableCellTextBytes = 0;
   std::vector<std::unique_ptr<ParsedText>> tableRowCells;
-  std::array<std::vector<std::shared_ptr<TextBlock>>, MAX_GRID_TABLE_COLUMNS> tableCellLines;
+  std::array<std::vector<std::unique_ptr<TextBlock>>, MAX_GRID_TABLE_COLUMNS> tableCellLines;
   std::vector<uint32_t> tableLineVisibleOffsets;
   bool listItemBulletOnly = false;  // true when currentTextBlock has only the <li> bullet
 
@@ -211,7 +211,7 @@ class ChapterHtmlSlimParser {
   bool finishParse();  // flush the trailing page and tear down; returns true
   void abortParse();   // tear down without flushing (error / abandon)
 
-  void addLineToPage(std::shared_ptr<TextBlock> line, uint32_t visibleOffset);
+  void addLineToPage(std::unique_ptr<TextBlock> line, uint32_t visibleOffset);
   const std::vector<std::pair<std::string, uint16_t>>& getAnchors() const { return anchorData; }
 
   // Byte progress of the in-flight parse, used to estimate a still-building section's total page

--- a/src/activities/reader/DictionaryWordSelectActivity.cpp
+++ b/src/activities/reader/DictionaryWordSelectActivity.cpp
@@ -76,7 +76,7 @@ void DictionaryWordSelectActivity::extractWords() {
   for (const auto& element : page->elements) {
     if (element->getTag() != TAG_PageLine) continue;
     const auto* line = static_cast<const PageLine*>(element.get());
-    const auto& block = line->getBlock();
+    const auto* block = line->getBlock();
     if (!block || !block->valid()) continue;
 
     bool rowHasWords = false;

--- a/src/activities/settings/TextSettingsPreview.cpp
+++ b/src/activities/settings/TextSettingsPreview.cpp
@@ -18,6 +18,9 @@
 
 namespace textsettings {
 
+PreviewLayout::PreviewLayout() = default;
+PreviewLayout::~PreviewLayout() = default;
+
 namespace {
 
 // Map the paragraph-alignment setting to the engine's CssTextAlign (BOOK_STYLE = justified)
@@ -54,7 +57,7 @@ void relayout(PreviewLayout& layout, const GfxRenderer& renderer, int fontId, in
 
   parsed.layoutAndExtractLines(
       renderer, fontId, static_cast<uint16_t>(textWidth),
-      [&layout](std::shared_ptr<TextBlock> line, uint32_t) { layout.lines.push_back(std::move(line)); });
+      [&layout](std::unique_ptr<TextBlock> line, uint32_t) { layout.lines.push_back(std::move(line)); });
 }
 
 }  // namespace

--- a/src/activities/settings/TextSettingsPreview.h
+++ b/src/activities/settings/TextSettingsPreview.h
@@ -25,7 +25,10 @@ struct PreviewKey {
 
 // Cached engine preview lines + the key that produced them
 struct PreviewLayout {
-  std::vector<std::shared_ptr<TextBlock>> lines;
+  PreviewLayout();
+  ~PreviewLayout();
+
+  std::vector<std::unique_ptr<TextBlock>> lines;
   PreviewKey key;
 };
 

--- a/test/chapter_html_slim_parser/CMakeLists.txt
+++ b/test/chapter_html_slim_parser/CMakeLists.txt
@@ -1,6 +1,10 @@
 add_executable(ChapterHtmlSlimParserTest
   ChapterHtmlSlimParserTest.cpp
   ParserLinkStubs.cpp
+  ${REPO_ROOT}/lib/Epub/Epub/Page.cpp
+  ${REPO_ROOT}/lib/Epub/Epub/blocks/TextBlock.cpp
+  ${REPO_ROOT}/lib/MiniBidi/BidiUtils.cpp
+  ${REPO_ROOT}/lib/MiniBidi/minibidi.c
   ${REPO_ROOT}/lib/Epub/Epub/parsers/ChapterHtmlSlimParser.cpp
   ${REPO_ROOT}/lib/Epub/Epub/css/CssParser.cpp
   ${REPO_ROOT}/lib/Epub/Epub/ParsedText.cpp
@@ -18,6 +22,7 @@ target_include_directories(ChapterHtmlSlimParserTest PRIVATE
   ${REPO_ROOT}/lib/EpdFont
   ${REPO_ROOT}/lib/Utf8
   ${REPO_ROOT}/lib/Memory
+  ${REPO_ROOT}/lib/Serialization
   ${REPO_ROOT}/lib/MiniBidi
   ${REPO_ROOT}/lib/FsHelpers
   ${REPO_ROOT}/lib/XmlParserUtils

--- a/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
+++ b/test/chapter_html_slim_parser/ChapterHtmlSlimParserTest.cpp
@@ -2,7 +2,9 @@
 #include <GfxRenderer.h>
 #include <gtest/gtest.h>
 
+#include <filesystem>
 #include <memory>
+#include <set>
 #include <string>
 
 #define class struct
@@ -40,6 +42,86 @@ class ChapterHtmlSlimParserTest : public ::testing::TestWithParam<const char*> {
 
   void SetUp() override { parser.currentTextBlock = std::make_unique<ParsedText>(false); }
 };
+
+TEST_F(ChapterHtmlSlimParserTest, RubySurvivesPartialParagraphExtraction) {
+  ParsedText text(false);
+  text.addWord("a", EpdFontFamily::REGULAR);
+  text.addWord("b", EpdFontFamily::REGULAR);
+  text.addWord("c", EpdFontFamily::REGULAR);
+  text.setRubyForWordAt(2, "c");
+  size_t lines = 0;
+  text.layoutAndExtractLines(
+      renderer, 0, 20,
+      [&](std::unique_ptr<TextBlock> line, auto) {
+        ++lines;
+        EXPECT_TRUE(line->getRubyTexts().empty());
+      },
+      false);
+  EXPECT_EQ(lines, 1u);
+  const size_t retainedWords = text.size();
+  ASSERT_GT(retainedWords, 0u);
+  ASSERT_LT(retainedWords, 3u);
+  text.layoutAndExtractLines(renderer, 0, 200, [&](std::unique_ptr<TextBlock> line, auto) {
+    ++lines;
+    ASSERT_EQ(line->getRubyTexts().size(), retainedWords);
+    EXPECT_EQ(line->getRubyTexts().back(), "c");
+    for (size_t i = 0; i + 1 < retainedWords; ++i) EXPECT_TRUE(line->getRubyTexts()[i].empty());
+  });
+  EXPECT_EQ(lines, 2u);
+}
+
+TEST_F(ChapterHtmlSlimParserTest, UnequalTableCellsAndRubySurvivePageBreaks) {
+  parser.viewportWidth = 240;
+  parser.viewportHeight = 32;
+  parser.tableRowCells.reserve(2);
+  std::multiset<std::string> expected;
+  for (int column = 0; column < 2; ++column) {
+    auto cell = std::make_unique<ParsedText>(false);
+    for (int index = 0; index < (column == 0 ? 30 : 3); ++index) {
+      const auto word = std::string(column == 0 ? "left" : "right") + std::to_string(index);
+      expected.insert(word);
+      cell->addWord(word, EpdFontFamily::REGULAR);
+    }
+    if (column == 0) cell->setRubyGroupAt(0, 2, "reading");
+    parser.tableRowCells.push_back(std::move(cell));
+  }
+  std::multiset<std::string> actual;
+  unsigned pages = 0;
+  unsigned rubyLines = 0;
+  auto inspect = [&](std::unique_ptr<Page> page, auto, auto, auto) {
+    ++pages;
+    for (const auto& element : page->elements) {
+      if (element->getTag() != TAG_PageLine) continue;
+      const auto& line = static_cast<const PageLine&>(*element);
+      const auto& block = *line.getBlock();
+      ASSERT_TRUE(block.valid());
+      EXPECT_LE(element->yPos + 16 + block.getRubyShift(12), parser.viewportHeight);
+      rubyLines += block.hasRuby();
+      for (uint16_t word = 0; word < block.wordCount(); ++word) actual.insert(block.wordText(word));
+    }
+  };
+  parser.completePageFn = inspect;
+  parser.finishTableRow();
+  ASSERT_NE(parser.currentPage, nullptr);
+  inspect(std::move(parser.currentPage), 0, 0, 0);
+  EXPECT_GT(pages, 2u);
+  EXPECT_EQ(rubyLines, 1u);
+  EXPECT_EQ(actual, expected);
+  for (const auto& lines : parser.tableCellLines) EXPECT_TRUE(lines.empty());
+}
+
+TEST_F(ChapterHtmlSlimParserTest, PageImageDeserializeRejectsMissingImageBlock) {
+  const auto path = std::filesystem::temp_directory_path() / "crosspoint-missing-image-cache.bin";
+  {
+    HalFile output;
+    ASSERT_TRUE(output.open(path.c_str(), "wb"));
+    const int16_t coordinates[] = {0, 0};
+    output.write(coordinates, sizeof(coordinates));
+  }
+  HalFile input;
+  ASSERT_TRUE(input.open(path.c_str(), "rb"));
+  EXPECT_EQ(PageImage::deserialize(input), nullptr);
+}
 
 TEST_P(ChapterHtmlSlimParserTest, KeepsCssVerticalAlignAndInternalLinkMetadata) {
   const char* verticalAlign = GetParam();

--- a/test/chapter_html_slim_parser/ParserLinkStubs.cpp
+++ b/test/chapter_html_slim_parser/ParserLinkStubs.cpp
@@ -16,23 +16,6 @@ bool isSoftHyphen(uint32_t) { return false; }
 
 std::vector<Hyphenator::BreakInfo> Hyphenator::breakOffsets(const std::string&, bool) { return {}; }
 
-namespace BidiUtils {
-bool startsWithRtl(const char*, int) { return false; }
-bool computeVisualWordOrder(const std::vector<std::string>& words, bool, std::vector<uint16_t>& order) {
-  order.resize(words.size());
-  for (size_t index = 0; index < words.size(); ++index) order[index] = static_cast<uint16_t>(index);
-  return true;
-}
-}  // namespace BidiUtils
-
-TextBlock::TextBlock(const std::vector<std::string>&, const std::vector<int16_t>&,
-                     const std::vector<EpdFontFamily::Style>&, const std::vector<uint8_t>&,
-                     const std::vector<uint16_t>&, const BlockStyle& blockStyle, std::vector<std::string> rubyTexts,
-                     std::vector<LinkSpan> linkSpans)
-    : blockStyle(blockStyle), rubyTexts(std::move(rubyTexts)), linkSpans(std::move(linkSpans)) {}
-
-bool TextBlock::hasRuby() const { return false; }
-
 ImageBlock::ImageBlock(const std::string& imagePath, const std::string& srcPath, int16_t width, int16_t height)
     : imagePath(imagePath), srcPath(srcPath), width(width), height(height) {}
 
@@ -42,12 +25,8 @@ bool ImageToFramebufferDecoder::validateAndStoreDimensions(int64_t, int64_t, Ima
   return false;
 }
 
-void PageLine::render(GfxRenderer&, int, int, int) {}
-bool PageLine::serialize(HalFile&) { return false; }
-
-void PageImage::render(GfxRenderer&, int, int, int) {}
-void PageImage::renderPlaceholder(GfxRenderer&, int, int) const {}
-bool PageImage::serialize(HalFile&) { return false; }
-
-void PageHorizontalRule::render(GfxRenderer&, int, int, int) {}
-bool PageHorizontalRule::serialize(HalFile&) { return false; }
+void ImageBlock::render(GfxRenderer&, int, int) {}
+void ImageBlock::renderPlaceholder(GfxRenderer&, int, int) const {}
+bool ImageBlock::needsDecode() const { return false; }
+bool ImageBlock::serialize(HalFile&) { return false; }
+std::unique_ptr<ImageBlock> ImageBlock::deserialize(HalFile&) { return nullptr; }

--- a/test/chapter_html_slim_parser/stubs/GfxRenderer.h
+++ b/test/chapter_html_slim_parser/stubs/GfxRenderer.h
@@ -5,8 +5,20 @@
 #include <deque>
 #include <string>
 
+namespace BidiUtils {
+enum class BidiBaseDir : signed char { AUTO = -1, LTR = 0, RTL = 1 };
+}
+
 class GfxRenderer {
  public:
+  bool isFontCacheScanning() const { return false; }
+  void drawLine(int, int, int, int, int, bool) const {}
+  void drawText(int, int, int, const char*, bool, EpdFontFamily::Style,
+                BidiUtils::BidiBaseDir = BidiUtils::BidiBaseDir::AUTO) const {}
+  int getTextWidth(int font, const char* text, EpdFontFamily::Style style,
+                   BidiUtils::BidiBaseDir = BidiUtils::BidiBaseDir::AUTO) const {
+    return getTextAdvanceX(font, text, style);
+  }
   int getScreenWidth() const { return 480; }
   int getScreenHeight() const { return 800; }
   int getLineHeight(int, float = 1.0f) const { return 16; }


### PR DESCRIPTION
## Summary

This is the first PR in a series investigating and reducing heap fragmentation in the EPUB reader. It focuses on the small allocations created by shared ownership of page elements and their text and image data.

This replaces shared ownership of EPUB page elements and their text/image data with `std::unique_ptr`, removing reference-counting allocations from page construction and cache loading.

During layout, `ParsedText` turns a paragraph into individual lines. Each line has a `TextBlock` containing its text and word positions, wrapped in a `PageLine` that places it on the page. `Page` keeps a list of these elements. Loading a page from the SD cache recreates the same object structure.

Previously, both the page element and its text block used `shared_ptr`. On the tested ESP32-C3 toolchain, each shared-pointer control block initializes a mutex, whose backing storage requires two additional heap allocations. A retained text line therefore carries four mutex-related allocations. These small allocations are interleaved with text and font buffers and can prevent freed memory from joining into a large contiguous block. A font allocation can then fail even when total free heap appears sufficient.

The ownership audit found that these objects can have one owner at each stage: layout transfers a completed line to the page, and the page owns it until it is discarded. The objects and their text buffers still use the heap; this change removes the shared-ownership bookkeeping and its mutex allocations.

### Changes

- `Page` owns its elements, each `PageLine` owns its `TextBlock`, and each `PageImage` owns its image data through `unique_ptr`.
- Layout callbacks transfer ownership explicitly. Table layout measures the cells needed for each row slice before moving their lines into a page; the font-settings preview owns its temporary lines.
- Dictionary selection borrows read-only text while keeping the owning page alive.
- Touched object factories use checked `makeUniqueNoThrow` allocations. The serialized page-cache format remains unchanged.

## Scope Check

- [x] I have read SCOPE.md and ROADMAP.md.
- [x] This PR is **not** a new built-in theme.
- [x] This PR is **not** a new external network connector.
- [x] This PR is **not** an interactive app, writing tool, RSS/news/browser, media playback, or PDF feature.
- [ ] The stock firmware does not already handle this well, **and** no other popular CrossPoint fork already does (or, if one does, I explain why CrossPoint still needs it below).
- [ ] If this PR touches `freeink-sdk/`, `lib/hal/`, the bootloader, OTA, or recovery code, I have coordinated with the relevant maintainer.

This is a reader-core memory/ownership refactor aligned with Phase 1. Stock/fork implementation comparison has not been established. The SDK/HAL/bootloader/OTA/recovery coordination item is not applicable; those components are unchanged.

## Additional Context

### Measured memory impact

The X3 A/B comparison used `develop` at `472b5e48` plus identical #3510 serial test support in both builds, with the ownership conversion as the only production-code difference.

A lightweight allocation trace followed the same cached title/copyright/image pages into the Korean *The Selfish Gene* prologue. At a matching checkpoint with 57 pending text tokens:

| Metric | `shared_ptr` | `unique_ptr` |
|---|---:|---:|
| Free heap | 16,932 B | 23,428 B |
| Largest available allocation | 3,700 B | 9,716 B |
| Live mutex-related allocations | 84 | 0 |

That is 6,496 bytes more free heap and 6,016 bytes more contiguous capacity at this checkpoint. The improvement depends on when in the allocation cycle it is measured, so **these figures should not be interpreted as fixed savings**. The largest block was smaller with the conversion at some earlier checkpoints.

### Validation

- Both default firmware builds pass. Expanded cppcheck covering `src`, `include`, and `lib` reports no new diagnostics; existing findings remain.
- All 237 host tests pass. The nine chapter-parser cases also pass under AddressSanitizer and UndefinedBehaviorSanitizer. This PR adds regression tests for ruby preservation during partial paragraph extraction, table pagination while completed pages are destroyed, and rejection of a missing image block during page-image deserialization. Image-block deserialization is stubbed to return null for the failure-path test.
- Normal firmware completed 160 Korean *Demian* turns per build and the five-page prologue traversal without crashes. Captured reading-area pixels match.
- English *Aesop* with the eng-kor dictionary passes selection, pagination, and activity-recreation checks with matching captures. Both builds reproduce the same existing definition-HTML parse errors and plain-text fallback.

### Outstanding device findings

In the fully cached cycles, median ordinary forward turns were 1,713 → 1,730 ms and backward turns were 1,694 → 1,723 ms—about 1.0% and 1.7% slower in this sample. This sequential paired trial does not establish whether those differences represent a consistent rendering-speed regression.

---

### AI Usage

Did you use AI tools to help write this code? **YES**
